### PR TITLE
front: display trains name below occupancy blocks on chronogram

### DIFF
--- a/front/src/modules/simulationResult/components/Chronogram/buildOccupancyBlocks.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/buildOccupancyBlocks.ts
@@ -15,7 +15,8 @@ const MIN_GAP_BETWEEN_OCCUPANCIES_MS = 15_000; // 15 seconds
  * we consider them as part of the same group.
  */
 function computeOccupanciesBlocks(
-  occupancies: PostLevelCrossingOccupancyApiResponse[number]
+  occupancies: PostLevelCrossingOccupancyApiResponse[number],
+  trainNameById: Map<number, string>
 ): LevelCrossingOccupancies {
   const sortedOccupancies = occupancies
     .map((occupancy) => ({
@@ -24,6 +25,7 @@ function computeOccupanciesBlocks(
         new Date(occupancy.time_begin),
         Duration.parse(occupancy.duration)
       ).getTime(),
+      trainNames: [trainNameById.get(occupancy.train_schedule_id) ?? ''],
     }))
     .sort((a, b) => a.startTime - b.startTime);
 
@@ -35,6 +37,7 @@ function computeOccupanciesBlocks(
         occupanciesGroups.push([occupancy]);
       } else if (occupancy.startTime <= lastOccupancy.endTime) {
         lastOccupancy.endTime = Math.max(lastOccupancy.endTime, occupancy.endTime);
+        lastOccupancy.trainNames.push(...occupancy.trainNames);
       } else if (occupancy.startTime - lastOccupancy.endTime < MIN_GAP_BETWEEN_OCCUPANCIES_MS) {
         currentGroup.push(occupancy);
       } else {
@@ -49,7 +52,8 @@ function computeOccupanciesBlocks(
 
 export function formatLevelCrossingOccupanciesForChronogram(
   levelCrossingOccupancies: PostLevelCrossingOccupancyApiResponse,
-  levelCrossingsMetadata: InfraObjectWithGeometry[]
+  levelCrossingsMetadata: InfraObjectWithGeometry[],
+  trainNameById: Map<number, string>
 ): LevelCrossingData[] {
   const levelCrossingsRailJsonById = levelCrossingsMetadata.reduce<Record<string, LevelCrossing>>(
     (acc, metadata) => {
@@ -61,7 +65,7 @@ export function formatLevelCrossingOccupanciesForChronogram(
   return Object.entries(levelCrossingOccupancies)
     .map(([levelCrossingId, occupancies]) => ({
       name: levelCrossingsRailJsonById[levelCrossingId].name,
-      occupancies: computeOccupanciesBlocks(occupancies),
+      occupancies: computeOccupanciesBlocks(occupancies, trainNameById),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
@@ -23,6 +23,11 @@ const useLevelCrossingsWithChronogram = ({ trains }: UseLevelCrossingsWithChrono
 
   const trainIds = useMemo(() => trains.map((train) => train.id), [trains]);
 
+  const trainNameById = useMemo(
+    () => new Map(trains.map((train) => [train.id, train.name])),
+    [trains]
+  );
+
   const { currentData: levelCrossingsIds } =
     osrdEditoastApi.endpoints.getInfraByInfraIdObjectsAndObjectTypeIds.useQuery(
       infraId
@@ -59,8 +64,12 @@ const useLevelCrossingsWithChronogram = ({ trains }: UseLevelCrossingsWithChrono
 
   const levelCrossingData = useMemo(() => {
     if (!levelCrossingOccupancies || !levelCrossings) return [];
-    return formatLevelCrossingOccupanciesForChronogram(levelCrossingOccupancies, levelCrossings);
-  }, [levelCrossingOccupancies, levelCrossings]);
+    return formatLevelCrossingOccupanciesForChronogram(
+      levelCrossingOccupancies,
+      levelCrossings,
+      trainNameById
+    );
+  }, [levelCrossingOccupancies, levelCrossings, trainNameById]);
 
   useEffect(() => {
     if (error) {

--- a/front/ui/storybook/stories/ui-charts/chronogram/level-crossing-data.ts
+++ b/front/ui/storybook/stories/ui-charts/chronogram/level-crossing-data.ts
@@ -12,6 +12,7 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE,
           endTime: +START_DATE + 3 * MINUTE,
+          trainNames: ['TS 1234'],
         },
       ],
 
@@ -19,10 +20,12 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 20 * MINUTE,
           endTime: +START_DATE + 25 * MINUTE,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 25 * MINUTE + 10 * SECOND,
           endTime: +START_DATE + 27 * MINUTE + 50 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
 
@@ -30,6 +33,7 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 30 * MINUTE,
           endTime: +START_DATE + 35 * MINUTE,
+          trainNames: ['TS 1234', 'TS 5678'],
         },
       ],
     ],
@@ -42,26 +46,31 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 2 * MINUTE + 30 * SECOND,
           endTime: +START_DATE + 4 * MINUTE + 30 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 4 * MINUTE + 40 * SECOND,
           endTime: +START_DATE + 5 * MINUTE + 50 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 10 * MINUTE + 40 * SECOND,
           endTime: +START_DATE + 12 * MINUTE + 35 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 15 * MINUTE,
           endTime: +START_DATE + 18 * MINUTE,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 18 * MINUTE + 15 * SECOND,
           endTime: +START_DATE + 19 * MINUTE + 30 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
 
@@ -69,6 +78,7 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 25 * MINUTE,
           endTime: +START_DATE + 26 * MINUTE + 30 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
     ],
@@ -81,22 +91,26 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 5 * MINUTE,
           endTime: +START_DATE + 8 * MINUTE,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 12 * MINUTE + 20 * SECOND,
           endTime: +START_DATE + 14 * MINUTE + 45 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 27 * MINUTE,
           endTime: +START_DATE + 28 * MINUTE + 49 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 29 * MINUTE,
           endTime: +START_DATE + 31 * MINUTE + 15 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
     ],
@@ -109,22 +123,26 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 1 * MINUTE + 15 * SECOND,
           endTime: +START_DATE + 5 * MINUTE + 45 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 6 * MINUTE,
           endTime: +START_DATE + 7 * MINUTE + 20 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 16 * MINUTE + 30 * SECOND,
           endTime: +START_DATE + 19 * MINUTE,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 29 * MINUTE,
           endTime: +START_DATE + 32 * MINUTE + 40 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
     ],
@@ -137,22 +155,26 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 8 * MINUTE + 10 * SECOND,
           endTime: +START_DATE + 11 * MINUTE + 25 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 17 * MINUTE,
           endTime: +START_DATE + 20 * MINUTE + 15 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 20 * MINUTE + 30 * SECOND,
           endTime: +START_DATE + 22 * MINUTE + 50 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 33 * MINUTE,
           endTime: +START_DATE + 36 * MINUTE,
+          trainNames: ['TS 1234'],
         },
       ],
     ],
@@ -165,22 +187,26 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 3 * MINUTE + 20 * SECOND,
           endTime: +START_DATE + 6 * MINUTE + 40 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 13 * MINUTE + 15 * SECOND,
           endTime: +START_DATE + 15 * MINUTE + 50 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 16 * MINUTE,
           endTime: +START_DATE + 17 * MINUTE + 30 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 26 * MINUTE + 20 * SECOND,
           endTime: +START_DATE + 29 * MINUTE,
+          trainNames: ['TS 1234'],
         },
       ],
     ],
