### PR TITLE
editoast: rewrite list_authorized_infra in authz::v2

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -71,14 +71,6 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
-    pub async fn list_authorized_infra(
-        &self,
-    ) -> Result<Authorization<Vec<Infra>>, Error<S::Error>> {
-        self.regulator
-            .list_authorized_infra(&User(self.user_id))
-            .await
-    }
-
     pub async fn give_infra_grant(
         &self,
         subject: &Subject,

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -156,6 +156,7 @@ pub struct RollingStock(pub i64);
     Eq,
     Hash,
 )]
+#[cfg_attr(test, derive(PartialOrd, Ord))]
 pub struct Infra(pub i64);
 
 #[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -239,24 +239,6 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(Authorization::from_privilege_check(check))
     }
 
-    /// Get IDS of infras a subject can read
-    pub async fn list_authorized_infra(
-        &self,
-        user: &User,
-    ) -> Result<Authorization<Vec<Infra>>, Error<S::Error>> {
-        // Bypass if user is an admin
-        if self.is_admin(user).await? {
-            return Ok(Authorization::Bypassed);
-        }
-
-        let infra_list = self
-            .openfga
-            .list_objects(Infra::can_read().query_objects(user))
-            .await?;
-
-        Ok(Authorization::Granted(infra_list))
-    }
-
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn give_infra_grant_unchecked(
         &self,

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -319,6 +319,36 @@ impl<'a, T, R: std::fmt::Debug> Access<'a, T, R> {
     }
 }
 
+/// Represents the list authorized resources returned by a [`Protected`] operation.
+///
+/// This enum can either represent the list of objects returned by openfga after looking up user
+/// permissions on a given resource type, or the [`AuthorizedResources::All`] bypass variant if
+/// the authorization was not checked against openfga as the user is an admin and would have had
+/// access to all objects of that resource type anyway.
+///
+/// Bypassing the authorization check prevents sending unnecessary queries with possibly massive
+/// response payloads, as for example the full list of existing infras when checking which infras
+/// an admin has access to. To retrieve all objects of one kind from the authorization store, we need to retrieve all tuples
+/// related to objects of that type and there is no way to do that only for tuples containing a
+/// specific type so we end up retrieving all tuples from the store and then filtering them per
+/// object type.
+#[cfg_attr(test, derive(PartialOrd, Ord, PartialEq, Eq))]
+pub enum ResourcesList<T: fga::model::Type> {
+    /// All objects of the given type are authorized, openfga was not called.
+    All,
+    /// The list of authorized objects returned by Openfga.
+    Privileged(Vec<T>),
+}
+
+impl<T: fga::model::Type> ResourcesList<T> {
+    pub fn unwrap_privileged(self) -> Vec<T> {
+        match self {
+            ResourcesList::All => panic!("enum is not a List::Privileged variant"),
+            ResourcesList::Privileged(objects) => objects,
+        }
+    }
+}
+
 pub mod special_authorizers {
     use std::convert::Infallible;
 

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -15,6 +15,8 @@ use crate::User;
 use crate::v2::Actor;
 use crate::v2::Check;
 use crate::v2::Protected;
+use crate::v2::ResourcesList;
+use crate::v2::subject_roles;
 
 /// Returns the *direct grant* a subject has on an [Infra], if any
 ///
@@ -309,6 +311,55 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
             infra,
         ))
         .with_check(Check::InfraExists(infra))
