### PR TITLE
core: stdcm: trim nodes as they're added to the queue

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -175,6 +175,31 @@ class STDCMGraph(
     }
 
     /**
+     * Return false if the given node is already covered by a pending node in the A* queue, meaning
+     * it should not be added. Return true and mark the node as pending if it's not in the queue.
+     */
+    fun tryMarkPending(node: STDCMNode): Boolean {
+        val explorer = node.infraExplorer
+        val fingerprint =
+            VisitedNodes.Fingerprint(
+                explorer.getLastEdgeIdentifier(),
+                explorer.getStepTracker().nStepsExcludingLookahead,
+                node.locationOnEdge?.distance ?: 0.meters,
+            )
+        val params =
+            VisitedNodes.Parameters(
+                fingerprint,
+                node.timeData,
+                maxMarginDuration = 0.0,
+                remainingTimeEstimation = node.remainingTimeEstimation,
+                explorer = explorer,
+            )
+        if (visitedNodes.isPending(params)) return false
+        visitedNodes.markAsPending(params)
+        return true
+    }
+
+    /**
      * Give a (rough) estimation of how much delay we could add before this node with engineering
      * margins. Should be on the pessimistic side.
      */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -247,6 +247,7 @@ class STDCMPathfinding(
             .getAdjacentEdges(node)
             .map { it.getEdgeEnd(graph) }
             .filter { it.timeData.timeSinceDeparture + it.remainingTimeEstimation <= maxRunTime }
+            .filter { graph.tryMarkPending(it) }
     }
 
     private fun buildResult(node: STDCMNode): Result {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
@@ -76,6 +76,13 @@ data class VisitedNodes(
     /** Any class that implements this interface may be added to the visited ranges. */
     private val visitedRangesPerLocation = mutableMapOf<Fingerprint, VisitedRangeMap>()
 
+    /**
+     * Tracks time ranges covered by nodes that have been added to the A* queue. Prevents equivalent
+     * nodes from accumulating in the queue, which would otherwise cause OOM. Uses the same
+     * structure as [visitedRangesPerLocation]. Dequeued nodes are not removed.
+     */
+    private val pendingRangesPerLocation = mutableMapOf<Fingerprint, VisitedRangeMap>()
+
     // For any given block, keep track of the maximum number of steps that have been reached.
     // Any future path that has less passed steps at this block will be discarded.
     // The underlying assumption being, for a requested path "A -> B -> C":
@@ -140,6 +147,23 @@ data class VisitedNodes(
         }
         val visitedRanges = visitedRangesPerLocation[parameters.fingerprint] ?: return false
         return visitedRanges.isVisited(parameters.withClippedMarginDuration(0.0))
+    }
+
+    /**
+     * Return true if this node is "pending", i.e. has been added to the queue. It may or may not
+     * have been dequeued since. Avoids duplicated notes in the queue, which can cause OOM issues.
+     */
+    fun isPending(parameters: Parameters): Boolean {
+        val pendingRanges = pendingRangesPerLocation[parameters.fingerprint] ?: return false
+        return pendingRanges.isVisited(parameters.withClippedMarginDuration(0.0))
+    }
+
+    /** Mark a node as "pending" as it's added to the A* queue. */
+    fun markAsPending(parameters: Parameters) {
+        val fingerprint = parameters.fingerprint!!
+        val newRangeMap = visitedRangeMapFromParameters(parameters, minDelay)
+        val pendingRanges = pendingRangesPerLocation.getOrPut(fingerprint) { VisitedRangeMap() }
+        pendingRanges.putAll(newRangeMap)
     }
 
     /** Marks the input as visited */


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16174

Disclaimer: first draft has been LLM generated, I've edited it since (comments in particular). 

Benchmark on a few very long fuzzer generated requests. The only changed result is two requests that used to timeout and now return a solution.


| | time_old | time_new | time_diff |
|---|---|---|---|
| count | 8.000000 | 8.000000 | 8.000000 |
| mean | 55.150555 | 52.303702 | -3.662050 |
| std | 62.958859 | 61.959942 | 24.647061 |
| min | 1.115000 | 1.144000 | -59.618000 |
| 25% | 5.308000 | 4.477313 | -2.921000 |
| 50% | 37.033864 | 33.899364 | -0.175250 |
| 75% | 81.812536 | 74.142982 | 4.213025 |
| max | 182.667000 | 181.841000 | 22.000000 |


| | mb_old | mb_new | mb_diff |
|---|---|---|---|
| count | 8.000000 | 8.000000 | 8.000000 |
| mean | 3929.480128 | 3311.620164 | -574.675854 |
| std | 2685.260745 | 2406.567426 | 1653.215827 |
| min | 22.000000 | 22.000000 | -4082.000000 |
| 25% | 2143.221679 | 1880.246011 | -980.801136 |
| 50% | 3581.500000 | 3126.250000 | -131.375000 |
| 75% | 5381.159091 | 4102.732955 | 208.750000 |
| max | 8073.000000 | 8139.000000 | 1256.911346 |