@@ -193,46 +219,54 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 4 * MINUTE,
           endTime: +START_DATE + 6 * MINUTE + 38 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 6 * MINUTE + 45 * SECOND,
           endTime: +START_DATE + 11 * MINUTE + 50 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 19 * MINUTE + 10 * SECOND,
           endTime: +START_DATE + 21 * MINUTE + 40 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 27 * MINUTE,
           endTime: +START_DATE + 28 * MINUTE + 45 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 34 * MINUTE,
           endTime: +START_DATE + 37 * MINUTE + 20 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 44 * MINUTE,
           endTime: +START_DATE + 47 * MINUTE + 20 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 49 * MINUTE,
           endTime: +START_DATE + 52 * MINUTE + 20 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 54 * MINUTE,
           endTime: +START_DATE + 57 * MINUTE + 20 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
     ],
@@ -244,6 +278,7 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE,
           endTime: +START_DATE + 3 * MINUTE,
+          trainNames: ['TS 1234'],
         },
       ],
 
@@ -251,16 +286,19 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 20 * MINUTE,
           endTime: +START_DATE + 25 * MINUTE,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 25 * MINUTE + 10 * SECOND,
           endTime: +START_DATE + 27 * MINUTE + 50 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 30 * MINUTE,
           endTime: +START_DATE + 35 * MINUTE,
