### PR TITLE
front: remove the exception key added to the store and use an empty string

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTimetableItem/helpers/postPayloads.ts
@@ -113,7 +113,7 @@ export const postFullImportPayload = async (
           ...change_groups,
           ...rest,
           // TODO_EXCEPTION: remove this when drop key in the model
-          key: rest.id.toString(),
+          key: '',
         })
       );
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/CreateTimetableItemButton.tsx
@@ -66,12 +66,12 @@ const CreateTimetableItemButton = ({
       const formattedNewTrainSchedule: TimetableItem = (
         await createPacedTrains(dispatch, sandboxId, [newTrainSchedulePayload])
       )[0];
-      dispatch(updateSelectedTrainId(formatEditoastIdToPacedTrainId(formattedNewPacedTrain.id)));
+      dispatch(updateSelectedTrainId(formatEditoastIdToPacedTrainId(formattedNewTrainSchedule.id)));
 
       let timetableItemToUpsert = formattedNewTrainSchedule;
 
-      const newAddedExceptions = addedExceptions.map(({ key, startTime: exStartTime }) => ({
-        key,
+      const newAddedExceptions = addedExceptions.map(({ startTime: exStartTime }) => ({
+        key: '', // TODO : remove this when the key will be removed from the model
         start_time: { value: exStartTime.toISOString() },
       }));
 
@@ -95,7 +95,7 @@ const CreateTimetableItemButton = ({
             ...change_groups,
             ...restExceptions,
             // TODO_EXCEPTION: remove this when drop key in the model
-            key: restExceptions.id.toString(),
+            key: '',
           };
         });
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PacedTrainSettings/AddedOccurrences.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/PacedTrainSettings/AddedOccurrences.tsx
@@ -27,8 +27,8 @@ const AddedOccurrences = () => {
     dispatch(addAddedException(new Date(`${date}T${time}`)));
   }
 
-  function handleDeleteException(key: string) {
-    dispatch(deleteAddedException(key));
+  function handleDeleteException(index: number) {
+    dispatch(deleteAddedException(index));
   }
 
   return (
@@ -84,15 +84,15 @@ const AddedOccurrences = () => {
       </div>
       <ul className="list" data-testid="added-occurrences-list">
         {addedExceptions.map(
-          ({ startTime, key }) =>
+          ({ startTime }, index) =>
             startTime && (
-              <li key={key}>
+              <li key={`${index}-${startTime.toISOString()}`}>
                 <Dot className="input-icon" variant="fill" />
                 {startTime.toLocaleString()}
                 <button
                   type="button"
                   onClick={() => {
-                    handleDeleteException(key);
+                    handleDeleteException(index);
                   }}
                 >
                   <Trash className="input-icon" />

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
@@ -177,8 +177,8 @@ const useUpdateTimetableItem = (
     const originalPacedExceptions = originalPacedTrain.paced?.exceptions ?? [];
 
     const newAddedExceptions: PacedTrainException[] = addedExceptions.map(
-      ({ key, startTime: exStartTime }) => ({
-        key,
+      ({ startTime: exStartTime }) => ({
+        key: '', // TODO : remove this when the key will be removed from the model
         start_time: { value: exStartTime.toISOString() },
       }),
     );
@@ -218,9 +218,9 @@ const useUpdateTimetableItem = (
           ...change_groups,
           ...rest,
           // TODO_EXCEPTION: remove this when drop key in the model
-          key: rest.id.toString(),
-        }),
-      );
+          key: '',
+        })
+    );
     }
 
     // If we just converted a unique train to a paced train, upsert with created exceptions and return

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -302,7 +302,7 @@ const PacedTrainItem = ({
         ...change_groups,
         ...restExceptions,
         // TODO_EXCEPTION: remove this when drop key in the model
-        key: restExceptions.id.toString(),
+        key: '',
       };
     });
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 
 import { useSelector } from 'react-redux';
-import { v4 as uuidV4 } from 'uuid';
 
 import { updatePacedTrainExceptionsList } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/buildPacedTrainException';
 import { formatPacedTrainWithDetailsToPacedTrainPayload } from 'applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload';
@@ -147,7 +146,7 @@ const useOccurrenceActions = ({
         }
 
         // TODO_EXCEPTION: remove key when using TrainSchedulingException type
-        const key = uuidV4();
+        const key = '';
         // No exception yet: create one with disabled: true
         const exceptionToCreate: PacedTrainException = {
           occurrence_index: occurrence.occurrenceIndex,
@@ -214,7 +213,7 @@ const useOccurrenceActions = ({
           // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
           id: exceptionToUpdate.id!,
           // TODO_EXCEPTION: remove `key` when using TrainSchedulingException type
-          key: exceptionToUpdate.id!.toString(),
+          key: '',
           start_time: exceptionToUpdate.start_time,
         };
         // for an added exception, we want to reset all change groups except the start time

--- a/front/src/modules/timetableItem/helpers/__tests__/pacedTrain.spec.ts
+++ b/front/src/modules/timetableItem/helpers/__tests__/pacedTrain.spec.ts
@@ -334,9 +334,10 @@ describe('isOccurrencePresentInPacedTrain', () => {
     timeWindow: Duration.parse('PT2H'),
     interval: Duration.parse('PT30M'),
     exceptions: [
-      { key: 'added-exception' },
-      { key: 'disabled-exception', occurrence_index: 1, disabled: true },
-      { key: 'modified-exception', occurrence_index: 2, disabled: false },
+      // TODO_EXCEPTION: delete `key` 
+      { id: 0, key: '0' },
+      { id: 1, key: '1', occurrence_index: 1, disabled: true },
+      { id: 2, key: '2', occurrence_index: 2, disabled: false },
     ],
   };
   const timetableItem = { paced, id: timetableItemId };
@@ -401,7 +402,7 @@ describe('isOccurrencePresentInPacedTrain', () => {
   it('should return true if the occurrence is an added exception present in the paced train', () => {
     expect(
       isOccurrencePresentInPacedTrain(
-        formatPacedTrainIdToExceptionId(pacedTrainId, 'added-exception'),
+        formatPacedTrainIdToExceptionId(pacedTrainId, 0),
         timetableItem
       )
     ).toEqual(true);
@@ -410,7 +411,7 @@ describe('isOccurrencePresentInPacedTrain', () => {
   it('should return false if the occurrence is an added exception not present in the paced train', () => {
     expect(
       isOccurrencePresentInPacedTrain(
-        formatPacedTrainIdToExceptionId(pacedTrainId, 'unknown-exception'),
+        formatPacedTrainIdToExceptionId(pacedTrainId, 999),
         timetableItem
       )
     ).toEqual(false);

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -269,7 +269,7 @@ export const isOccurrencePresentInPacedTrain = (
 
   if (isAddedExceptionId(occurrenceId)) {
     const exceptionId = extractExceptionIdFromOccurrenceId(occurrenceId);
-    return paced.exceptions.some((exception) => exception.key === exceptionId);
+    return paced.exceptions.some((exception) => exception.id === exceptionId);
   }
 
   const occurrenceIndex = extractOccurrenceIndexFromOccurrenceId(occurrenceId);

--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -1,5 +1,4 @@
 import { isEmpty } from 'lodash';
-import { v4 as uuidV4 } from 'uuid';
 
 import {
   osrdEditoastApi,
@@ -151,7 +150,8 @@ export async function syncOccurrenceException(
       // Return the empty exception so updatePacedTrainExceptionsList removes it from local state
       return {
         ...generatedException,
-        key: existingException.key,
+        // TODO_EXCEPTION: remove this when key is dropped from the model
+        key: '',
         occurrence_index: occurrenceIndex,
       };
     }
@@ -159,7 +159,7 @@ export async function syncOccurrenceException(
       ...generatedException,
       id: existingException.id,
       // TODO_EXCEPTION: remove this when key is dropped from the model
-      key: existingException.key,
+      key: '',
       occurrence_index: occurrenceIndex,
     };
     await updateExceptions(dispatch, [toUpdate], pacedTrainId);
@@ -169,7 +169,7 @@ export async function syncOccurrenceException(
   const exceptionToCreate: PacedTrainException = {
     ...generatedException,
     // TODO_EXCEPTION: remove this when key is dropped from the model
-    key: uuidV4(),
+    key: '',
     occurrence_index: occurrenceIndex,
   };
   const [created] = await createExceptions(

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -1,5 +1,4 @@
 import { createSlice, type Draft, type PayloadAction } from '@reduxjs/toolkit';
-import { v4 as uuidV4 } from 'uuid';
 
 import computeBasePathStep from 'modules/timetableItem/helpers/computeBasePathStep';
 import { isPacedTrainWithDetails } from 'modules/timetableItem/helpers/pacedTrain';
@@ -117,12 +116,11 @@ export const operationalStudiesConfSlice = createSlice({
     },
     addAddedException(state: Draft<OperationalStudiesConfState>, action: PayloadAction<Date>) {
       state.addedExceptions.push({
-        key: uuidV4(),
         startTime: action.payload,
       });
     },
-    deleteAddedException(state: Draft<OperationalStudiesConfState>, action: PayloadAction<string>) {
-      const indexToDelete = state.addedExceptions.findIndex((e) => e.key === action.payload);
+    deleteAddedException(state: Draft<OperationalStudiesConfState>, action: PayloadAction<number>) {
+      const indexToDelete = action.payload;
       state.addedExceptions.splice(indexToDelete, 1);
     },
     clearAddedExceptionsList(state: Draft<OperationalStudiesConfState>) {

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -66,7 +66,6 @@ export type OperationalStudiesConfState = OsrdConfState & {
   timeWindow: Duration;
   interval: Duration;
   addedExceptions: {
-    key: string;
     startTime: Date;
   }[];
   editingItemType: 'uniqueTrain' | 'pacedTrain' | 'occurrence';

--- a/front/src/utils/__tests__/trainId.spec.ts
+++ b/front/src/utils/__tests__/trainId.spec.ts
@@ -181,9 +181,10 @@ describe('isTrainIdInTimetable', () => {
         timeWindow: Duration.parse('PT2H'),
         interval: Duration.parse('PT30M'),
         exceptions: [
-          { key: 'added-exception' },
-          { key: 'disabled-exception', occurrence_index: 1, disabled: true },
-          { key: 'modified-exception', occurrence_index: 2, disabled: false },
+          // TODO_EXCEPTION: delete `key` 
+          { key: '0', id: 0 },
+          { key: '1', id: 1, occurrence_index: 1, disabled: true },
+          { key: '2', id: 2, occurrence_index: 2, disabled: false },
         ],
       },
     },
@@ -254,7 +255,7 @@ describe('isTrainIdInTimetable', () => {
   it('should return true if added exception id is present in timetable', () => {
     expect(
       isTrainIdInTimetable(
-        formatPacedTrainIdToExceptionId(pacedTrainId, 'added-exception'),
+        formatPacedTrainIdToExceptionId(pacedTrainId, 0),
         timetableItems
       )
     ).toEqual(true);
@@ -263,7 +264,7 @@ describe('isTrainIdInTimetable', () => {
   it('should return false if added exception id is not present in timetable', () => {
     expect(
       isTrainIdInTimetable(
-        formatPacedTrainIdToExceptionId(pacedTrainId, 'unknown-exception'),
+        formatPacedTrainIdToExceptionId(pacedTrainId, 999),
         timetableItems
       )
     ).toEqual(false);


### PR DESCRIPTION
Pending the removal of the backend key, we can stop generating this key and use an empty string instead, as we are no longer supposed to use this key