### PR TITLE
editoast: remove `StorageDriver::add_user_identities`

### DIFF
--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -133,8 +133,6 @@ mod mock_driver {
     use std::sync::Mutex;
     use std::sync::RwLock;
 
-    use itertools::Either;
-
     use crate::InfraGrant;
     use crate::Regulator;
     use crate::Role;
@@ -300,31 +298,6 @@ mod mock_driver {
 
         async fn infra_exists(&self, _infra_id: i64) -> Result<bool, Self::Error> {
             // Mock implementation, always return true
-            Ok(true)
-        }
-
-        async fn add_user_identities(
-            &self,
-            user_identity: Either<i64, String>,
-            new_identities: &[String],
-        ) -> Result<bool, Self::Error> {
-            let mut map = self.users.lock().unwrap();
-            let user_id = match user_identity {
-                Either::Left(user_id) => map
-                    .iter()
-                    .find(|(_, id)| **id == user_id)
-                    .map(|(_, id)| *id),
-                Either::Right(identity) => map.get(&identity).copied(),
-            };
-            match user_id {
-                Some(user_id) => map.extend(
-                    new_identities
-                        .iter()
-                        .map(ToString::to_string)
-                        .zip(std::iter::repeat(user_id)),
-                ),
-                None => return Ok(false),
-            };
             Ok(true)
         }
     }

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use fga::client::QueryError;
 use fga::client::UserList;
 use fga::model::Relation;
-use itertools::Either;
 use tracing::Level;
 
 use crate::Authorization;
@@ -73,12 +72,6 @@ pub trait StorageDriver: Clone {
         user_name: &UserName,
         user: &UserIdentity,
     ) -> impl Future<Output = Result<UserSubject, Self::Error>> + Send;
-
-    fn add_user_identities(
-        &self,
-        user_identity: Either<i64, String>,
-        new_identities: &[String],
-    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
     fn infra_exists(&self, infra_id: i64)
     -> impl Future<Output = Result<bool, Self::Error>> + Send;

--- a/editoast/editoast_models/src/auth_driver.rs
+++ b/editoast/editoast_models/src/auth_driver.rs
@@ -15,7 +15,6 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
 use database::tables::*;
-use itertools::Either;
 use itertools::Itertools;
 use tracing::Level;
 
@@ -177,76 +176,6 @@ impl StorageDriver for PgAuthDriver {
             }
         })
         .await
