### PR TITLE
front: allow no train selection in op studies

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -671,6 +671,8 @@
         "title": "ETCS",
         "transition": "Trans."
       },
+      "invalidSimulation": "The selected train can't be simulated",
+      "noData": "Data is displayed when a train is selected",
       "powerRestrictions": "Power restrictions",
       "reticleInfos": "Reticle infos",
       "slopes": "Slopes",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -671,6 +671,8 @@
         "title": "ETCS",
         "transition": "Trans."
       },
+      "invalidSimulation": "Le train sélectionné ne peut pas être simulé",
+      "noData": "La donnée est affichée lorsqu'un train est sélectionné",
       "powerRestrictions": "Restrictions de puissance",
       "reticleInfos": "Infos réticule",
       "slopes": "Déclivités",

--- a/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoSelectTrainIds.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -52,6 +52,10 @@ const useAutoSelectTrainIds = (
   const localKey = `useAutoSelectTrainIds_project${urlProjectId}_study${urlStudyId}_scenario${urlScenarioId}`;
 
   const [parametersLoaded, setParametersLoaded] = useState<boolean>(false);
+
+  // We want to have a default selection only at first load,
+  // not when the selected train is deleted
+  const initialAutoSelectDoneRef = useRef(false);
 
   /**
    * Get a parameter from the URL, or if absent from local storage
@@ -114,6 +118,7 @@ const useAutoSelectTrainIds = (
     }
 
     if (trainSchedulesWithDetails.length === 0) {
+      initialAutoSelectDoneRef.current = false;
       if (selectedTrainId) dispatch(updateSelectedTrain(undefined));
       if (currentTrainIdForProjection) dispatch(updateTrainIdUsedForProjection(undefined));
       setParametersLoaded(true);
@@ -134,6 +139,8 @@ const useAutoSelectTrainIds = (
 
     // if a selected train schedule is given and is still in the timetable, don't change the selected train
     if (isSelectedTrainIdValid) {
+      initialAutoSelectDoneRef.current = true;
+
       // if no train is used for the projection or the id is invalid, use the selected train
       if (!isProjectedTrainIdValid) {
         dispatch(updateTrainIdUsedForProjection(selectedTrainId));
@@ -142,8 +149,11 @@ const useAutoSelectTrainIds = (
     }
 
     // at this point, the selected train is not in the timetable anymore or is undefined
-    // by default, select the first valid train schedule for the projection
-    // if no valid train schedule is found, select train schedule with valid pathfinding
+    if (!selectedTrainId && initialAutoSelectDoneRef.current) {
+      return;
+    }
+    // by default, select the first valid item for the projection
+    // if no valid item is found, select item with valid pathfinding
     const firstTrainCanBeUsedForProjection =
       trainSchedulesWithDetails.find((trainSchedule) => trainSchedule.summary?.isValid) ??
       trainSchedulesWithDetails.find(
@@ -151,6 +161,7 @@ const useAutoSelectTrainIds = (
       );
 
     if (firstTrainCanBeUsedForProjection) {
+      initialAutoSelectDoneRef.current = true;
       const pacedTrainId = formatEditoastIdToPacedTrainId(firstTrainCanBeUsedForProjection.id);
       dispatch(updateSelectedTrain({ id: pacedTrainId, by: 'timetable' }));
       if (!isProjectedTrainIdValid) dispatch(updateTrainIdUsedForProjection(pacedTrainId));

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 
 import { ChevronLeft, ChevronRight, Eye } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
@@ -89,6 +89,15 @@ const SimulationResults = ({
     MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT
   );
 
+  const sddData = simulationResults?.isValid
+    ? {
+        trainScheduleSimulation: simulationResults.simulation,
+        powerRestrictions: simulationResults.powerRestrictions,
+        rollingStock: simulationResults.rollingStock,
+        pathProperties: simulationResults.pathProperties,
+      }
+    : undefined;
+
   const [SDDHeight, setSDDHeight] = useState(SDD_INITIAL_HEIGHT);
 
   const [chronogramHeight, setChronogramHeight] = useState(CHRONOGRAM_INITIAL_HEIGHT);
@@ -177,6 +186,15 @@ const SimulationResults = ({
     simulationResults?.isValid ? simulationResults.simulation : undefined,
     trainSchedules
   );
+
+  const prevSddDataRef = useRef(sddData);
+  // We need to reset the SDD height when SDD data goes from undefined to defined in order to keep a consistent size.
+  useEffect(() => {
+    if (!prevSddDataRef.current && sddData) {
+      setSDDHeight(SDD_INITIAL_HEIGHT);
+    }
+    prevSddDataRef.current = sddData;
+  }, [sddData]);
 
   if (!simulationResults && !projectionData) {
     return null;
@@ -269,51 +287,48 @@ const SimulationResults = ({
         </BoardWrapper>
       )}
 
+      {/* SIMULATION : SPEED SPACE CHART */}
+      {activeBoards.has('sdd') && (
+        <BoardWrapper
+          name={t('simulationResults.speedDistanceDiagram')}
+          fullName={t('boardFullNames.sdd')}
+          resizable={{
+            height: SDDHeight,
+            setHeight: setSDDHeight,
+            minHeight: SDD_MIN_HEIGHT,
+          }}
+        >
+          <div className="osrd-simulation-container">
+            <SpeedDistanceDiagramWrapper
+              trainScheduleSimulation={sddData?.trainScheduleSimulation}
+              selectedTrainSchedulePowerRestrictions={sddData?.powerRestrictions}
+              rollingStock={sddData?.rollingStock}
+              pathProperties={sddData?.pathProperties}
+              height={SDDHeight - HIDDEN_CHART_TOP_HEIGHT}
+              setHeight={setSDDHeight}
+              fetchEtcsBrakingCurves={fetchEtcsBrakingCurves}
+              etcsBrakingCurves={etcsBrakingCurves}
+              isSimulationInvalid={simulationResults !== undefined && !simulationResults.isValid}
+            />
+          </div>
+        </BoardWrapper>
+      )}
+
+      {/* SIMULATION : MAP */}
+      <BoardWrapper hidden={!activeBoards.has('map')} name={t('boards.map')} withFooter>
+        <div data-testid="simulation-map" className="simulation-map">
+          <SimulationResultsMap
+            pathSteps={simulationResults?.train.path}
+            pathProperties={
+              simulationResults?.isValid ? simulationResults.pathProperties : undefined
+            }
+            setMapCanvas={setMapCanvas}
+          />
+        </div>
+      </BoardWrapper>
+
       {simulationResults && (
         <>
-          {simulationResults.isValid && (
-            <>
-              {/* SIMULATION : SPEED SPACE CHART */}
-              {activeBoards.has('sdd') && (
-                <BoardWrapper
-                  name={t('simulationResults.speedDistanceDiagram')}
-                  fullName={t('boardFullNames.sdd')}
-                  resizable={{
-                    height: SDDHeight,
-                    setHeight: setSDDHeight,
-                    minHeight: SDD_MIN_HEIGHT,
-                  }}
-                >
-                  <div className="osrd-simulation-container">
-                    <SpeedDistanceDiagramWrapper
-                      trainScheduleSimulation={simulationResults.simulation}
-                      selectedTrainSchedulePowerRestrictions={simulationResults.powerRestrictions}
-                      rollingStock={simulationResults.rollingStock}
-                      pathProperties={simulationResults.pathProperties}
-                      height={SDDHeight - HIDDEN_CHART_TOP_HEIGHT}
-                      setHeight={setSDDHeight}
-                      fetchEtcsBrakingCurves={fetchEtcsBrakingCurves}
-                      etcsBrakingCurves={etcsBrakingCurves}
-                    />
-                  </div>
-                </BoardWrapper>
-              )}
-            </>
-          )}
-
-          {/* SIMULATION : MAP */}
-          <BoardWrapper hidden={!activeBoards.has('map')} name={t('boards.map')} withFooter>
-            <div data-testid="simulation-map" className="simulation-map">
-              <SimulationResultsMap
-                pathSteps={simulationResults.train.path}
-                pathProperties={
-                  simulationResults.isValid ? simulationResults.pathProperties : undefined
-                }
-                setMapCanvas={setMapCanvas}
-              />
-            </div>
-          </BoardWrapper>
-
           {/* CHRONOGRAMME */}
           {trainSchedulesWithDetails.length > 0 && (
             <BoardWrapper

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -28,7 +28,7 @@ import { mToMm } from 'utils/physics';
 const MAP_ID = 'simulation-result-map';
 
 type SimulationResultMapProps = {
-  pathSteps: TrainSchedule['path'];
+  pathSteps?: TrainSchedule['path'];
   pathProperties?: PathPropertiesFormatted;
   setMapCanvas?: (mapCanvas: string) => void;
 };
@@ -121,7 +121,7 @@ const SimulationResultMap = ({
           let name = '';
           if (index === 0) {
             name = t('requestedOrigin');
-          } else if (index === pathSteps.length - 1) {
+          } else if (pathSteps && index === pathSteps.length - 1) {
             name = t('requestedDestination');
           } else {
             name = t('requestedPoint', { count: index + 1 });
@@ -259,9 +259,7 @@ const SimulationResultMap = ({
           <Itinerary geojsonPath={geojsonPath} layerOrder={LAYER_GROUPS_ORDER[LAYERS.PATH.GROUP]} />
         )}
 
-        {mapMarkers.map((marker) => (
-          <PathStepMarker key={marker.id} {...marker} />
-        ))}
+        {pathSteps && mapMarkers.map((marker) => <PathStepMarker key={marker.id} {...marker} />)}
       </BaseMap>
     </MapContextProvider>
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -72,7 +72,7 @@ const OccurrenceItem = ({
   isSelected,
   nextOccurrence,
   occurrenceActions: {
-    selectOccurrence,
+    toggleOccurrenceSelection,
     selectOccurrenceForProjection,
     editOccurrence,
     updateOccurrenceStatus,
@@ -215,7 +215,7 @@ const OccurrenceItem = ({
       onMouseLeave={() => dispatch(updateHoveredTrainId(undefined))}
       onClick={() => {
         if (isMenuOpen || disabled) return;
-        selectOccurrence(occurrence.id);
+        toggleOccurrenceSelection(occurrence.id);
       }}
     >
       <div

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -181,8 +181,14 @@ const PacedTrainItem = ({
     }
   };
 
-  const selectPacedTrainId = () => {
-    dispatch(updateSelectedTrain({ id: formattedPacedTrainId, by: 'timetable' }));
+  const togglePacedTrainSelection = () => {
+    dispatch(
+      updateSelectedTrain(
+        selectedTrainId === formattedPacedTrainId
+          ? undefined
+          : { id: formattedPacedTrainId, by: 'timetable' }
+      )
+    );
   };
 
   const deleteAllExceptions = async () => {
@@ -381,7 +387,7 @@ const PacedTrainItem = ({
             className="train-info"
             data-testid="selected-paced-train-area"
             role="button"
-            onClick={selectPacedTrainId}
+            onClick={togglePacedTrainSelection}
             tabIndex={0}
           >
             <span

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -71,9 +71,16 @@ const useOccurrenceActions = ({
     [pacedTrain, upsertTrainSchedules]
   );
 
-  const selectOccurrence = useCallback((occurrenceId: OccurrenceId) => {
-    dispatch(updateSelectedTrain({ id: occurrenceId, by: 'timetable' }));
-  }, []);
+  const toggleOccurrenceSelection = useCallback(
+    (occurrenceId: OccurrenceId) => {
+      dispatch(
+        updateSelectedTrain(
+          occurrenceId === selectedTrainId ? undefined : { id: occurrenceId, by: 'timetable' }
+        )
+      );
+    },
+    [dispatch, selectedTrainId]
+  );
 
   const selectOccurrenceForProjection = useCallback((occurrenceId: OccurrenceId) => {
     dispatch(updateTrainIdUsedForProjection(occurrenceId));
@@ -268,7 +275,7 @@ const useOccurrenceActions = ({
   );
 
   return {
-    selectOccurrence,
+    toggleOccurrenceSelection,
     selectOccurrenceForProjection,
     editOccurrence,
     updateOccurrenceStatus,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -82,8 +82,8 @@ const UniqueTrainItem = ({
 
   const formattedTrainId = formatEditoastIdToPacedTrainId(train.id);
 
-  const changeSelectedTrainId = (trainId: TrainId) => {
-    dispatch(updateSelectedTrain({ id: trainId, by: 'timetable' }));
+  const toggleUniqueTrainSelection = (trainId: TrainId) => {
+    dispatch(updateSelectedTrain(isSelected ? undefined : { id: trainId, by: 'timetable' }));
   };
 
   const deleteTrain = async () => {
@@ -184,7 +184,7 @@ const UniqueTrainItem = ({
         data-testid="scenario-timetable-unique-train-button"
         role="button"
         tabIndex={0}
-        onClick={() => changeSelectedTrainId(formattedTrainId)}
+        onClick={() => toggleUniqueTrainSelection(formattedTrainId)}
         className="w-full clickable-button"
       >
         <div

--- a/front/src/modules/conflict/components/Conflicts.tsx
+++ b/front/src/modules/conflict/components/Conflicts.tsx
@@ -19,15 +19,13 @@ const Conflicts = ({
 }: ConflictsProps) => (
   <div className="scenario-conflicts">
     <div className="scenario-conflicts-content">
-      {selectedTrainName && (
-        <ConflictsToolbar
-          isFilterActive={showOnlySelectedTrain}
-          onToggleFilter={onToggleFilter}
-          selectedTrainName={selectedTrainName}
-          conflictsCount={conflictsCount}
-          disabled={!selectedTrainName}
-        />
-      )}
+      <ConflictsToolbar
+        isFilterActive={showOnlySelectedTrain}
+        onToggleFilter={onToggleFilter}
+        selectedTrainName={selectedTrainName}
+        conflictsCount={conflictsCount}
+        disabled={!selectedTrainName}
+      />
       <div className="conflicts-container">
         {displayedConflicts.map((conflict, index) => (
           <ConflictCard key={index} conflict={conflict} />

--- a/front/src/modules/conflict/components/ConflictsToolbar.tsx
+++ b/front/src/modules/conflict/components/ConflictsToolbar.tsx
@@ -20,7 +20,9 @@ const ConflictsToolbar = ({
 
   const getDisplayText = () => {
     if (!selectedTrainName) {
-      return <span className="filter-text">{t('main.conflicts.filterWithSelectedTrain')}</span>;
+      return (
+        <span className="filter-text-disabled">{t('main.conflicts.filterWithSelectedTrain')}</span>
+      );
     }
 
     const conflictsText = t('main.conflicts.conflictsCount', { count: conflictsCount });

--- a/front/src/modules/conflict/styles/_conflictsToolbar.scss
+++ b/front/src/modules/conflict/styles/_conflictsToolbar.scss
@@ -32,4 +32,7 @@
       margin-bottom: 0;
     }
   }
+  .filter-text-disabled {
+    color: var(--grey30);
+  }
 }

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
@@ -17,15 +17,16 @@ import type {
 import { formatData } from './helpers';
 
 export type SpeedDistanceDiagramWrapperProps = {
-  trainScheduleSimulation: SimulationResponseSuccess;
+  trainScheduleSimulation?: SimulationResponseSuccess;
   selectedTrainSchedulePowerRestrictions?: LayerData<PowerRestrictionValues>[];
-  pathProperties: PathPropertiesFormatted;
+  pathProperties?: PathPropertiesFormatted;
   height: number;
-  rollingStock: RollingStockWithLiveries;
+  rollingStock?: RollingStockWithLiveries;
   setHeight: React.Dispatch<React.SetStateAction<number>>;
   fetchEtcsBrakingCurves?: () => Promise<void>;
   etcsBrakingCurves?: EtcsBrakingCurves;
   initialLayersDisplay?: Parameters<typeof SpeedSpaceChart>[0]['initialLayersDisplay'];
+  isSimulationInvalid?: boolean;
 };
 
 const SPEED_DISTANCE_DIAGRAM_MIN_HEIGHT = 400;
@@ -41,18 +42,22 @@ const SpeedDistanceDiagramWrapper = ({
   fetchEtcsBrakingCurves,
   etcsBrakingCurves,
   initialLayersDisplay,
+  isSimulationInvalid,
 }: SpeedDistanceDiagramWrapperProps) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'simulationResults' });
 
   const root = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState<number>(root.current?.clientWidth || 0);
 
-  const data = formatData(
-    trainScheduleSimulation,
-    rollingStock.length,
-    selectedTrainSchedulePowerRestrictions,
-    pathProperties
-  );
+  const data =
+    trainScheduleSimulation && rollingStock
+      ? formatData(
+          trainScheduleSimulation,
+          rollingStock.length,
+          selectedTrainSchedulePowerRestrictions,
+          pathProperties
+        )
+      : null;
 
   const translations = {
     detailsBoxDisplay: {
@@ -119,7 +124,7 @@ const SpeedDistanceDiagramWrapper = ({
       data-testid="speed-space-chart"
       style={{ height: `${height}px` }}
     >
-      {containerWidth > 0 && (
+      {data && containerWidth > 0 ? (
         <SpeedSpaceChart
           width={containerWidth || SPEED_DISTANCE_DIAGRAM_MIN_HEIGHT}
           height={height}
@@ -131,6 +136,14 @@ const SpeedDistanceDiagramWrapper = ({
           fetchEtcsBrakingCurves={fetchEtcsBrakingCurves}
           etcsBrakingCurves={etcsBrakingCurves}
         />
+      ) : (
+        <div className="speed-space-chart-wrapper" style={{ height: `${height}px` }}>
+          <span className="no-data">
+            {isSimulationInvalid
+              ? t('speedDistanceSettings.invalidSimulation')
+              : t('speedDistanceSettings.noData')}
+          </span>
+        </div>
       )}
     </div>
   );

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
@@ -138,7 +138,7 @@ const SpeedDistanceDiagramWrapper = ({
         />
       ) : (
         <div className="speed-space-chart-wrapper" style={{ height: `${height}px` }}>
-          <span className="no-data">
+          <span className="no-data" data-testid="no-data-sdd">
             {isSimulationInvalid
               ? t('speedDistanceSettings.invalidSimulation')
               : t('speedDistanceSettings.noData')}

--- a/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
@@ -92,6 +92,16 @@
       .speed-space-chart-wrapper {
         overflow: hidden;
       }
+      .no-data {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: rgba(121, 118, 113, 1);
+        font-size: 14px;
+        font-family: 'IBM Plex Sans-Regular', sans-serif;
+        line-height: 20px;
+      }
     }
 
     .simulation-map {

--- a/front/tests/pages/operational-studies/paced-train-section.ts
+++ b/front/tests/pages/operational-studies/paced-train-section.ts
@@ -12,7 +12,6 @@ import CommonPage from '../common-page';
 
 class PacedTrainSection extends CommonPage {
   private readonly pacedTrainItem: Locator;
-  private readonly selectedPacedTrainArea: Locator;
   private readonly testedPacedTrain: Locator;
   private readonly testedPacedTrainShowOccurrencesButton: Locator;
   private readonly testedPacedTrainName: Locator;
@@ -39,7 +38,6 @@ class PacedTrainSection extends CommonPage {
   constructor(page: Page) {
     super(page);
     this.pacedTrainItem = page.getByTestId('paced-train');
-    this.selectedPacedTrainArea = page.getByTestId('selected-paced-train-area');
     this.testedPacedTrain = page.locator('.paced-train:not(.closed)');
     this.testedPacedTrainShowOccurrencesButton =
       this.testedPacedTrain.getByTestId('show-occurrences-button');
@@ -82,10 +80,6 @@ class PacedTrainSection extends CommonPage {
 
   private async collapsePacedTrainToggleIcon(index: number) {
     return this.pacedTrainItem.nth(index).getByTestId('toggle-icon-close');
-  }
-
-  private async selectPacedTrain(pacedTrainIndex: number) {
-    await this.selectedPacedTrainArea.nth(pacedTrainIndex).click();
   }
 
   async expandPacedTrainOccurrenceList(index: number) {
@@ -151,7 +145,6 @@ class PacedTrainSection extends CommonPage {
   }
 
   async verifyPacedTrainSelected(pacedTrainIndex: number) {
-    await this.selectPacedTrain(pacedTrainIndex);
     await expect(this.pacedTrainItem.nth(pacedTrainIndex)).toHaveClass(/selected/);
   }
 

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -312,7 +312,14 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
       const count = await occurrences.count();
       for (let occurrenceIndex = 0; occurrenceIndex < count; occurrenceIndex += 1) {
         const occurrenceButton = occurrences.nth(occurrenceIndex);
-        await occurrenceButton.click();
+
+        const isSelected = await occurrenceButton.evaluate((el) =>
+          el.classList.contains('selected')
+        );
+        if (!isSelected) {
+          await occurrenceButton.click();
+        }
+
         await this.verifySimulationResultsVisibility();
       }
 

--- a/front/tests/pages/operational-studies/scenario-timetable-section.ts
+++ b/front/tests/pages/operational-studies/scenario-timetable-section.ts
@@ -313,9 +313,8 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
       for (let occurrenceIndex = 0; occurrenceIndex < count; occurrenceIndex += 1) {
         const occurrenceButton = occurrences.nth(occurrenceIndex);
 
-        const isSelected = await occurrenceButton.evaluate((el) =>
-          el.classList.contains('selected')
-        );
+        const isSelected =
+          (await occurrenceButton.getAttribute('class'))?.includes('selected') ?? false;
         if (!isSelected) {
           await occurrenceButton.click();
         }
@@ -344,7 +343,8 @@ class ScenarioTimetableSection extends OpSimulationResultPage {
   // TODO: This function must be modified after we drop the old itinerary interface
   async editTrainSchedule(index = 0) {
     await expect(this.trainSchedules.nth(index)).toBeVisible();
-    await this.trainSchedules.nth(index).click();
+    await this.trainSchedules.nth(index).hover();
+    await expect(this.editTrainButton.nth(index)).toBeVisible();
     await this.editTrainButton.nth(index).click();
     await expect(this.itineraryModal).toBeVisible();
     await this.closeItineraryModalButton.click();

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -18,6 +18,7 @@ class OpSimulationResultPage extends ScenarioPage {
   private readonly macroEditor: Locator;
   private readonly conflictsList: Locator;
   private readonly chronogram: Locator;
+  private readonly noDataSpan: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -36,6 +37,7 @@ class OpSimulationResultPage extends ScenarioPage {
     this.timeStopsOutputs = page.getByTestId('time-stop-outputs');
     this.macroEditor = page.getByTestId('macro-editor');
     this.chronogram = page.getByTestId('chronogram');
+    this.noDataSpan = page.getByTestId('no-data-sdd');
   }
 
   private async openSettingsPanel(): Promise<void> {
@@ -62,6 +64,8 @@ class OpSimulationResultPage extends ScenarioPage {
       expect(this.manchetteSpaceTimeChart).toBeVisible(),
       expect(this.spaceTimeChart).toBeVisible(),
       expect(this.timesStopsDataSheet).toBeVisible(),
+      expect(this.speedSpaceChart).toBeVisible(),
+      expect(this.noDataSpan).toBeVisible(),
       expect(this.simulationMap).toBeVisible(),
       expect(this.chronogram).toBeVisible(),
     ]);

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -62,7 +62,6 @@ class OpSimulationResultPage extends ScenarioPage {
       expect(this.manchetteSpaceTimeChart).toBeVisible(),
       expect(this.spaceTimeChart).toBeVisible(),
       expect(this.timesStopsDataSheet).toBeVisible(),
-      expect(this.speedSpaceChart).toBeHidden(),
       expect(this.simulationMap).toBeVisible(),
       expect(this.chronogram).toBeVisible(),
     ]);


### PR DESCRIPTION
closes #16367 

the only difference with the ACs, in this PR, is that I don't display the checkbox for conflicts when no train is selected. We just see all the conflicts. (AC was to disable the checkbox). 
Can disable it instead if you think it's better to. 


NEW ACs : 

We dont want to unselect a train by clicking on the SpaceTimeChart / Track occupancy diagram.
It can be unselected only by clicking on it in the timetable