### PR TITLE
docker: make the telemetry optional (off by default)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
       VALKEY_URL: "redis://valkey"
       DATABASE_URL: "postgres://osrd:password@postgres/osrd"
       OSRDYNE_API_URL: "http://osrdyne:4242/"
-      TELEMETRY_KIND: "opentelemetry"
+      TELEMETRY_KIND: "none"
       TELEMETRY_ENDPOINT: "http://jaeger:4317"
       OSRD_MQ_URL: "amqp://osrd:password@rabbitmq:5672/%2f"
       FGA_API_URL: "http://openfga:8091"
@@ -241,6 +241,8 @@ services:
   jaeger:
     image: jaegertracing/jaeger:latest
     container_name: osrd-jaeger
+    profiles:
+      - telemetry
     restart: unless-stopped
     ports:
       - "4317:4317"

--- a/docker/docker-compose.telemetry.yml
+++ b/docker/docker-compose.telemetry.yml
@@ -1,0 +1,8 @@
+services:
+  core:
+    environment:
+      CORE_MONITOR_TYPE: "opentelemetry"
+
+  editoast:
+    environment:
+      TELEMETRY_KIND: "opentelemetry"

--- a/osrd-compose
+++ b/osrd-compose
@@ -21,6 +21,7 @@ Flags (optional, can be combined):
   sw           Enable single worker mode (docker/docker-compose.single-worker.yml)
   host         Use host networking mode (docker/docker-compose.host.yml)
   playwright   Start playwright container with the stack (docker/docker-compose.playwright.yml)
+  telemetry    Activate telemetry on the webservices and start Jaeger (docker/docker-compose.telemetry.yml)
   default      Reset to base configuration only and clear saved state
 
 Examples:
@@ -61,7 +62,7 @@ while [[ $# -gt 0 ]]; do
             DEFAULT_FLAG=true
             shift
             ;;
-        dev-front|ext-front|sw|host|playwright)
+        dev-front|ext-front|sw|host|playwright|telemetry)
             flags+=("$1")
             shift
             ;;
@@ -152,6 +153,12 @@ if has_flag "playwright"; then
 
     compose_files+=("$OVERRIDE_DIR/docker-compose.playwright.yml")
 fi
+
+if has_flag "telemetry"; then
+    compose_files+=("$OVERRIDE_DIR/docker-compose.telemetry.yml")
+    export COMPOSE_PROFILES=telemetry
+fi
+
 
 # Check if DOCKER_SOCKET is already set
 if [ -z "$DOCKER_SOCKET" ]; then


### PR DESCRIPTION
We start a lot of services to launch the OSRD stack, but for daily development, some of them are not necessary, and still use some memory and CPU. Let’s make them optional and do not start them by default.