### PR TITLE
editoast: zero-copy From<String> for NonBlankString

### DIFF
--- a/editoast/schemas/src/primitives/non_blank_string.rs
+++ b/editoast/schemas/src/primitives/non_blank_string.rs
@@ -57,20 +57,20 @@ impl DerefMut for NonBlankString {
 
 impl From<String> for NonBlankString {
     fn from(s: String) -> Self {
-        s.as_str().into()
+        assert!(!s.is_empty());
+        NonBlankString(s)
     }
 }
 
 impl From<&String> for NonBlankString {
     fn from(s: &String) -> Self {
-        s.as_str().into()
+        s.clone().into()
     }
 }
 
 impl From<&str> for NonBlankString {
     fn from(s: &str) -> Self {
-        assert!(!s.is_empty());
-        NonBlankString(s.into())
+        s.to_string().into()
     }
 }
 


### PR DESCRIPTION
swap this impl with the From<&str> one. The copy was most likely elided by LLVM, but this way makes more sense.