+          trainNames: ['TS 1234', 'TS 5678'],
         },
       ],
     ],
@@ -273,32 +311,38 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 2 * MINUTE + 30 * SECOND,
           endTime: +START_DATE + 4 * MINUTE + 30 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 4 * MINUTE + 40 * SECOND,
           endTime: +START_DATE + 5 * MINUTE + 50 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 10 * MINUTE + 40 * SECOND,
           endTime: +START_DATE + 12 * MINUTE + 35 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 15 * MINUTE,
           endTime: +START_DATE + 18 * MINUTE,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 18 * MINUTE + 15 * SECOND,
           endTime: +START_DATE + 19 * MINUTE + 30 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 25 * MINUTE,
           endTime: +START_DATE + 26 * MINUTE + 30 * SECOND,
+          trainNames: ['TS 1234'],
         },
       ],
     ],
@@ -311,22 +355,26 @@ export const levelCrossingData: LevelCrossingData[] = [
         {
           startTime: +START_DATE + 5 * MINUTE,
           endTime: +START_DATE + 8 * MINUTE,
+          trainNames: ['TS 1234'],
         },
       ],
       [
         {
           startTime: +START_DATE + 12 * MINUTE + 20 * SECOND,
           endTime: +START_DATE + 14 * MINUTE + 45 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
       [
         {
           startTime: +START_DATE + 27 * MINUTE,
           endTime: +START_DATE + 28 * MINUTE + 49 * SECOND,
+          trainNames: ['TS 1234'],
         },
         {
           startTime: +START_DATE + 29 * MINUTE,
           endTime: +START_DATE + 31 * MINUTE + 15 * SECOND,
+          trainNames: ['TS 5678'],
         },
       ],
     ],

--- a/front/ui/ui-charts/src/chronogram/components/OccupancyBlocksLayer.tsx
+++ b/front/ui/ui-charts/src/chronogram/components/OccupancyBlocksLayer.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useContext } from 'react';
 
 import { TimeChartCanvasContext } from '../../common/context';
-import { BLACK_100, GREY_30, GREY_90, RED_100, WHITE_100 } from '../../common/helpers/colors';
+import {
+  BLACK_100,
+  GREY_30,
+  GREY_50,
+  GREY_90,
+  RED_100,
+  WHITE_100,
+} from '../../common/helpers/colors';
 import { useDraw } from '../../common/hooks/useCanvas';
 import type { TimeChartContextType, DrawingFunction } from '../../common/types';
 import { CHRONOGRAM_HEADER_HEIGHT, LEVEL_CROSSING_ITEM_HEIGHT } from '../lib/const';
@@ -15,6 +22,7 @@ const STRIPE_SPACING = 24;
 const STRIPE_WIDTH = 8;
 const TRACKS_INTERVALS = 3;
 const CLOSING_TIME_Y_OFFSET = 5;
+const TRAIN_NAME_Y_OFFSET = 14;
 
 const drawTrackLines = (
   ctx: CanvasRenderingContext2D,
@@ -82,50 +90,72 @@ const drawGapBlock = (
   }
 };
 
