### PR TITLE
editoast: authz: remove `StorageDriver::ensure_group`

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -118,7 +118,6 @@ mod tests {
     use super::*;
     use crate::Role;
     use crate::authz_client;
-    use crate::identity::GroupInfo;
     use crate::identity::User;
     use crate::mock_driver::MockAuthDriver;
     use crate::model;
@@ -270,9 +269,6 @@ mod tests {
             identities: vec![bob_identity()],
             name: "Bob".to_owned(),
         };
-        let friends = || GroupInfo {
-            name: "friends".to_owned(),
-        };
 
         let regulator = Regulator::new(authz_client!(), MockAuthDriver::default());
         let regulator = move || regulator.clone();
@@ -290,13 +286,7 @@ mod tests {
             .await
             .expect("bob should be created")
             .id;
-        let friends = model::Group(
-            regulator()
-                .driver
-                .ensure_group(&friends())
-                .await
-                .expect("group should be created"),
-        );
+        let friends = model::Group(0);
 
         // add members
         v2::add_members(friends, HashSet::from([User(alice_id), User(bob_id)]))

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -262,16 +262,6 @@ mod mock_driver {
             })
         }
 
-        async fn ensure_group(&self, group: &GroupInfo) -> Result<i64, Self::Error> {
-            let mut groups = self.groups.lock().unwrap();
-            let group_id = {
-                let id = self.counter.read().unwrap();
-                *groups.entry(group.name.clone()).or_insert(*id)
-            };
-            *self.counter.write().unwrap() += 1;
-            Ok(group_id)
-        }
-
         async fn get_user_id(
             &self,
             user_identity: &UserIdentity,

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -74,11 +74,6 @@ pub trait StorageDriver: Clone {
         user: &UserIdentity,
     ) -> impl Future<Output = Result<UserSubject, Self::Error>> + Send;
 
-    fn ensure_group(
-        &self,
-        group: &GroupInfo,
-    ) -> impl Future<Output = Result<i64, Self::Error>> + Send;
-
     fn add_user_identities(
         &self,
         user_identity: Either<i64, String>,

--- a/editoast/editoast_models/src/auth_driver.rs
+++ b/editoast/editoast_models/src/auth_driver.rs
@@ -179,37 +179,6 @@ impl StorageDriver for PgAuthDriver {
         .await
     }
 
-    #[tracing::instrument(skip_all, fields(%group), ret(level = Level::DEBUG), err)]
-    async fn ensure_group(&self, group: &GroupInfo) -> Result<i64, Self::Error> {
-        let conn = self.pool.get().await?;
-        conn.transaction(async move |conn| {
-            let group_id = authn_group::table
-                .select(authn_group::id)
-                .filter(authn_group::name.eq(&group.name))
-                .first::<i64>(conn.write().await.deref_mut())
-                .await
-                .optional()?;
-            match group_id {
-                Some(group_id) => {
-                    tracing::debug!(group_id, "group already exists in db");
-                    Ok(group_id)
-                }
-
-                None => {
-                    tracing::info!("registering new group in db");
-                    let id = dsl::insert_into(authn_group::table)
-                        .values(authn_group::name.eq(&group.name))
-                        .returning(authn_group::id)
-                        .get_result(conn.write().await.deref_mut())
-                        .await?;
-
-                    Ok(id)
-                }
-            }
-        })
-        .await
-    }
-
     #[tracing::instrument(skip_all, fields(identities, user = %user_identity), ret(level = Level::DEBUG), err)]
     async fn add_user_identities(
         &self,

--- a/editoast/editoast_models/src/authn/group.rs
+++ b/editoast/editoast_models/src/authn/group.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use editoast_derive::Model;
 use serde::Deserialize;
 use serde::Serialize;
@@ -5,8 +6,47 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Hash, Clone, Model, ToSchema, Serialize, Deserialize, PartialEq, Eq)]
 #[model(table = database::tables::authn_group)]
-#[model(gen(ops = rd, list, batch_ops = r))]
+#[model(gen(ops = crd, list, batch_ops = r))]
 pub struct Group {
     pub id: i64,
+    #[model(identifier)]
     pub name: String,
+}
+
+impl Group {
+    #[tracing::instrument(skip_all, fields(%name), ret(level = "debug"), err)]
+    pub async fn upsert(conn: database::DbConnection, name: String) -> Result<Self, crate::Error> {
+        conn.transaction(async move |mut conn| {
+            if let Some(group) = Self::retrieve(conn.clone(), name.clone()).await? {
+                Ok(group)
+            } else {
+                let group = Self::changeset().name(name).create(&mut conn).await?;
+                tracing::debug!(?group, "group created");
+                Ok(group)
+            }
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn group_upsert() {
+        let pool = database::DbConnectionPoolV2::for_tests();
+
+        let created = Group::upsert(pool.get_ok(), "tom and jerry".to_string())
+            .await
+            .expect("failed to insert group");
+        assert_eq!(created.name, "tom and jerry");
+
+        let updated = Group::upsert(pool.get_ok(), "tom and jerry".to_string())
+            .await
+            .expect("failed to upsert existing group");
+        assert_eq!(updated, created);
+    }
 }

--- a/editoast/src/client/garbage_collector.rs
+++ b/editoast/src/client/garbage_collector.rs
@@ -213,7 +213,6 @@ mod tests {
     use crate::fixtures::create_scenario_fixtures_set;
     use crate::fixtures::create_timetable;
     use authz::StorageDriver;
-    use authz::identity::GroupInfo;
     use editoast_models::PgAuthDriver;
     use editoast_models::stdcm_search_environment::StdcmSearchEnvironment;
     use editoast_models::stdcm_search_environment::fixtures::stdcm_search_env_fixtures;
@@ -337,20 +336,16 @@ mod tests {
                 .id,
         );
         let existing_group = authz::Group(
-            driver
-                .ensure_group(&GroupInfo {
-                    name: "existing-group".into(),
-                })
+            Group::upsert(db_pool.get_ok(), "existing-group".into())
                 .await
-                .unwrap(),
+                .unwrap()
+                .id,
         );
         let orphan_group = authz::Group(
-            driver
-                .ensure_group(&GroupInfo {
-                    name: "orphan-group".into(),
-                })
+            Group::upsert(db_pool.get_ok(), "orphan-group".into())
                 .await
-                .unwrap(),
+                .unwrap()
+                .id,
         );
 
         // Write tuples: direct users + group usersets, on both the existing and orphan infra

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -14,7 +14,6 @@ use database::DbConnectionPoolV2;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use editoast_models::PgAuthDriver;
 use editoast_models::prelude::*;
 
 use crate::authorizers::Rejection;
@@ -73,11 +72,12 @@ pub struct DeleteArgs {
     name: String,
 }
 
-pub async fn create_group(args: CreateArgs, pool: Arc<DbConnectionPoolV2>) -> anyhow::Result<()> {
-    let driver = PgAuthDriver::new(pool);
-    let group_info = GroupInfo { name: args.name };
-    let id = driver.ensure_group(&group_info).await?;
-    tracing::info!(name = group_info.name, id, "Group created");
+pub async fn create_group(
+    CreateArgs { name }: CreateArgs,
+    pool: Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<()> {
+    let editoast_models::Group { id, .. } =
+        editoast_models::Group::upsert(pool.get().await?, name).await?;
     println!("{id}");
     Ok(())
 }

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -589,11 +589,11 @@ impl<'a> GroupBuilder<'a> {
         }
         let regulator = &app.app_state.regulator;
 
-        let id = regulator
-            .driver()
-            .ensure_group(&info)
-            .await
-            .expect("Group should be created successfully");
+        let id =
+            editoast_models::Group::upsert(app.db_pool().get().await.unwrap(), info.name.clone())
+                .await
+                .expect("group should be created successfully")
+                .id;
         let group = authz::identity::Group { id, info };
         if !authz_disabled {
             let group_auth = authz::Group(group.id);


### PR DESCRIPTION
refs https://github.com/osrd-project/osrd-confidential/issues/1168

This PR, like a bunch of similar ones linked in https://github.com/osrd-project/osrd-confidential/issues/1168, removes calls to `StorageDriver` outside of code we're migrating out of. As a reminder, `StorageDriver`, `Regulator` and `authz::Authorizer` (not `authz::v2::Authorizer`) will be removed. Many functions were wrongfully added to the `StorageDriver` instead of using the database directly. `ensure_group` is one of those. By converting `Regulator` functions to our new `Protected` interface we already reduce the usage area of the `StorageDriver`. But there are other use cases, in the CLI especially.