### PR TITLE
front: upgrade eslint-plugin-react-hooks to v7.1

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -124,7 +124,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^7.0.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "glob": "^13.0.6",
         "happy-dom": "^20.9.0",
         "i18next-fs-backend": "^2.6.5",
@@ -10559,7 +10559,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10573,7 +10575,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -19839,7 +19841,7 @@
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-react": "^7.35.0",
-        "eslint-plugin-react-hooks": "^7.0.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-storybook": "^10.3.6",
         "oxfmt": "^0.48.0",
         "postcss": "^8.5.13",

--- a/front/package.json
+++ b/front/package.json
@@ -124,7 +124,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "glob": "^13.0.6",
     "happy-dom": "^20.9.0",
     "i18next-fs-backend": "^2.6.5",

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -332,15 +332,16 @@ const EntitySumUp = ({ entity, id, objType, classes, status, error }: EntitySumU
     const fetchEntities = async () => {
       setState({ type: 'loading' });
 
-      if (!entity && objType && id) {
-        entity = await getEntity(infraID!, id, objType, dispatch);
+      let effectiveEntity = entity;
+      if (!effectiveEntity && objType && id) {
+        effectiveEntity = await getEntity(infraID!, id, objType, dispatch);
       }
 
-      if (entity) {
-        const additionalEntities = await getAdditionalEntities(infraID!, entity, dispatch);
+      if (effectiveEntity) {
+        const additionalEntities = await getAdditionalEntities(infraID!, effectiveEntity, dispatch);
         setState({
           type: 'ready',
-          entity,
+          entity: effectiveEntity,
           additionalEntities,
         });
       }

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -150,7 +150,7 @@ const usePathfinding = ({
     }));
 
     if (invalidPathItems.length > 0) {
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define, react-hooks/immutability
       launchPathfinding(updatedPathSteps);
     } else {
       setError(t('missingPathSteps'));

--- a/front/ui/base/package.json
+++ b/front/ui/base/package.json
@@ -19,7 +19,7 @@
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-react-hooks": "^7.0.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-storybook": "^10.3.6",
     "oxfmt": "^0.48.0",
     "postcss": "^8.5.13",

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/AnchoredMenu.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/AnchoredMenu.tsx
@@ -31,8 +31,6 @@ const AnchoredMenu = ({ children, anchorRef, onDismiss }: AnchoreMenuParams) => 
     const menuRefBoundingRect = menuRef.current?.getBoundingClientRect();
 
     if (anchorRefBoundingRect && menuRefBoundingRect) {
-      // TODO: fix this lint
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setMenuPosition({
         top: anchorRefBoundingRect.bottom,
         left: anchorRefBoundingRect.left,

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
@@ -62,6 +62,8 @@ const ManchetteWithSpaceTimeWrapper = ({
     },
   ];
 
+  // TODO: fix this lint
+  /* eslint-disable-next-line react-hooks/refs */
   const waypointMenu = AnchoredMenu({
     children: activeWaypointId && <Menu menuRef={menuRef} items={menuItems} />,
     anchorRef: activeWaypointRef,

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/horizontal-zoom.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/horizontal-zoom.stories.tsx
@@ -55,6 +55,8 @@ const SpaceTimeHorizontalZoomWrapper = ({
     panning: null,
   });
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setState((prev) => ({ ...prev, xOffset: offset }));
   }, [offset]);
   const handleZoom = (zoomValue: number, position = DEFAULT_WIDTH / 2) => {

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/performances.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/performances.stories.tsx
@@ -54,6 +54,8 @@ const Wrapper = ({
     return range(operationalPointsCount).map((i) => ({
       id: `op-${i}`,
       label: `Operational point n°${i + 1}`,
+      // TODO: fix this lint
+      /* eslint-disable-next-line react-hooks/immutability */
       position: (position += random(50 * KILOMETER, 150 * KILOMETER)),
       // TODO: fix this lint
       // eslint-disable-next-line react-hooks/purity

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
@@ -106,9 +106,13 @@ const RectangleZoomWrapper = ({
   ];
 
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setState((prev) => ({ ...prev, xOffset }));
   }, [xOffset]);
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setState((prev) => ({ ...prev, yOffset }));
   }, [yOffset]);
 
@@ -230,6 +234,8 @@ const RectangleZoomWrapper = ({
       const chosenSpaceScale = !swapAxes
         ? spaceRange / (DEFAULT_HEIGHT - captionSize)
         : spaceRange / (DEFAULT_WIDTH - captionSize);
+      // TODO: fix this lint
+      /* eslint-disable-next-line react-hooks/set-state-in-effect */
       handleRectangleZoom({
         scales: { chosenTimeScale, chosenSpaceScale },
         overrideState: { rect: null },

--- a/front/ui/storybook/stories/ui-charts/speedSpaceChart/SpeedSpaceChart.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/speedSpaceChart/SpeedSpaceChart.stories.tsx
@@ -30,6 +30,8 @@ const SpeedSpaceChartStory = ({
   const [containerHeight, setContainerHeight] = useState(460);
 
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setContainerHeight(height);
   }, [height]);
 

--- a/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
@@ -20,6 +20,8 @@ const TrackOccupancyDiagramStory = ({
   const [selectedTrainId, setSelectedTrainId] = useState<string>();
 
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setSelectedTrainId(`${trainId}`);
   }, [trainId]);
 

--- a/front/ui/storybook/stories/ui-warped-map/useAsyncMemo.ts
+++ b/front/ui/storybook/stories/ui-warped-map/useAsyncMemo.ts
@@ -23,6 +23,8 @@ export function useAsyncMemo<T>(fn: () => Promise<T>, deps: DependencyList): Asy
 
   useEffect(() => {
     let aborted = false;
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setState({ type: 'loading', previousData: getAsyncMemoData(state) });
     fn()
       .then((data) => {

--- a/front/ui/ui-charts/src/chronogram/components/Chronogram.tsx
+++ b/front/ui/ui-charts/src/chronogram/components/Chronogram.tsx
@@ -42,6 +42,8 @@ export const Chronogram = ({
   }
 
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setLevelCrossingsOccupancies(levelCrossingData);
   }, [levelCrossingData]);
 

--- a/front/ui/ui-charts/src/chronogram/hooks/useChronogram.tsx
+++ b/front/ui/ui-charts/src/chronogram/hooks/useChronogram.tsx
@@ -71,6 +71,8 @@ const useChronogram = ({
   );
 
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setHeight(chronogramHeight);
   }, [chronogramHeight, setHeight]);
 

--- a/front/ui/ui-charts/src/speedSpaceChart/components/layers/ReticleLayer.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/layers/ReticleLayer.tsx
@@ -29,8 +29,6 @@ const ReticleLayer = ({
     // The tooltip shouldn't be displayed when hovering on the linear layers
     if (store.cursor.y && store.cursor.y < height - MARGINS.MARGIN_TOP - MARGINS.MARGIN_BOTTOM) {
       const detailsBox = drawCursor({ ctx, width, height, store });
-      // TODO: fix this lint
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTrainDetails(detailsBox || null);
     } else {
       clearCanvas(ctx, width, height);

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -27,6 +27,8 @@ const TrackOccupancyStandalone = ({
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
   const spaceTimeChartRef = useRef<HTMLDivElement>(null);
   const defaultTimeOrigin = useMemo(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/purity */
     const minTime = Math.min(...(occupancyZones.map((zone) => zone.startTime) || Date.now()));
     // Take first round hour before minTime:
     return Math.floor(minTime / HOUR) * HOUR;

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -95,6 +95,8 @@ const ComboBox = <T,>({
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (value) {
+      // TODO: fix this lint
+      /* eslint-disable-next-line react-hooks/set-state-in-effect */
       setInputValue(getSuggestionLabel(value));
     } else {
       setInputValue('');

--- a/front/ui/ui-core/src/components/DatePicker/useDatePicker.ts
+++ b/front/ui/ui-core/src/components/DatePicker/useDatePicker.ts
@@ -101,6 +101,8 @@ export default function useDatePicker(datePickerProps: DatePickerProps) {
     if (newInput !== inputValue) {
       // we only set the input value if it has changed
       // otherwise the user loses the focus
+      // TODO: fix this lint
+      /* eslint-disable-next-line react-hooks/set-state-in-effect */
       setInputValue(newInput);
     }
     setStatusWithMessage(undefined);

--- a/front/ui/ui-core/src/components/RadioGroup.tsx
+++ b/front/ui/ui-core/src/components/RadioGroup.tsx
@@ -35,6 +35,7 @@ const RadioGroup = ({
   const [selectedValue, setSelectedValue] = useState<string | undefined>(value);
 
   useEffect(() => {
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setSelectedValue(value);
   }, [value]);
 

--- a/front/ui/ui-core/src/components/Select.tsx
+++ b/front/ui/ui-core/src/components/Select.tsx
@@ -49,6 +49,8 @@ const Select = <T,>({
   };
 
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setSelectedOption(value);
   }, [value]);
 

--- a/front/ui/ui-core/src/components/Slider.tsx
+++ b/front/ui/ui-core/src/components/Slider.tsx
@@ -29,6 +29,8 @@ const Slider = ({
   );
 
   useEffect(() => {
+    // TODO: fix this lint
+    /* eslint-disable-next-line react-hooks/set-state-in-effect */
     setValue(Number(initialValue));
   }, [initialValue]);
 

--- a/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
+++ b/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
@@ -44,6 +44,8 @@ const TolerancePicker = ({
     const plusToleranceIndex = TOLERANCE_RANGES.findIndex((range) => range.value === plusTolerance);
     if (minusToleranceIndex < 0 || plusToleranceIndex < 0) {
       const invalidTolerance = minusToleranceIndex < 0 ? minusTolerance : plusTolerance;
+      // TODO: fix this lint
+      /* eslint-disable-next-line react-hooks/set-state-in-effect */
       setWarningStatus({
         status: 'warning',
         message:


### PR DESCRIPTION
_See individual commits._

This new version changes a bit how rules are triggered. We break
React rules of hooks in quite a lot of places. To avoid blocking
the upgrade, add TODOs for fixing these issues.