### PR TITLE
backport: core, front: move point filtering logic from front to core

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/ProgressLogger.kt
@@ -13,6 +13,7 @@ import fr.sncf.osrd.utils.units.seconds
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import java.time.Instant
+import kotlin.math.absoluteValue
 import kotlin.math.pow
 
 /**
@@ -30,6 +31,14 @@ data class ProgressLogger(
     private var seenSteps = 0
     private var nextMemoryReport =
         Instant.now() + java.time.Duration.ofMillis(memoryReportTimeInterval.milliseconds)
+
+    // A mapping between a geographical location (lat, lon with 1/10th precision) and the time
+    // of when it was last added.
+    // Used to filter points to send to the queue for the live search progression display
+    private val geopointFilteringCache = HashMap<Int, Long>()
+    // The time for which an entry is considered valid in the cache.
+    // 2 seconds
+    private val geopointEvictionTime = (2 * 10e9).toLong()
 
     /** Process one node, logging it if it reaches a new threshold */
     fun processNode(node: STDCMNode) {
@@ -100,7 +109,20 @@ data class ProgressLogger(
                 bestTravelTime = bestTravelTime,
             )
 
-        callback?.let { it(data) }
+        val latKey = kotlin.math.round(geo.lat * 10).toInt() + 900
+        val lonKey = kotlin.math.round(geo.lon * 10).toInt() + 1800
+        val cacheKey = latKey * 3601 + lonKey
+
+        val cacheEntry = geopointFilteringCache.get(cacheKey)
+
+        if (
+            cacheEntry == null ||
+                (cacheEntry - System.nanoTime()).absoluteValue > geopointEvictionTime
+        ) {
+            geopointFilteringCache[cacheKey] = System.nanoTime()
+            callback?.let { it(data) }
+        }
+
         return data
     }
 }

--- a/front/src/applications/stdcm/components/StdcmMapProgressLayer.tsx
+++ b/front/src/applications/stdcm/components/StdcmMapProgressLayer.tsx
@@ -163,10 +163,7 @@ const StdcmMapProgressLayer = ({
           // Point timestamp can be in the futur. If so its delta time is O except if it override a previous point
           // In this case it takes the max animation value
           const deltaTime = Date.now() - point.animationStartTime;
-          let elapsedTime = deltaTime;
-          if (deltaTime < 0) {
-            elapsedTime = point.skipFadeIn ? ANIMATION_STEPS.at(-1)!.time : 0;
-          }
+          const elapsedTime = Math.max(0, deltaTime);
           const animation = ANIMATIONS.find(
             (a) => a.timeRange.min <= elapsedTime && elapsedTime < a.timeRange.max
           )!;

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -11,7 +11,6 @@ import {
   STDCM_TRAIN_TIMETABLE_ID,
 } from 'applications/stdcm/consts';
 import type {
-  StdcmProgressPoint,
   StdcmProgressPoints,
   StdcmRequestStatus,
   StdcmSimulation,
@@ -223,11 +222,6 @@ const useStdcm = ({
     try {
       const { subscribe, unsubscribe } = postTimetableByIdStdcm(payload);
       abortRequests.current = [unsubscribe];
-      // This Map acts as a spatial grid.
-      // The key is built from rounded coordinates (toFixed(1)),
-      // allowing nearby points to be grouped into the same grid cell
-      // and avoiding storing too many very close points
-      const pointsOnGrid = new Map<string, StdcmProgressPoint>();
 
       // We can receive many points at the same timestamp. To avoid displaying them at once,
       // we track the number of nodes received at the same timestamp to be able to add a delay
@@ -250,17 +244,7 @@ const useStdcm = ({
               geoPoint: event.data.point,
               animationStartTime: lastPointReceivedAt.timestamp + 10 * lastPointReceivedAt.nb,
             };
-            const newPointKey = newPoint.geoPoint.coordinates.map((n) => n.toFixed(1)).join('/');
-            const pointOnGrid = pointsOnGrid.get(newPointKey);
-
-            if (!pointOnGrid) {
-              pointsOnGrid.set(newPointKey, newPoint);
-              // If a point is already present, we check that its animation is ended before to replace it to avoid blink effect
-              // and we set that if this new point override a previous one
-            } else if (now - pointOnGrid.animationStartTime > 2000) {
-              pointsOnGrid.set(newPointKey, { ...newPoint, skipFadeIn: true });
-            }
-            progressPoints.current = [...pointsOnGrid.values()];
+            progressPoints.current = [...progressPoints.current, newPoint];
             break;
           }
           case 'completed': {

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -264,10 +264,5 @@ export type StdcmProgressPoint = {
    *  don't all appear together (can be in the future).
    */
   animationStartTime: number;
-  /** If true, show the point directly in its final state and skip the
-   *  fade-in. Used when a new point replaces an old one whose animation
-   *  was already done.
-   */
-  skipFadeIn?: boolean;
 };
 export type StdcmProgressPoints = StdcmProgressPoint[];


### PR DESCRIPTION
This is done to avoid spamming the queue with unnecessary points. A fairly long path now sends about a hundred points to the queue instead of several thousands