### PR TITLE
ci: allow uppercase in submodule names in commit titles

### DIFF
--- a/.github/scripts/check-commit-titles.sh
+++ b/.github/scripts/check-commit-titles.sh
@@ -32,7 +32,7 @@ check_forbidden_chars() {
 
 # shellcheck disable=SC2329 # Called indirectly
 check_structure() {
-    if grep -q -E -v '^([-_.a-z0-9]+[,:] )*[-_.a-z0-9]+: [a-z](:[^ ]|[^:])*$'; then
+    if grep -q -E -v '^([-_.a-z0-9]+, )*[-_.a-z0-9]+: (([-_.[:alnum:]]+, )*[-_.[:alnum:]]+: )*[a-z]([^:]|:[^ ])*$'; then
         echo 'Invalid commit title structure'
     fi
 }
@@ -87,7 +87,8 @@ The following characters are forbidden:
   - #
 
 Commit title structure has to be as follows:
-  - one or more module names ([-_.a-z]+), separated by comma or colon, terminated by ": "
+  - one or more module names ([-_.a-z0-9]+), separated by ", ", terminated by ": "
+  - optionally one or more group of submodule names (alphanumeric), submodules separated by ", ", groups terminated by ": "
   - the actual title, starting with a lowercase letter and not containing ": "
 EOF
 exit 1


### PR DESCRIPTION
This would make some commit titles more legible