### PR TITLE
Fix unrecognized waypoints display in schedule sheet

### DIFF
--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -324,7 +324,8 @@ const useTimesStopsTableData = (
           startDate,
           schedule,
           computedArrival,
-          invalidPathStep: !matchingOp,
+          invalidPathStep:
+            !matchingOp && pathStepLocation.type === 'operational_point_part_reference',
           scheduleNotHonored,
           marginNotHonored,
           powerRestriction,

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -79,7 +79,7 @@
           background: var(--ambientB15);
         }
 
-        &.invalid-path-step {
+        &.invalid-path-step td {
           background: var(--grey10);
         }
 


### PR DESCRIPTION
close #16387 

> [!NOTE]
> I had to update `invalidPathStep` in `useTimesStopsTableData` because without it, waypoints added on the map were considered invalid path steps by the table