### PR TITLE
Fix power restriction code missing when waypoints share an id

### DIFF
--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -356,8 +356,13 @@ const useTimesStopsTableData = (
           : undefined;
 
         if (matchingPathStepRow) {
+          // Backend data can contain several OPs at the same UIC sharing the
+          // same op.id, all matching the same path step. Append op.position
+          // to the row id so each occurrence stays unique, mirroring what is
+          // done below for OP rows.
           formattedRows.push({
             ...matchingPathStepRow,
+            id: `${matchingPathStepRow.id}-${op.position}`,
             track: trackName,
             opOnPathIndex: opIndex,
           });


### PR DESCRIPTION
## What this fixes

Close #16407. 

Two path-step rows can end up with the same `row.id`. Map lookups by `row.id` then overwrite each other, so:
- The propagated code is missing in the warning cell
- The block is missing from the banner count

This happens when several OPs at the same UIC share an `op.id` (a backend data quirk) and all match the same path step. In the timetable from #16408, this happens at Lyon-Part-Dieu BV and Marseille-St-Charles BF.

## History

1. **First version of this PR**: keyed the Map by row index, on the side that reads the Map.
2. **Closed** in favor of #16426, which adds `op.position` to OP row ids.
3. **Reopened**: #16426 only fixes OP rows. Path-step rows still collide when two OPs share an `op.id` and both match the same path step.

## Fix

Add `op.position` to the path-step row id when it is pushed, the same way #16426 does for OP rows. Each row now has a unique id.
