### PR TITLE
editoast: authz: replace `StorageDriver::list_users` by direct DB access

### DIFF
--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -133,7 +133,6 @@ mod mock_driver {
     use std::sync::Mutex;
     use std::sync::RwLock;
 
-    use futures::stream;
     use itertools::Either;
 
     use crate::InfraGrant;
@@ -307,30 +306,6 @@ mod mock_driver {
                 .find(|(_, id)| **id == group_id)
                 .map(|(name, _)| GroupInfo { name: name.clone() });
             Ok(group_info)
-        }
-
-        async fn list_users(
-            &self,
-        ) -> Result<impl stream::TryStream<Ok = (i64, UserInfo), Error = Self::Error>, Self::Error>
-        {
-            let mut user_identities: HashMap<i64, Vec<String>> = HashMap::new();
-            for (identity, &id) in self.users.lock().unwrap().iter() {
-                user_identities
-                    .entry(id)
-                    .or_default()
-                    .push(identity.clone());
-            }
-            Ok(stream::iter(user_identities.into_iter().map(
-                |(id, identities)| {
-                    Ok((
-                        id,
-                        UserInfo {
-                            name: format!("Mocked user ({})", identities.join(", ")),
-                            identities,
-                        },
-                    ))
-                },
-            )))
         }
 
         async fn infra_exists(&self, _infra_id: i64) -> Result<bool, Self::Error> {

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use fga::client::QueryError;
 use fga::client::UserList;
 use fga::model::Relation;
-use futures::stream;
 use itertools::Either;
 use tracing::Level;
 
@@ -79,15 +78,6 @@ pub trait StorageDriver: Clone {
         &self,
         group: &GroupInfo,
     ) -> impl Future<Output = Result<i64, Self::Error>> + Send;
-
-    fn list_users(
-        &self,
-    ) -> impl Future<
-        Output = Result<
-            impl stream::TryStream<Ok = (i64, UserInfo), Error = Self::Error>,
-            Self::Error,
-        >,
-    > + Send;
 
     fn add_user_identities(
         &self,

--- a/editoast/editoast_models/src/auth_driver.rs
+++ b/editoast/editoast_models/src/auth_driver.rs
@@ -15,7 +15,6 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
 use database::tables::*;
-use futures::StreamExt;
 use itertools::Either;
 use itertools::Itertools;
 use tracing::Level;
@@ -209,42 +208,6 @@ impl StorageDriver for PgAuthDriver {
             }
         })
         .await
-    }
-
-    async fn list_users(
-        &self,
-    ) -> Result<
-        impl futures::stream::TryStream<Ok = (i64, UserInfo), Error = Self::Error>,
-        Self::Error,
-    > {
-        let conn = self.pool.get().await?;
-        let users = authn_user::table
-            .left_join(authn_user_identity::table)
-            .group_by(authn_user::id)
-            .select((
-                authn_user::id,
-                authn_user::name,
-                diesel::dsl::sql::<
-                    diesel::sql_types::Array<
-                        diesel::sql_types::Nullable<diesel::sql_types::Varchar>,
-                    >,
-                >("array_agg(")
-                .bind(authn_user_identity::identity)
-                .sql(")"),
-            ))
-            .load_stream::<(i64, String, Vec<Option<String>>)>(&mut conn.write().await)
-            .await?
-            .map(|res| match res {
-                Ok((id, name, identities)) => Ok((
-                    id,
-                    UserInfo {
-                        identities: identities.into_iter().flatten().collect_vec(),
-                        name,
-                    },
-                )),
-                Err(e) => Err(e.into()),
-            });
-        Ok(users)
     }
 
     #[tracing::instrument(skip_all, fields(identities, user = %user_identity), ret(level = Level::DEBUG), err)]

--- a/editoast/editoast_models/src/authn/user.rs
+++ b/editoast/editoast_models/src/authn/user.rs
@@ -6,8 +6,6 @@ use authz::identity::UserInfo;
 use database::DbConnection;
 use database::tables::authn_user;
 use database::tables::authn_user_identity;
