### PR TITLE
editoast: authz: removes `StorageDriver::delete_group`

### DIFF
--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -376,21 +376,5 @@ mod mock_driver {
             };
             Ok(true)
         }
-
-        async fn delete_group(&self, group_id: i64) -> Result<bool, Self::Error> {
-            let groups = self.groups.lock().unwrap();
-
-            let group_name = groups
-                .iter()
-                .find_map(|(k, &v)| if v == group_id { Some(k) } else { None });
-
-            if let Some(name) = group_name {
-                let mut groups = self.groups.lock().unwrap();
-                groups.remove(name);
-                Ok(true)
-            } else {
-                Ok(false)
-            }
-        }
     }
 }

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -104,9 +104,6 @@ pub trait StorageDriver: Clone {
         new_identities: &[String],
     ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
-    fn delete_group(&self, group_id: i64)
-    -> impl Future<Output = Result<bool, Self::Error>> + Send;
-
     fn infra_exists(&self, infra_id: i64)
     -> impl Future<Output = Result<bool, Self::Error>> + Send;
 }

--- a/editoast/editoast_models/src/auth_driver.rs
+++ b/editoast/editoast_models/src/auth_driver.rs
@@ -335,16 +335,6 @@ impl StorageDriver for PgAuthDriver {
         }).await
     }
 
-    #[tracing::instrument(skip_all, fields(%group_id), ret(level = Level::DEBUG), err)]
-    async fn delete_group(&self, group_id: i64) -> Result<bool, Self::Error> {
-        let conn = self.pool.get().await?;
-        let s = dsl::delete(authn_group::table.filter(authn_group::id.eq(group_id)))
-            .execute(&mut conn.write().await)
-            .await?;
-
-        Ok(s > 0)
-    }
-
     async fn infra_exists(&self, infra_id: i64) -> Result<bool, Self::Error> {
         // TODO model_migration: use Infra once available in editoast_models
         Ok(

--- a/editoast/editoast_models/src/authn/group.rs
+++ b/editoast/editoast_models/src/authn/group.rs
@@ -6,7 +6,7 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Hash, Clone, Model, ToSchema, Serialize, Deserialize, PartialEq, Eq)]
 #[model(table = database::tables::authn_group)]
-#[model(gen(ops = r, list, batch_ops = r))]
+#[model(gen(ops = rd, list, batch_ops = r))]
 pub struct Group {
     pub id: i64,
     pub name: String,

--- a/editoast/src/client/garbage_collector.rs
+++ b/editoast/src/client/garbage_collector.rs
@@ -372,10 +372,12 @@ mod tests {
             .unwrap();
 
         // Delete orphan entities from DB
-        driver.delete_group(orphan_group.0).await.unwrap();
         {
             let conn = &mut db_pool.get_ok();
             editoast_models::authn::user::User::delete_static(conn, orphan_user.0)
+                .await
+                .unwrap();
+            editoast_models::Group::delete_static(conn, orphan_group.0)
                 .await
                 .unwrap();
             Infra::delete_static(conn, orphan_infra.0).await.unwrap();

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use editoast_models::PgAuthDriver;
+use editoast_models::prelude::*;
 
 use crate::authorizers::Rejection;
 use crate::authorizers::SystemAuthorizer;
@@ -214,9 +215,10 @@ pub async fn delete_group(
 ) -> anyhow::Result<()> {
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
     let driver = regulator.driver();
+    let mut conn = pool.get().await?;
     let system = SystemAuthorizer {
         openfga: regulator.openfga(),
-        conn: pool.get().await?,
+        conn: conn.clone(),
     };
     let group_id = if let Some(id) = driver.get_group_id(&name).await? {
         id
@@ -235,7 +237,7 @@ pub async fn delete_group(
         Err(rejection) => impossible!(rejection),
     }
 
-    let deleted = driver.delete_group(group_id).await?;
+    let deleted = editoast_models::Group::delete_static(&mut conn, group_id).await?;
     if deleted {
         tracing::info!("group '{name}' deleted");
     } else {


### PR DESCRIPTION
Removes a `AuthzDriver` test to be able to delete the function instead of deprecating it.

refs https://github.com/osrd-project/osrd-confidential/issues/1168