### PR TITLE
editoast: add max pool size for valkey

### DIFF
--- a/editoast/cache/src/client.rs
+++ b/editoast/cache/src/client.rs
@@ -29,6 +29,7 @@ pub enum Config {
     Valkey {
         url: Url,
         response_timeout: Duration,
+        pool_size: usize,
     },
 }
 
@@ -41,9 +42,15 @@ impl Client {
                 Config::Valkey {
                     url,
                     response_timeout,
+                    pool_size,
                 } => ClientInner::Tokio(
                     deadpool_redis::Config::from_url(url)
-                        .create_pool(Some(Runtime::Tokio1))
+                        .builder()
+                        .unwrap()
+                        .runtime(Runtime::Tokio1)
+                        .max_size(pool_size)
+                        .wait_timeout(Some(std::time::Duration::from_millis(100)))
+                        .build()
                         .unwrap(),
                     response_timeout,
                 ),

--- a/editoast/src/client/postgres_config.rs
+++ b/editoast/src/client/postgres_config.rs
@@ -15,7 +15,7 @@ pub struct PostgresConfig {
     )]
     pub database_url: Url,
     #[educe(Default = 32)]
-    #[arg(long, env, default_value_t = 32)]
+    #[arg(long, env = "DATABASE_POOL_SIZE", default_value_t = 32)]
     pub pool_size: usize,
 }
 

--- a/editoast/src/client/valkey_config.rs
+++ b/editoast/src/client/valkey_config.rs
@@ -18,6 +18,9 @@ pub struct ValkeyConfig {
     #[arg(long, env, default_value_t = 1000)]
     /// Response timeout for Valkey requests in ms
     pub valkey_timeout: u64,
+    #[educe(Default = 200)]
+    #[arg(long, env, default_value_t = 200)]
+    pub valkey_pool_size: usize,
 }
 
 impl ValkeyConfig {
@@ -28,6 +31,7 @@ impl ValkeyConfig {
             cache::Config::Valkey {
                 url: self.valkey_url,
                 response_timeout: Duration::from_millis(self.valkey_timeout),
+                pool_size: self.valkey_pool_size,
             }
         }
     }


### PR DESCRIPTION
This allow to define a max pool size. Default was `cpu_core_count * 2`.