-/** Draws the closing time text above an occupancy block */
-const drawClosingTime = (
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  blockWidth: number,
-  text: string
-) => {
+/** Draws text around an occupancy block */
+const drawBlockText = ({
+  ctx,
+  x,
+  y,
+  text,
+  color,
+  maxWidth,
+}: {
+  ctx: CanvasRenderingContext2D;
+  x: number;
+  y: number;
+  text: string;
+  color?: string;
+  maxWidth?: number;
+}) => {
   ctx.save();
   ctx.font = '12px IBM Plex Sans';
-
-  const textWidth = ctx.measureText(text).width;
-  const startX = textWidth < blockWidth ? x + (blockWidth - textWidth) / 2 : x;
-
-  ctx.fillText(text, startX, y - CLOSING_TIME_Y_OFFSET, blockWidth);
+  if (color) ctx.fillStyle = color;
+  ctx.textAlign = 'center';
+  ctx.fillText(text, x, y, maxWidth);
   ctx.restore();
 };
 
-const drawBlocks = (
-  ctx: CanvasRenderingContext2D,
-  blocks: OccupancyBlock[],
-  getTimePixel: (time: number) => number,
-  bandTop: number
-) => {
+const drawBlocks = ({
+  ctx,
+  blocks,
+  getTimePixel,
+  bandTop,
+  bandBottom,
+}: {
+  ctx: CanvasRenderingContext2D;
+  blocks: OccupancyBlock[];
+  getTimePixel: (time: number) => number;
+  bandTop: number;
+  bandBottom: number;
+}) => {
   let previousBlockEndX: number | undefined;
 
   for (const block of blocks) {
     const blockStartX = getTimePixel(block.startTime);
     const blockEndX = getTimePixel(block.endTime);
     const blockWidth = blockEndX - blockStartX;
+    const blockCenterX = blockStartX + blockWidth / 2;
     if (blockWidth <= 0) continue;
 
     if (previousBlockEndX !== undefined) {
       drawGapBlock(ctx, bandTop, previousBlockEndX, blockStartX);
     }
 
-    drawClosingTime(
+    drawBlockText({
       ctx,
-      blockStartX,
-      bandTop,
-      blockWidth,
-      formatDuration(block.startTime, block.endTime)
-    );
+      x: blockCenterX,
+      y: bandTop - CLOSING_TIME_Y_OFFSET,
+      text: formatDuration(block.startTime, block.endTime),
+      maxWidth: blockWidth,
+    });
     drawStripedBlock(ctx, blockStartX, bandTop, blockWidth);
+
+    drawBlockText({
+      ctx,
+      x: blockCenterX,
+      y: bandBottom + TRAIN_NAME_Y_OFFSET,
+      text: block.trainNames.join('; '),
+      color: GREY_50,
+    });
 
     previousBlockEndX = blockEndX;
   }
@@ -148,7 +178,7 @@ export const OccupancyBlocksLayer = () => {
         for (const blocks of levelCrossing) {
           if (!blocks.length) continue;
 
-          drawBlocks(ctx, blocks, getTimePixel, bandTop);
+          drawBlocks({ ctx, blocks, getTimePixel, bandTop, bandBottom });
         }
 
         startY += LEVEL_CROSSING_ITEM_HEIGHT;

--- a/front/ui/ui-charts/src/chronogram/lib/types.ts
+++ b/front/ui/ui-charts/src/chronogram/lib/types.ts
@@ -4,6 +4,7 @@ import type { SpaceTimeChartTheme } from '../../spaceTimeChart';
 export type OccupancyBlock = {
   startTime: number;
   endTime: number;
+  trainNames: string[];
 };
 
 export type LevelCrossingOccupancies = OccupancyBlock[][];


### PR DESCRIPTION
This PR aims to display trains name below each occupancy blocks on chronogram. The main modification are :

- Adjustment of the `OccupancyBlock` type definition to include a `trainNames: string[]` field
- Modifying of the `computeOccupanciesBlocks` functions to accept a mapping from train IDs to train names, and to attach the train names to each occupancy block. When occupancy blocks are merged, their train names are merged too
- Adding a new function, `drawTrainNames` to render train names below each occupancy block
- Updating chronogram storybook test data to include the new `trainNames` field