-use diesel::ExpressionMethods;
-use diesel::QueryDsl;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
@@ -133,9 +131,68 @@ impl User {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserWithIdentities {
+    pub user: User,
+    pub identities: Vec<String>,
+}
+
+#[derive(diesel::QueryableByName)]
+struct UserWithIdentitiesRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    id: i64,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    name: String,
+    // authn_user_identities has a non-null constraint on identities so array items cannot be null
+    // and a trigger ensures a user has at least one identity, so the array itself cannot be null
+    // or empty
+    #[diesel(sql_type = diesel::sql_types::Array<diesel::sql_types::Text>)]
+    identities: Vec<String>,
+}
+
+impl From<UserWithIdentitiesRow> for UserWithIdentities {
+    fn from(row: UserWithIdentitiesRow) -> Self {
+        Self {
+            user: User {
+                id: row.id,
+                name: row.name,
+            },
+            identities: row.identities,
+        }
+    }
+}
+
+impl UserWithIdentities {
+    pub async fn stream(
+        conn: database::DbConnection,
+    ) -> Result<
+        impl futures::stream::TryStream<Ok = Self, Error = database::DatabaseError>,
+        database::DatabaseError,
+    > {
+        use futures::TryStreamExt as _;
+
+        let query = diesel::sql_query(
+            r#"
+            SELECT u.id, u.name, ARRAY_AGG(i.identity) as identities
+            FROM authn_user u
+            LEFT JOIN authn_user_identity i ON i.user_id = u.id
+            GROUP BY u.id
+            "#,
+        );
+
+        Ok(query
+            .load_stream::<UserWithIdentitiesRow>(&mut conn.write().await)
+            .await?
+            .map_ok(Self::from)
+            .map_err(database::DatabaseError::from))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::stream::TryStreamExt as _;
+    use pretty_assertions::assert_eq;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn register_twice_fails() {
@@ -169,6 +226,44 @@ mod tests {
         assert!(
             result.is_err(),
             "Second registration with same identity should fail"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn stream() {
+        let pool = database::DbConnectionPoolV2::for_tests();
+        let conn = pool.get_ok();
+
+        let alice = User::register(
+            conn.clone(),
+            vec!["alice".to_owned(), "alice.alt".to_owned()],
+            "Alice".to_owned(),
+        )
+        .await
+        .unwrap();
+        let bob = User::register(conn.clone(), vec!["bob".to_owned()], "Bob".to_string())
+            .await
+            .unwrap();
+
+        let users = UserWithIdentities::stream(conn)
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            users,
+            vec![
+                UserWithIdentities {
+                    user: alice,
+                    identities: vec!["alice".to_owned(), "alice.alt".to_owned()],
+                },
+                UserWithIdentities {
+                    user: bob,
+                    identities: vec!["bob".to_owned()],
+                },
+            ]
         );
     }
 }

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -6,14 +6,16 @@ use authz::identity::UserInfo;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnectionPoolV2;
+use editoast_models::PgAuthDriver;
+use editoast_models::User;
+use editoast_models::authn::user::UserWithIdentities;
 use editoast_models::prelude::*;
-use futures::TryStreamExt;
+use futures::TryStreamExt as _;
 use futures::future::try_join_all;
 use itertools::Either;
+
 use std::collections::HashSet;
 use std::sync::Arc;
-
-use editoast_models::PgAuthDriver;
 
 use super::openfga_config::OpenfgaConfig;
 
@@ -78,10 +80,16 @@ pub async fn list_user(
     pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
-    let driver = regulator.driver();
 
     let (users, groups) = tokio::join!(
-        async { driver.list_users().await?.try_collect::<Vec<_>>().await },
+        async {
+            let conn = pool.get().await?;
+            let users = UserWithIdentities::stream(conn)
+                .await?
+                .try_collect::<Vec<_>>()
+                .await?;
+            anyhow::Ok(users)
+        },
         async {
             let conn = &mut pool.get().await?;
             let groups = editoast_models::Group::list(conn, Default::default()).await?;
@@ -101,13 +109,17 @@ pub async fn list_user(
             .collect::<HashSet<_>>();
         users?
             .into_iter()
-            .filter(|(user_id, _)| !group_members.contains(&authz::User(*user_id)))
+            .filter(|user| !group_members.contains(&authz::User(user.user.id)))
             .collect::<Vec<_>>()
     } else {
         users?
     };
 
-    for (id, UserInfo { identities, name }) in &users {
+    for UserWithIdentities {
+        user: User { id, name },
+        identities,
+    } in &users
+    {
         println!("[{id}]: {name} ({})", identities.join(", "));
     }
     if users.is_empty() {


### PR DESCRIPTION
Introduces `UserWithIdentities` to conveniently work with entries from both tables.

`ARRAY_AGG` and subqueries make the DSL difficult to use, hence the raw query.

refs https://github.com/osrd-project/osrd-confidential/issues/1168