### PR TITLE
front: add debug interface to access logged data

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -196,8 +196,8 @@ class STDCMEndpoint(
                     failureExplainer = failureExplainer,
                     callback,
                 )
+            failureExplainer.saveReport(s3Context)
             if (path == null || hasDuplicateTracks(infra, path.trainPath)) {
-                failureExplainer.saveReport(s3Context)
                 val result = PathNotFound()
                 val response = STDCMFinalResult(status = STDCMProgressStatus.DONE, result = result)
                 return RsJson(RsWithBody(STDCMFinalResult.adapter.toJson(response)))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,6 @@ services:
       valkey: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
       openfga: { condition: service_started }
-      s3_init: { condition: service_completed_successfully }
     build:
       context: editoast
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,7 @@ services:
       valkey: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
       openfga: { condition: service_started }
+      s3_init: { condition: service_completed_successfully }
     build:
       context: editoast
       dockerfile: Dockerfile
@@ -189,6 +190,10 @@ services:
       FGA_API_URL: "http://openfga:8091"
       EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
       EDITOAST_NO_CACHE: ${EDITOAST_NO_CACHE:-false}
+      S3_ACCESS_KEY_ID: access_key
+      S3_SECRET_ACCESS_KEY: secret_key
+      S3_ENDPOINT_URL: http://s3:9900
+      S3_BUCKET_NAME: osrd
     command: >
       /bin/sh -c "
         fga_migrations apply &&

--- a/docker/docker-compose.host.yml
+++ b/docker/docker-compose.host.yml
@@ -43,6 +43,10 @@ services:
       TELEMETRY_ENDPOINT: "http://localhost:4317"
       OSRD_MQ_URL: "amqp://osrd:password@127.0.0.1:5672/%2f"
       FGA_API_URL: "http://localhost:8091"
+      S3_ACCESS_KEY_ID: access_key
+      S3_SECRET_ACCESS_KEY: secret_key
+      S3_ENDPOINT_URL: http://127.0.0.1:9900
+      S3_BUCKET_NAME: osrd
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8090/health" ]
 

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -184,6 +184,7 @@ services:
       valkey: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
       openfga: { condition: service_started }
+      s3_init: { condition: service_completed_successfully }
     restart: unless-stopped
     ports: [ "8089:8089" ]
     environment:
@@ -198,6 +199,10 @@ services:
       FGA_API_URL: "http://openfga:8191"
       EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
       EDITOAST_NO_CACHE: ${EDITOAST_NO_CACHE:-false}
+      S3_ACCESS_KEY_ID: access_key
+      S3_SECRET_ACCESS_KEY: secret_key
+      S3_ENDPOINT_URL: http://s3:9002
+      S3_BUCKET_NAME: osrd
     command: >
       /bin/sh -c "
         fga_migrations apply &&

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol"
-version = "10.2.0"
+version = "10.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95442d3faf08b9bed7491ceda36b0e0268126cb20d44e6e7573cf930d9aa5073"
+checksum = "46b92ce9a8b7d332c4b54ef7ea1b00570692bd94fe225901eab63bd12930c63f"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "10.2.0"
+version = "10.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc754c77e62e58ea7323c3f257a97f747ac57f0ff3f7a91185f484dc1cb25bd2"
+checksum = "06f3177d5d2aff2ec51e1d77ac433fcd1b297ea2bb97c2089152a7d2a58a7e3f"
 dependencies = [
  "amq-protocol-uri",
  "async-rs",
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "10.2.0"
+version = "10.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8cb8fa210da5ec52799abf7ce45e2275b5a3f82ec4efafcd3e8161b7dbc9a8"
+checksum = "7b9f2a0015cd0471a2b823060f3424760a7a84787ee89edd1039ca8d715f6de0"
 dependencies = [
  "cookie-factory",
  "nom",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "10.2.0"
+version = "10.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bc3e8b145641e20b57777a17b3bd7ba6bbdbb2b2ae2f26f6224be35e42c330"
+checksum = "69f66f887c5445e087e811794d7e5d071145c81e83568f77529e2f1203b68202"
 dependencies = [
  "amq-protocol-types",
  "percent-encoding",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -268,14 +268,13 @@ dependencies = [
 
 [[package]]
 name = "async-rs"
-version = "0.8.2"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7d98bcae2752f5f3edb17288ff34b799760be54f63261073eed9f6982367b5"
+checksum = "53bf71bee8a75907b6e3c81c5476efa7fcbb34df6e12d30b706888abded72091"
 dependencies = [
  "async-compat",
  "async-global-executor",
  "async-trait",
- "cfg-if",
  "futures-core",
  "futures-io",
  "hickory-resolver",
@@ -505,9 +504,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -615,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -632,6 +631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,7 +644,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -697,6 +702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,9 +715,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -751,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -765,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -819,6 +830,16 @@ name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -968,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -994,6 +1015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1067,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1081,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "database"
@@ -1216,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.3.7"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47618bf0fac06bb670c036e48404c26a865e6a71af4114dfd97dfe89936e404e"
+checksum = "d1817b7f4279b947fc4cafddec12b0e5f8727141706561ce3ac94a60bddd1cf5"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -1272,18 +1302,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1360,6 +1390,7 @@ dependencies = [
  "itertools",
  "json-patch",
  "linkme",
+ "object_store",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "ordered-float",
@@ -1369,7 +1400,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.10.1",
  "rangemap",
- "reqwest",
+ "reqwest 0.13.3",
  "rstest",
  "schemas",
  "search",
@@ -1490,18 +1521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1629,29 +1648,15 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1672,7 +1677,7 @@ dependencies = [
  "futures 0.3.32",
  "futures-util",
  "itertools",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "stdext",
@@ -1998,8 +2003,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2009,9 +2016,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2023,16 +2032,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2046,9 +2055,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2118,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "headers"
@@ -2194,23 +2203,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -2219,21 +2227,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2241,11 +2274,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2320,19 +2353,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.10"
+name = "humantime"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2345,10 +2384,25 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2381,7 +2435,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2413,12 +2467,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2426,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2439,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2453,15 +2508,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2473,15 +2528,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2517,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2561,7 +2616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2598,14 +2653,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2613,6 +2669,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2640,9 +2699,58 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2656,10 +2764,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2719,9 +2829,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2731,9 +2841,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -2772,9 +2882,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2790,6 +2900,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -2823,6 +2939,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2891,9 +3017,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2964,6 +3090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3087,6 +3219,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "md-5 0.10.6",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.1",
+ "reqwest 0.12.28",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -3208,7 +3378,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3221,7 +3391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -3374,18 +3544,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3397,12 +3567,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -3417,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -3474,18 +3638,18 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
  "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
- "rand 0.9.2",
+ "rand 0.10.1",
  "sha2",
  "stringprep",
 ]
@@ -3503,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3534,6 +3698,17 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -3647,15 +3822,80 @@ checksum = "858afdbecdce657c6e32031348cf7326da7700c869c368a136d31565972f7018"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "quote"
@@ -3680,9 +3920,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
  "serde",
@@ -3690,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3706,7 +3946,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3739,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rangemap"
@@ -3751,9 +3991,9 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "redis"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
+checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
 dependencies = [
  "arcstr",
  "async-lock",
@@ -3766,7 +4006,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -3780,9 +4020,9 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c44e98700033fcce3c3774ab8e4f31b9cebb2761df3298600f4be30a95d2f2a"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "redis",
- "socket2 0.6.3",
+ "socket2",
  "tempfile",
 ]
 
@@ -3829,6 +4069,48 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
 
 [[package]]
 name = "reqwest"
@@ -3994,9 +4276,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4034,6 +4316,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,6 +4373,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -4103,7 +4441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4127,9 +4465,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4201,9 +4539,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4261,18 +4599,18 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4292,9 +4630,25 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -4304,9 +4658,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4329,16 +4683,6 @@ dependencies = [
  "autocfg",
  "static_assertions",
  "version_check",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4454,6 +4798,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4461,9 +4826,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tcp-stream"
-version = "0.34.5"
+version = "0.34.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6638f031787a4854f0ecc669514404d201a3f4eab1849e4151f01a28324972de"
+checksum = "e8da40490cac3733b85c67b831f64e2132fdaa0929f42a6d4cf458d339777473"
 dependencies = [
  "async-rs",
  "cfg-if",
@@ -4579,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4589,9 +4954,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4612,7 +4977,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4669,10 +5034,20 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.10.1",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4709,7 +5084,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4723,18 +5098,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -4758,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -4788,9 +5163,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -4889,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry-instrumentation-sdk"
-version = "0.32.3"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d05242e88c440ef1bc997c7ae5e0ed76085c5d817ca29c0be12f0813b024e7"
+checksum = "b8f2540011f6d5ac30e1fc9ff169573b4559406498ac27e0242549d9bf527ed1"
 dependencies = [
  "http",
  "opentelemetry",
@@ -4938,15 +5313,15 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typetag"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -4957,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5001,9 +5376,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -5111,6 +5486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,11 +5521,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5149,7 +5534,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5163,9 +5548,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5176,23 +5561,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5200,9 +5581,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5213,9 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -5243,6 +5624,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5256,9 +5650,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5294,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -5310,6 +5704,15 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-core"
@@ -5353,6 +5756,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5368,15 +5782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5399,26 +5804,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5430,7 +5829,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -5438,10 +5837,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+name = "windows-targets"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5450,10 +5860,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5462,10 +5872,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
+name = "windows_aarch64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5474,16 +5884,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
+name = "windows_i686_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5492,10 +5908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
+name = "windows_i686_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5504,10 +5920,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+name = "windows_x86_64_gnu"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5516,10 +5932,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5528,20 +5944,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "winnow"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -5551,6 +5969,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5633,9 +6057,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
@@ -5651,9 +6075,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5662,9 +6086,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5674,18 +6098,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5694,18 +6118,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5714,10 +6138,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerotrie"
-version = "0.2.3"
+name = "zeroize"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5726,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5737,9 +6167,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5788,9 +6218,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -92,6 +92,7 @@ lapin = { version = "4.7.4", default-features = false, features = ["tokio"] }
 linkme = "0.3.36"
 mvt = "0.13.0"
 openssl = "0.10.80"
+object_store = { version = "0.13", features = ["aws"] }
 opentelemetry = { version = "0.31.0", default-features = false, features = [
   "trace",
 ] }
@@ -209,6 +210,7 @@ json-patch = { version = "4.1.0", default-features = false, features = [
   "utoipa",
 ] }
 linkme.workspace = true
+object_store.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 ordered-float.workspace = true

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -91,8 +91,8 @@ itertools = "0.14.0"
 lapin = { version = "4.7.4", default-features = false, features = ["tokio"] }
 linkme = "0.3.36"
 mvt = "0.13.0"
+object_store = { version = "0.13.2", features = ["aws"] }
 openssl = "0.10.80"
-object_store = { version = "0.13", features = ["aws"] }
 opentelemetry = { version = "0.31.0", default-features = false, features = [
   "trace",
 ] }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2891,6 +2891,27 @@ paths:
           description: Atlas image of config
         '404':
           description: Signaling system not found
+  /stdcm/debug_data/{trace_id}:
+    get:
+      tags:
+      - stdcm
+      parameters:
+      - name: trace_id
+        in: path
+        description: OpenTelemetry trace ID of the STDCM request
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  failure: {}
+                  simulation_data: {}
   /stdcm/search_environment:
     get:
       tags:
@@ -7218,6 +7239,9 @@ components:
       - $ref: '#/components/schemas/EditoastSimilarTrainsErrorSpeedLimitNotFound'
       - $ref: '#/components/schemas/EditoastSpriteErrorsFileNotFound'
       - $ref: '#/components/schemas/EditoastSpriteErrorsUnknownSignalingSystem'
+      - $ref: '#/components/schemas/EditoastStdcmDebugErrorJsonParseError'
+      - $ref: '#/components/schemas/EditoastStdcmDebugErrorS3Error'
+      - $ref: '#/components/schemas/EditoastStdcmDebugErrorS3NotConfigured'
       - $ref: '#/components/schemas/EditoastStdcmErrorBatchRollingStockNotFound'
       - $ref: '#/components/schemas/EditoastStdcmErrorDatabase'
       - $ref: '#/components/schemas/EditoastStdcmErrorInfraNotFound'
@@ -8744,6 +8768,82 @@ components:
           type: string
           enum:
           - editoast:sprites:UnknownSignalingSystem
+    EditoastStdcmDebugErrorJsonParseError:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastStdcmDebugErrorJsonParseErrorContext
+          required:
+          - message
+          - path
+          properties:
+            message:
+              type: string
+            path:
+              type: string
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:stdcm_debug:JsonParseError
+    EditoastStdcmDebugErrorS3Error:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastStdcmDebugErrorS3ErrorContext
+          required:
+          - message
+          - path
+          properties:
+            message:
+              type: string
+            path:
+              type: string
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:stdcm_debug:S3Error
+    EditoastStdcmDebugErrorS3NotConfigured:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastStdcmDebugErrorS3NotConfiguredContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 503
+        type:
+          type: string
+          enum:
+          - editoast:stdcm_debug:S3NotConfigured
     EditoastStdcmErrorBatchRollingStockNotFound:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2910,8 +2910,14 @@ paths:
               schema:
                 type: object
                 properties:
-                  failure: {}
-                  simulation_data: {}
+                  failure:
+                    oneOf:
+                    - type: 'null'
+                    - $ref: '#/components/schemas/SimDebugFailureReport'
+                  simulation_data:
+                    oneOf:
+                    - type: 'null'
+                    - $ref: '#/components/schemas/SimDebugData'
   /stdcm/search_environment:
     get:
       tags:
@@ -14217,6 +14223,147 @@ components:
         side:
           $ref: '#/components/schemas/Side'
       additionalProperties: false
+    SimDebugConflictReport:
+      type: object
+      required:
+      - at
+      - time_lost
+      - best_remaining_time
+      - current_travel_time
+      - caused_by
+      - lat
+      - lon
+      properties:
+        at:
+          type: string
+          format: date-time
+        best_remaining_time:
+          type: number
+          format: double
+        caused_by:
+          type: string
+        current_travel_time:
+          type: number
+          format: double
+        lastOPName:
+          type:
+          - string
+          - 'null'
+        lat:
+          type: number
+          format: double
+        lon:
+          type: number
+          format: double
+        time_lost:
+          type: number
+          format: double
+    SimDebugData:
+      type: object
+      required:
+      - path_properties
+      - other_requirements
+      - departure_time
+      - engineering_allowances_ranges
+      - zone_locations
+      - train_times
+      - train_positions
+      properties:
+        departure_time:
+          type: string
+          format: date-time
+        engineering_allowances_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimDebugEngineeringAllowanceRange'
+        other_requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimDebugTrainZoneRequirement'
+        path_properties:
+          $ref: '#/components/schemas/PathProperties'
+        sim_output:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/SimulationResponseSuccess'
+        train_positions:
+          type: array
+          items:
+            type: number
+            format: double
+        train_times:
+          type: array
+          items:
+            type: number
+            format: double
+        zone_locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimDebugZoneLocation'
+    SimDebugEngineeringAllowanceRange:
+      type: object
+      required:
+      - from
+      - to
+      - added_duration
+      properties:
+        added_duration:
+          type: number
+          format: double
+        from:
+          type: number
+          format: double
+        to:
+          type: number
+          format: double
+    SimDebugFailureReport:
+      type: object
+      required:
+      - largest_conflicts
+      - closest_conflicts
+      properties:
+        closest_conflicts:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimDebugConflictReport'
+        largest_conflicts:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimDebugConflictReport'
+    SimDebugTrainZoneRequirement:
+      type: object
+      required:
+      - zone_name
+      - begin_time
+      - end_time
+      properties:
+        begin_time:
+          type: number
+          format: double
+        end_time:
+          type: number
+          format: double
+        train_name:
+          type:
+          - string
+          - 'null'
+        zone_name:
+          type: string
+    SimDebugZoneLocation:
+      type: object
+      required:
+      - name
+      - from
+      - to
+      properties:
+        from:
+          type: number
+          format: double
+        name:
+          type: string
+        to:
+          type: number
+          format: double
     SimilarTrainWaypoint:
       type: object
       required:

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -36,6 +36,20 @@ pub struct CoreArgs {
 }
 
 #[derive(Args, Debug)]
+pub struct S3Args {
+    #[clap(long, env = "S3_ENDPOINT_URL")]
+    pub endpoint: Option<Url>,
+    #[clap(long, env = "S3_BUCKET_NAME")]
+    pub bucket_name: Option<String>,
+    #[clap(long, env = "S3_ACCESS_KEY_ID")]
+    pub access_key_id: Option<String>,
+    #[clap(long, env = "S3_SECRET_ACCESS_KEY")]
+    pub secret_access_key: Option<String>,
+    #[clap(long, env = "S3_REGION")]
+    pub region: Option<String>,
+}
+
+#[derive(Args, Debug)]
 #[command(about, long_about = "Launch the server")]
 pub struct RunserverArgs {
     #[clap(long, env = "ROOT_URL", default_value_t = Url::parse("http://localhost:8090").unwrap())]
@@ -59,6 +73,8 @@ pub struct RunserverArgs {
     health_check_timeout_ms: u64,
     #[clap(long, env = "EDITOAST_TRAINS_TRAFFIC_PATH")]
     trains_traffic_path: Option<PathBuf>,
+    #[command(flatten)]
+    s3: S3Args,
 }
 
 /// Create and run the server
@@ -80,6 +96,7 @@ pub async fn runserver(
         root_url,
         dynamic_assets_path,
         trains_traffic_path,
+        s3,
     }: RunserverArgs,
     postgres: PostgresConfig,
     valkey_config: ValkeyConfig,
@@ -115,8 +132,19 @@ pub async fn runserver(
         dynamic_assets_path,
         app_version,
         trains_traffic,
+        s3_config: build_s3_config(s3),
     };
 
     let server = views::Server::new(config).await?;
     Ok(server.start().await?)
+}
+
+fn build_s3_config(s3: S3Args) -> Option<views::S3Config> {
+    Some(views::S3Config {
+        endpoint: s3.endpoint?,
+        bucket_name: s3.bucket_name?,
+        access_key_id: s3.access_key_id?,
+        secret_access_key: s3.secret_access_key?,
+        region: s3.region,
+    })
 }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -19,6 +19,7 @@ mod router;
 pub mod scenario;
 pub mod search;
 pub mod sprites;
+pub mod stdcm_debug;
 pub mod stdcm_search_environment;
 pub mod study;
 pub mod sub_categories;
@@ -77,6 +78,8 @@ use core_client::mq_client;
 use database::DbConnectionPoolV2;
 use database::db_connection_pool::ping_database;
 use editoast_derive::EditoastError;
+use object_store::aws::AmazonS3;
+use object_store::aws::AmazonS3Builder;
 use thiserror::Error;
 use tokio::time::timeout;
 use tower::Layer as _;
@@ -170,6 +173,10 @@ fn service_router() -> router::DocumentedRouter {
                     .route("/{signaling_system}/{file_name}", get!(sprites::sprites))
             })
             .route("/search", post!(search::search))
+            .route(
+                "/stdcm/debug_data/{trace_id}",
+                get!(stdcm_debug::get_debug_data),
+            )
             .nests("/infra", |path| {
                 path.route("/", get!(infra::list))
                     .route("/", post!(infra::create))
@@ -1047,6 +1054,14 @@ pub struct PostgresConfig {
     pub pool_size: usize,
 }
 
+pub struct S3Config {
+    pub endpoint: Url,
+    pub bucket_name: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub region: Option<String>,
+}
+
 pub struct ServerConfig {
     pub port: u16,
     pub address: String,
@@ -1060,6 +1075,7 @@ pub struct ServerConfig {
     pub root_url: Url,
     pub dynamic_assets_path: PathBuf,
     pub app_version: Option<String>,
+    pub s3_config: Option<S3Config>,
     pub trains_traffic: Arc<RwLock<timetable::similar_trains::trains_traffic::TrainsTrafficPool>>,
 }
 
@@ -1085,6 +1101,7 @@ pub struct AppState {
     pub health_check_timeout: Duration,
     pub regulator: Regulator,
     pub trains_traffic: Arc<RwLock<timetable::similar_trains::trains_traffic::TrainsTrafficPool>>,
+    pub s3_client: Option<Arc<AmazonS3>>,
 }
 
 impl FromRef<AppState> for Arc<DbConnectionPoolV2> {
@@ -1180,6 +1197,8 @@ impl AppState {
             config.app_version.as_deref().unwrap_or("NO_APP_VERSION"),
         ));
 
+        let s3_client = build_s3_client(&config.s3_config);
+
         let (db_pool, core_client, openfga) = tokio::try_join!(
             async { db_pool_fut.await? },
             async { core_client_fut.await? },
@@ -1196,8 +1215,31 @@ impl AppState {
             speed_limit_tag_ids,
             health_check_timeout: config.health_check_timeout,
             trains_traffic: config.trains_traffic.clone(),
+            s3_client,
             config: Arc::new(config),
         })
+    }
+}
+
+fn build_s3_client(optional_config: &Option<S3Config>) -> Option<Arc<AmazonS3>> {
+    let config = optional_config.as_ref()?;
+    let bucket = config.bucket_name.clone();
+    let mut builder = AmazonS3Builder::new()
+        .with_bucket_name(bucket)
+        .with_virtual_hosted_style_request(false)
+        .with_allow_http(true)
+        .with_endpoint(config.endpoint.as_str())
+        .with_access_key_id(config.access_key_id.clone())
+        .with_secret_access_key(config.secret_access_key.clone());
+    if let Some(region) = &config.region {
+        builder = builder.with_region(region)
+    }
+    match builder.build() {
+        Ok(client) => Some(Arc::new(client)),
+        Err(e) => {
+            warn!("Failed to build S3 client: {e}");
+            None
+        }
     }
 }
 

--- a/editoast/src/views/stdcm_debug.rs
+++ b/editoast/src/views/stdcm_debug.rs
@@ -2,17 +2,22 @@ use authz::Role;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
+use chrono::DateTime;
+use chrono::Utc;
 use editoast_derive::EditoastError;
 use object_store::GetOptions;
 use object_store::ObjectStore as _;
 use object_store::aws::AmazonS3;
-use object_store::path::Path as OsPath;
+use object_store::path::Path as ObjStorePath;
+use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
 
 use crate::AppState;
 use crate::error::Result;
+use crate::views::path::properties::PathProperties;
+use crate::views::timetable::simulation::SimulationResponseSuccess;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "stdcm_debug")]
@@ -28,10 +33,63 @@ enum StdcmDebugError {
     JsonParseError { path: String, message: String },
 }
 
-#[derive(Serialize, serde::Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct SimDebugConflictReport {
+    at: DateTime<Utc>,
+    time_lost: f64,
+    best_remaining_time: f64,
+    current_travel_time: f64,
+    caused_by: String,
+    lat: f64,
+    lon: f64,
+    #[serde(rename = "lastOPName")]
+    last_op_name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct SimDebugFailureReport {
+    largest_conflicts: Vec<SimDebugConflictReport>,
+    closest_conflicts: Vec<SimDebugConflictReport>,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct SimDebugTrainZoneRequirement {
+    zone_name: String,
+    begin_time: f64,
+    end_time: f64,
+    train_name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct SimDebugZoneLocation {
+    name: String,
+    from: f64,
+    to: f64,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct SimDebugEngineeringAllowanceRange {
+    from: f64,
+    to: f64,
+    added_duration: f64,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct SimDebugData {
+    sim_output: Option<SimulationResponseSuccess>,
+    path_properties: PathProperties,
+    other_requirements: Vec<SimDebugTrainZoneRequirement>,
+    departure_time: DateTime<Utc>,
+    engineering_allowances_ranges: Vec<SimDebugEngineeringAllowanceRange>,
+    zone_locations: Vec<SimDebugZoneLocation>,
+    train_times: Vec<f64>,
+    train_positions: Vec<f64>,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
 pub(in crate::views) struct StdcmDebugDataResponse {
-    failure: Option<serde_json::Value>,
-    simulation_data: Option<serde_json::Value>,
+    failure: Option<SimDebugFailureReport>,
+    simulation_data: Option<SimDebugData>,
 }
 
 #[editoast_derive::route(Role::Admin)]
@@ -51,10 +109,17 @@ pub(in crate::views) async fn get_debug_data(
 ) -> Result<Json<StdcmDebugDataResponse>> {
     let s3 = s3_client.as_ref().ok_or(StdcmDebugError::S3NotConfigured)?;
 
-    let prefix = OsPath::from("stdcm/requests/").join(trace_id);
-    let failure = fetch_optional_json(s3.as_ref(), &prefix.clone().join("failure.json")).await?;
-    let simulation_data =
-        fetch_optional_json(s3.as_ref(), &prefix.join("output_simulation_data.json")).await?;
+    let prefix = ObjStorePath::from("stdcm/requests/").join(trace_id);
+    let failure = fetch_optional_json::<SimDebugFailureReport>(
+        s3.as_ref(),
+        &prefix.clone().join("failure.json"),
+    )
+    .await?;
+    let simulation_data = fetch_optional_json::<SimDebugData>(
+        s3.as_ref(),
+        &prefix.join("output_simulation_data.json"),
+    )
+    .await?;
 
     let response = StdcmDebugDataResponse {
         failure,
@@ -63,11 +128,11 @@ pub(in crate::views) async fn get_debug_data(
     Ok(Json(response))
 }
 
-async fn fetch_optional_json(
+async fn fetch_optional_json<T: serde::de::DeserializeOwned>(
     s3: &AmazonS3,
-    path: &OsPath,
-) -> Result<Option<serde_json::Value>, StdcmDebugError> {
-    match s3.get_opts(&path, GetOptions::default()).await {
+    path: &ObjStorePath,
+) -> Result<Option<T>, StdcmDebugError> {
+    match s3.get_opts(path, GetOptions::default()).await {
         Ok(result) => {
             let bytes = result.bytes().await.map_err(|e| StdcmDebugError::S3Error {
                 path: path.to_string(),

--- a/editoast/src/views/stdcm_debug.rs
+++ b/editoast/src/views/stdcm_debug.rs
@@ -1,0 +1,89 @@
+use authz::Role;
+use axum::extract::Json;
+use axum::extract::Path;
+use axum::extract::State;
+use editoast_derive::EditoastError;
+use object_store::GetOptions;
+use object_store::ObjectStore as _;
+use object_store::aws::AmazonS3;
+use object_store::path::Path as OsPath;
+use serde::Serialize;
+use thiserror::Error;
+use utoipa::ToSchema;
+
+use crate::AppState;
+use crate::error::Result;
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "stdcm_debug")]
+enum StdcmDebugError {
+    #[error("S3 is not configured")]
+    #[editoast_error(status = 503)]
+    S3NotConfigured,
+    #[error("S3 error fetching '{path}': {message}")]
+    #[editoast_error(status = 500)]
+    S3Error { path: String, message: String },
+    #[error("Failed to parse JSON from S3 object '{path}': {message}")]
+    #[editoast_error(status = 500)]
+    JsonParseError { path: String, message: String },
+}
+
+#[derive(Serialize, serde::Deserialize, ToSchema)]
+pub(in crate::views) struct StdcmDebugDataResponse {
+    failure: Option<serde_json::Value>,
+    simulation_data: Option<serde_json::Value>,
+}
+
+#[editoast_derive::route(Role::Admin)]
+#[utoipa::path(
+    get, path = "",
+    tag = "stdcm",
+    params(
+        ("trace_id" = String, Path, description = "OpenTelemetry trace ID of the STDCM request")
+    ),
+    responses(
+        (status = 200, body = inline(StdcmDebugDataResponse)),
+    )
+)]
+pub(in crate::views) async fn get_debug_data(
+    State(AppState { s3_client, .. }): State<AppState>,
+    Path(trace_id): Path<String>,
+) -> Result<Json<StdcmDebugDataResponse>> {
+    let s3 = s3_client.as_ref().ok_or(StdcmDebugError::S3NotConfigured)?;
+
+    let prefix = OsPath::from("stdcm/requests/").join(trace_id);
+    let failure = fetch_optional_json(s3.as_ref(), &prefix.clone().join("failure.json")).await?;
+    let simulation_data =
+        fetch_optional_json(s3.as_ref(), &prefix.join("output_simulation_data.json")).await?;
+
+    let response = StdcmDebugDataResponse {
+        failure,
+        simulation_data,
+    };
+    Ok(Json(response))
+}
+
+async fn fetch_optional_json(
+    s3: &AmazonS3,
+    path: &OsPath,
+) -> Result<Option<serde_json::Value>, StdcmDebugError> {
+    match s3.get_opts(&path, GetOptions::default()).await {
+        Ok(result) => {
+            let bytes = result.bytes().await.map_err(|e| StdcmDebugError::S3Error {
+                path: path.to_string(),
+                message: e.to_string(),
+            })?;
+            let value =
+                serde_json::from_slice(&bytes).map_err(|e| StdcmDebugError::JsonParseError {
+                    path: path.to_string(),
+                    message: e.to_string(),
+                })?;
+            Ok(Some(value))
+        }
+        Err(object_store::Error::NotFound { .. }) => Ok(None),
+        Err(e) => Err(StdcmDebugError::S3Error {
+            path: path.to_string(),
+            message: e.to_string(),
+        }),
+    }
+}

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -198,6 +198,7 @@ impl TestAppBuilder {
                 max_tuples_per_write: DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE,
             },
             trains_traffic: Arc::new(RwLock::new(self.trains_traffic)),
+            s3_config: None,
         };
 
         // Setup tracing
@@ -283,6 +284,7 @@ impl TestAppBuilder {
             health_check_timeout: config.health_check_timeout,
             trains_traffic: config.trains_traffic.clone(),
             config: Arc::new(config),
+            s3_client: None,
         };
 
         // Configure the axum router

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -237,6 +237,11 @@
       "TowedRollingStockNotFound": "Towed rolling stock {towed_rolling_stock_id} does not exist",
       "TrainSimulationFail": "Train simulation failed"
     },
+    "stdcm_debug": {
+      "JsonParseError": "Error parsing json file",
+      "S3Error": "Error getting s3 data",
+      "S3NotConfigured": "Editoast isn't configured to access s3"
+    },
     "stdcm_search_env": {
       "Database": "Internal error (database)",
       "NotFound": "Stdcm search environment '{{env_id}}' could not be found"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -237,6 +237,11 @@
       "TowedRollingStockNotFound": "Matériel roulant remorqué {towed_rolling_stock_id} non trouvé",
       "TrainSimulationFail": "Échec de la simulation du train"
     },
+    "stdcm_debug": {
+      "JsonParseError": "Erreur de lecture du fichier json",
+      "S3Error": "Erreur d'accès au s3",
+      "S3NotConfigured": "Editoast n'est pas configuré pour accéder au s3"
+    },
     "stdcm_search_env": {
       "Database": "Erreur interne (base de données)",
       "NotFound": "Environnement de recherche stdcm '{{env_id}}' non trouvé"

--- a/front/src/applications/stdcm/StdcmDebugView.tsx
+++ b/front/src/applications/stdcm/StdcmDebugView.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import DebugSpaceTimeChart from 'applications/stdcm/components/DebugView/DebugSpaceTimeChart';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+
+const StdcmDebugView = () => {
+  const [searchParams] = useSearchParams();
+  const traceId = searchParams.get('traceId');
+  const navigate = useNavigate();
+  const [inputId, setInputId] = useState('');
+
+  const { data, isLoading, error } = osrdEditoastApi.endpoints.getStdcmDebugDataByTraceId.useQuery(
+    { traceId: traceId ?? '' },
+    { skip: !traceId }
+  );
+  const simulationData = data?.simulation_data;
+
+  const inputForm = (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (inputId.trim()) navigate(`/stdcm/debug?traceId=${encodeURIComponent(inputId.trim())}`);
+      }}
+    >
+      <input
+        id="trace-id-input"
+        value={inputId}
+        onChange={(e) => setInputId(e.target.value)}
+        placeholder="Enter trace ID"
+      />
+      <button type="submit">Open</button>
+    </form>
+  );
+
+  if (!traceId) {
+    return <div>{inputForm}</div>;
+  }
+
+  let result;
+  if (isLoading) {
+    result = <div>Loading...</div>;
+  } else if (error) {
+    result = <div>Error: {JSON.stringify(error)}</div>;
+  } else {
+    result = <DebugSpaceTimeChart simulationData={simulationData} />;
+  }
+  return (
+    <div>
+      {inputForm}
+      {result}
+    </div>
+  );
+};
+
+export default StdcmDebugView;

--- a/front/src/applications/stdcm/StdcmDebugView.tsx
+++ b/front/src/applications/stdcm/StdcmDebugView.tsx
@@ -43,6 +43,8 @@ const StdcmDebugView = () => {
     result = <div>Loading...</div>;
   } else if (error) {
     result = <div>Error: {JSON.stringify(error)}</div>;
+  } else if (!simulationData) {
+    result = <div>No simulation data available</div>;
   } else {
     result = <DebugSpaceTimeChart simulationData={simulationData} />;
   }

--- a/front/src/applications/stdcm/StdcmDebugView.tsx
+++ b/front/src/applications/stdcm/StdcmDebugView.tsx
@@ -1,5 +1,8 @@
-import { useState } from 'react';
+import { useRef } from 'react';
 
+import { Button, Input } from '@osrd-project/ui-core';
+import { Search } from '@osrd-project/ui-icons';
+import { skipToken } from '@reduxjs/toolkit/query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import DebugFailureMap from 'applications/stdcm/components/DebugView/DebugFailureMap';
@@ -11,56 +14,67 @@ const StdcmDebugView = () => {
   const [searchParams] = useSearchParams();
   const traceId = searchParams.get('traceId');
   const navigate = useNavigate();
-  const [inputId, setInputId] = useState('');
+  const formRef = useRef<HTMLFormElement | null>(null);
 
-  const { data, isLoading, error } = osrdEditoastApi.endpoints.getStdcmDebugDataByTraceId.useQuery(
-    { traceId: traceId ?? '' },
-    { skip: !traceId }
+  const {
+    data: { simulation_data, failure } = {},
+    isLoading,
+    error,
+  } = osrdEditoastApi.endpoints.getStdcmDebugDataByTraceId.useQuery(
+    traceId ? { traceId } : skipToken
   );
-  const simulationData = data?.simulation_data;
-  const failureData = data?.failure;
 
-  const inputForm = (
+  const handleSubmit = () => {
+    if (formRef.current) {
+      const id = (new FormData(formRef.current).get('traceId') as string).trim();
+      if (id) navigate(`/stdcm/debug?traceId=${encodeURIComponent(id)}`);
+    }
+  };
+
+  const form = (
     <form
+      ref={formRef}
+      className="stdcm-debug-view__form"
       onSubmit={(e) => {
         e.preventDefault();
-        if (inputId.trim()) navigate(`/stdcm/debug?traceId=${encodeURIComponent(inputId.trim())}`);
+        handleSubmit();
       }}
     >
-      <input
-        id="trace-id-input"
-        value={inputId}
-        onChange={(e) => setInputId(e.target.value)}
-        placeholder="Enter trace ID"
-      />
-      <button type="submit">Open</button>
+      <Input id="trace-id-input" name="traceId" type="text" placeholder="Enter trace ID" narrow />
+      <Button label="Open" onClick={() => {}} />
     </form>
   );
 
   if (!traceId) {
-    return <div>{inputForm}</div>;
-  }
-
-  let result;
-  if (isLoading) {
-    result = <div>Loading...</div>;
-  } else if (error) {
-    result = <div>Error: {JSON.stringify(error)}</div>;
-  } else if (!simulationData && !failureData) {
-    result = <div>No data available</div>;
-  } else {
-    result = (
-      <>
-        {simulationData && <DebugSpaceTimeChart simulationData={simulationData} />}
-        {simulationData && <DebugSpeedDistanceDiagram simulationData={simulationData} />}
-        {failureData && <DebugFailureMap failureData={failureData} />}
-      </>
+    return (
+      <div className="stdcm-debug-view">
+        <div className="stdcm-debug-view__empty">
+          <span className="stdcm-debug-view__empty-icon">
+            <Search size="lg" />
+          </span>
+          <h2>Debug view</h2>
+          <p>Enter a trace ID to view debug data for a simulation.</p>
+          {form}
+        </div>
+      </div>
     );
   }
+  let viewStatus = null;
+  if (isLoading) viewStatus = 'Loading...';
+  else if (error) viewStatus = 'Failed to load debug data.';
+  else if (!simulation_data && !failure) viewStatus = 'No data available for this trace.';
+
   return (
-    <div>
-      {inputForm}
-      {result}
+    <div className="stdcm-debug-view">
+      <div className="stdcm-debug-view__form-bar">{form}</div>
+      {simulation_data && (
+        <>
+          <DebugSpaceTimeChart simData={simulation_data} />
+          <DebugSpeedDistanceDiagram simData={simulation_data} />
+        </>
+      )}
+      {failure && <DebugFailureMap failureData={failure} />}
+      {!simulation_data && !failure && <div className="stdcm-debug-view__status">{viewStatus}</div>}
     </div>
   );
 };

--- a/front/src/applications/stdcm/StdcmDebugView.tsx
+++ b/front/src/applications/stdcm/StdcmDebugView.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import DebugFailureMap from 'applications/stdcm/components/DebugView/DebugFailureMap';
 import DebugSpaceTimeChart from 'applications/stdcm/components/DebugView/DebugSpaceTimeChart';
+import DebugSpeedDistanceDiagram from 'applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 
 const StdcmDebugView = () => {
@@ -51,6 +52,7 @@ const StdcmDebugView = () => {
     result = (
       <>
         {simulationData && <DebugSpaceTimeChart simulationData={simulationData} />}
+        {simulationData && <DebugSpeedDistanceDiagram simulationData={simulationData} />}
         {failureData && <DebugFailureMap failureData={failureData} />}
       </>
     );

--- a/front/src/applications/stdcm/StdcmDebugView.tsx
+++ b/front/src/applications/stdcm/StdcmDebugView.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
+import DebugFailureMap from 'applications/stdcm/components/DebugView/DebugFailureMap';
 import DebugSpaceTimeChart from 'applications/stdcm/components/DebugView/DebugSpaceTimeChart';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 
@@ -16,6 +17,7 @@ const StdcmDebugView = () => {
     { skip: !traceId }
   );
   const simulationData = data?.simulation_data;
+  const failureData = data?.failure;
 
   const inputForm = (
     <form
@@ -43,10 +45,15 @@ const StdcmDebugView = () => {
     result = <div>Loading...</div>;
   } else if (error) {
     result = <div>Error: {JSON.stringify(error)}</div>;
-  } else if (!simulationData) {
-    result = <div>No simulation data available</div>;
+  } else if (!simulationData && !failureData) {
+    result = <div>No data available</div>;
   } else {
-    result = <DebugSpaceTimeChart simulationData={simulationData} />;
+    result = (
+      <>
+        {simulationData && <DebugSpaceTimeChart simulationData={simulationData} />}
+        {failureData && <DebugFailureMap failureData={failureData} />}
+      </>
+    );
   }
   return (
     <div>

--- a/front/src/applications/stdcm/components/DebugView/DebugFailureMap.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugFailureMap.tsx
@@ -5,189 +5,143 @@ import type { MapLayerMouseEvent } from 'maplibre-gl';
 import type { MapRef } from 'react-map-gl/maplibre';
 import ReactMapGL, { Source } from 'react-map-gl/maplibre';
 
+import type { SimDebugConflictReport, SimDebugFailureReport } from 'common/api/osrdEditoastApi';
 import { OrderedLayer, VirtualLayers, genOSMLayerProps, useMapBlankStyle } from 'common/Map/Layers';
 import OpenStreetMapSource from 'common/Map/Sources/OpenStreetMap';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 
-type ConflictPoint = {
-  at: string;
-  time_lost: number;
-  best_remaining_time: number;
-  current_travel_time: number;
-  caused_by: string;
-  lat: number;
-  lon: number;
-  lastOPName: string;
-};
+type HoveredPoint = SimDebugConflictReport & { category: 'largest' | 'closest' };
 
-type FailureData = {
-  largest_conflicts: ConflictPoint[];
-  closest_conflicts: ConflictPoint[];
-};
-
-type HoveredPoint = ConflictPoint & { category: 'largest' | 'closest' };
-
-const toFeatures = (points: ConflictPoint[], category: 'largest' | 'closest'): Feature<Point>[] =>
-  points.map((p, i) => ({
+const toFeatures = (
+  points: SimDebugConflictReport[],
+  category: 'largest' | 'closest'
+): Feature<Point>[] =>
+  points.map((point, i) => ({
     type: 'Feature',
     id: i,
-    properties: { ...p, category },
-    geometry: { type: 'Point', coordinates: [p.lon, p.lat] },
+    properties: { ...point, category },
+    geometry: { type: 'Point', coordinates: [point.lon, point.lat] },
   }));
 
-const fmtSeconds = (s: number) => `${Math.round(s)}s`;
+const fmtSeconds = (seconds: number) => `${Math.round(seconds)}s`;
 
-type DebugFailureMapProps = { failureData: unknown };
+type DebugFailureMapProps = { failureData: SimDebugFailureReport };
 
 const DebugFailureMap = ({ failureData }: DebugFailureMapProps) => {
-  const data = failureData as FailureData;
   const mapRef = useRef<MapRef | null>(null);
   const mapBlankStyle = useMapBlankStyle();
-  const [hovered, setHovered] = useState<{ point: HoveredPoint; x: number; y: number } | null>(
-    null
-  );
+  const [hovered, setHovered] = useState<{
+    point: HoveredPoint;
+    clientX: number;
+    clientY: number;
+  } | null>(null);
 
   const geojson = useMemo<FeatureCollection<Point>>(
     () => ({
       type: 'FeatureCollection',
       features: [
-        ...toFeatures(data.largest_conflicts ?? [], 'largest'),
-        ...toFeatures(data.closest_conflicts ?? [], 'closest'),
+        ...toFeatures(failureData.largest_conflicts ?? [], 'largest'),
+        ...toFeatures(failureData.closest_conflicts ?? [], 'closest'),
       ],
     }),
-    [data]
+    [failureData]
   );
 
   const initialViewState = useMemo(() => {
-    const allPoints = [...(data.largest_conflicts ?? []), ...(data.closest_conflicts ?? [])];
+    const allPoints = [
+      ...(failureData.largest_conflicts ?? []),
+      ...(failureData.closest_conflicts ?? []),
+    ];
     if (allPoints.length === 0) return { latitude: 46.2, longitude: 2.5, zoom: 5 };
-    const lats = allPoints.map((p) => p.lat);
-    const lons = allPoints.map((p) => p.lon);
+    const lats = allPoints.map((point) => point.lat);
+    const lons = allPoints.map((point) => point.lon);
     return {
       latitude: (Math.min(...lats) + Math.max(...lats)) / 2,
       longitude: (Math.min(...lons) + Math.max(...lons)) / 2,
       zoom: 8,
     };
-  }, [data]);
+  }, [failureData]);
 
-  const handleMouseMove = useCallback((e: MapLayerMouseEvent) => {
-    const feature = e.features?.[0];
+  const handleMouseMove = useCallback((event: MapLayerMouseEvent) => {
+    const feature = event.features?.[0];
     if (!feature) {
       setHovered(null);
       return;
     }
     setHovered({
       point: feature.properties as HoveredPoint,
-      x: e.point.x,
-      y: e.point.y,
+      clientX: event.point.x,
+      clientY: event.point.y,
     });
   }, []);
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: 500 }}>
-      <ReactMapGL
-        ref={mapRef}
-        initialViewState={initialViewState}
-        style={{ width: '100%', height: '100%' }}
-        mapStyle={mapBlankStyle}
-        interactiveLayerIds={['conflicts-largest', 'conflicts-closest']}
-        onMouseMove={handleMouseMove}
-        onMouseLeave={() => setHovered(null)}
-      >
-        <VirtualLayers />
-        <OpenStreetMapSource />
-        {genOSMLayerProps(
-          'normal',
-          { showOSM3dBuildings: false },
-          LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]
-        )
-          .filter((p): p is typeof p & { id: string } => p.id !== undefined)
-          .map(({ id, ...props }) => (
-            <OrderedLayer key={id} id={id} {...props} />
-          ))}
-        <Source id="conflicts" type="geojson" data={geojson}>
-          <OrderedLayer
-            id="conflicts-largest"
-            type="circle"
-            layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
-            filter={['==', ['get', 'category'], 'largest']}
-            paint={{
-              'circle-radius': 8,
-              'circle-color': 'rgba(220, 50, 50, 0.85)',
-              'circle-stroke-width': 1.5,
-              'circle-stroke-color': '#fff',
-            }}
-          />
-          <OrderedLayer
-            id="conflicts-closest"
-            type="circle"
-            layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
-            filter={['==', ['get', 'category'], 'closest']}
-            paint={{
-              'circle-radius': 8,
-              'circle-color': 'rgba(50, 120, 220, 0.85)',
-              'circle-stroke-width': 1.5,
-              'circle-stroke-color': '#fff',
-            }}
-          />
-        </Source>
-      </ReactMapGL>
+    <div className="debug-failure-map">
+      <div className="debug-failure-map__map">
+        <ReactMapGL
+          ref={mapRef}
+          initialViewState={initialViewState}
+          style={{ width: '100%', height: '100%' }}
+          mapStyle={mapBlankStyle}
+          interactiveLayerIds={['conflicts-largest', 'conflicts-closest']}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={() => setHovered(null)}
+        >
+          <VirtualLayers />
+          <OpenStreetMapSource />
+          {genOSMLayerProps(
+            'normal',
+            { showOSM3dBuildings: false },
+            LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]
+          )
+            .filter((layer): layer is typeof layer & { id: string } => layer.id !== undefined)
+            .map(({ id, ...props }) => (
+              <OrderedLayer key={id} id={id} {...props} />
+            ))}
+          <Source id="conflicts" type="geojson" data={geojson}>
+            <OrderedLayer
+              id="conflicts-largest"
+              type="circle"
+              layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
+              filter={['==', ['get', 'category'], 'largest']}
+              paint={{
+                'circle-radius': 8,
+                'circle-color': 'rgba(220, 50, 50, 0.85)',
+                'circle-stroke-width': 1.5,
+                'circle-stroke-color': '#fff',
+              }}
+            />
+            <OrderedLayer
+              id="conflicts-closest"
+              type="circle"
+              layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
+              filter={['==', ['get', 'category'], 'closest']}
+              paint={{
+                'circle-radius': 8,
+                'circle-color': 'rgba(50, 120, 220, 0.85)',
+                'circle-stroke-width': 1.5,
+                'circle-stroke-color': '#fff',
+              }}
+            />
+          </Source>
+        </ReactMapGL>
+      </div>
 
-      <div
-        style={{
-          position: 'absolute',
-          top: 8,
-          right: 8,
-          background: 'white',
-          border: '1px solid #ccc',
-          padding: '4px 8px',
-          fontSize: 12,
-          display: 'flex',
-          gap: 12,
-        }}
-      >
+      <div className="debug-failure-map__legend">
         <span>
-          <span
-            style={{
-              display: 'inline-block',
-              width: 10,
-              height: 10,
-              borderRadius: '50%',
-              background: 'rgba(220,50,50,0.85)',
-              marginRight: 4,
-            }}
-          />
+          <span className="debug-failure-map__legend-dot debug-failure-map__legend-dot--largest" />
           Largest conflicts
         </span>
         <span>
-          <span
-            style={{
-              display: 'inline-block',
-              width: 10,
-              height: 10,
-              borderRadius: '50%',
-              background: 'rgba(50,120,220,0.85)',
-              marginRight: 4,
-            }}
-          />
+          <span className="debug-failure-map__legend-dot debug-failure-map__legend-dot--closest" />
           Closest conflicts
         </span>
       </div>
 
       {hovered && (
         <div
-          style={{
-            position: 'absolute',
-            left: hovered.x + 12,
-            top: hovered.y + 12,
-            background: 'white',
-            border: '1px solid #ccc',
-            padding: '6px 10px',
-            pointerEvents: 'none',
-            fontSize: 12,
-            maxWidth: 280,
-            lineHeight: 1.6,
-          }}
+          className="debug-failure-map__tooltip"
+          style={{ left: hovered.clientX + 12, top: hovered.clientY + 12 }}
         >
           <div>
             <strong>{hovered.point.lastOPName}</strong>

--- a/front/src/applications/stdcm/components/DebugView/DebugFailureMap.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugFailureMap.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import type { Feature, FeatureCollection, Point } from 'geojson';
+import type { MapLayerMouseEvent } from 'maplibre-gl';
+import type { MapRef } from 'react-map-gl/maplibre';
+import ReactMapGL, { Source } from 'react-map-gl/maplibre';
+
+import { OrderedLayer, VirtualLayers, genOSMLayerProps, useMapBlankStyle } from 'common/Map/Layers';
+import OpenStreetMapSource from 'common/Map/Sources/OpenStreetMap';
+import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
+
+type ConflictPoint = {
+  at: string;
+  time_lost: number;
+  best_remaining_time: number;
+  current_travel_time: number;
+  caused_by: string;
+  lat: number;
+  lon: number;
+  lastOPName: string;
+};
+
+type FailureData = {
+  largest_conflicts: ConflictPoint[];
+  closest_conflicts: ConflictPoint[];
+};
+
+type HoveredPoint = ConflictPoint & { category: 'largest' | 'closest' };
+
+const toFeatures = (points: ConflictPoint[], category: 'largest' | 'closest'): Feature<Point>[] =>
+  points.map((p, i) => ({
+    type: 'Feature',
+    id: i,
+    properties: { ...p, category },
+    geometry: { type: 'Point', coordinates: [p.lon, p.lat] },
+  }));
+
+const fmtSeconds = (s: number) => `${Math.round(s)}s`;
+
+type DebugFailureMapProps = { failureData: unknown };
+
+const DebugFailureMap = ({ failureData }: DebugFailureMapProps) => {
+  const data = failureData as FailureData;
+  const mapRef = useRef<MapRef | null>(null);
+  const mapBlankStyle = useMapBlankStyle();
+  const [hovered, setHovered] = useState<{ point: HoveredPoint; x: number; y: number } | null>(
+    null
+  );
+
+  const geojson = useMemo<FeatureCollection<Point>>(
+    () => ({
+      type: 'FeatureCollection',
+      features: [
+        ...toFeatures(data.largest_conflicts ?? [], 'largest'),
+        ...toFeatures(data.closest_conflicts ?? [], 'closest'),
+      ],
+    }),
+    [data]
+  );
+
+  const initialViewState = useMemo(() => {
+    const allPoints = [...(data.largest_conflicts ?? []), ...(data.closest_conflicts ?? [])];
+    if (allPoints.length === 0) return { latitude: 46.2, longitude: 2.5, zoom: 5 };
+    const lats = allPoints.map((p) => p.lat);
+    const lons = allPoints.map((p) => p.lon);
+    return {
+      latitude: (Math.min(...lats) + Math.max(...lats)) / 2,
+      longitude: (Math.min(...lons) + Math.max(...lons)) / 2,
+      zoom: 8,
+    };
+  }, [data]);
+
+  const handleMouseMove = useCallback((e: MapLayerMouseEvent) => {
+    const feature = e.features?.[0];
+    if (!feature) {
+      setHovered(null);
+      return;
+    }
+    setHovered({
+      point: feature.properties as HoveredPoint,
+      x: e.point.x,
+      y: e.point.y,
+    });
+  }, []);
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: 500 }}>
+      <ReactMapGL
+        ref={mapRef}
+        initialViewState={initialViewState}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle={mapBlankStyle}
+        interactiveLayerIds={['conflicts-largest', 'conflicts-closest']}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={() => setHovered(null)}
+      >
+        <VirtualLayers />
+        <OpenStreetMapSource />
+        {genOSMLayerProps(
+          'normal',
+          { showOSM3dBuildings: false },
+          LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]
+        )
+          .filter((p): p is typeof p & { id: string } => p.id !== undefined)
+          .map(({ id, ...props }) => (
+            <OrderedLayer key={id} id={id} {...props} />
+          ))}
+        <Source id="conflicts" type="geojson" data={geojson}>
+          <OrderedLayer
+            id="conflicts-largest"
+            type="circle"
+            layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
+            filter={['==', ['get', 'category'], 'largest']}
+            paint={{
+              'circle-radius': 8,
+              'circle-color': 'rgba(220, 50, 50, 0.85)',
+              'circle-stroke-width': 1.5,
+              'circle-stroke-color': '#fff',
+            }}
+          />
+          <OrderedLayer
+            id="conflicts-closest"
+            type="circle"
+            layerOrder={LAYER_GROUPS_ORDER[LAYERS.OPERATIONAL_POINTS.GROUP]}
+            filter={['==', ['get', 'category'], 'closest']}
+            paint={{
+              'circle-radius': 8,
+              'circle-color': 'rgba(50, 120, 220, 0.85)',
+              'circle-stroke-width': 1.5,
+              'circle-stroke-color': '#fff',
+            }}
+          />
+        </Source>
+      </ReactMapGL>
+
+      <div
+        style={{
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          background: 'white',
+          border: '1px solid #ccc',
+          padding: '4px 8px',
+          fontSize: 12,
+          display: 'flex',
+          gap: 12,
+        }}
+      >
+        <span>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              background: 'rgba(220,50,50,0.85)',
+              marginRight: 4,
+            }}
+          />
+          Largest conflicts
+        </span>
+        <span>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              background: 'rgba(50,120,220,0.85)',
+              marginRight: 4,
+            }}
+          />
+          Closest conflicts
+        </span>
+      </div>
+
+      {hovered && (
+        <div
+          style={{
+            position: 'absolute',
+            left: hovered.x + 12,
+            top: hovered.y + 12,
+            background: 'white',
+            border: '1px solid #ccc',
+            padding: '6px 10px',
+            pointerEvents: 'none',
+            fontSize: 12,
+            maxWidth: 280,
+            lineHeight: 1.6,
+          }}
+        >
+          <div>
+            <strong>{hovered.point.lastOPName}</strong>
+          </div>
+          <div>at: {hovered.point.at}</div>
+          <div>caused by: {hovered.point.caused_by}</div>
+          <div>time lost: {fmtSeconds(hovered.point.time_lost)}</div>
+          <div>best remaining: {fmtSeconds(hovered.point.best_remaining_time)}</div>
+          <div>travel time: {fmtSeconds(hovered.point.current_travel_time)}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DebugFailureMap;

--- a/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
@@ -1,18 +1,16 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   type DrawingFunction,
-  type OperationalPoint,
   type PathData,
   type SpaceTimeChartContextType,
-  DEFAULT_ZOOM_MS_PER_PX,
+  Manchette,
   PathLayer,
   SpaceTimeChart,
   SpaceTimeChartCanvasContext,
-  timeScaleToZoomValue,
   useDraw,
+  useManchetteWithSpaceTimeChart,
 } from '@osrd-project/ui-charts';
-import { clamp } from 'lodash';
 
 type ZoneLocation = { name: string; from: number; to: number };
 type OtherRequirement = {
@@ -44,12 +42,7 @@ type DebugBlock = {
   trainName: string;
 };
 
-const MIN_ZOOM_MS_PER_PX = 600_000;
-const MAX_ZOOM_MS_PER_PX = 625;
-const zoomValueToTimeScale = (slider: number) =>
-  MIN_ZOOM_MS_PER_PX * Math.pow(MAX_ZOOM_MS_PER_PX / MIN_ZOOM_MS_PER_PX, slider / 100);
-
-const SPACE_COEFFICIENT = 100; // m/px
+const CHART_HEIGHT = 600;
 
 function DebugOtherTrainsLayer({ blocks }: { blocks: DebugBlock[] }) {
   const draw = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
@@ -77,14 +70,13 @@ type DebugSpaceTimeChartProps = { simulationData: unknown };
 const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
   const simData = simulationData as SimulationData;
 
-  const chartData = useMemo(() => {
-    if (!simData) return null;
+  const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
+  const spaceTimeChartRef = useRef<HTMLDivElement>(null);
 
+  const chartData = useMemo(() => {
+    // All positions kept in mm (raw from the API)
     const zoneMap = new Map(
-      simData.zone_locations.map((z) => [
-        z.name,
-        { spaceStart: z.from / 1000, spaceEnd: z.to / 1000 },
-      ])
+      simData.zone_locations.map((z) => [z.name, { spaceStart: z.from, spaceEnd: z.to }])
     );
     const departureMs = Date.parse(simData.departure_time);
 
@@ -103,15 +95,12 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
       ];
     });
 
-    const operationalPoints: OperationalPoint[] = simData.path_properties.operational_points.map(
-      (op) => ({
-        id: op.extensions.identifier.name + '-' + op.extensions.sncf.ch,
-        label: op.extensions.identifier.name + ' ' + op.extensions.sncf.ch,
-        position: op.position / 1000,
-      })
-    );
-
-    const maxSpace = Math.max(...simData.zone_locations.map((z) => z.to / 1000), 1);
+    const manchetteWaypoints = simData.path_properties.operational_points.map((op) => ({
+      id: op.extensions.identifier.name + '-' + op.extensions.sncf.ch,
+      position: op.position, // mm
+      name: op.extensions.identifier.name,
+      secondaryCode: op.extensions.sncf.ch,
+    }));
 
     const trainPath: PathData | null =
       simData.train_positions?.length > 0
@@ -120,56 +109,25 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
             label: 'New train',
             points: simData.train_positions.map((pos, i) => ({
               time: departureMs + simData.train_times[i],
-              position: pos / 1000,
+              position: pos, // mm
             })),
           }
         : null;
 
-    return { departureMs, otherBlocks, operationalPoints, maxSpace, trainPath };
+    return { departureMs, otherBlocks, manchetteWaypoints, trainPath };
   }, [simData]);
 
-  const [xOffset, setXOffset] = useState(0);
-  const [yOffset, setYOffset] = useState(0);
-  const [timeScale, setTimeScale] = useState(DEFAULT_ZOOM_MS_PER_PX);
-  const [spaceCoefficient, setSpaceCoefficient] = useState(SPACE_COEFFICIENT);
-  const panRef = useRef<{ initialXOffset: number; initialYOffset: number } | null>(null);
+  const { manchetteProps, spaceTimeChartProps, handleScroll, handleXZoom, xZoom, setTimeOrigin } =
+    useManchetteWithSpaceTimeChart({
+      waypoints: chartData.manchetteWaypoints ?? [],
+      manchetteWithSpaceTimeChartRef,
+      height: CHART_HEIGHT,
+      spaceTimeChartRef,
+    });
 
-  const handlePan = useCallback<NonNullable<Parameters<typeof SpaceTimeChart>[0]['onPan']>>(
-    ({ isPanning, initialPosition, position }) => {
-      if (!isPanning) {
-        panRef.current = null;
-        return;
-      }
-      if (!panRef.current) {
-        panRef.current = { initialXOffset: xOffset, initialYOffset: yOffset };
-        return;
-      }
-      setXOffset(panRef.current.initialXOffset + (position.x - initialPosition.x));
-      setYOffset(panRef.current.initialYOffset + (position.y - initialPosition.y));
-    },
-    [xOffset, yOffset]
-  );
-
-  const handleZoom = useCallback<NonNullable<Parameters<typeof SpaceTimeChart>[0]['onZoom']>>(
-    ({ delta, position, event }) => {
-      if (event.shiftKey) {
-        // Shift+scroll: horizontal (time) zoom
-        setTimeScale((prev) => {
-          const next = clamp(prev / (1 + delta * 0.1), MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
-          setXOffset((off) => position.x - ((position.x - off) * prev) / next);
-          return next;
-        });
-      } else {
-        // Plain scroll: vertical (space) zoom
-        setSpaceCoefficient((prev) => {
-          const next = clamp(prev / (1 + delta * 0.1), 10, 5000);
-          setYOffset((off) => position.y - (position.y - off) * (prev / next));
-          return next;
-        });
-      }
-    },
-    []
-  );
+  useEffect(() => {
+    setTimeOrigin(chartData.departureMs);
+  }, [chartData]);
 
   const [hoveredBlock, setHoveredBlock] = useState<DebugBlock | null>(null);
   const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
@@ -178,7 +136,6 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
     NonNullable<Parameters<typeof SpaceTimeChart>[0]['onMouseMove']>
   >(
     ({ data: dataPoint }) => {
-      if (!chartData) return;
       const hit = chartData.otherBlocks.find(
         (b) =>
           dataPoint.time >= b.timeStart &&
@@ -190,10 +147,6 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
     },
     [chartData]
   );
-
-  if (!chartData) return <div>No simulation data available</div>;
-
-  const xZoom = timeScaleToZoomValue(timeScale);
 
   return (
     <div style={{ position: 'relative', width: '100%' }}>
@@ -208,7 +161,7 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
           fontSize: 13,
         }}
       >
-        <span>Time zoom (Shift+scroll):</span>
+        <span>Time zoom:</span>
         <input
           type="range"
           min={0}
@@ -216,48 +169,52 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
           step={0.5}
           value={xZoom}
           style={{ width: 140 }}
-          onChange={(e) => setTimeScale(zoomValueToTimeScale(Number(e.target.value)))}
+          onChange={(e) => handleXZoom(Number(e.target.value))}
         />
-        <button
-          type="button"
-          onClick={() => {
-            setTimeScale(DEFAULT_ZOOM_MS_PER_PX);
-            setXOffset(0);
-            setYOffset(0);
-            setSpaceCoefficient(SPACE_COEFFICIENT);
-          }}
-        >
+        <button type="button" onClick={() => manchetteProps.resetZoom()}>
           Reset
         </button>
         <span style={{ color: '#888', marginLeft: 8 }}>
-          Scroll: space zoom · Drag: pan · Shift+scroll: time zoom
+          Scroll: space zoom · Drag: pan · Ctrl+scroll: Y zoom
         </span>
       </div>
 
       <div
-        style={{ position: 'relative', width: '100%', height: '80vh' }}
+        className="ui-manchette-space-time-chart-wrapper"
         onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}
         onMouseLeave={() => {
           setMousePos(null);
           setHoveredBlock(null);
         }}
       >
-        <SpaceTimeChart
-          className="w-full h-full"
-          spaceOrigin={0}
-          spaceScales={[{ to: chartData.maxSpace, coefficient: spaceCoefficient }]}
-          timeOrigin={chartData.departureMs}
-          timeScale={timeScale}
-          xOffset={xOffset}
-          yOffset={yOffset}
-          operationalPoints={chartData.operationalPoints}
-          onPan={handlePan}
-          onZoom={handleZoom}
-          onMouseMove={handleMouseMove}
+        <div
+          ref={manchetteWithSpaceTimeChartRef}
+          className="manchette flex"
+          style={{ height: CHART_HEIGHT }}
+          onScroll={handleScroll}
         >
-          <DebugOtherTrainsLayer blocks={chartData.otherBlocks} />
-          {chartData.trainPath && <PathLayer path={chartData.trainPath} color="#0000ff" />}
-        </SpaceTimeChart>
+          <Manchette {...manchetteProps} />
+          <div ref={spaceTimeChartRef} className="space-time-chart-container w-full sticky">
+            <SpaceTimeChart
+              className="inset-0 absolute h-full"
+              height={CHART_HEIGHT}
+              {...spaceTimeChartProps}
+              onZoom={(payload) => {
+                if (payload.event.ctrlKey) {
+                  payload.event.preventDefault();
+                  if (payload.delta > 0) manchetteProps.zoomYIn();
+                  else manchetteProps.zoomYOut();
+                } else {
+                  spaceTimeChartProps.onZoom?.(payload);
+                }
+              }}
+              onMouseMove={handleMouseMove}
+            >
+              <DebugOtherTrainsLayer blocks={chartData.otherBlocks} />
+              {chartData.trainPath && <PathLayer path={chartData.trainPath} color="#0000ff" />}
+            </SpaceTimeChart>
+          </div>
+        </div>
       </div>
 
       {hoveredBlock && mousePos && (

--- a/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import {
+  type DrawingFunction,
+  type OperationalPoint,
+  type PathData,
+  type SpaceTimeChartContextType,
+  DEFAULT_ZOOM_MS_PER_PX,
+  PathLayer,
+  SpaceTimeChart,
+  SpaceTimeChartCanvasContext,
+  timeScaleToZoomValue,
+  useDraw,
+} from '@osrd-project/ui-charts';
+import { clamp } from 'lodash';
+
+type ZoneLocation = { name: string; from: number; to: number };
+type OtherRequirement = {
+  zone_name: string;
+  begin_time: number;
+  end_time: number;
+  train_name?: string;
+};
+type OperationalPointRaw = {
+  position: number;
+  extensions: { identifier: { name: string }; sncf: { ch: string } };
+};
+
+type SimulationData = {
+  departure_time: string;
+  train_positions: number[];
+  train_times: number[];
+  zone_locations: ZoneLocation[];
+  other_requirements: OtherRequirement[];
+  path_properties: { operational_points: OperationalPointRaw[] };
+};
+
+type DebugBlock = {
+  timeStart: number;
+  timeEnd: number;
+  spaceStart: number;
+  spaceEnd: number;
+  zoneName: string;
+  trainName: string;
+};
+
+const MIN_ZOOM_MS_PER_PX = 600_000;
+const MAX_ZOOM_MS_PER_PX = 625;
+const zoomValueToTimeScale = (slider: number) =>
+  MIN_ZOOM_MS_PER_PX * Math.pow(MAX_ZOOM_MS_PER_PX / MIN_ZOOM_MS_PER_PX, slider / 100);
+
+const SPACE_COEFFICIENT = 100; // m/px
+
+function DebugOtherTrainsLayer({ blocks }: { blocks: DebugBlock[] }) {
+  const draw = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
+    (ctx, { getTimePixel, getSpacePixel }) => {
+      ctx.fillStyle = 'rgba(240, 128, 128, 0.5)';
+      ctx.strokeStyle = 'rgba(200, 60, 60, 0.9)';
+      ctx.lineWidth = 1;
+      for (const b of blocks) {
+        const x = getTimePixel(b.timeStart);
+        const y = getSpacePixel(b.spaceStart);
+        const w = getTimePixel(b.timeEnd) - x;
+        const h = getSpacePixel(b.spaceEnd) - y;
+        ctx.fillRect(x, y, w, h);
+        ctx.strokeRect(x, y, w, h);
+      }
+    },
+    [blocks]
+  );
+  useDraw(SpaceTimeChartCanvasContext, 'background', draw);
+  return null;
+}
+
+type DebugSpaceTimeChartProps = { simulationData: unknown };
+
+const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
+  const simData = simulationData as SimulationData;
+
+  const chartData = useMemo(() => {
+    if (!simData) return null;
+
+    const zoneMap = new Map(
+      simData.zone_locations.map((z) => [
+        z.name,
+        { spaceStart: z.from / 1000, spaceEnd: z.to / 1000 },
+      ])
+    );
+    const departureMs = Date.parse(simData.departure_time);
+
+    const otherBlocks = simData.other_requirements.flatMap((req) => {
+      const pos = zoneMap.get(req.zone_name);
+      if (!pos) return [];
+      return [
+        {
+          timeStart: departureMs + req.begin_time,
+          timeEnd: departureMs + req.end_time,
+          spaceStart: pos.spaceStart,
+          spaceEnd: pos.spaceEnd,
+          zoneName: req.zone_name,
+          trainName: req.train_name ?? '',
+        },
+      ];
+    });
+
+    const operationalPoints: OperationalPoint[] = simData.path_properties.operational_points.map(
+      (op) => ({
+        id: op.extensions.identifier.name + '-' + op.extensions.sncf.ch,
+        label: op.extensions.identifier.name + ' ' + op.extensions.sncf.ch,
+        position: op.position / 1000,
+      })
+    );
+
+    const maxSpace = Math.max(...simData.zone_locations.map((z) => z.to / 1000), 1);
+
+    const trainPath: PathData | null =
+      simData.train_positions?.length > 0
+        ? {
+            id: 'new-train',
+            label: 'New train',
+            points: simData.train_positions.map((pos, i) => ({
+              time: departureMs + simData.train_times[i],
+              position: pos / 1000,
+            })),
+          }
+        : null;
+
+    return { departureMs, otherBlocks, operationalPoints, maxSpace, trainPath };
+  }, [simData]);
+
+  const [xOffset, setXOffset] = useState(0);
+  const [yOffset, setYOffset] = useState(0);
+  const [timeScale, setTimeScale] = useState(DEFAULT_ZOOM_MS_PER_PX);
+  const [spaceCoefficient, setSpaceCoefficient] = useState(SPACE_COEFFICIENT);
+  const panRef = useRef<{ initialXOffset: number; initialYOffset: number } | null>(null);
+
+  const handlePan = useCallback<NonNullable<Parameters<typeof SpaceTimeChart>[0]['onPan']>>(
+    ({ isPanning, initialPosition, position }) => {
+      if (!isPanning) {
+        panRef.current = null;
+        return;
+      }
+      if (!panRef.current) {
+        panRef.current = { initialXOffset: xOffset, initialYOffset: yOffset };
+        return;
+      }
+      setXOffset(panRef.current.initialXOffset + (position.x - initialPosition.x));
+      setYOffset(panRef.current.initialYOffset + (position.y - initialPosition.y));
+    },
+    [xOffset, yOffset]
+  );
+
+  const handleZoom = useCallback<NonNullable<Parameters<typeof SpaceTimeChart>[0]['onZoom']>>(
+    ({ delta, position, event }) => {
+      if (event.shiftKey) {
+        // Shift+scroll: horizontal (time) zoom
+        setTimeScale((prev) => {
+          const next = clamp(prev / (1 + delta * 0.1), MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
+          setXOffset((off) => position.x - ((position.x - off) * prev) / next);
+          return next;
+        });
+      } else {
+        // Plain scroll: vertical (space) zoom
+        setSpaceCoefficient((prev) => {
+          const next = clamp(prev / (1 + delta * 0.1), 10, 5000);
+          setYOffset((off) => position.y - (position.y - off) * (prev / next));
+          return next;
+        });
+      }
+    },
+    []
+  );
+
+  const [hoveredBlock, setHoveredBlock] = useState<DebugBlock | null>(null);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+
+  const handleMouseMove = useCallback<
+    NonNullable<Parameters<typeof SpaceTimeChart>[0]['onMouseMove']>
+  >(
+    ({ data: dataPoint }) => {
+      if (!chartData) return;
+      const hit = chartData.otherBlocks.find(
+        (b) =>
+          dataPoint.time >= b.timeStart &&
+          dataPoint.time <= b.timeEnd &&
+          dataPoint.position >= b.spaceStart &&
+          dataPoint.position <= b.spaceEnd
+      );
+      setHoveredBlock(hit ?? null);
+    },
+    [chartData]
+  );
+
+  if (!chartData) return <div>No simulation data available</div>;
+
+  const xZoom = timeScaleToZoomValue(timeScale);
+
+  return (
+    <div style={{ position: 'relative', width: '100%' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '4px 8px',
+          background: '#f5f5f5',
+          borderBottom: '1px solid #ddd',
+          fontSize: 13,
+        }}
+      >
+        <span>Time zoom (Shift+scroll):</span>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={0.5}
+          value={xZoom}
+          style={{ width: 140 }}
+          onChange={(e) => setTimeScale(zoomValueToTimeScale(Number(e.target.value)))}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            setTimeScale(DEFAULT_ZOOM_MS_PER_PX);
+            setXOffset(0);
+            setYOffset(0);
+            setSpaceCoefficient(SPACE_COEFFICIENT);
+          }}
+        >
+          Reset
+        </button>
+        <span style={{ color: '#888', marginLeft: 8 }}>
+          Scroll: space zoom · Drag: pan · Shift+scroll: time zoom
+        </span>
+      </div>
+
+      <div
+        style={{ position: 'relative', width: '100%', height: '80vh' }}
+        onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}
+        onMouseLeave={() => {
+          setMousePos(null);
+          setHoveredBlock(null);
+        }}
+      >
+        <SpaceTimeChart
+          className="w-full h-full"
+          spaceOrigin={0}
+          spaceScales={[{ to: chartData.maxSpace, coefficient: spaceCoefficient }]}
+          timeOrigin={chartData.departureMs}
+          timeScale={timeScale}
+          xOffset={xOffset}
+          yOffset={yOffset}
+          operationalPoints={chartData.operationalPoints}
+          onPan={handlePan}
+          onZoom={handleZoom}
+          onMouseMove={handleMouseMove}
+        >
+          <DebugOtherTrainsLayer blocks={chartData.otherBlocks} />
+          {chartData.trainPath && <PathLayer path={chartData.trainPath} color="#0000ff" />}
+        </SpaceTimeChart>
+      </div>
+
+      {hoveredBlock && mousePos && (
+        <div
+          style={{
+            position: 'fixed',
+            left: mousePos.x + 12,
+            top: mousePos.y + 12,
+            background: 'white',
+            border: '1px solid #ccc',
+            padding: '4px 8px',
+            pointerEvents: 'none',
+            zIndex: 1000,
+            maxWidth: 400,
+          }}
+        >
+          <div>
+            <strong>{hoveredBlock.trainName}</strong>
+          </div>
+          <div style={{ fontSize: 11, wordBreak: 'break-all' }}>{hoveredBlock.zoneName}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DebugSpaceTimeChart;

--- a/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
@@ -19,6 +19,8 @@ type OtherRequirement = {
   end_time: number;
   train_name?: string;
 };
+type ZoneUpdate = { zone: string; is_entry: boolean; time: number };
+type SpacingRequirement = { zone: string; begin_time: number; end_time: number };
 type OperationalPointRaw = {
   position: number;
   extensions: { identifier: { name: string }; sncf: { ch: string } };
@@ -31,6 +33,12 @@ type SimulationData = {
   zone_locations: ZoneLocation[];
   other_requirements: OtherRequirement[];
   path_properties: { operational_points: OperationalPointRaw[] };
+  sim_output?: {
+    final_output: {
+      zone_updates: ZoneUpdate[];
+      spacing_requirements: SpacingRequirement[];
+    };
+  };
 };
 
 type DebugBlock = {
@@ -40,15 +48,24 @@ type DebugBlock = {
   spaceEnd: number;
   zoneName: string;
   trainName: string;
+  kind: 'other' | 'zone_update' | 'spacing_req';
 };
+
+type BlockLayerStyle = { fill: string; stroke: string };
 
 const CHART_HEIGHT = 600;
 
-function DebugOtherTrainsLayer({ blocks }: { blocks: DebugBlock[] }) {
+const KIND_LABEL: Record<DebugBlock['kind'], string> = {
+  other: 'Other train',
+  zone_update: 'Zone update',
+  spacing_req: 'Spacing requirement',
+};
+
+function DebugBlocksLayer({ blocks, style }: { blocks: DebugBlock[]; style: BlockLayerStyle }) {
   const draw = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
     (ctx, { getTimePixel, getSpacePixel }) => {
-      ctx.fillStyle = 'rgba(240, 128, 128, 0.5)';
-      ctx.strokeStyle = 'rgba(200, 60, 60, 0.9)';
+      ctx.fillStyle = style.fill;
+      ctx.strokeStyle = style.stroke;
       ctx.lineWidth = 1;
       for (const b of blocks) {
         const x = getTimePixel(b.timeStart);
@@ -59,11 +76,17 @@ function DebugOtherTrainsLayer({ blocks }: { blocks: DebugBlock[] }) {
         ctx.strokeRect(x, y, w, h);
       }
     },
-    [blocks]
+    [blocks, style]
   );
   useDraw(SpaceTimeChartCanvasContext, 'background', draw);
   return null;
 }
+
+const LAYER_STYLES: Record<DebugBlock['kind'], BlockLayerStyle> = {
+  other: { fill: 'rgba(240, 128, 128, 0.5)', stroke: 'rgba(200, 60, 60, 0.9)' },
+  zone_update: { fill: 'rgba(135, 206, 250, 0.5)', stroke: 'rgba(65, 105, 225, 0.9)' },
+  spacing_req: { fill: 'rgba(244, 164, 96, 0.5)', stroke: 'rgba(210, 105, 30, 0.9)' },
+};
 
 type DebugSpaceTimeChartProps = { simulationData: unknown };
 
@@ -74,13 +97,12 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
   const spaceTimeChartRef = useRef<HTMLDivElement>(null);
 
   const chartData = useMemo(() => {
-    // All positions kept in mm (raw from the API)
     const zoneMap = new Map(
       simData.zone_locations.map((z) => [z.name, { spaceStart: z.from, spaceEnd: z.to }])
     );
     const departureMs = Date.parse(simData.departure_time);
 
-    const otherBlocks = simData.other_requirements.flatMap((req) => {
+    const otherBlocks: DebugBlock[] = simData.other_requirements.flatMap((req) => {
       const pos = zoneMap.get(req.zone_name);
       if (!pos) return [];
       return [
@@ -91,13 +113,57 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
           spaceEnd: pos.spaceEnd,
           zoneName: req.zone_name,
           trainName: req.train_name ?? '',
+          kind: 'other',
         },
       ];
     });
 
+    const finalOutput = simData.sim_output?.final_output;
+
+    const zoneUpdateBlocks: DebugBlock[] = [];
+    if (finalOutput) {
+      const entries: Record<string, number> = {};
+      const exits: Record<string, number> = {};
+      for (const u of finalOutput.zone_updates) {
+        if (u.is_entry) entries[u.zone] = u.time;
+        else exits[u.zone] = u.time;
+      }
+      for (const zone of Object.keys(entries)) {
+        if (!(zone in exits)) continue;
+        const pos = zoneMap.get(zone);
+        if (!pos) continue;
+        zoneUpdateBlocks.push({
+          timeStart: departureMs + entries[zone],
+          timeEnd: departureMs + exits[zone],
+          spaceStart: pos.spaceStart,
+          spaceEnd: pos.spaceEnd,
+          zoneName: zone,
+          trainName: '',
+          kind: 'zone_update',
+        });
+      }
+    }
+
+    const spacingReqBlocks: DebugBlock[] = [];
+    if (finalOutput) {
+      for (const req of finalOutput.spacing_requirements) {
+        const pos = zoneMap.get(req.zone);
+        if (!pos) continue;
+        spacingReqBlocks.push({
+          timeStart: departureMs + req.begin_time,
+          timeEnd: departureMs + req.end_time,
+          spaceStart: pos.spaceStart,
+          spaceEnd: pos.spaceEnd,
+          zoneName: req.zone,
+          trainName: '',
+          kind: 'spacing_req',
+        });
+      }
+    }
+
     const manchetteWaypoints = simData.path_properties.operational_points.map((op) => ({
       id: op.extensions.identifier.name + '-' + op.extensions.sncf.ch,
-      position: op.position, // mm
+      position: op.position,
       name: op.extensions.identifier.name,
       secondaryCode: op.extensions.sncf.ch,
     }));
@@ -109,12 +175,22 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
             label: 'New train',
             points: simData.train_positions.map((pos, i) => ({
               time: departureMs + simData.train_times[i],
-              position: pos, // mm
+              position: pos,
             })),
           }
         : null;
 
-    return { departureMs, otherBlocks, manchetteWaypoints, trainPath };
+    const allBlocks = [...otherBlocks, ...zoneUpdateBlocks, ...spacingReqBlocks];
+
+    return {
+      departureMs,
+      otherBlocks,
+      zoneUpdateBlocks,
+      spacingReqBlocks,
+      allBlocks,
+      manchetteWaypoints,
+      trainPath,
+    };
   }, [simData]);
 
   const { manchetteProps, spaceTimeChartProps, handleScroll, handleXZoom, xZoom, setTimeOrigin } =
@@ -136,7 +212,7 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
     NonNullable<Parameters<typeof SpaceTimeChart>[0]['onMouseMove']>
   >(
     ({ data: dataPoint }) => {
-      const hit = chartData.otherBlocks.find(
+      const hit = chartData.allBlocks.find(
         (b) =>
           dataPoint.time >= b.timeStart &&
           dataPoint.time <= b.timeEnd &&
@@ -210,7 +286,15 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
               }}
               onMouseMove={handleMouseMove}
             >
-              <DebugOtherTrainsLayer blocks={chartData.otherBlocks} />
+              <DebugBlocksLayer blocks={chartData.otherBlocks} style={LAYER_STYLES.other} />
+              <DebugBlocksLayer
+                blocks={chartData.zoneUpdateBlocks}
+                style={LAYER_STYLES.zone_update}
+              />
+              <DebugBlocksLayer
+                blocks={chartData.spacingReqBlocks}
+                style={LAYER_STYLES.spacing_req}
+              />
               {chartData.trainPath && <PathLayer path={chartData.trainPath} color="#0000ff" />}
             </SpaceTimeChart>
           </div>
@@ -232,7 +316,8 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
           }}
         >
           <div>
-            <strong>{hoveredBlock.trainName}</strong>
+            <strong>{KIND_LABEL[hoveredBlock.kind]}</strong>
+            {hoveredBlock.trainName && <span> — {hoveredBlock.trainName}</span>}
           </div>
           <div style={{ fontSize: 11, wordBreak: 'break-all' }}>{hoveredBlock.zoneName}</div>
         </div>

--- a/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
@@ -10,36 +10,10 @@ import {
   SpaceTimeChartCanvasContext,
   useDraw,
   useManchetteWithSpaceTimeChart,
+  type Waypoint,
 } from '@osrd-project/ui-charts';
 
-type ZoneLocation = { name: string; from: number; to: number };
-type OtherRequirement = {
-  zone_name: string;
-  begin_time: number;
-  end_time: number;
-  train_name?: string;
-};
-type ZoneUpdate = { zone: string; is_entry: boolean; time: number };
-type SpacingRequirement = { zone: string; begin_time: number; end_time: number };
-type OperationalPointRaw = {
-  position: number;
-  extensions: { identifier: { name: string }; sncf: { ch: string } };
-};
-
-type SimulationData = {
-  departure_time: string;
-  train_positions: number[];
-  train_times: number[];
-  zone_locations: ZoneLocation[];
-  other_requirements: OtherRequirement[];
-  path_properties: { operational_points: OperationalPointRaw[] };
-  sim_output?: {
-    final_output: {
-      zone_updates: ZoneUpdate[];
-      spacing_requirements: SpacingRequirement[];
-    };
-  };
-};
+import type { SimDebugData } from 'common/api/osrdEditoastApi';
 
 type DebugBlock = {
   timeStart: number;
@@ -67,13 +41,13 @@ function DebugBlocksLayer({ blocks, style }: { blocks: DebugBlock[]; style: Bloc
       ctx.fillStyle = style.fill;
       ctx.strokeStyle = style.stroke;
       ctx.lineWidth = 1;
-      for (const b of blocks) {
-        const x = getTimePixel(b.timeStart);
-        const y = getSpacePixel(b.spaceStart);
-        const w = getTimePixel(b.timeEnd) - x;
-        const h = getSpacePixel(b.spaceEnd) - y;
-        ctx.fillRect(x, y, w, h);
-        ctx.strokeRect(x, y, w, h);
+      for (const block of blocks) {
+        const timePixel = getTimePixel(block.timeStart);
+        const spacePixel = getSpacePixel(block.spaceStart);
+        const rectWidth = getTimePixel(block.timeEnd) - timePixel;
+        const rectHeight = getSpacePixel(block.spaceEnd) - spacePixel;
+        ctx.fillRect(timePixel, spacePixel, rectWidth, rectHeight);
+        ctx.strokeRect(timePixel, spacePixel, rectWidth, rectHeight);
       }
     },
     [blocks, style]
@@ -88,17 +62,18 @@ const LAYER_STYLES: Record<DebugBlock['kind'], BlockLayerStyle> = {
   spacing_req: { fill: 'rgba(244, 164, 96, 0.5)', stroke: 'rgba(210, 105, 30, 0.9)' },
 };
 
-type DebugSpaceTimeChartProps = { simulationData: unknown };
+type DebugSpaceTimeChartProps = { simData: SimDebugData };
 
-const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
-  const simData = simulationData as SimulationData;
-
+const DebugSpaceTimeChart = ({ simData }: DebugSpaceTimeChartProps) => {
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
   const spaceTimeChartRef = useRef<HTMLDivElement>(null);
 
   const chartData = useMemo(() => {
     const zoneMap = new Map(
-      simData.zone_locations.map((z) => [z.name, { spaceStart: z.from, spaceEnd: z.to }])
+      simData.zone_locations.map((zone) => [
+        zone.name,
+        { spaceStart: zone.from, spaceEnd: zone.to },
+      ])
     );
     const departureMs = Date.parse(simData.departure_time);
 
@@ -124,9 +99,9 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
     if (finalOutput) {
       const entries: Record<string, number> = {};
       const exits: Record<string, number> = {};
-      for (const u of finalOutput.zone_updates) {
-        if (u.is_entry) entries[u.zone] = u.time;
-        else exits[u.zone] = u.time;
+      for (const zoneUpdate of finalOutput.zone_updates) {
+        if (zoneUpdate.is_entry) entries[zoneUpdate.zone] = zoneUpdate.time;
+        else exits[zoneUpdate.zone] = zoneUpdate.time;
       }
       for (const zone of Object.keys(entries)) {
         if (!(zone in exits)) continue;
@@ -161,11 +136,12 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
       }
     }
 
-    const manchetteWaypoints = simData.path_properties.operational_points.map((op) => ({
-      id: op.extensions.identifier.name + '-' + op.extensions.sncf.ch,
+    const manchetteWaypoints: Waypoint[] = simData.path_properties.operational_points.map((op) => ({
+      id: `${op.id}-${op.position}`,
       position: op.position,
-      name: op.extensions.identifier.name,
-      secondaryCode: op.extensions.sncf.ch,
+      name: op.extensions?.identifier?.name ?? '',
+      secondaryCode: op.extensions?.sncf?.ch ?? '',
+      weight: op.weight ?? 0,
     }));
 
     const trainPath: PathData | null =
@@ -206,37 +182,11 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
   }, [chartData]);
 
   const [hoveredBlock, setHoveredBlock] = useState<DebugBlock | null>(null);
-  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
-
-  const handleMouseMove = useCallback<
-    NonNullable<Parameters<typeof SpaceTimeChart>[0]['onMouseMove']>
-  >(
-    ({ data: dataPoint }) => {
-      const hit = chartData.allBlocks.find(
-        (b) =>
-          dataPoint.time >= b.timeStart &&
-          dataPoint.time <= b.timeEnd &&
-          dataPoint.position >= b.spaceStart &&
-          dataPoint.position <= b.spaceEnd
-      );
-      setHoveredBlock(hit ?? null);
-    },
-    [chartData]
-  );
+  const [mousePos, setMousePos] = useState<{ clientX: number; clientY: number } | null>(null);
 
   return (
-    <div style={{ position: 'relative', width: '100%' }}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          padding: '4px 8px',
-          background: '#f5f5f5',
-          borderBottom: '1px solid #ddd',
-          fontSize: 13,
-        }}
-      >
+    <div className="debug-space-time-chart">
+      <div className="debug-space-time-chart__controls">
         <span>Time zoom:</span>
         <input
           type="range"
@@ -244,20 +194,20 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
           max={100}
           step={0.5}
           value={xZoom}
-          style={{ width: 140 }}
-          onChange={(e) => handleXZoom(Number(e.target.value))}
+          className="debug-space-time-chart__zoom-slider"
+          onChange={(event) => handleXZoom(Number(event.target.value))}
         />
         <button type="button" onClick={() => manchetteProps.resetZoom()}>
           Reset
         </button>
-        <span style={{ color: '#888', marginLeft: 8 }}>
-          Scroll: space zoom · Drag: pan · Ctrl+scroll: Y zoom
+        <span className="debug-space-time-chart__hint">
+          Shift+scroll: time zoom · Ctrl+scroll: space zoom · Drag: pan
         </span>
       </div>
 
       <div
         className="ui-manchette-space-time-chart-wrapper"
-        onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}
+        onMouseMove={(event) => setMousePos({ clientX: event.clientX, clientY: event.clientY })}
         onMouseLeave={() => {
           setMousePos(null);
           setHoveredBlock(null);
@@ -266,7 +216,6 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
         <div
           ref={manchetteWithSpaceTimeChartRef}
           className="manchette flex"
-          style={{ height: CHART_HEIGHT }}
           onScroll={handleScroll}
         >
           <Manchette {...manchetteProps} />
@@ -284,7 +233,16 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
                   spaceTimeChartProps.onZoom?.(payload);
                 }
               }}
-              onMouseMove={handleMouseMove}
+              onMouseMove={({ data: dataPoint }) => {
+                const hit = chartData.allBlocks.find(
+                  (block) =>
+                    dataPoint.time >= block.timeStart &&
+                    dataPoint.time <= block.timeEnd &&
+                    dataPoint.position >= block.spaceStart &&
+                    dataPoint.position <= block.spaceEnd
+                );
+                setHoveredBlock(hit ?? null);
+              }}
             >
               <DebugBlocksLayer blocks={chartData.otherBlocks} style={LAYER_STYLES.other} />
               <DebugBlocksLayer
@@ -303,23 +261,14 @@ const DebugSpaceTimeChart = ({ simulationData }: DebugSpaceTimeChartProps) => {
 
       {hoveredBlock && mousePos && (
         <div
-          style={{
-            position: 'fixed',
-            left: mousePos.x + 12,
-            top: mousePos.y + 12,
-            background: 'white',
-            border: '1px solid #ccc',
-            padding: '4px 8px',
-            pointerEvents: 'none',
-            zIndex: 1000,
-            maxWidth: 400,
-          }}
+          className="debug-space-time-chart__tooltip"
+          style={{ left: mousePos.clientX + 12, top: mousePos.clientY + 12 }}
         >
           <div>
             <strong>{KIND_LABEL[hoveredBlock.kind]}</strong>
             {hoveredBlock.trainName && <span> — {hoveredBlock.trainName}</span>}
           </div>
-          <div style={{ fontSize: 11, wordBreak: 'break-all' }}>{hoveredBlock.zoneName}</div>
+          <div className="debug-space-time-chart__tooltip-zone">{hoveredBlock.zoneName}</div>
         </div>
       )}
     </div>

--- a/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import type {
-  BoundariesData,
   ElectricalBoundariesData,
   ElectrificationUsage,
   PathPropertiesFormatted,
@@ -10,46 +9,35 @@ import {
   transformBoundariesDataToPositionDataArray,
   transformElectricalBoundariesToRanges,
 } from 'applications/operationalStudies/utils';
-import type {
-  RollingStockWithLiveries,
-  SimulationResponseSuccess,
-} from 'common/api/osrdEditoastApi';
+import type { RollingStockWithLiveries, SimDebugData } from 'common/api/osrdEditoastApi';
 import SpeedDistanceDiagramWrapper from 'modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper';
 
-type LocalSimData = {
-  sim_output: SimulationResponseSuccess;
-  path_properties: {
-    slopes: BoundariesData;
-    electrifications: ElectricalBoundariesData<ElectrificationUsage>;
-    operational_points: NonNullable<PathPropertiesFormatted['operationalPoints']>;
-  };
-};
-
-const DebugSpeedDistanceDiagram = ({ simulationData }: { simulationData: unknown }) => {
-  const simData = simulationData as LocalSimData;
+const DebugSpeedDistanceDiagram = ({ simData }: { simData: SimDebugData }) => {
   const [height, setHeight] = useState(400);
+
+  if (!simData.sim_output) return null;
 
   const pathLength = simData.sim_output.base.positions.at(-1) ?? 0;
 
-  const pathProperties = {
+  const pathProperties: PathPropertiesFormatted = {
     slopes: transformBoundariesDataToPositionDataArray(
       simData.path_properties.slopes,
       pathLength,
       'gradient'
     ),
     electrifications: transformElectricalBoundariesToRanges(
-      simData.path_properties.electrifications,
+      simData.path_properties.electrifications as ElectricalBoundariesData<ElectrificationUsage>,
       pathLength
     ),
     operationalPoints: simData.path_properties.operational_points,
     curves: [],
     voltages: [],
     geometry: { type: 'LineString', coordinates: [] },
-  } as unknown as PathPropertiesFormatted;
+  };
 
   return (
     <SpeedDistanceDiagramWrapper
-      timetableItemSimulation={simData.sim_output}
+      trainScheduleSimulation={simData.sim_output}
       pathProperties={pathProperties}
       rollingStock={{ length: 0 } as RollingStockWithLiveries}
       initialLayersDisplay={{ speedLimits: true }}

--- a/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
@@ -52,6 +52,7 @@ const DebugSpeedDistanceDiagram = ({ simulationData }: { simulationData: unknown
       timetableItemSimulation={simData.sim_output}
       pathProperties={pathProperties}
       rollingStock={{ length: 0 } as RollingStockWithLiveries}
+      initialLayersDisplay={{ speedLimits: true }}
       height={height}
       setHeight={setHeight}
     />

--- a/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+
+import type {
+  BoundariesData,
+  ElectricalBoundariesData,
+  ElectrificationUsage,
+  PathPropertiesFormatted,
+} from 'applications/operationalStudies/types';
+import {
+  transformBoundariesDataToPositionDataArray,
+  transformElectricalBoundariesToRanges,
+} from 'applications/operationalStudies/utils';
+import type {
+  RollingStockWithLiveries,
+  SimulationResponseSuccess,
+} from 'common/api/osrdEditoastApi';
+import SpeedDistanceDiagramWrapper from 'modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper';
+
+type LocalSimData = {
+  sim_output: SimulationResponseSuccess;
+  path_properties: {
+    slopes: BoundariesData;
+    electrifications: ElectricalBoundariesData<ElectrificationUsage>;
+    operational_points: NonNullable<PathPropertiesFormatted['operationalPoints']>;
+  };
+};
+
+const DebugSpeedDistanceDiagram = ({ simulationData }: { simulationData: unknown }) => {
+  const simData = simulationData as LocalSimData;
+  const [height, setHeight] = useState(400);
+
+  const pathLength = simData.sim_output.base.positions.at(-1) ?? 0;
+
+  const pathProperties = {
+    slopes: transformBoundariesDataToPositionDataArray(
+      simData.path_properties.slopes,
+      pathLength,
+      'gradient'
+    ),
+    electrifications: transformElectricalBoundariesToRanges(
+      simData.path_properties.electrifications,
+      pathLength
+    ),
+    operationalPoints: simData.path_properties.operational_points,
+    curves: [],
+    voltages: [],
+    geometry: { type: 'LineString', coordinates: [] },
+  } as unknown as PathPropertiesFormatted;
+
+  return (
+    <SpeedDistanceDiagramWrapper
+      timetableItemSimulation={simData.sim_output}
+      pathProperties={pathProperties}
+      rollingStock={{ length: 0 } as RollingStockWithLiveries}
+      height={height}
+      setHeight={setHeight}
+    />
+  );
+};
+
+export default DebugSpeedDistanceDiagram;

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -446,7 +446,7 @@ const StdcmResults = ({
               href={`/stdcm/debug?traceId=${encodeURIComponent(traceId)}`}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ fontSize: '0.75rem', opacity: 0.9 }}
+              className="stdcm-debug-link"
             >
               Link to debug page with more simulation details
             </a>

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -36,7 +36,6 @@ import {
 import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
 import SendToRailwayManagerModal from './SendToRailwayManagerModal';
-import StdcmDebugResults from './StdcmDebugResults';
 import StdcmFeedback from './StdcmFeedback';
 import StdcmResultsTable from './StdcmResultsTable';
 import StdcmSimulationNavigator from './StdcmSimulationNavigator';
@@ -100,6 +99,7 @@ const StdcmResults = ({
   const { outputs, alternativePath } = selectedSimulation;
 
   const hasSimulationResults = hasResults(outputs);
+  const traceId = outputs && ('results' in outputs ? outputs.results.traceId : outputs.traceId);
 
   const simulationReportSheetNumber = useMemo(
     () => generateCodeNumber(),
@@ -441,8 +441,16 @@ const StdcmResults = ({
               />
             </div>
           </div>
-
-          {isDebugMode && <StdcmDebugResults simulationOutputs={outputs} />}
+          {isDebugMode && traceId && (
+            <a
+              href={`/stdcm/debug?traceId=${encodeURIComponent(traceId)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ fontSize: '0.75rem', opacity: 0.9 }}
+            >
+              Link to debug page with more simulation details
+            </a>
+          )}
         </>
       )}
     </>

--- a/front/src/applications/stdcm/styles/_debugView.scss
+++ b/front/src/applications/stdcm/styles/_debugView.scss
@@ -1,0 +1,150 @@
+.stdcm-debug-view {
+  min-height: 100vh;
+
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+
+    h2 {
+      color: rgba(0, 0, 0, 1);
+      font-size: 1.5rem;
+      font-weight: 600;
+      text-align: center;
+      margin: 0 0 12px;
+    }
+
+    p {
+      color: var(--grey80);
+      font-size: 1rem;
+      font-weight: 400;
+      text-align: center;
+      margin: 0 0 24px;
+    }
+  }
+
+  &__empty-icon {
+    padding: 8px;
+    border-radius: 50%;
+    background-color: var(--white100);
+    color: var(--primary60);
+    border: 2px solid var(--primary60);
+    margin-bottom: 32px;
+  }
+
+  &__form {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+  }
+
+  &__form-bar {
+    padding: 8px 32px;
+    background: var(--ambientA10);
+    border-bottom: 1px solid var(--grey20);
+    display: flex;
+    justify-content: center;
+  }
+
+  &__status {
+    text-align: center;
+    padding: 48px 0;
+    color: var(--grey50);
+    font-size: 1rem;
+  }
+}
+
+.debug-failure-map {
+  position: relative;
+  width: 100%;
+  height: 500px;
+
+  &__map {
+    width: 100%;
+    height: 100%;
+  }
+
+  &__legend {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: white;
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    font-size: 0.75rem;
+    display: flex;
+    gap: 12px;
+  }
+
+  &__legend-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 4px;
+
+    &--largest {
+      background: rgba(220, 50, 50, 0.85);
+    }
+
+    &--closest {
+      background: rgba(50, 120, 220, 0.85);
+    }
+  }
+
+  &__tooltip {
+    position: absolute;
+    background: white;
+    border: 1px solid #ccc;
+    padding: 6px 10px;
+    pointer-events: none;
+    font-size: 0.75rem;
+    max-width: 280px;
+    line-height: 1.6;
+  }
+}
+
+.debug-space-time-chart {
+  position: relative;
+  width: 100%;
+
+  &__controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    font-size: 0.8125rem;
+  }
+
+  &__zoom-slider {
+    width: 140px;
+  }
+
+  &__hint {
+    color: #888;
+    margin-left: 8px;
+  }
+
+  .manchette {
+    height: 600px;
+  }
+
+  &__tooltip {
+    position: fixed;
+    background: white;
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    pointer-events: none;
+    z-index: 1000;
+    max-width: 400px;
+  }
+
+  &__tooltip-zone {
+    font-size: 0.6875rem;
+    word-break: break-all;
+  }
+}

--- a/front/src/applications/stdcm/styles/_results.scss
+++ b/front/src/applications/stdcm/styles/_results.scss
@@ -408,6 +408,11 @@
   .stdcm-debug-results {
     position: relative;
   }
+
+  .stdcm-debug-link {
+    font-size: 0.75rem;
+    opacity: 0.9;
+  }
 }
 
 .feedback-card {

--- a/front/src/applications/stdcm/styles/_stdcm.scss
+++ b/front/src/applications/stdcm/styles/_stdcm.scss
@@ -8,3 +8,4 @@
 @use './results';
 @use './scenarioExplorer';
 @use './railwayManagerModal';
+@use './debugView';

--- a/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
+++ b/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
@@ -2,6 +2,7 @@ import type {
   PostTimetableByIdStdcmApiArg,
   PostTimetableByIdStdcmApiResponseWithTraceId,
   StdcmResponse,
+  StdcmResponseWithTraceId,
 } from 'common/api/osrdEditoastApi';
 
 export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiArg) {
@@ -63,11 +64,11 @@ export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiAr
   };
 
   const runAndAwaitResult = () =>
-    new Promise<StdcmResponse>((resolve, reject) => {
+    new Promise<StdcmResponseWithTraceId>((resolve, reject) => {
       subscribe((event) => {
         if (event.event === 'error') reject(event.error);
         else {
-          if (event.event === 'completed') resolve(event.data);
+          if (event.event === 'completed') resolve({ ...event.data, traceId: event.traceId });
         }
       });
     });

--- a/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
+++ b/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
@@ -1,7 +1,6 @@
 import type {
   PostTimetableByIdStdcmApiArg,
   PostTimetableByIdStdcmApiResponseWithTraceId,
-  StdcmResponse,
   StdcmResponseWithTraceId,
 } from 'common/api/osrdEditoastApi';
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -934,6 +934,13 @@ const injectedRtkApi = api
         }),
         providesTags: ['sprites'],
       }),
+      getStdcmDebugDataByTraceId: build.query<
+        GetStdcmDebugDataByTraceIdApiResponse,
+        GetStdcmDebugDataByTraceIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/stdcm/debug_data/${queryArg.traceId}` }),
+        providesTags: ['stdcm'],
+      }),
       getStdcmSearchEnvironment: build.query<
         GetStdcmSearchEnvironmentApiResponse,
         GetStdcmSearchEnvironmentApiArg
@@ -2292,6 +2299,15 @@ export type GetSpritesBySignalingSystemAndFileNameApiArg = {
   signalingSystem: string;
   /** File name (json, png or svg) */
   fileName: string;
+};
+export type GetStdcmDebugDataByTraceIdApiResponse =
+  /** status 200  */ {
+    failure?: unknown;
+    simulation_data?: unknown;
+  };
+export type GetStdcmDebugDataByTraceIdApiArg = {
+  /** OpenTelemetry trace ID of the STDCM request */
+  traceId: string;
 };
 export type GetStdcmSearchEnvironmentApiResponse =
   /** status 200  */ StdcmSearchEnvironmentResponse;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2302,8 +2302,8 @@ export type GetSpritesBySignalingSystemAndFileNameApiArg = {
 };
 export type GetStdcmDebugDataByTraceIdApiResponse =
   /** status 200  */ {
-    failure?: unknown;
-    simulation_data?: unknown;
+    failure?: null | SimDebugFailureReport;
+    simulation_data?: null | SimDebugData;
   };
 export type GetStdcmDebugDataByTraceIdApiArg = {
   /** OpenTelemetry trace ID of the STDCM request */
@@ -4337,6 +4337,150 @@ export type SimilarTrainWaypoint = {
   id: string;
   stop: boolean;
 };
+export type SimDebugConflictReport = {
+  at: string;
+  best_remaining_time: number;
+  caused_by: string;
+  current_travel_time: number;
+  lastOPName?: string | null;
+  lat: number;
+  lon: number;
+  time_lost: number;
+};
+export type SimDebugFailureReport = {
+  closest_conflicts: SimDebugConflictReport[];
+  largest_conflicts: SimDebugConflictReport[];
+};
+export type SimDebugEngineeringAllowanceRange = {
+  added_duration: number;
+  from: number;
+  to: number;
+};
+export type SimDebugTrainZoneRequirement = {
+  begin_time: number;
+  end_time: number;
+  train_name?: string | null;
+  zone_name: string;
+};
+export type CoreReportTrain = {
+  /** Total energy consumption */
+  energy_consumption: number;
+  /** Time in ms of each path item given as input of the pathfinding
+    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
+  path_item_times: number[];
+  /** List of positions of a train
+    Both positions (in mm) and times (in ms) must have the same length */
+  positions: number[];
+  /** List of speeds associated to a position */
+  speeds: number[];
+  times: number[];
+};
+export type CoreRoutingZoneRequirement = {
+  /** Time in ms */
+  end_time: number;
+  entry_detector: string;
+  exit_detector: string;
+  switches: {
+    [key: string]: string;
+  };
+  zone: string;
+};
+export type CoreRoutingRequirement = {
+  /** Time in ms */
+  begin_time: number;
+  route: string;
+  zones: CoreRoutingZoneRequirement[];
+};
+export type CoreSignalCriticalPosition = {
+  /** Position in mm */
+  position: number;
+  signal: string;
+  state: string;
+  /** Time in ms */
+  time: number;
+};
+export type CoreSpacingRequirement = {
+  begin_time: number;
+  end_time: number;
+  zone: string;
+};
+export type CoreZoneUpdate = {
+  is_entry: boolean;
+  position: number;
+  time: number;
+  zone: string;
+};
+export type SimulationResponseSuccess = {
+  /** Simulation without any regularity margins */
+  base: CoreReportTrain;
+  electrical_profiles: {
+    /** List of `n` boundaries of the ranges (block path).
+        A boundary is a distance from the beginning of the path in mm. */
+    boundaries: number[];
+    /** List of `n+1` values associated to the ranges */
+    values: (
+      | {
+          electrical_profile_type: 'no_profile';
+        }
+      | {
+          electrical_profile_type: 'profile';
+          handled: boolean;
+          profile?: string | null;
+        }
+    )[];
+  };
+  /** Simulation that takes into account the regularity margins and the schedule item times */
+  final_output: CoreReportTrain & {
+    routing_requirements: CoreRoutingRequirement[];
+    signal_critical_positions: CoreSignalCriticalPosition[];
+    spacing_requirements: CoreSpacingRequirement[];
+    zone_updates: CoreZoneUpdate[];
+  };
+  /** A MRSP computation result (Most Restrictive Speed Profile) */
+  mrsp: {
+    /** List of `n` boundaries of the ranges (block path).
+        A boundary is a distance from the beginning of the path in mm. */
+    boundaries: number[];
+    /** List of `n+1` values associated to the ranges */
+    values: {
+      /** source of the speed-limit if relevant (tag used) */
+      source?:
+        | null
+        | (
+            | {
+                speed_limit_source_type: 'given_train_tag';
+                tag: string;
+              }
+            | {
+                speed_limit_source_type: 'fallback_tag';
+                tag: string;
+              }
+            | {
+                speed_limit_source_type: 'unknown_tag';
+              }
+          );
+      /** in meters per second */
+      speed: number;
+    }[];
+  };
+  /** Simulation that takes into account the regularity margins */
+  provisional: CoreReportTrain;
+};
+export type SimDebugZoneLocation = {
+  from: number;
+  name: string;
+  to: number;
+};
+export type SimDebugData = {
+  departure_time: string;
+  engineering_allowances_ranges: SimDebugEngineeringAllowanceRange[];
+  other_requirements: SimDebugTrainZoneRequirement[];
+  path_properties: PathProperties;
+  sim_output?: null | SimulationResponseSuccess;
+  train_positions: number[];
+  train_times: number[];
+  zone_locations: SimDebugZoneLocation[];
+};
 export type SpeedLimits = {
   default_speed_limit_tag?: string | null;
   speed_limit_tags: {
@@ -4507,27 +4651,6 @@ export type Conflict = {
   /** List of work schedule ids involved in the conflict */
   work_schedule_ids: number[];
 };
-export type CoreRoutingZoneRequirement = {
-  /** Time in ms */
-  end_time: number;
-  entry_detector: string;
-  exit_detector: string;
-  switches: {
-    [key: string]: string;
-  };
-  zone: string;
-};
-export type CoreRoutingRequirement = {
-  /** Time in ms */
-  begin_time: number;
-  route: string;
-  zones: CoreRoutingZoneRequirement[];
-};
-export type CoreSpacingRequirement = {
-  begin_time: number;
-  end_time: number;
-  zone: string;
-};
 export type CoreTrainRequirementsById = {
   routing_requirements: CoreRoutingRequirement[];
   spacing_requirements: CoreSpacingRequirement[];
@@ -4643,89 +4766,6 @@ export type CoreStdcmRequest = {
   timetable_id: number;
   /** List of planned work schedules */
   work_schedules: CoreWorkSchedule[];
-};
-export type CoreReportTrain = {
-  /** Total energy consumption */
-  energy_consumption: number;
-  /** Time in ms of each path item given as input of the pathfinding
-    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
-  path_item_times: number[];
-  /** List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length */
-  positions: number[];
-  /** List of speeds associated to a position */
-  speeds: number[];
-  times: number[];
-};
-export type CoreSignalCriticalPosition = {
-  /** Position in mm */
-  position: number;
-  signal: string;
-  state: string;
-  /** Time in ms */
-  time: number;
-};
-export type CoreZoneUpdate = {
-  is_entry: boolean;
-  position: number;
-  time: number;
-  zone: string;
-};
-export type SimulationResponseSuccess = {
-  /** Simulation without any regularity margins */
-  base: CoreReportTrain;
-  electrical_profiles: {
-    /** List of `n` boundaries of the ranges (block path).
-        A boundary is a distance from the beginning of the path in mm. */
-    boundaries: number[];
-    /** List of `n+1` values associated to the ranges */
-    values: (
-      | {
-          electrical_profile_type: 'no_profile';
-        }
-      | {
-          electrical_profile_type: 'profile';
-          handled: boolean;
-          profile?: string | null;
-        }
-    )[];
-  };
-  /** Simulation that takes into account the regularity margins and the schedule item times */
-  final_output: CoreReportTrain & {
-    routing_requirements: CoreRoutingRequirement[];
-    signal_critical_positions: CoreSignalCriticalPosition[];
-    spacing_requirements: CoreSpacingRequirement[];
-    zone_updates: CoreZoneUpdate[];
-  };
-  /** A MRSP computation result (Most Restrictive Speed Profile) */
-  mrsp: {
-    /** List of `n` boundaries of the ranges (block path).
-        A boundary is a distance from the beginning of the path in mm. */
-    boundaries: number[];
-    /** List of `n+1` values associated to the ranges */
-    values: {
-      /** source of the speed-limit if relevant (tag used) */
-      source?:
-        | null
-        | (
-            | {
-                speed_limit_source_type: 'given_train_tag';
-                tag: string;
-              }
-            | {
-                speed_limit_source_type: 'fallback_tag';
-                tag: string;
-              }
-            | {
-                speed_limit_source_type: 'unknown_tag';
-              }
-          );
-      /** in meters per second */
-      speed: number;
-    }[];
-  };
-  /** Simulation that takes into account the regularity margins */
-  provisional: CoreReportTrain;
 };
 export type SimulationResponse =
   | (SimulationResponseSuccess & {

--- a/front/src/main/app.tsx
+++ b/front/src/main/app.tsx
@@ -10,6 +10,7 @@ import Scenario from 'applications/operationalStudies/views/Scenario';
 import Study from 'applications/operationalStudies/views/Study';
 import HomeMap from 'applications/referenceMap/Home';
 import RollingStockEditor from 'applications/rollingStockEditor/RollingStockEditorView';
+import StdcmDebugView from 'applications/stdcm/StdcmDebugView';
 import Stdcm from 'applications/stdcm/StdcmView';
 import Error403 from 'common/authorization/components/Error403';
 import InitialRedirect from 'common/authorization/components/InitialRedirect';
@@ -66,6 +67,10 @@ const router = createBrowserRouter([
       <OsrdContextLayout slice={stdcmConfSlice} selectors={stdcmConfSelectors} mode={MODES.stdcm} />
     ),
     children: [
+      {
+        path: 'debug',
+        element: <StdcmDebugView />,
+      },
       {
         path: '*',
         element: <Stdcm />,

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
@@ -25,6 +25,7 @@ export type SpeedDistanceDiagramWrapperProps = {
   setHeight: React.Dispatch<React.SetStateAction<number>>;
   fetchEtcsBrakingCurves?: () => Promise<void>;
   etcsBrakingCurves?: EtcsBrakingCurves;
+  initialLayersDisplay?: Parameters<typeof SpeedSpaceChart>[0]['initialLayersDisplay'];
 };
 
 const SPEED_DISTANCE_DIAGRAM_MIN_HEIGHT = 400;
@@ -39,6 +40,7 @@ const SpeedDistanceDiagramWrapper = ({
   setHeight,
   fetchEtcsBrakingCurves,
   etcsBrakingCurves,
+  initialLayersDisplay,
 }: SpeedDistanceDiagramWrapperProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'simulationResults' });
 
@@ -125,6 +127,7 @@ const SpeedDistanceDiagramWrapper = ({
           backgroundColor={SPEED_DISTANCE_DIAGRAM_BACKGROUND_COLOR}
           data={data}
           translations={translations}
+          initialLayersDisplay={initialLayersDisplay}
           fetchEtcsBrakingCurves={fetchEtcsBrakingCurves}
           etcsBrakingCurves={etcsBrakingCurves}
         />

--- a/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
@@ -30,6 +30,7 @@ export type SpeedSpaceChartProps = {
   setHeight: React.Dispatch<React.SetStateAction<number>>;
   fetchEtcsBrakingCurves?: () => Promise<void>;
   etcsBrakingCurves?: EtcsBrakingCurves;
+  initialLayersDisplay?: Partial<Store['layersDisplay']>;
   data: Data;
   translations?: {
     detailsBoxDisplay: {
@@ -79,6 +80,7 @@ const SpeedSpaceChart = ({
   translations,
   fetchEtcsBrakingCurves,
   etcsBrakingCurves,
+  initialLayersDisplay,
 }: SpeedSpaceChartProps) => {
   const [store, setStore] = useState<Store>({
     speeds: [],
@@ -112,6 +114,7 @@ const SpeedSpaceChart = ({
       electricalProfiles: false,
       powerRestrictions: false,
       speedLimitTags: false,
+      ...initialLayersDisplay,
     },
     etcsLayersDisplay: DEFAULT_ETCS_LAYERS_DISPLAY,
     isSettingsPanelOpened: false,

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -1665,6 +1665,46 @@ class EditoastSpriteErrorsUnknownSignalingSystem(BaseModel):
     type: Literal["EditoastSpriteErrorsUnknownSignalingSystem"]
 
 
+class EditoastStdcmDebugErrorJsonParseErrorContext(BaseModel):
+    message: str
+    path: str
+
+
+class EditoastStdcmDebugErrorJsonParseError(BaseModel):
+    context: Annotated[
+        EditoastStdcmDebugErrorJsonParseErrorContext | None,
+        Field(title="EditoastStdcmDebugErrorJsonParseErrorContext"),
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["EditoastStdcmDebugErrorJsonParseError"]
+
+
+class EditoastStdcmDebugErrorS3ErrorContext(BaseModel):
+    message: str
+    path: str
+
+
+class EditoastStdcmDebugErrorS3Error(BaseModel):
+    context: Annotated[
+        EditoastStdcmDebugErrorS3ErrorContext | None,
+        Field(title="EditoastStdcmDebugErrorS3ErrorContext"),
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["EditoastStdcmDebugErrorS3Error"]
+
+
+class EditoastStdcmDebugErrorS3NotConfigured(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None,
+        Field(title="EditoastStdcmDebugErrorS3NotConfiguredContext"),
+    ] = None
+    message: str
+    status: Literal[503]
+    type: Literal["EditoastStdcmDebugErrorS3NotConfigured"]
+
+
 class EditoastStdcmErrorBatchRollingStockNotFoundContext(BaseModel):
     ids: dict[str, Any]
 
@@ -3292,6 +3332,41 @@ class SignalSncfExtension(BaseModel):
     side: Side | None = None
 
 
+class SimDebugConflictReport(BaseModel):
+    at: AwareDatetime
+    best_remaining_time: float
+    caused_by: str
+    current_travel_time: float
+    lastOPName: str | None = None
+    lat: float
+    lon: float
+    time_lost: float
+
+
+class SimDebugEngineeringAllowanceRange(BaseModel):
+    added_duration: float
+    from_: Annotated[float, Field(alias="from")]
+    to: float
+
+
+class SimDebugFailureReport(BaseModel):
+    closest_conflicts: list[SimDebugConflictReport]
+    largest_conflicts: list[SimDebugConflictReport]
+
+
+class SimDebugTrainZoneRequirement(BaseModel):
+    begin_time: float
+    end_time: float
+    train_name: str | None = None
+    zone_name: str
+
+
+class SimDebugZoneLocation(BaseModel):
+    from_: Annotated[float, Field(alias="from")]
+    name: str
+    to: float
+
+
 class SimilarTrainWaypoint(BaseModel):
     id: str
     stop: bool
@@ -4351,6 +4426,9 @@ class EditoastError(
         | EditoastSimilarTrainsErrorSpeedLimitNotFound
         | EditoastSpriteErrorsFileNotFound
         | EditoastSpriteErrorsUnknownSignalingSystem
+        | EditoastStdcmDebugErrorJsonParseError
+        | EditoastStdcmDebugErrorS3Error
+        | EditoastStdcmDebugErrorS3NotConfigured
         | EditoastStdcmErrorBatchRollingStockNotFound
         | EditoastStdcmErrorDatabase
         | EditoastStdcmErrorInfraNotFound
@@ -4509,6 +4587,9 @@ class EditoastError(
         | EditoastSimilarTrainsErrorSpeedLimitNotFound
         | EditoastSpriteErrorsFileNotFound
         | EditoastSpriteErrorsUnknownSignalingSystem
+        | EditoastStdcmDebugErrorJsonParseError
+        | EditoastStdcmDebugErrorS3Error
+        | EditoastStdcmDebugErrorS3NotConfigured
         | EditoastStdcmErrorBatchRollingStockNotFound
         | EditoastStdcmErrorDatabase
         | EditoastStdcmErrorInfraNotFound
@@ -6052,6 +6133,17 @@ class Signal(BaseModel):
     position: float
     sight_distance: float
     track: Annotated[str, Field(max_length=255, min_length=1)]
+
+
+class SimDebugData(BaseModel):
+    departure_time: AwareDatetime
+    engineering_allowances_ranges: list[SimDebugEngineeringAllowanceRange]
+    other_requirements: list[SimDebugTrainZoneRequirement]
+    path_properties: PathProperties
+    sim_output: SimulationResponseSuccess | None = None
+    train_positions: list[float]
+    train_times: list[float]
+    zone_locations: list[SimDebugZoneLocation]
 
 
 class ResponseSuccess(SimulationResponseSuccess):


### PR DESCRIPTION
Disclamer: the code was mostly LLM generated at first, but I did carefully review everything. And it's just for parts I'm not familiar with, and just the code, this description is written normally.

(for the record, I kind of regret doing it that way for the front-end changes, but it's hard to go back and rewrite it from scratch now)

I recommend reviewing per file and not per commit, as I didn't manage to distribute the review comments over their matching commits. I did try to fix the history and the result was *mostly* correct but still left a few commits in an invalid state, it would take quite a lot of time to entirely fix it.


---


Change summary:

* New endpoint in editoast + core to access s3 data for a given requests
    * Requires admin access
* Add a new front-end page at `/stdcm/debug`, with:
    * A space-time chart, with the new train and requirements from other trains and work schedules (if a path is found)
    * A speed chart (if a path is found)
    * A map with conflicts encountered during the search
* In stdcm page, when debug mode is enabled, each request tab has a link towards its debug page. It replaces the previous speed and time charts, which were too slow and had a chance to kill the browser on large timetables.

Minor changes to existing code:

* Speed distance diagram has a new property to specify layers that are initially displayed (we always want max speed to be shown here)
* Core generates a conflict list even on successful searches
* A few minor changes to editoast openapi schema (to avoid duplicated type names)

Not included (yet) but could be added later on:

* Engineering allowance data, it was part of the space time chart in the original python script
* Train paths on the map: could include the path toward each listed conflict (on hover?), and the full path if successful
* Removing original time and speed charts from the result tab results in lots of unused code, this isn't removed yet

---

How to test the happy path:

* Run the stack normally
    * With telemetry enabled: `./osrd-compose telemetry ...` 
    * Editoast needs to be recompiled
    * Core doesn't *need* to be, but if not recompiled the conflict map would only show up on unsuccessful searches
* Run an stdcm request
* Then there's two ways to visit the debug page:
    1. Get the PDF and look for an ID at the bottom right, visit http://localhost:4000/stdcm/debug and enter the ID
    2. Activate debug mode and look for the `Link to debug page with more simulation details` link at the bottom. It's discreet. 

How to test the not happy paths:

* Run editoast with no or incorrect s3 configuration
* Enter IDs that don't exist
* Try to access the page without having admin rights (the page is accessible but unlisted, the endpoint would return an error) 

No automated test has been included, it's a POC / MVP and this version is intended for internal use by the OSRD team. Front-end / E2E tests are a bit tedious to setup and would be overkill here (in my opinion at least).

---

The new page looks like this. It's not fancy but it does its job

<img width="1456" height="1342" alt="image" src="https://github.com/user-attachments/assets/f6017b0f-2346-4af8-9fa4-d282dbe360a7" />

Accessing /stdcm/debug directly looks like this:

<img width="584" height="368" alt="image" src="https://github.com/user-attachments/assets/dfab6e5e-c825-4a35-9ca3-2615fdf8e2c0" />