+}
+
+pub fn infra_list(user: User, privilege: InfraPrivilege) -> Protected<ResourcesList<Infra>> {
+    subject_roles(Subject::user(user)).map(move |openfga, roles| {
+        async move {
+            if roles.contains(&Role::Admin) {
+                return Ok(ResourcesList::All);
+            }
+            let authorized_infras = match privilege {
+                InfraPrivilege::CanRead => {
+                    openfga
+                        .list_objects(Infra::can_read().query_objects(&user))
+                        .await?
+                }
+                InfraPrivilege::CanShareRead => {
+                    openfga
+                        .list_objects(Infra::can_share_read().query_objects(&user))
+                        .await?
+                }
+                InfraPrivilege::CanWrite => {
+                    openfga
+                        .list_objects(Infra::can_write().query_objects(&user))
+                        .await?
+                }
+                InfraPrivilege::CanShareWrite => {
+                    openfga
+                        .list_objects(Infra::can_share_write().query_objects(&user))
+                        .await?
+                }
+                InfraPrivilege::CanDelete => {
+                    openfga
+                        .list_objects(Infra::can_delete().query_objects(&user))
+                        .await?
+                }
+                InfraPrivilege::CanShareOwnership => {
+                    openfga
+                        .list_objects(Infra::can_share_ownership().query_objects(&user))
+                        .await?
+                }
+                InfraPrivilege::CanRevoke => {
+                    openfga
+                        .list_objects(Infra::can_revoke().query_objects(&user))
+                        .await?
+                }
+            };
+            Ok(ResourcesList::Privileged(authorized_infras))
+        }
+        .boxed()
+    })
 }
 
 #[cfg(test)]
@@ -631,5 +682,68 @@ mod tests {
         expected.sort();
         response.sort();
         assert_eq!(response, expected);
+    }
+
+    #[tokio::test]
+    async fn infra_list() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&Infra::reader().tuple(&User(1), &Infra(1)))
+            .write(&Infra::reader().tuple(&User(1), &Infra(3)))
+            .write(&Infra::writer().tuple(&User(2), &Infra(2)))
+            .write(&User::role().tuple(&Role::Admin, &User(3)))
+            .execute()
+            .await
+            .unwrap();
+        let infras_1 = openfga
+            .infra_list(User(1), InfraPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let infras_2 = openfga
+            .infra_list(User(2), InfraPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let infras_no_rights = openfga
+            .infra_list(User(4), InfraPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        let infras_admin = openfga.infra_list(User(3), InfraPrivilege::CanRead).await;
+        assert_eq!(infras_1.sorted().collect_vec(), vec![Infra(1), Infra(3)]);
+        assert_eq!(infras_2.sorted().collect_vec(), vec![Infra(2)]);
+        assert_eq!(infras_no_rights, vec![]);
+        assert!(matches!(infras_admin, ResourcesList::All));
+    }
+
+    #[tokio::test]
+    async fn infra_list_different_privileges() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&Infra::reader().tuple(&User(1), &Infra(1)))
+            .write(&Infra::writer().tuple(&User(2), &Infra(1)))
+            .execute()
+            .await
+            .unwrap();
+        let infras_read_user_1 = openfga.infra_list(User(1), InfraPrivilege::CanRead).await;
+        let infras_read_user_2 = openfga.infra_list(User(2), InfraPrivilege::CanRead).await;
+        let infras_write_user_1 = openfga.infra_list(User(1), InfraPrivilege::CanWrite).await;
+        let infras_write_user_2 = openfga.infra_list(User(2), InfraPrivilege::CanWrite).await;
+        let (infras_1, infras_2) = (
+            infras_read_user_1.unwrap_privileged(),
+            infras_read_user_2.unwrap_privileged(),
+        );
+        // Both users should have the infra listed as readable
+        assert_eq!(infras_1, vec![Infra(1)]);
+        assert_eq!(infras_2, vec![Infra(1)]);
+        let (infras_1, infras_2) = (
+            infras_write_user_1.unwrap_privileged(),
+            infras_write_user_2.unwrap_privileged(),
+        );
+        // Only user_2 with reader grant should see the infra as being writable
+        assert_eq!(infras_1, vec![]);
+        assert_eq!(infras_2, vec![Infra(1)]);
     }
 }

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -10,9 +10,10 @@ use crate::InfraPrivilege;
 use crate::Role;
 use crate::RollingStock;
 use crate::RollingStockGrant;
-use crate::RollingStockPrivilege;
 use crate::Subject;
 use crate::User;
