### PR TITLE
editoast: improve tracing for the health check

### DIFF
--- a/editoast/cache/src/client.rs
+++ b/editoast/cache/src/client.rs
@@ -4,6 +4,8 @@ use arcstr::ArcStr;
 use deadpool_redis::Pool;
 use deadpool_redis::PoolError;
 use deadpool_redis::Runtime;
+use tracing::Instrument as _;
+use tracing::debug_span;
 use url::Url;
 
 use crate::connection::Connection;
@@ -59,10 +61,18 @@ impl Client {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn get_connection(&self) -> Result<Connection, PoolError> {
         match &self.inner {
             ClientInner::Tokio(pool, response_timeout) => Ok({
-                let mut connection = pool.get().await?;
+                let pool_status = pool.status();
+                let pool_status_span = debug_span!(
+                    "valkey.pool.get",
+                    pool.size = pool_status.size,
+                    pool.available = pool_status.available,
+                    pool.waiting = pool_status.waiting
+                );
+                let mut connection = pool.get().instrument(pool_status_span).await?;
                 connection.set_response_timeout(*response_timeout);
                 Connection::new(ConnectionInner::Tokio(connection), self.app_version.clone())
             }),

--- a/editoast/core_client/src/mq_client.rs
+++ b/editoast/core_client/src/mq_client.rs
@@ -26,7 +26,8 @@ use tokio::sync::mpsc;
 use tokio::task;
 use tokio::time::Duration;
 use tokio_stream::StreamExt;
-use tracing::Instrument;
+use tracing::Instrument as _;
+use tracing::debug_span;
 use url::Url;
 use uuid::Uuid;
 
@@ -297,9 +298,17 @@ impl RabbitMQClient {
 
     #[tracing::instrument(name = "ping_mq", skip_all)]
     pub async fn ping(&self) -> Result<bool, MqClientError> {
+        let pool_status = self.pool.status();
+        let pool_status_span = debug_span!(
+            "mq.pool.get",
+            pool.size = pool_status.size,
+            pool.available = pool_status.available,
+            pool.waiting = pool_status.waiting
+        );
         let channel_worker = self
             .pool
             .get()
+            .instrument(pool_status_span)
             .await
             .map_err(|_| MqClientError::PoolChannelFail)?;
         let channel = channel_worker.get_channel();

--- a/editoast/database/src/db_connection_pool.rs
+++ b/editoast/database/src/db_connection_pool.rs
@@ -22,6 +22,8 @@ use openssl::ssl::SslMethod;
 use openssl::ssl::SslVerifyMode;
 use tokio::sync::OwnedRwLockWriteGuard;
 use tokio::sync::RwLock;
+use tracing::Instrument as _;
+use tracing::debug_span;
 use tracing::trace;
 use url::Url;
 
@@ -285,10 +287,18 @@ impl DbConnectionPoolV2 {
     /// hold several opened. This function is intended to be a drop-in replacement for the
     /// `deadpool`'s `get` function.
     /// ```
+    #[tracing::instrument(skip_all)]
     pub async fn get(&self) -> Result<DbConnection, DatabasePoolError> {
         use diesel_async::AsyncConnection as _;
 
-        let mut connection = self.pool.get().await?;
+        let pool_status = self.pool.status();
+        let pool_status_span = debug_span!(
+            "database.pool.get",
+            pool.size = pool_status.size,
+            pool.available = pool_status.available,
+            pool.waiting = pool_status.waiting
+        );
+        let mut connection = self.pool.get().instrument(pool_status_span).await?;
         connection.set_instrumentation(tracing_instrumentation::TracingInstrumentation::default());
         Ok(DbConnection::new(Arc::new(RwLock::new(connection))))
     }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -40,6 +40,7 @@ use fga::client::Limits;
 #[cfg(test)]
 use test_app::test_app;
 use tracing::Instrument;
+use tracing::info_span;
 
 use ::core::str;
 use std::collections::HashSet;
@@ -984,6 +985,7 @@ async fn health(
     Ok("ok")
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn check_health(
     db_pool: Arc<DbConnectionPoolV2>,
     valkey_client: Arc<cache::Client>,
@@ -991,6 +993,7 @@ pub async fn check_health(
     openfga: &fga::Client,
 ) -> Result<()> {
     let mut db_connection = db_pool.clone().get().await?;
+    let database_ping = ping_database(&mut db_connection).map_err(AppHealthError::Database);
     let openfga_ping = async move {
         openfga
             .is_healthy()
@@ -1008,6 +1011,7 @@ pub async fn check_health(
                 }
             })
     };
+    let mq_ping = core_client.ping().map_err(AppHealthError::Core);
     let valkey_ping = async {
         use deadpool_redis::redis::AsyncCommands as _;
         let mut vkconn = valkey_client
@@ -1023,10 +1027,10 @@ pub async fn check_health(
         Ok(())
     };
     tokio::try_join!(
-        ping_database(&mut db_connection).map_err(AppHealthError::Database),
-        valkey_ping,
-        core_client.ping().map_err(AppHealthError::Core),
-        openfga_ping
+        database_ping.instrument(info_span!("database ping")),
+        valkey_ping.instrument(info_span!("valkey ping")),
+        mq_ping.instrument(info_span!("mq ping")),
+        openfga_ping.instrument(info_span!("openfga ping"))
     )?;
     Ok(())
 }


### PR DESCRIPTION
<img width="1612" height="471" alt="image" src="https://github.com/user-attachments/assets/cf7781dc-b40a-44db-86eb-4a572f0d83ef" />

The second commit should bring more information about the status of the pools, each time we’re trying to get a connection.

<img width="1612" height="1781" alt="Screen Shot 2026-04-24 at 13 00 11" src="https://github.com/user-attachments/assets/a23e2d7d-c3da-43b0-8086-32ba9d66e1c2" />
