### PR TITLE
devx: make the use of `process-compose` possible

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,10 @@
 /docker                                                  @openrailassociation/OSRD-DevOps
 /docker-compose.yml                                      @openrailassociation/OSRD-DevOps
 
+# -- Process Compose --
+/process-compose                                         @openrailassociation/OSRD-NixTools
+/process-compose.yaml                                    @openrailassociation/OSRD-NixTools
+
 # -- Scripts --
 /scripts                                                 @openrailassociation/OSRD-DevOps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Nice-to-have tools (and unofficial maintainers/main users):
 
 * `pr-tests-compose.sh` script (@bougue-pe)
 * `justfile`s to run component-specific commands (@Tristramg @bougue-pe)
-* `process-compose`, a non-containerized alternative to docker-compose (@leovalais)
+* `process-compose`, a non-containerized alternative to docker-compose (@leovalais @woshilapin)
 * `Podman`, a container-management tool (@emersion)
 * `Nix` package-management tool (@woshilapin @Synar @flomonster)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,29 @@ docker cp /tmp/allowed_tracks.json osrd-editoast:/tmp/
 docker compose exec editoast editoast stdcm-search-env set-from-scenario <id> --speed-limit-tags "CC100|100" "CC90|90" "CC200|200" --default-speed-limit-tag "CC100" /tmp/allowed_tracks.json
 ```
 
+### Alternative with `nix` and `process-compose` (experimental)
+
+The project also attempts to maintain a `flake.nix` to have a full development
+environment. If you are a user of `nix` package manager, you can `nix shell` to
+enter a shell where all the necessary components to develop are available.
+First, you need to set up 2 things:
+- `export OSRD_PATH="$(pwd)"`
+- download [`opentelemetry-javaagent.jar`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar) in `core/`
+
+Then, you can start the stack with the two following commands.
+
+```sh
+# Launch all the external services, still relies on Docker
+./osrd-compose up --detach postgres rabbitmq valkey openfga jaeger s3
+# Launch the OSRD stack
+process-compose
+```
+
+> [!WARNING]
+> Most scripts in the `scripts/` folder depends on using the Docker stack. So
+> use them with precaution if you start the stack with `process-compose`: they
+> may work, or crash, or produce weird behaviors.
+
 ## Working on a single component
 
 Each component has a _justfile_ to run usual development tasks. Install [just](https://github.com/casey/just#installation) and run it to see available recipes. All the components include:

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             taplo
             uv
             openfga-cli
+            process-compose
 
             # Core
             gradle

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,0 +1,69 @@
+version: "0.5"
+is_strict: true
+
+environment:
+  - "OSRD_PATH=${OSRD_PATH}" # Define `OSRD_PATH` in your `.env` (or `.envrc` with `direnv`)
+  - "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc"
+  - "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317"
+  - "OTEL_METRICS_EXPORTER=none"
+  - "OTEL_LOGS_EXPORTER=none"
+
+processes:
+  core:
+    working_dir: "${OSRD_PATH}/core/"
+    command: "gradle run --args='worker'"
+    environment:
+      - "ALL_INFRA=true"
+      - "CORE_EDITOAST_URL=http://localhost:8090"
+      - "JAVA_TOOL_OPTIONS=-ea -javaagent:${OSRD_PATH}/core/opentelemetry-javaagent.jar"
+      - "CORE_MONITOR_TYPE=opentelemetry"
+      - "OTEL_SERVICE_NAME=osrd-core"
+      - "VALKEY_URL=redis://localhost"
+      - "AWS_ACCESS_KEY_ID=access_key"
+      - "AWS_SECRET_ACCESS_KEY=secret_key"
+      - "AWS_ENDPOINT_URL_S3=http://localhost:9900"
+      - "BUCKET_NAME=osrd"
+  gateway:
+    working_dir: "${OSRD_PATH}/gateway/"
+    command: "cargo run"
+    environment:
+      - "OTEL_SERVICE_NAME=osrd-gateway"
+  editoast:
+    working_dir: "${OSRD_PATH}/editoast/"
+    command: |
+      cargo run --package fga_migrations -- apply
+      diesel migration run --locked-schema
+      cargo run -- user add --skip-if-exists 'Example User' 'mock/mocked'
+      cargo run -- roles add 'mock/mocked' Admin
+      cargo run -- runserver
+    environment:
+      - "EDITOAST_PORT=8090"
+      - "ROOT_URL=http://localhost:4000/api"
+      - "VALKEY_URL=redis://localhost"
+      - "DATABASE_URL=postgres://osrd:password@localhost/osrd"
+      - "OSRDYNE_API_URL=http://localhost:4242/"
+      - "OTEL_SERVICE_NAME=osrd-editoast"
+      - "TELEMETRY_KIND=opentelemetry"
+      - "TELEMETRY_ENDPOINT=http://localhost:4317"
+      - "OSRD_MQ_URL=amqp://osrd:password@localhost:5672/%2f"
+      - "FGA_API_URL=http://localhost:8091"
+      - "EDITOAST_ENABLE_AUTHORIZATION=${EDITOAST_ENABLE_AUTHORIZATION:-true}"
+      - "EDITOAST_NO_CACHE=${EDITOAST_NO_CACHE:-false}"
+      - "EDITOAST_CORE_SINGLE_WORKER=true"
+      - "DYNAMIC_ASSETS_PATH=${OSRD_PATH}/assets"
+  front:
+    working_dir: "${OSRD_PATH}/front/"
+    command: |
+      npm install
+      npm run build-ui
+      npm start
+  osrdyne:
+    working_dir: "${OSRD_PATH}/osrdyne/"
+    command: "cargo run -- ${OSRD_PATH}/process-compose/osrdyne.yaml"
+    environment:
+      - "OTEL_SERVICE_NAME=osrd-osrdyne"
+      - "OSRDYNE__OPENTELEMETRY__ENDPOINT=http://localhost:4317"
+      - "OSRDYNE__AMQP_URI=amqp://osrd:password@localhost:5672/%2f"
+      - "OSRDYNE__MAX_MSG_SIZE=671088640" # 1024 * 1024 * 128 * 5
+      - "OSRDYNE__MANAGEMENT_URI=http://osrd:password@localhost:15672/"
+      - "OSRDYNE__OPENTELEMETRY__ENDPOINT=http://localhost:4317"

--- a/process-compose/osrdyne.yaml
+++ b/process-compose/osrdyne.yaml
@@ -1,0 +1,2 @@
+worker_driver:
+  type: "Noop"


### PR DESCRIPTION
Since we do have a `flake.nix` that installs all the needed dependencies to build all the components of the stack, there is little reason, when using Nix, to launch the stack through another layer of abstraction like Docker. The stack can just be launched directly on local. In order to orchestrate the launch of all the components of the stack, we can use `process-compose` which works similarly to `docker-compose`, just directly in the shell instead of inside container.

One important aspect of the stack is the way `osrdyne` automatically scales `core` workers. It needs an orchestrator (`docker` can play this role, `kube` also can). In `orsdyne`, we have this notion of “worker driver”. When we launch the stack on Docker, we use the Docker worker driver. The trick is that the stack can also work without this auto-scaling capability: use `core` in single-worker mode (it will load all the infras, and `editoast` will send all messages to this single instance). `osrdyne` can then use the `Noop` worker driver. It’s obviously a bit limited in some ways, but for the vast majority of local development situations, it’s more than enough (and there is a limited implementation of a `process-compose` worker driver in `osrdyne` if you really want the enhanced flavor).