+use crate::model::RollingStockPrivilege;
+use crate::v2::ResourcesList;
 use crate::v2::infra_direct_grant;
 use crate::v2::infra_effective_grant;
 use crate::v2::infra_granted_subjects;
@@ -37,7 +38,7 @@ pub trait TestClientExt {
     async fn infra_revoke_grant(&self, subject: Subject, infra: Infra) -> bool;
     async fn infra_privileges(&self, user: User, infra: Infra) -> HashSet<InfraPrivilege>;
     async fn infra_granted_subjects(&self, infra: Infra, grant: InfraGrant) -> Vec<Subject>;
-
+    async fn infra_list(&self, user: User, privilege: InfraPrivilege) -> ResourcesList<Infra>;
     async fn rolling_stock_privileges(
         &self,
         user: User,
@@ -236,5 +237,13 @@ impl TestClientExt for fga::Client {
             }
         }
         .unwrap()
+    }
+
+    async fn infra_list(&self, user: User, privilege: InfraPrivilege) -> ResourcesList<Infra> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(crate::v2::infra::infra_list(user, privilege))
+            .await
+            .unwrap()
     }
 }

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -37,7 +37,6 @@ use ::core::str;
 
 use ::authz::Authorization;
 use ::authz::Authorizer;
-use ::authz::Infra;
 use core_client::CoreClient;
 use editoast_derive::EditoastError;
 use editoast_models::PgAuthDriver;
@@ -484,18 +483,6 @@ impl Authentication {
                 .map_err(Into::into)?
                 .allowed()
                 .map_err(|_| AuthorizationError::Forbidden),
-        }
-    }
-
-    /// Returns the list of infra IDs that the issuer of the request is authorized to read.
-    /// If user has full access (in case of admin or skip authorization), it return a Bypassed with an empty list
-    async fn list_authorized_infra(&self) -> Result<Authorization<Vec<Infra>>, AuthorizerError> {
-        match self {
-            Authentication::SkipAuthorization { .. } => Ok(Authorization::Bypassed),
-            Authentication::Unauthenticated => Ok(Authorization::Denied {
-                reason: "user is not authenticated",
-            }),
-            Authentication::Authenticated(authorizer) => authorizer.list_authorized_infra().await,
         }
     }
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -11,6 +11,9 @@ pub(in crate::views) mod routes;
 
 use authz;
 use authz::InfraGrant;
+use authz::InfraPrivilege;
+use authz::v2::Authorizer as _;
+use authz::v2::Check;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -46,6 +49,7 @@ use crate::generated_data::operational_point::OperationalPointLayer;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
 use crate::map;