-    }
-
-    #[tracing::instrument(skip_all, fields(identities, user = %user_identity), ret(level = Level::DEBUG), err)]
-    async fn add_user_identities(
-        &self,
-        user_identity: Either<i64, String>,
-        new_identities: &[String],
-    ) -> Result<bool, Self::Error> {
-        let conn = self.pool.get().await?;
-        conn.transaction(async move |conn| {
-            let existing_user = match user_identity {
-                Either::Left(user_id) => authn_user::table
-                    .left_join(authn_user_identity::table)
-                    .select(authn_user::id)
-                    .filter(authn_user::id.eq(user_id))
-                    .first::<i64>(conn.write().await.deref_mut())
-                    .await
-                    .optional()?,
-                Either::Right(identity) => authn_user::table
-                    .left_join(authn_user_identity::table)
-                    .select(authn_user::id)
-                    .filter(authn_user_identity::identity.eq(identity))
-                    .first::<i64>(conn.write().await.deref_mut())
-                    .await
-                    .optional()?,
-            };
-            match existing_user {
-                None => Ok(false),
-                Some(user_id) => {
-                    for new_identity in new_identities {
-                        let identity_owner = authn_user_identity::table
-                            .select(authn_user_identity::user_id)
-                            .filter(authn_user_identity::identity.eq(&new_identity))
-                            .first::<i64>(conn.write().await.deref_mut())
-                            .await
-                            .optional()?;
-                        match identity_owner {
-                            Some(same_owner_id) if same_owner_id == user_id => {
-                                tracing::warn!(
-                                    "The identity `{}` is already associated with the target user (user_id: {})",
-                                    new_identity,
-                                    user_id
-                                );
-                                continue;
-                            }
-                            Some(different_owner_id) => {
-                                tracing::warn!(
-                                    "Could not add to user `{}` the identity `{}` as it is already associated with another user (user_id: {})",
-                                    user_id,
-                                    new_identity,
-                                    different_owner_id
-                                );
-                                continue;
-                            }
-                            None => {
-                                dsl::insert_into(authn_user_identity::table)
-                                    .values(&vec![(
-                                        authn_user_identity::identity.eq(&new_identity),
-                                        authn_user_identity::user_id.eq(user_id),)])
-
-                                    .execute(&mut conn.write().await)
-                                .await
-                                .map_err(AuthDriverError::from)?;
-                        }
-                    }
-                }
-                Ok(true)
-            }
-        }
-        }).await
     }
 
     async fn infra_exists(&self, infra_id: i64) -> Result<bool, Self::Error> {

--- a/editoast/editoast_models/src/authn/user.rs
+++ b/editoast/editoast_models/src/authn/user.rs
@@ -19,6 +19,15 @@ pub struct User {
     pub name: String,
 }
 
+#[derive(Debug, thiserror::Error, derive_more::From)]
+pub enum AddIdentitiesError {
+    #[error("duplicate identity \"{0}\"")]
+    DuplicateIdentity(String),
+    #[error(transparent)]
+    #[from(forward)]
+    Error(crate::Error),
+}
+
 impl User {
     /// Inserts a new [User], fails if the identity is already associated with another user
     #[tracing::instrument(skip(conn), ret(level = "debug"), err)]
@@ -26,30 +35,73 @@ impl User {
         conn: DbConnection,
         identities: Vec<String>,
         name: String,
-    ) -> Result<User, database::DatabaseError> {
+    ) -> Result<User, AddIdentitiesError> {
         conn.transaction(async move |conn| {
             let id = diesel::dsl::insert_into(authn_user::table)
                 .values(authn_user::name.eq(&name))
                 .returning(authn_user::id)
                 .get_result::<i64>(&mut conn.write().await)
                 .await?;
-            diesel::dsl::insert_into(authn_user_identity::table)
-                .values(
-                    identities
-                        .iter()
-                        .map(|identity| {
-                            (
-                                authn_user_identity::identity.eq(identity),
-                                authn_user_identity::user_id.eq(id),
-                            )
-                        })
-                        .collect_vec(),
-                )
-                .execute(&mut conn.write().await)
-                .await?;
-            Ok(Self { id, name })
+            let user = Self { id, name };
+            user.add_identities(conn, identities).await?;
+            Ok(user)
         })
         .await
+    }
+
+    /// Add one or more identity to this user
+    ///
+    /// Remember a model is valid in the scope of its transaction. So better run
+    /// this method in a transaction to avoid races.
+    #[tracing::instrument(skip_all, err)]
+    pub async fn add_identities(
+        &self,
+        conn: DbConnection,
+        identities: impl IntoIterator<Item = String>,
+    ) -> Result<(), AddIdentitiesError> {
+        let mut conn = conn.write().await;
+        match diesel::dsl::insert_into(authn_user_identity::table)
+            .values(
+                identities
+                    .into_iter()
+                    .map(|identity| {
+                        (
+                            authn_user_identity::user_id.eq(self.id),
+                            authn_user_identity::identity.eq(identity),
+                        )
+                    })
+                    .collect_vec(),
+            )
+            .execute(&mut conn)
+            .await
+            .map_err(crate::Error::from)
+        {
+            Ok(_) => Ok(()),
+            Err(crate::Error::UniqueViolation {
+                constraint,
+                column: _,
+                value,
+            }) if &constraint == "authn_user_identity_identity_key" => {
+                Err(AddIdentitiesError::DuplicateIdentity(value))
+            }
+            Err(err) => Err(AddIdentitiesError::from(err)),
+        }
+    }
+
+    /// Return the identities for this user
+    ///
+    /// Remember a model is valid in the scope of its transaction. So better run
+    /// this method in a transaction to avoid races.
+    #[tracing::instrument(skip_all, err)]
+    pub async fn get_identities(
+        &self,
+        conn: DbConnection,
+    ) -> Result<Vec<UserIdentity>, database::DatabaseError> {
+        Ok(authn_user_identity::table
+            .select(authn_user_identity::identity)
+            .filter(authn_user_identity::user_id.eq(self.id))
+            .load::<String>(conn.write().await.deref_mut())
+            .await?)
     }
 
     /// Return the [User] with the provided identity, if any
@@ -262,6 +314,36 @@ mod tests {
                     identities: vec!["bob".to_owned()],
                 },
             ]
+        );
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn add_duplicate_identity_fails() {
+        let pool = database::DbConnectionPoolV2::for_tests();
+        let conn = pool.get_ok();
+
+        let user = User::register(conn.clone(), vec!["toto".to_owned()], "Toto".to_owned())
+            .await
+            .unwrap();
+
+        user.add_identities(
+            conn.clone(),
+            vec!["titi".to_owned(), "grosminet".to_owned()],
+        )
+        .await
+        .expect("adding new identities should succeed");
+
+        user.add_identities(conn.clone(), vec!["toto".to_owned()])
+            .await
+            .expect_err("adding duplicate identity should fail");
+
+        assert_eq!(
+            user.get_identities(conn)
+                .await
+                .unwrap()
+                .iter()
+                .sorted()
+                .collect_vec(),
+            vec!["grosminet", "titi", "toto"]
         );
     }
 }

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use anyhow::bail;
 use authz;
 use authz::StorageDriver;
 use authz::identity::GroupInfo;
