### PR TITLE
backport: editoast: disable payload compression for stdcm endpoint

### DIFF
--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -6,7 +6,9 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
+use axum::http::header;
 use axum::response::IntoResponse;
+use axum::response::Response;
 use axum_streams::StreamBodyAs;
 use chrono::DateTime;
 use chrono::Duration;
@@ -236,7 +238,7 @@ pub(in crate::views) async fn stdcm_handler(
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
     returned_request: &mut Option<core_client::stdcm::Request>,
-) -> Result<impl IntoResponse + use<>> {
+) -> Result<Response> {
     let authorized = auth
         .check_roles([authz::Role::Stdcm].into())
         .await
@@ -356,7 +358,7 @@ pub(in crate::views) async fn stdcm_handler(
             error: failure.simulation,
             core_payload: None,
         };
-        return Ok(StreamBodyAs::json_nl(stream::once(async { payload })));
+        return Ok(StreamBodyAs::json_nl(stream::once(async { payload })).into_response());
     }
 
     let total_simulation_run_time = runs
@@ -489,7 +491,15 @@ pub(in crate::views) async fn stdcm_handler(
         }
     });
     let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
-    Ok(StreamBodyAs::json_nl(stream))
+    // Set `Content-Encoding` header to `identity` to not compress the payloads
+    // This made the lmr live search progress display very laggy because the compression
+    // layer compresses 8KB at a time which we do not wish to wait for (8KB of core intermediate
+    // payloads is about 50 of them which is a lot to wait for)
+    Ok((
+        [(header::CONTENT_ENCODING, "identity")],
+        StreamBodyAs::json_nl(stream),
+    )
+        .into_response())
 }
 
 struct VirtualTrainRun {


### PR DESCRIPTION
This made the lmr live progress tracking very laggy as we needed to fill the gzip compression layer's internal buffer before it sent the compressed payload. This buffer is 8KB in size which represents roughly 50 intermediate payloads (about half of a long path) which made the front receive all the points at once at the end of the request