### PR TITLE
core: avoid blocking multiple threads on timetable load

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -86,6 +86,7 @@ class TimetableCacheManager(
     private val mutexes = ConcurrentHashMap<String, Mutex>()
 
     private val fetchDispatcher = Dispatchers.IO
+    private val scope = CoroutineScope(fetchDispatcher + SupervisorJob())
 
     private val logger = LoggerFactory.getLogger(TimetableCacheManager::class.java)
 
@@ -101,39 +102,48 @@ class TimetableCacheManager(
             if (disableAllCaching) {
                 logger.info("Cache disabled")
                 return@coroutineScope withContext(fetchDispatcher) {
-                    return@withContext fetchTimetableRequirements(infra, timetableId, cacheKey)
+                    fetchTimetableRequirements(infra, timetableId, cacheKey)
                 }
             }
             cache[cacheKey]?.let {
                 logger.debug("Timetable cache hit for ID $timetableId")
                 return@coroutineScope it
             }
-
             val mutex = mutexes.computeIfAbsent(cacheKey) { Mutex() }
             mutex.withLock {
                 try {
                     cache[cacheKey]?.let {
                         return@coroutineScope it
                     }
-                    logger.info("Start computing timetable requirements")
-                    val requirements: STDCMTimetableData
-                    val time = measureTime {
-                        requirements =
-                            withContext(fetchDispatcher) {
-                                fetchTimetableRequirements(infra, timetableId, cacheKey)
-                            }
-                    }
-                    cache[cacheKey] = requirements
-                    val nEntries = requirements.zoneUses.entries.sumOf { it.value.asRanges().size }
-                    logger.info(
-                        "timetable requirements computed in ${time.inWholeSeconds} seconds, $nEntries map entries"
-                    )
-                    return@coroutineScope requirements
+                    fetchAndCache(infra, timetableId, cacheKey)
                 } finally {
                     mutexes.remove(cacheKey)
                 }
             }
         }
+
+    /** Starts loading timetable data in the background. Noop if already loaded or loading. */
+    fun startLoading(infra: FullInfra, timetableId: TimetableId) {
+        if (disableAllCaching) return
+        val cacheKey = getCacheKey(infra, timetableId)
+        if (cache.containsKey(cacheKey)) return
+        val mutex = mutexes.computeIfAbsent(cacheKey) { Mutex() }
+        if (!mutex.tryLock()) return
+        scope.launch {
+            try {
+                fetchAndCache(infra, timetableId, cacheKey)
+            } finally {
+                mutex.unlock()
+                mutexes.remove(cacheKey)
+            }
+        }
+    }
+
+    /** Returns true if the timetable data is already in the in-memory cache. */
+    fun isLoaded(infra: FullInfra, timetableId: TimetableId): Boolean {
+        if (disableAllCaching) return true
+        return cache.containsKey(getCacheKey(infra, timetableId))
+    }
 
     /** Generates a string key for a given infra + timetable. */
     fun getCacheKey(infra: FullInfra, timetableId: TimetableId): String {
@@ -146,6 +156,27 @@ class TimetableCacheManager(
     @WithSpan(value = "Preloading timetable content", kind = SpanKind.SERVER)
     fun load(infra: FullInfra, timetableId: TimetableId) {
         if (!disableAllCaching) runBlocking { get(infra, timetableId) }
+    }
+
+    private suspend fun fetchAndCache(
+        infra: FullInfra,
+        timetableId: TimetableId,
+        cacheKey: String,
+    ): STDCMTimetableData {
+        logger.info("Start computing timetable requirements")
+        val requirements: STDCMTimetableData
+        val time = measureTime {
+            requirements =
+                withContext(fetchDispatcher) {
+                    fetchTimetableRequirements(infra, timetableId, cacheKey)
+                }
+        }
+        cache[cacheKey] = requirements
+        val nEntries = requirements.zoneUses.entries.sumOf { it.value.asRanges().size }
+        logger.info(
+            "timetable requirements computed in ${time.inWholeSeconds} seconds, $nEntries map entries"
+        )
+        return requirements
     }
 
     @WithSpan(kind = SpanKind.SERVER)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
@@ -25,11 +25,15 @@ class WorkerLoadEndpoint(
                 adapterRequest.fromJson(body)
                     ?: return RsWithStatus(RsText("missing request body"), 400)
 
-            // load infra and timetable
             val infra = infraManager.load(request.infra, request.expectedVersion)
-            if (request.timetable != null) timetableManager.load(infra, request.timetable!!)
+            val timetableId = request.timetable
+            if (timetableId != null) timetableManager.startLoading(infra, timetableId)
+            val isLoaded = timetableId == null || timetableManager.isLoaded(infra, timetableId)
 
-            return RsWithStatus(RsWithBody(""), 204)
+            return RsWithStatus(
+                RsWithBody(responseAdapterRequest.toJson(WorkerLoadResponse(isLoaded))),
+                200,
+            )
         } catch (ex: Throwable) {
             // TODO: include warnings in the response
             return ExceptionHandler.handle(ex)
@@ -52,5 +56,17 @@ class WorkerLoadEndpoint(
                 .addLast(KotlinJsonAdapterFactory())
                 .build()
                 .adapter(WorkerLoadRequest::class.java)
+
+        @JvmField
+        val responseAdapterRequest: JsonAdapter<WorkerLoadResponse?> =
+            Moshi.Builder()
+                .addLast(KotlinJsonAdapterFactory())
+                .build()
+                .adapter(WorkerLoadResponse::class.java)
     }
+
+    data class WorkerLoadResponse(
+        /** Is everything loaded */
+        var loaded: Boolean
+    )
 }

--- a/core/src/test/java/fr/sncf/osrd/api/WorkerLoadingTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/api/WorkerLoadingTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.CsvSource
 @OptIn(ExperimentalSerializationApi::class)
 class WorkerLoadingTest : ApiTest() {
     @ParameterizedTest
-    @CsvSource("true, 400", "false, 204")
+    @CsvSource("true, 400", "false, 200")
     @Throws(IOException::class)
     fun infraLoadEndpoint_act_request_returns_correct_responses(
         isRequestNull: Boolean,

--- a/editoast/core_client/src/worker_load.rs
+++ b/editoast/core_client/src/worker_load.rs
@@ -1,5 +1,7 @@
+use serde::Deserialize;
 use serde::Serialize;
 
+use crate::Json;
 use crate::WorkerKey;
 
 use super::AsCoreRequest;
@@ -13,7 +15,13 @@ pub struct WorkerLoadRequest {
     pub timetable: Option<i64>,
 }
 
-impl AsCoreRequest<()> for WorkerLoadRequest {
+/// A Core infra load response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct WorkerLoadResponse {
+    pub loaded: bool,
+}
+
+impl AsCoreRequest<Json<WorkerLoadResponse>> for WorkerLoadRequest {
     const URL_PATH: &'static str = "/worker_load";
     const OVERRIDE_TIMEOUT: Option<std::time::Duration> = Some(std::time::Duration::from_secs(1));
 

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -5,6 +5,7 @@ use core_client::AsCoreRequest;
 use core_client::Error as CoreClientError;
 use core_client::mq_client::MqClientError;
 use core_client::worker_load::WorkerLoadRequest;
+use core_client::worker_load::WorkerLoadResponse;
 use editoast_derive::EditoastError;
 use editoast_models::prelude::*;
 use serde::Deserialize;
@@ -122,7 +123,8 @@ pub(in crate::views) async fn worker_load(
     let status = infra_request.fetch(core_client.as_ref()).await;
 
     let status = match status {
-        Ok(()) => WorkerStatus::Ready,
+        Ok(WorkerLoadResponse { loaded: true }) => WorkerStatus::Ready,
+        Ok(WorkerLoadResponse { loaded: false }) => WorkerStatus::NotReady,
         Err(CoreClientError::MqClientError(MqClientError::ResponseTimeout)) => {
             // Treat timeout as NotReady
             WorkerStatus::NotReady
@@ -136,23 +138,27 @@ pub(in crate::views) async fn worker_load(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::fixtures::create_empty_infra;
+    use crate::views::test_app::TestAppBuilder;
     use core_client::CoreClient;
     use core_client::mocking::MockingClient;
     use database::DbConnectionPoolV2;
     use reqwest::StatusCode;
+    use rstest::rstest;
+    use serde_json::json;
 
-    use crate::models::fixtures::create_empty_infra;
-    use crate::views::test_app::TestAppBuilder;
-
+    #[rstest]
+    #[case(true, WorkerStatus::Ready)]
+    #[case(false, WorkerStatus::NotReady)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn worker_load_test() {
+    async fn worker_load_test(#[case] loaded: bool, #[case] expected: WorkerStatus) {
         let db_pool = DbConnectionPoolV2::for_tests();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let mut core = MockingClient::default();
         core.stub("/worker_load")
             .response(StatusCode::OK)
-            .body("")
+            .json(json!({ "loaded": loaded }))
             .finish();
 
         let app = TestAppBuilder::new()
@@ -168,6 +174,6 @@ mod tests {
             .await
             .assert_status(StatusCode::OK)
             .json_into();
-        assert_eq!(response, WorkerStatus::Ready);
+        assert_eq!(response, expected);
     }
 }


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16366

Note: several threads can still be stuck together *during the infra loading stage*, but it's less of an issue: it has no external dependency (no deadlock), the worker is likely unable to process other requests while an infra is loaded anyway, and it's much shorter. 