@@ -8,12 +9,11 @@ use clap::Subcommand;
 use database::DbConnectionPoolV2;
 use editoast_models::PgAuthDriver;
 use editoast_models::User;
+use editoast_models::authn::user::AddIdentitiesError;
 use editoast_models::authn::user::UserWithIdentities;
 use editoast_models::prelude::*;
 use futures::TryStreamExt as _;
 use futures::future::try_join_all;
-use itertools::Either;
-
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -29,7 +29,7 @@ pub enum UserCommand {
     Info(InfoArgs),
     /// Delete a user
     Delete(DeleteArgs),
-    /// Add identities to a new or an already existing user
+    /// Add identities to an existing user
     AddIdentities(AddIdentitiesArg),
 }
 
@@ -129,18 +129,17 @@ pub async fn list_user(
 }
 
 /// Add a user
-pub async fn add_user(args: AddArgs, pool: Arc<DbConnectionPoolV2>) -> anyhow::Result<()> {
-    let driver = PgAuthDriver::new(pool);
-    if args.identities.is_empty() {
+pub async fn add_user(
+    AddArgs { name, identities }: AddArgs,
+    pool: Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<()> {
+    if identities.is_empty() {
         println!("No identities provided.");
         return Ok(());
     }
-    let created_user = driver
-        .ensure_user(&args.name.unwrap_or_default(), &args.identities[0])
-        .await?;
-    driver
-        .add_user_identities(Either::Left(created_user.id), &args.identities[1..])
-        .await?;
+    let conn = pool.get().await?;
+    let created_user =
+        editoast_models::User::register(conn, identities, name.unwrap_or_default()).await?;
     println!("User added with id: {}", created_user.id);
     Ok(())
 }
@@ -218,14 +217,111 @@ pub async fn add_identities(
     }: AddIdentitiesArg,
     pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
-    let driver = PgAuthDriver::new(pool);
-    let user_identity = match (user_id, user_identity) {
-        (Some(user_id), _) => Either::Left(user_id),
-        (_, Some(identity)) => Either::Right(identity.clone()),
-        _ => unreachable!("ensured by clap"),
+    let conn = pool.get().await?;
+    let user = match (user_id, user_identity) {
+        (Some(user_id), None) => editoast_models::User::retrieve(conn.clone(), user_id).await?,
+        (None, Some(identity)) => {
+            editoast_models::User::retrieve_by_identity(&identity, conn.clone()).await?
+        }
+        (Some(_), Some(_)) => unreachable!("ensured by clap"),
+        (None, None) => bail!("either a user ID or a user identity must be provided"),
     };
-    driver
-        .add_user_identities(user_identity.clone(), &new_identities)
-        .await?;
+    let Some(user) = user else {
+        bail!("no such user");
+    };
+    let mut identities = HashSet::<_>::from_iter(new_identities);
+    while !identities.is_empty() {
+        match user.add_identities(conn.clone(), identities.clone()).await {
+            Ok(()) => return Ok(()),
+            Err(AddIdentitiesError::DuplicateIdentity(identity)) => {
+                tracing::warn!(identity, "duplicate identity");
+                identities.remove(&identity);
+            }
+            Err(AddIdentitiesError::Error(err)) => return Err(err.into()),
+        }
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editoast_models::authn::user::User;
+    use itertools::Itertools as _;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn add_identities_multiple_times() {
+        let pool = Arc::new(database::DbConnectionPoolV2::for_tests());
+
+        let conn = pool.get_ok();
+        let user = User::register(conn.clone(), vec!["toto".to_owned()], "Toto".to_owned())
+            .await
+            .expect("user should be created");
+
+        add_identities(
+            AddIdentitiesArg {
+                user_id: Some(user.id),
+                user_identity: None,
+                new_identities: vec!["titi".to_owned(), "grosminet".to_owned()],
+            },
+            pool.clone(),
+        )
+        .await
+        .expect("new identities should succeed");
+
+        add_identities(
+            AddIdentitiesArg {
+                user_id: Some(user.id),
+                user_identity: None,
+                new_identities: vec![
+                    "mémé".to_owned(),
+                    "grosminet".to_owned(),
+                    "hector".to_owned(),
+                ],
+            },
+            pool.clone(),
+        )
+        .await
+        .expect("partially new identities should succeed");
+
+        assert_eq!(
+            user.get_identities(conn)
+                .await
+                .unwrap()
+                .iter()
+                .sorted()
+                .collect_vec(),
+            vec!["grosminet", "hector", "mémé", "titi", "toto"]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn add_identities_wrong_user_id() {
+        let pool = Arc::new(database::DbConnectionPoolV2::for_tests());
+        add_identities(
+            AddIdentitiesArg {
+                user_id: Some(i64::MAX),
+                user_identity: None,
+                new_identities: vec!["won't_be_added".to_owned()],
+            },
+            pool,
+        )
+        .await
+        .expect_err("should fail for unknown user id");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn add_identities_wrong_identity() {
+        let pool = Arc::new(database::DbConnectionPoolV2::for_tests());
+        add_identities(
+            AddIdentitiesArg {
+                user_id: None,
+                user_identity: Some("tom".to_owned()),
+                new_identities: vec!["rejected_anyway".to_owned()],
+            },
+            pool,
+        )
+        .await
+        .expect_err("should fail for unknown user identity");
+    }
 }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -617,11 +617,9 @@ async fn authentication_validation_middleware(
         Ok((Some(user), ::authz::v2::subject_roles(authz_user)))
     }
 
-    let (user, roles_prot) = if authn.origin().is_none() {
-        (None, ::authz::v2::Protected::default())
-    } else {
+    let (user, roles_prot) = if let Some(req_origin) = authn.origin() {
         let conn = db_pool.get().await?;
-        conn.transaction(async move |conn| {
+        conn.transaction(async |conn| {
             let origin = match &authn {
                 crate::authentication::Authentication::Authenticated { identity, name } => {
                     let user =
@@ -661,10 +659,12 @@ async fn authentication_validation_middleware(
 
             Ok(match origin {
                 Some((user, roles_prot)) => (Some(user), roles_prot),
-                None => register_origin_user(conn, authn.origin().unwrap()).await?,
+                None => register_origin_user(conn, req_origin).await?,
             })
         })
         .await?
+    } else {
+        (None, ::authz::v2::Protected::default())
     };
 
     // A failed OpenFGA request does not invalidate the creation of a new user

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -36,6 +36,7 @@ use ::authz::StorageDriver;
 use ::authz::v2::special_authorizers;
 use axum::Extension;
 use common::Version;
+use editoast_models::authn::user::AddIdentitiesError;
 use fga::client::Limits;
 #[cfg(test)]
 use test_app::test_app;
@@ -596,9 +597,22 @@ async fn authentication_validation_middleware(
         ::authz::v2::Protected<Vec<Role>>,
     )> {
         tracing::info!(identity, name, "registering new user");
-        let user =
-            editoast_models::User::register(conn, vec![identity.to_owned()], name.to_owned())
-                .await?;
+        let user = match editoast_models::User::register(
+            conn,
+            vec![identity.to_owned()],
+            name.to_owned(),
+        )
+        .await
+        {
+            Ok(user) => user,
+            Err(AddIdentitiesError::DuplicateIdentity(_)) => {
+                unreachable!(
+                    "the current function is only called when the user don't exists, and the `.register()`\n\
+                    operation above only creates the user with one unique identity"
+                );
+            }
+            Err(AddIdentitiesError::Error(err)) => return Err(err.into()),
+        };
         let authz_user = ::authz::Subject::user(user.id);
         Ok((Some(user), ::authz::v2::subject_roles(authz_user)))
     }


### PR DESCRIPTION
Replaces it with `User::add_identities`. It parses UNIQUE violations
and has its own error type. The function is also used in
`User::register`, which now also handles UNIQUE violations.

Identity adding CLI has been rewriten with the following changes:
* Updated docs now stating that the provided user must now exist. (Former behavior as well.)
* Identifier insertion is retried each time a duplicate is found.
* No transaction is added still: it's not that serious since it's the CLI.

A couple tests to help review.

refs https://github.com/osrd-project/osrd-confidential/issues/1168