### PR TITLE
editoast: simplify traces for authentication middleware

### DIFF
--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -25,7 +25,7 @@ pub enum Authentication {
     },
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AuthenticationParameters {
     pub identity: Option<String>,
     pub name: Option<String>,
@@ -35,6 +35,7 @@ pub struct AuthenticationParameters {
 }
 
 impl Authentication {
+    #[tracing::instrument(name = "authentication request")]
     pub fn try_new(params: AuthenticationParameters) -> Result<Self, AuthenticationParameters> {
         let authn = match params {
             AuthenticationParameters {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -553,7 +553,7 @@ async fn authentication_extraction_middleware(
 /// - the impersonator must be an admin
 /// - the impersonated user must already exist in the database, we do not create it if it does not
 /// - push the roles of the origin user in the request extensions
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, fields(user.id, user.name, user.roles))]
 async fn authentication_validation_middleware(
     Extension(authn): Extension<crate::authentication::Authentication>,
     State(AppState {
@@ -667,6 +667,14 @@ async fn authentication_validation_middleware(
             tracing::info!("impersonation enabled");
         }
     }
+
+    let span = Span::current();
+    if let Some(user) = &user {
+        span.record("user.id", user.id);
+        span.record("user.name", tracing::field::display(&user.name));
+    }
+    span.record("user.roles", tracing::field::debug(&roles));
+    span.record("user.is_admin", roles.contains(&Role::Admin));
 
     let user_id = user.as_ref().map(|editoast_models::User { id, .. }| *id);
     req.extensions_mut().insert(roles);

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -553,6 +553,7 @@ async fn authentication_extraction_middleware(
 /// - the impersonator must be an admin
 /// - the impersonated user must already exist in the database, we do not create it if it does not
 /// - push the roles of the origin user in the request extensions
+#[tracing::instrument(skip_all)]
 async fn authentication_validation_middleware(
     Extension(authn): Extension<crate::authentication::Authentication>,
     State(AppState {
@@ -668,21 +669,12 @@ async fn authentication_validation_middleware(
     }
 
     let user_id = user.as_ref().map(|editoast_models::User { id, .. }| *id);
-    Ok(tracing::info_span!(
-        "authentication validation",
-        user_id,
-        ?roles,
-        is_admin = roles.contains(&Role::Admin) // easy way to filter real user requests in logs
-    )
-    .in_scope(move || {
-        req.extensions_mut().insert(roles);
-        // for `fga` queries and `authz` interface
-        req.extensions_mut().insert(user_id.map(::authz::User));
-        // database model, also carries the user name
-        req.extensions_mut().insert(user);
-        next.run(req).in_current_span()
-    })
-    .await)
+    req.extensions_mut().insert(roles);
+    // for `fga` queries and `authz` interface
+    req.extensions_mut().insert(user_id.map(::authz::User));
+    // database model, also carries the user name
+    req.extensions_mut().insert(user);
+    Ok(next.run(req).await)
 }
 
 /// Represents the bundle of information about the issuer of a request

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -40,6 +40,7 @@ use fga::client::Limits;
 #[cfg(test)]
 use test_app::test_app;
 use tracing::Instrument;
+use tracing::Span;
 use tracing::info_span;
 
 use ::core::str;
@@ -484,6 +485,7 @@ fn service_router() -> router::DocumentedRouter {
     })
 }
 
+#[tracing::instrument(skip_all, fields(authn))]
 async fn authentication_extraction_middleware(
     State(AppState { config, .. }): State<AppState>,
     mut req: Request,
@@ -512,49 +514,37 @@ async fn authentication_extraction_middleware(
     });
     let skip_authz = headers.contains_key(SKIP_AUTHZ);
 
-    let authn = tracing::info_span!(
-        "authenticating request",
+    let authn = crate::authentication::Authentication::try_new(AuthenticationParameters {
         identity,
         name,
         impersonate,
-        skip_authz,
-    )
-    .in_scope(move || {
-        crate::authentication::Authentication::try_new(AuthenticationParameters {
-            identity,
-            name,
-            impersonate,
-            skip: skip_authz,
-            authorization_enabled: config.enable_authorization,
-        })
-        .map_err(
-            |AuthenticationParameters {
-                 identity,
-                 name,
-                 impersonate,
-                 skip,
-                 authorization_enabled,
-             }| {
-                tracing::error!(
-                    identity,
-                    name,
-                    impersonate,
-                    skip,
-                    authorization_enabled,
-                    "invalid authentication parameters"
-                );
-                AuthorizationError::Unauthorized
-            },
-        )
-    })?;
+        skip: skip_authz,
+        authorization_enabled: config.enable_authorization,
+    })
+    .map_err(
+        |AuthenticationParameters {
+             identity,
+             name,
+             impersonate,
+             skip,
+             authorization_enabled,
+         }| {
+            tracing::error!(
+                identity,
+                name,
+                impersonate,
+                skip,
+                authorization_enabled,
+                "invalid authentication parameters"
+            );
+            AuthorizationError::Unauthorized
+        },
+    )?;
 
     tracing::info!(?authn, "authentication complete");
-    Ok(tracing::info_span!("authentication", ?authn)
-        .in_scope(move || {
-            req.extensions_mut().insert(authn.clone());
-            next.run(req).in_current_span()
-        })
-        .await)
+    Span::current().record("authn", tracing::field::debug(&authn));
+    req.extensions_mut().insert(authn);
+    Ok(next.run(req).await)
 }
 
 /// Takes an authenticated request and performs a few verifications


### PR DESCRIPTION
Just using the more straightforward `#[tracing::instrument]` in most places. And also, wrapping the entire middleware instead of only the last call to the next middleware.

<img width="1612" height="1040" alt="image" src="https://github.com/user-attachments/assets/940e1372-6d99-4e8e-a8f6-30bfe5d44e79" />
