### PR TITLE
front: editor: fix some missing translation keys

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -160,10 +160,13 @@
       "Detector": "Detector",
       "Electrification": "Electrification",
       "LevelCrossing": "Level crossing",
+      "NeutralSection": "Neutral section",
+      "OperationalPoint": "Operational point",
       "Route": "Route",
       "Signal": "Signal",
       "SpeedSection": "Speed limit",
       "Switch": "Switch",
+      "SwitchType": "Switch type",
       "TrackSection": "Track section"
     },
     "tools": {
@@ -389,6 +392,7 @@
         "link": "Link",
         "no-track-picked-yet": "No track selected yet",
         "point_switch": "Point switch",
+        "port": "Port {{portId}}",
         "single_slip_switch": "Single slip switch",
         "switch-type": "Switch type",
         "switch_type_w_port_count_one": "{{type}} ({{count}} port)",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -160,10 +160,13 @@
       "Detector": "Détecteur",
       "Electrification": "Électrification",
       "LevelCrossing": "Passage à niveau",
+      "NeutralSection": "Section neutre",
+      "OperationalPoint": "Point remarquable",
       "Route": "Itinéraire",
       "Signal": "Signal",
       "SpeedSection": "Vitesse limite",
       "Switch": "Aiguillage",
+      "SwitchType": "Type d'aiguillage",
       "TrackSection": "Section de voie"
     },
     "tools": {
@@ -389,6 +392,7 @@
         "link": "Lien",
         "no-track-picked-yet": "Aucune voie n'a encore été sélectionnée",
         "point_switch": "Branchement 2 voies",
+        "port": "Port {{portId}}",
         "single_slip_switch": "Traversée jonction simple",
         "switch-type": "Type d'aiguillage",
         "switch_type_w_port_count_one": "{{type}} ({{count}} port)",

--- a/front/scripts/i18n-checker.ts
+++ b/front/scripts/i18n-checker.ts
@@ -12,9 +12,6 @@ const IGNORE_MISSING: RegExp[] = [
   /stdcm-help-section:externalSupport/,
   /stdcm-help-section:sections/,
   /stdcm:stdcmErrors\..*/,
-  /translation:Editor.obj-types.NeutralSection/,
-  /translation:Editor.obj-types.SwitchType/,
-  /translation:Editor.obj-types.OperationalPoint/,
 ];
 
 const IGNORE_UNUSED: RegExp[] = [

--- a/front/src/applications/editor/tools/switchEdition/components/TrackSectionEndpointSelector.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/TrackSectionEndpointSelector.tsx
@@ -110,7 +110,7 @@ const TrackSectionEndpointSelector = ({
 
   return (
     <div className="mb-4">
-      {schema.title && <h5>{schema.title}</h5>}
+      <h5>{t(`Editor.tools.switch-edition.port`, { portId })}</h5>
       {schema.description && <p>{schema.description}</p>}
       {duplicateWith.map(({ track, port }, i) => (
         <div className="text-danger small font-weight-bold" key={`${name}-${track}-${i}`}>


### PR DESCRIPTION
Close #13397

Based on #13491 by @Akctarus 

We drop the "port::" prefix of the port names (of the form "port::A1") as t expects :: to be a namespace indicator, not part of the key. Also we don't want to add these keys to the python schema, as it already has a generic ports property.

Also worth mentioning that while we can't edit Ops yet, we can hover them, which displays a broken translation string currently (as pointed out in the comments of the issue).