+use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::params;
@@ -169,6 +173,7 @@ pub(in crate::views) async fn refresh(
 }
 
 #[derive(Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize))]
 pub(in crate::views) struct InfraListResponse {
     #[serde(flatten)]
     stats: PaginationStats,
@@ -186,25 +191,47 @@ pub(in crate::views) struct InfraListResponse {
     ),
 )]
 pub(in crate::views) async fn list(
-    State(AppState { db_pool, .. }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(user): Extension<Option<authz::User>>,
+    Extension(roles): Extension<Vec<authz::Role>>,
+    Extension(authn): Extension<crate::authentication::State>,
     Query(pagination): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<InfraListResponse>> {
     let conn = &mut db_pool.get().await?;
-
     let default_settings = pagination.into_selection_settings();
-    let settings = match auth.list_authorized_infra().await? {
-        authz::Authorization::Granted(infras) => default_settings
-            .filter(move || Infra::ID.eq_any(infras.iter().map(|infra| infra.0).collect())),
-        authz::Authorization::Bypassed => default_settings,
-        authz::Authorization::Denied { reason } => {
-            unreachable!("user is authenticated at this point: {reason}")
+    let settings = match (user, authn) {
+        (_, crate::authentication::State::Skip { .. }) => default_settings,
+        (Some(user), _) => {
+            let authorizer = crate::authorizers::UserAuthorizer::new(
+                user,
+                roles.clone(),
+                regulator.openfga(),
+                conn.clone(),
+            );
+            let authorized_infras = authorizer
+                .authorize(authz::v2::infra_list(user, InfraPrivilege::CanRead))
+                .await?
+                .access()
+                .await?
+                .map_err(|err| match err {
+                    Check::SubjectExists(_) => unreachable!("checked above"),
+                    _ => AuthorizationError::Forbidden,
+                })?;
+            match authorized_infras {
+                authz::v2::ResourcesList::All => default_settings,
+                authz::v2::ResourcesList::Privileged(authorized_infras) => {
+                    default_settings.filter(move || {
+                        Infra::ID.eq_any(authorized_infras.iter().map(|infra| infra.0).collect())
+                    })
+                }
+            }
         }
+        (None, _) => return Err(AuthorizationError::Unauthorized)?,
     };
-
     let (infras, stats) =
         Infra::list_paginated(conn, settings.order_by(move || Infra::ID.asc())).await?;
-
     let response = InfraListResponse {
         stats,
         results: infras,
@@ -855,7 +882,7 @@ pub mod tests {
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
-
+    use crate::views::test_app::TestRequestExt as _;
     use editoast_models::infra::DEFAULT_INFRA_VERSION;
     use editoast_models::infra_objects::get_geometry_layer_table;
     use editoast_models::infra_objects::get_table;
@@ -987,6 +1014,89 @@ pub mod tests {
     async fn infra_list() {
         let app = test_app!().skip_authz().build();
         app.get("/infra/").await.assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_list_filters_authorized_infras() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
+
+        // Regular user with the correct roles should see only the infra he is associated with:
+        let user = app
+            .user("user_identity", "user_name")
+            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+        let response: InfraListResponse = app
+            .get("/infra/")
+            .by_user(user.as_ref())
+            .await
+            .assert_status(StatusCode::OK)
+            .json();
+        assert_eq!(
+            response.results.iter().map(|infra| infra.id).collect_vec(),
+            vec![infra.id]
+        );
+
+        // An admin should see all the infras:
+        let admin = app
+            .user("admin", "admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let response: InfraListResponse = app
+            .get("/infra/")
+            .by_user(admin.as_ref())
+            .await
+            .assert_status(StatusCode::OK)
+            .json();
+        assert_eq!(
+            response.results.iter().map(|infra| infra.id).collect_vec(),
+            vec![infra.id, infra_no_grant.id]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_list_impersonated_user() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
+        let infra_impersonated = create_small_infra(&mut db_pool.get_ok()).await;
+        let impersonator = app
+            .user("impersonator_identity", "impersonator_name")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let impersonated = app
+            .user("impersonated_identity", "impersonated_name")
+            .with_infra_grant(infra_impersonated.id, InfraGrant::Reader)
+            .create()
+            .await;
+
+        let request_normal = app.get("/infra/").by_user(impersonator.as_ref());
+        let request_impersonate = app
+            .get("/infra/")
+            .by_user(impersonator.as_ref())
+            .impersonate(impersonated.as_ref());
+
+        // The impersonator is admin and should see all the infras by default:
+        let InfraListResponse {
+            results: infras, ..
+        } = request_normal.await.assert_status(StatusCode::OK).json();
+        let infra_ids = infras.iter().map(|infra| infra.id).collect_vec();
+        assert_eq!(infra_ids, vec![infra_no_grant.id, infra_impersonated.id]);
+
+        // When impersonating, the impersonator should only see infras `impersonated` has access to:
+        let InfraListResponse {
+            results: infras, ..
+        } = request_impersonate
+            .await
+            .assert_status(StatusCode::OK)
+            .json();
+        let infra_ids = infras.iter().map(|infra| infra.id).collect_vec();
+        assert_eq!(infra_ids, vec![infra_impersonated.id]);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
Context: https://github.com/osrd-project/osrd-confidential/issues/1168

Rewrite `list_authorized_infra` in authz::v2, remove the old implementation and update the endpoint that was using it.