### PR TITLE
editoast: remove role checking preambles

### DIFF
--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -266,10 +266,19 @@ pub fn annotate_units(_attr: TokenStream, input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Axum handlers must be annotated with this macro to tie them to their utoipa documentation
+///
+/// A role to be verified can be specified, in which case an additional role verification layer
+/// is added to the handler.
+///
+/// Syntaxes:
+/// * `#[editoast_derive::route]` — all roles are allowed
+/// * `#[editoast_derive::route(authz::Role::Stdcm)]` — only `authz::Role::Stdcm` and `authz::Role::Admin`
 #[proc_macro_attribute]
-pub fn route(_attr: TokenStream, input: TokenStream) -> TokenStream {
+pub fn route(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = proc_macro2::TokenStream::from(attr);
     let input = parse_macro_input!(input as syn::ItemFn);
-    route::route(&input)
+    route::route(attr, &input)
         .unwrap_or_else(darling::Error::write_errors)
         .into()
 }

--- a/editoast/editoast_derive/src/route.rs
+++ b/editoast/editoast_derive/src/route.rs
@@ -4,8 +4,23 @@ use std::hash::Hasher as _;
 use proc_macro2::TokenStream;
 use syn::Ident;
 use syn::ItemFn;
+use syn::Path;
+use syn::parse::Parser as _;
 
-pub(super) fn route(input: &ItemFn) -> darling::Result<TokenStream> {
+fn parse_role(attr: TokenStream) -> darling::Result<Option<Path>> {
+    if attr.is_empty() {
+        return Ok(None);
+    }
+    let role = Path::parse_mod_style
+        .parse2(attr)
+        .map_err(darling::Error::from)?;
+    Ok(Some(role))
+}
+
+pub(super) fn route(attr: TokenStream, input: &ItemFn) -> darling::Result<TokenStream> {
+    let required_role = parse_role(attr)?
+        .map(|role| quote::quote! { Some(#role) })
+        .unwrap_or_else(|| quote::quote! { None });
     let name = &input.sig.ident;
     // some handlers have the same name (eg: get, create, list) which would result in duplicate
     // static names
@@ -28,19 +43,22 @@ pub(super) fn route(input: &ItemFn) -> darling::Result<TokenStream> {
         #[doc(hidden)]
         #[linkme::distributed_slice(crate::views::router::OPENAPI_ROUTES)]
         static #static_name: crate::views::router::OpenApiRouteSliceItem = |type_name: &str| {
-            (type_name == std::any::type_name_of_val(&#name)).then_some(|| {
-                use utoipa::Path;
-                use utoipa::__dev::Tags; // private API, but can't find another way :/
-                use utoipa::__dev::SchemaReferences; // same...
+            (type_name == std::any::type_name_of_val(&#name)).then_some(crate::views::router::RouteMetadata {
+                required_role: #required_role,
+                documentation: || {
+                    use utoipa::Path;
+                    use utoipa::__dev::Tags; // private API, but can't find another way :/
+                    use utoipa::__dev::SchemaReferences; // same...
 
-                let mut schemas = Vec::new();
-                <#path_name as SchemaReferences>::schemas(&mut schemas);
+                    let mut schemas = Vec::new();
+                    <#path_name as SchemaReferences>::schemas(&mut schemas);
 
-                crate::views::router::RouteDocumentation {
-                    http_methods: <#path_name as Path>::methods(),
-                    operation: <#path_name as Path>::operation(),
-                    tags: <#path_name as Tags>::tags(),
-                    schemas,
+                    crate::views::router::RouteDocumentation {
+                        http_methods: <#path_name as Path>::methods(),
+                        operation: <#path_name as Path>::operation(),
+                        tags: <#path_name as Tags>::tags(),
+                        schemas,
+                    }
                 }
             })
         };

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -176,7 +176,7 @@ pub(in crate::views) struct UserInfo {
     groups: HashSet<Group>,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Admin)]
 #[utoipa::path(
     post,
     path = "",
@@ -192,19 +192,11 @@ pub(in crate::views) struct UserInfo {
     ))
 )]
 pub(in crate::views) async fn users_info(
-    Extension(auth): AuthenticationExt,
     State(AppState {
         regulator, db_pool, ..
     }): State<AppState>,
     Json(body): Json<UsersInfoRequest>,
 ) -> Result<Json<Vec<UserInfo>>> {
-    let authorized = auth
-        .check_roles([Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let UsersInfoRequest { ids: user_ids, .. } = body.clone();
 
     // Retrieve users by IDs
@@ -755,7 +747,7 @@ pub(in crate::views) async fn update_grants(
     }
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Admin)]
 #[utoipa::path(
     get,
     path = "",
@@ -767,17 +759,8 @@ pub(in crate::views) async fn update_grants(
     ))
 )]
 pub(in crate::views) async fn list_groups(
-    Extension(auth): AuthenticationExt,
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
 ) -> Result<Json<Vec<Group>>> {
-    let authorized = auth
-        .check_roles([Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut groups = Group::list(&mut db_pool.get().await?, SelectionSettings::new()).await?;
 
     groups.sort_by_key(|g| g.id);

--- a/editoast/src/views/catalog_entry.rs
+++ b/editoast/src/views/catalog_entry.rs
@@ -4,12 +4,9 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -52,7 +49,7 @@ pub(in crate::views) struct CatalogEntryIdParam {
     id: i64,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "catalog_entry",
@@ -63,16 +60,8 @@ pub(in crate::views) struct CatalogEntryIdParam {
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(catalog_entry_create_form): Json<CatalogEntryForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let catalog_entry_changeset = catalog_entry_create_form.into_changeset();
     let catalog_entry = catalog_entry_changeset
         .create(&mut db_pool.get().await?)
@@ -88,7 +77,7 @@ pub(in crate::views) struct CatalogEntryPage {
     results: Vec<CatalogEntry>,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "catalog_entry",
@@ -99,17 +88,8 @@ pub(in crate::views) struct CatalogEntryPage {
 )]
 pub(in crate::views) async fn list_paginated(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(pagination_params): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<CatalogEntryPage>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    };
-
     let settings = pagination_params.into_selection_settings();
     let conn = &mut db_pool.get().await?;
     let (catalog_entries, stats) = CatalogEntry::list_paginated(conn, settings).await?;
@@ -120,7 +100,7 @@ pub(in crate::views) async fn list_paginated(
     }))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "catalog_entry",
@@ -133,20 +113,11 @@ pub(in crate::views) async fn list_paginated(
 )]
 pub(in crate::views) async fn put(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(CatalogEntryIdParam {
         id: catalog_entry_id,
     }): Path<CatalogEntryIdParam>,
     Json(catalog_entry_form): Json<CatalogEntryForm>,
 ) -> Result<Json<CatalogEntry>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let catalog_entry_changeset = catalog_entry_form.into_changeset();
     let catalog_entry = catalog_entry_changeset
@@ -157,7 +128,7 @@ pub(in crate::views) async fn put(
     Ok(Json(catalog_entry))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "catalog_entry",
@@ -169,18 +140,10 @@ pub(in crate::views) async fn put(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(CatalogEntryIdParam {
         id: catalog_entry_id,
     }): Path<CatalogEntryIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     CatalogEntry::delete_static_or_fail(&mut db_pool.get().await?, catalog_entry_id, || {
         CatalogEntryError::NotFound { catalog_entry_id }
     })

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -1,5 +1,4 @@
 use authz::Role;
-use axum::Extension;
 use axum::Json;
 use axum::body::Bytes;
 use axum::extract::Path;
@@ -18,9 +17,6 @@ use crate::error::Result;
 use database::DbConnectionPoolV2;
 use editoast_models::Document;
 use editoast_models::prelude::*;
-
-use super::AuthenticationExt;
-use super::AuthorizationError;
 
 #[derive(Error, Debug, EditoastError)]
 #[editoast_error(base_id = "document")]
@@ -52,16 +48,8 @@ pub enum DocumentErrors {
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(document_id): Path<i64>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
     let doc = Document::retrieve_or_fail(conn.clone(), document_id, || DocumentErrors::NotFound {
         document_key: document_id,
@@ -83,7 +71,7 @@ struct NewDocumentResponse {
 }
 
 /// Post a new document (content_type by header + binary data)
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "documents",
@@ -97,17 +85,9 @@ struct NewDocumentResponse {
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     axum_extra::TypedHeader(content_type): axum_extra::TypedHeader<headers::ContentType>,
     bytes: Bytes,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let content_type = content_type.to_string();
 
     // Create document
@@ -128,7 +108,7 @@ pub(in crate::views) async fn post(
 }
 
 /// Delete an existing document
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "documents",
@@ -141,16 +121,8 @@ pub(in crate::views) async fn post(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(document_id): Path<i64>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
     Document::delete_static_or_fail(conn, document_id, || DocumentErrors::NotFound {
         document_key: document_id,

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -17,8 +16,6 @@ use serde::Deserialize;
 use thiserror::Error;
 use utoipa::IntoParams;
 
-use super::AuthenticationExt;
-use super::AuthorizationError;
 use crate::error::Result;
 use editoast_models::ElectricalProfileSet;
 use editoast_models::LightElectricalProfileSet;
@@ -41,15 +38,7 @@ pub struct ElectricalProfileSetId {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<LightElectricalProfileSet>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let mut conn = db_pool.get().await?;
     Ok(Json(ElectricalProfileSet::list_light(&mut conn).await?))
 }
@@ -66,16 +55,8 @@ pub(in crate::views) async fn list(
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(electrical_profile_set_id): Path<i64>,
 ) -> Result<Json<ElectricalProfileSetData>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let ep_set = ElectricalProfileSet::retrieve_or_fail(
         db_pool.get().await?,
         electrical_profile_set_id,
@@ -106,16 +87,8 @@ pub(in crate::views) async fn get(
 )]
 pub(in crate::views) async fn get_level_order(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(electrical_profile_set_id): Path<i64>,
 ) -> Result<Json<HashMap<String, LevelValues>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let ep_set = ElectricalProfileSet::retrieve_or_fail(
         db_pool.get().await?,
         electrical_profile_set_id,
@@ -128,7 +101,7 @@ pub(in crate::views) async fn get_level_order(
 }
 
 /// Delete an electrical profile set
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "electrical_profiles",
@@ -139,16 +112,8 @@ pub(in crate::views) async fn get_level_order(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(electrical_profile_set_id): Path<i64>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
     let deleted = ElectricalProfileSet::delete_static(conn, electrical_profile_set_id).await?;
     if deleted {
@@ -165,7 +130,7 @@ pub(in crate::views) struct ElectricalProfileQueryArgs {
 }
 
 /// import a new electrical profile set
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "electrical_profiles",
@@ -177,17 +142,9 @@ pub(in crate::views) struct ElectricalProfileQueryArgs {
 )]
 pub(in crate::views) async fn post_electrical_profile(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(ep_set_name): Query<ElectricalProfileQueryArgs>,
     Json(ep_data): Json<ElectricalProfileSetData>,
 ) -> Result<Json<ElectricalProfileSet>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let ep_set = ElectricalProfileSet::changeset()
         .name(ep_set_name.name)
         .data(ep_data);

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -13,7 +13,6 @@ use crate::AppState;
 use crate::error::Result;
 use crate::infra_cache::InfraCache;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
@@ -72,14 +71,6 @@ pub(in crate::views) async fn attached(
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<HashMap<ObjectType, Vec<String>>>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Check that infra exists
     let mut conn = db_pool.get().await?;
     // TODO: lock for share

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -26,7 +26,6 @@ use crate::infra_cache::operation::Operation;
 use crate::infra_cache::operation::UpdateOperation;
 use crate::infra_cache::operation::patch_infra_object;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use editoast_models::Infra;
@@ -100,14 +99,6 @@ pub(in crate::views) async fn list_auto_fixes(
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<Operation>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -3,7 +3,6 @@ use crate::error::Result;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use authz;
@@ -106,7 +105,7 @@ impl From<Sign> for DirectedLocation {
     }
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "delimited_area",
@@ -123,7 +122,6 @@ impl From<Sign> for DirectedLocation {
 /// To prevent a missing exit to cause the graph traversal to never stop exploring, the exploration
 /// stops when a maximum distance is reached and no exit has been found.
 pub(in crate::views) async fn delimited_area(
-    Extension(auth): AuthenticationExt,
     State(AppState {
         infra_caches,
         db_pool,
@@ -132,18 +130,11 @@ pub(in crate::views) async fn delimited_area(
         ..
     }): State<AppState>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
+    Extension(auth): AuthenticationExt,
     Json(DelimitedAreaForm { entries, exits }): Json<DelimitedAreaForm>,
 ) -> Result<Json<DelimitedAreaResponse>> {
     // TODO in case of a missing exit, return an empty list of track ranges instead of returning all
     // the track ranges explored until the stopping condition ?
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Retrieve the infra
     let mut conn = db_pool.get().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -39,7 +39,6 @@ use crate::infra_cache::operation::Operation;
 use crate::infra_cache::operation::UpdateOperation;
 use crate::map;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use database::DbConnection;
@@ -57,7 +56,7 @@ use schemas::infra::InfraObject;
 ///
 /// After editing the object, the generated cartographic layers are invalidated and
 /// regenerated. The edition step fails if the regeneration fails.
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -80,13 +79,6 @@ pub(in crate::views) async fn edit(
     Extension(auth): AuthenticationExt,
     Json(operations): Json<Vec<Operation>>,
 ) -> Result<Json<Vec<InfraObject>>> {
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // TODO: lock for update
     let mut infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
@@ -131,7 +123,7 @@ pub(in crate::views) async fn edit(
     Ok(Json(operation_results))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -154,14 +146,6 @@ pub(in crate::views) async fn split_track_section(
     Extension(auth): AuthenticationExt,
     Json(payload): Json<TrackOffset>,
 ) -> Result<Json<Vec<String>>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     info!(
         track_id = payload.track.as_str(),
         offset = payload.offset,

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -19,7 +19,6 @@ use crate::generated_data::InfraGeneratedData as _;
 use crate::generated_data::infra_error::InfraError;
 use crate::generated_data::infra_error::InfraErrorTypeLabel;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdParam;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -71,7 +70,6 @@ pub(in crate::views) struct InfraErrorResponse {
  )]
 pub(in crate::views) async fn list_errors(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<100>>,
     Query(ErrorListQueryParams {
@@ -79,15 +77,8 @@ pub(in crate::views) async fn list_errors(
         error_type,
         object_id,
     }): Query<ErrorListQueryParams>,
+    Extension(auth): AuthenticationExt,
 ) -> Result<Json<ErrorListResponse>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let error_type = match error_type.map(|et| InfraErrorTypeLabel::from_str(&et).ok()) {
         Some(None) => return Err(ListErrorsErrors::WrongErrorTypeProvided.into()),
         Some(et) => et,

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -12,7 +12,6 @@ use thiserror::Error;
 
 use crate::error::Result;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use editoast_models::Infra;
@@ -44,14 +43,6 @@ pub(in crate::views) async fn get_line_bbox(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<BoundingBox>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let line_code: i32 = line_code.try_into().unwrap();
 
     let mut conn = db_pool.get().await?;

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -45,7 +45,6 @@ use crate::generated_data::operational_point::OperationalPointLayer;
 use crate::generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use crate::infra_cache::InfraCache;
 use crate::map;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::params;
@@ -98,7 +97,7 @@ pub(in crate::views) struct RefreshResponse {
 }
 
 /// Refresh infra generated geographic layers
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -117,16 +116,8 @@ pub(in crate::views) async fn refresh(
         config,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
     Query(query_params): Query<RefreshQueryParams>,
 ) -> Result<Json<RefreshResponse>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Use a transaction to give scope to infra list lock
     let RefreshQueryParams {
         force,
@@ -199,13 +190,6 @@ pub(in crate::views) async fn list(
     Extension(auth): AuthenticationExt,
     Query(pagination): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<InfraListResponse>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let default_settings = pagination.into_selection_settings();
@@ -251,14 +235,6 @@ pub(in crate::views) async fn get(
     Extension(auth): AuthenticationExt,
     Path(infra): Path<InfraIdParam>,
 ) -> Result<Json<Infra>> {
-    // check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let infra_id = infra.infra_id;
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
@@ -294,7 +270,7 @@ impl InfraCreateForm {
 /// Creates an empty infra
 ///
 /// The infra may be edited by batch later via the `POST /infra/ID` or `POST /infra/ID/railjson` endpoints.
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -310,14 +286,6 @@ pub(in crate::views) async fn create(
     Extension(auth): AuthenticationExt,
     Json(infra_form): Json<InfraCreateForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let infra: Changeset<Infra> = infra_form.into_changeset();
     let infra = infra.create(&mut db_pool.get().await?).await?;
 
@@ -344,7 +312,7 @@ pub(in crate::views) struct CloneQuery {
 }
 
 /// Duplicate an infra
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -362,15 +330,6 @@ pub(in crate::views) async fn clone(
     }): State<AppState>,
     Query(CloneQuery { name }): Query<CloneQuery>,
 ) -> Result<Json<i64>> {
-    // check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
         infra_id,
@@ -412,7 +371,7 @@ pub(in crate::views) async fn clone(
 /// You've been warned.
 ///
 /// This operation may take a while to complete.
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "infra",
@@ -427,15 +386,6 @@ pub(in crate::views) async fn delete(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<impl IntoResponse> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
@@ -464,7 +414,7 @@ impl InfraPatchForm {
 }
 
 /// Rename an infra
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "infra",
@@ -477,18 +427,9 @@ impl InfraPatchForm {
 )]
 pub(in crate::views) async fn put(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(infra): Path<i64>,
     Json(patch): Json<InfraPatchForm>,
 ) -> Result<Json<Infra>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let infra_cs: Changeset<Infra> = patch.into_changeset();
     let infra = infra_cs
         .update_or_fail(&mut db_pool.get().await?, infra, || {
@@ -514,14 +455,6 @@ pub(in crate::views) async fn get_switch_types(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<Json<Vec<SwitchType>>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
@@ -573,14 +506,6 @@ pub(in crate::views) async fn get_speed_limit_tags(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     State(builtin_tags): State<Arc<SpeedLimitTagIds>>,
 ) -> Result<Json<HashSet<String>>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
@@ -630,13 +555,6 @@ pub(in crate::views) async fn get_voltages(
     Query(param): Query<GetVoltagesQueryParams>,
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
 ) -> Result<Json<Vec<String>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
@@ -669,16 +587,7 @@ pub(in crate::views) async fn get_voltages(
 )]
 pub(in crate::views) async fn get_all_voltages(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<String>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let voltages = Infra::get_all_voltages(&mut db_pool.get().await?).await?;
     Ok(Json(voltages.into_iter().map(|el| el.voltage).collect()))
 }
@@ -695,7 +604,7 @@ async fn set_locked(mut conn: DbConnection, infra_id: i64, locked: bool) -> Resu
 }
 
 /// Lock an infra
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -710,14 +619,6 @@ pub(in crate::views) async fn lock(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
 ) -> Result<impl IntoResponse> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
@@ -731,7 +632,7 @@ pub(in crate::views) async fn lock(
 }
 
 /// Unlock an infra
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -746,14 +647,6 @@ pub(in crate::views) async fn unlock(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
 ) -> Result<impl IntoResponse> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
@@ -802,7 +695,7 @@ pub(in crate::views) struct MatchOperationalPointsResponse {
     related_operational_points: Vec<Option<RelatedOperationalPoint>>,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -823,13 +716,6 @@ pub(in crate::views) async fn match_operational_points(
         operational_point_references,
     }): Json<MatchOperationalPointsForm>,
 ) -> Result<Json<MatchOperationalPointsResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     auth.check_authorization(async |authorizer| {
         authorizer
             .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -16,7 +16,6 @@ use super::InfraApiError;
 use super::InfraIdParam;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use editoast_models::Infra;
 use editoast_models::infra::ObjectQueryable;
 use editoast_models::prelude::*;
@@ -60,14 +59,6 @@ pub(in crate::views) async fn get_objects(
     Extension(auth): AuthenticationExt,
     Json(obj_ids): Json<Vec<String>>,
 ) -> Result<Json<Vec<ObjectQueryable>>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     if !has_unique_ids(&obj_ids) {
         return Err(GetObjectsErrors::DuplicateIdsProvided.into());
     }
@@ -140,15 +131,6 @@ pub(in crate::views) async fn list_objects_ids(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<ListObjectsResponse>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -20,7 +20,6 @@ use crate::error::Result;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use editoast_models::Infra;
@@ -99,14 +98,6 @@ pub(in crate::views) async fn pathfinding_view(
     Query(params): Query<QueryParam>,
     Json(input): Json<InfraPathfindingInput>,
 ) -> Result<Json<Vec<PathfindingOutput>>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Parse and check input
     let number = params.number.unwrap_or(DEFAULT_NUMBER_OF_PATHS);
     if !(1..=MAX_NUMBER_OF_PATHS).contains(&number) {

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -26,7 +26,6 @@ use crate::generated_data::InfraGeneratedData as _;
 use crate::infra_cache::InfraCache;
 use crate::views::Authentication;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use database::DbConnectionPoolV2;
@@ -50,14 +49,6 @@ pub(in crate::views) async fn get_railjson(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
 ) -> Result<impl IntoResponse> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let infra_id = infra.infra_id;
     let infra_meta = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
@@ -181,7 +172,7 @@ impl From<editoast_models::railjson::RailJsonError> for RailJsonError {
 }
 
 /// Import an infra from railjson
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "infra",
@@ -205,13 +196,6 @@ pub(in crate::views) async fn post_railjson(
     Query(params): Query<PostRailjsonQueryParams>,
     Json(railjson): Json<RailJson>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut infra = Infra::changeset()
         .name(params.name.clone())
         .last_railjson_version()

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -19,7 +19,6 @@ use crate::error::Result;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use crate::views::params::List;
@@ -64,14 +63,6 @@ pub(in crate::views) async fn get_routes_from_waypoint(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<RoutesResponse>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), path.infra_id, || InfraApiError::NotFound {
         infra_id: path.infra_id,
@@ -158,15 +149,6 @@ pub(in crate::views) async fn get_routes_track_ranges(
     Path(infra): Path<i64>,
     Query(params): Query<RouteTrackRangesParams>,
 ) -> Result<Json<Vec<RouteTrackRangesResult>>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let db_pool = db_pool.clone();
     let infra_caches = infra_caches.clone();
     let infra_id = infra;
@@ -237,14 +219,6 @@ pub(in crate::views) async fn get_routes_nodes(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Json(node_states): Json<HashMap<String, Option<String>>>,
 ) -> Result<Json<RoutesFromNodesPositions>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -20,8 +18,6 @@ use crate::AppState;
 use crate::error::Result;
 use crate::map::get_cache_tile_key;
 use crate::map::get_view_cache_prefix;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use editoast_models::map::GeoJsonAndData;
 use editoast_models::map::Layer;
 use editoast_models::map::MapLayers;
@@ -107,18 +103,9 @@ pub(in crate::views) async fn layer_view(
     State(AppState {
         map_layers, config, ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
     Path((layer_slug, view_slug)): Path<(String, String)>,
     Query(InfraQueryParam { infra: infra_id }): Query<InfraQueryParam>,
 ) -> Result<Json<ViewMetadata>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let layer = match map_layers.layers.get(&layer_slug) {
         Some(layer) => layer,
         None => return Err(LayersError::new_layer_not_found(layer_slug, &map_layers).into()),
@@ -177,18 +164,9 @@ pub(in crate::views) async fn cache_and_get_mvt_tile(
         config,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
     Path((layer_slug, view_slug, z, x, y)): Path<(String, String, u64, u64, u64)>,
     Query(InfraQueryParam { infra: infra_id }): Query<InfraQueryParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let layer = match map_layers.layers.get(&layer_slug) {
         Some(layer) => layer,
         None => return Err(LayersError::new_layer_not_found(layer_slug, &map_layers).into()),

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -3,7 +3,6 @@ use crate::error::Result;
 use crate::models::TrainSchedule;
 use crate::models::train_schedule::OccurrenceId;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
 use crate::views::projection::interpolate_arrival_time;
@@ -76,7 +75,7 @@ pub(in crate::views) struct LevelCrossingOccupancy {
 }
 
 /// Get the occupancy of a set of level crossings for a set of trains
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "level_crossing",
@@ -101,14 +100,6 @@ pub(in crate::views) async fn occupancy(
         electrical_profile_set_id,
     }): Json<LevelCrossingOccupancyForm>,
 ) -> Result<Json<HashMap<Identifier, Vec<LevelCrossingOccupancy>>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     auth.check_authorization(async |authorizer| {
         authorizer
             .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -744,18 +744,6 @@ impl Authentication {
         }
     }
 
-    /// Checks if the issuer of the request has at least one of the required roles.
-    /// Always returns `false` if the request is unauthenticated.
-    async fn check_roles(&self, required_roles: HashSet<Role>) -> Result<bool, AuthorizerError> {
-        match self {
-            Authentication::SkipAuthorization { .. } => Ok(true),
-            Authentication::Unauthenticated => Ok(false),
-            Authentication::Authenticated(authorizer) => {
-                authorizer.check_roles(required_roles).await
-            }
-        }
-    }
-
     /// Function wrapper that allows you to check if the issuer of the request has the good privilege, grant, role....
     /// If the request is unauthenticated, it will return an Unauthorized error, and for the SkipAuthorization.
     /// The provided function will be called with the authorizer and its result will be checked by the allowed() method.

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -6,7 +6,6 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use authz;
-use authz::Role;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -36,7 +35,6 @@ use crate::AppState;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::path::PathfindingError;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use editoast_models::Infra;
@@ -229,14 +227,6 @@ pub(in crate::views) async fn post(
     Path(infra_id): Path<i64>,
     Json(path_input): Json<PathfindingInput>,
 ) -> Result<Json<PathfindingResult>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         PathfindingError::InfraNotFound { infra_id }

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -1,5 +1,4 @@
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -19,13 +18,11 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::AuthenticationExt;
 use super::operational_studies::OperationalStudiesOrderingParam;
 use super::pagination::PaginatedList;
 use super::pagination::PaginationStats;
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginationQueryParams;
 use editoast_models::Document;
 use editoast_models::project::Project;
@@ -133,7 +130,7 @@ impl ProjectWithStudyCount {
 }
 
 /// Create a new project
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "projects",
@@ -144,16 +141,8 @@ impl ProjectWithStudyCount {
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(project_create_form): Json<ProjectCreateForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
     if let Some(image) = project_create_form.image {
         check_image_content(conn, image).await?;
@@ -174,7 +163,7 @@ pub(in crate::views) struct ProjectWithStudyCountList {
 }
 
 /// Returns a paginated list of projects
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "projects",
@@ -185,18 +174,9 @@ pub(in crate::views) struct ProjectWithStudyCountList {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(ordering_params): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<ProjectWithStudyCountList>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let ordering = ordering_params.ordering;
     let settings = pagination_params
         .into_selection_settings()
@@ -227,7 +207,7 @@ pub(in crate::views) struct ProjectIdParam {
 }
 
 /// Retrieve a project
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "projects",
@@ -238,16 +218,8 @@ pub(in crate::views) struct ProjectIdParam {
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,
 ) -> Result<Json<ProjectWithStudyCount>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let mut conn = db_pool.get().await?;
     let project = Project::retrieve_or_fail(conn.clone(), project_id, || ProjectError::NotFound {
         project_id,
@@ -259,7 +231,7 @@ pub(in crate::views) async fn get(
 }
 
 /// Delete a project
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "projects",
@@ -270,17 +242,8 @@ pub(in crate::views) async fn get(
 )]
 pub(in crate::views) async fn delete(
     Path(project_id): Path<i64>,
-    Extension(auth): AuthenticationExt,
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     db_pool
         .get()
         .await?
@@ -335,7 +298,7 @@ impl ProjectPatchForm {
 }
 
 /// Update a project
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     patch, path = "",
     tag = "projects",
@@ -350,18 +313,9 @@ impl ProjectPatchForm {
 )]
 pub(in crate::views) async fn patch(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,
     Json(mut form): Json<ProjectPatchForm>,
 ) -> Result<Json<ProjectWithStudyCount>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
     let update_image = match form.image {
         // image replacement

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -7,7 +7,6 @@ use std::io::Cursor;
 use std::sync::Arc;
 
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Multipart;
 use axum::extract::Path;
@@ -39,8 +38,6 @@ use utoipa::ToSchema;
 
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct RollingStockWithLiveries {
@@ -173,7 +170,7 @@ pub struct RollingStockNameParam {
 }
 
 /// Get a rolling stock by Id
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -184,16 +181,8 @@ pub struct RollingStockNameParam {
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
 ) -> Result<Json<RollingStockWithLiveries>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let rolling_stock = retrieve_existing_rolling_stock(
         &mut db_pool.get().await?,
         RollingStockKey::Id(rolling_stock_id),
@@ -205,7 +194,7 @@ pub(in crate::views) async fn get(
 }
 
 /// Get a rolling stock by name
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -216,17 +205,8 @@ pub(in crate::views) async fn get(
 )]
 pub(in crate::views) async fn get_by_name(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(rolling_stock_name): Path<String>,
 ) -> Result<Json<RollingStockWithLiveries>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let rolling_stock = retrieve_existing_rolling_stock(
         &mut db_pool.get().await?,
         RollingStockKey::Name(rolling_stock_name),
@@ -238,7 +218,7 @@ pub(in crate::views) async fn get_by_name(
 }
 
 /// Returns the set of power restrictions for all rolling_stocks modes.
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
@@ -248,15 +228,7 @@ pub(in crate::views) async fn get_by_name(
 )]
 pub(in crate::views) async fn get_power_restrictions(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<String>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
     let power_restrictions = RollingStock::get_power_restrictions(conn).await?;
     Ok(Json(
@@ -275,7 +247,7 @@ pub(in crate::views) struct PostRollingStockQueryParams {
 }
 
 /// Create a rolling stock
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "rolling_stock",
@@ -287,18 +259,9 @@ pub(in crate::views) struct PostRollingStockQueryParams {
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(query_params): Query<PostRollingStockQueryParams>,
     Json(rolling_stock_form): Json<RollingStockForm>,
 ) -> Result<Json<RollingStock>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let rolling_stock_changeset: Changeset<RollingStock> = rolling_stock_form.into();
 
@@ -313,7 +276,7 @@ pub(in crate::views) async fn create(
 }
 
 /// Modify a rolling stock
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "rolling_stock",
@@ -325,18 +288,9 @@ pub(in crate::views) async fn create(
 )]
 pub(in crate::views) async fn update(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
     Json(rolling_stock_form): Json<RollingStockForm>,
 ) -> Result<Json<RollingStockWithLiveries>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let new_rolling_stock = db_pool
         .get()
         .await?
@@ -383,7 +337,7 @@ pub(in crate::views) struct DeleteRollingStockQueryParams {
 }
 
 /// Delete a rolling_stock and all entities linked to it
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "rolling_stock",
@@ -397,17 +351,9 @@ pub(in crate::views) struct DeleteRollingStockQueryParams {
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
     Query(DeleteRollingStockQueryParams { force }): Query<DeleteRollingStockQueryParams>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
 
     let rolling_stock = RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
@@ -453,7 +399,7 @@ pub(in crate::views) struct RollingStockLockedUpdateForm {
 }
 
 /// Update rolling_stock locked field
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     patch, path = "",
     tag = "rolling_stock",
@@ -465,18 +411,9 @@ pub(in crate::views) struct RollingStockLockedUpdateForm {
 )]
 pub(in crate::views) async fn update_locked(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
     Json(RollingStockLockedUpdateForm { locked }): Json<RollingStockLockedUpdateForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     RollingStock::changeset()
@@ -535,7 +472,7 @@ async fn parse_multipart_content(
 }
 
 /// Create a rolling stock livery
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tags = ["rolling_stock", "rolling_stock_livery"],
@@ -548,17 +485,9 @@ async fn parse_multipart_content(
 )]
 pub(in crate::views) async fn create_livery(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(rolling_stock_id): Path<i64>,
     form: Multipart,
 ) -> Result<Json<schemas::rolling_stock::RollingStockLivery>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
 
     let (name, images) = parse_multipart_content(form)

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,5 +1,3 @@
-use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -37,9 +35,6 @@ use crate::views::pagination::PaginationStats;
 
 #[cfg(test)]
 use serde::Deserialize;
-
-use super::AuthenticationExt;
-use super::AuthorizationError;
 
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
@@ -90,16 +85,8 @@ pub(in crate::views) struct LightRollingStockWithLiveriesCountList {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(page_settings): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<LightRollingStockWithLiveriesCountList>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let settings = page_settings
         .into_selection_settings()
         .order_by(|| RollingStock::ID.asc());
@@ -132,16 +119,8 @@ pub(in crate::views) async fn list(
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(light_rolling_stock_id): Path<i64>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let rolling_stock =
         RollingStock::retrieve_or_fail(db_pool.get().await?, light_rolling_stock_id, || {
             RollingStockError::KeyNotFound {
@@ -166,16 +145,8 @@ pub(in crate::views) async fn get(
 )]
 pub(in crate::views) async fn get_by_name(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(light_rolling_stock_name): Path<String>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let rolling_stock = RollingStock::retrieve_or_fail(
         db_pool.get().await?,
         light_rolling_stock_name.clone(),

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -2,13 +2,10 @@ use std::sync::Arc;
 
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
 use authz::Role;
-use axum::Extension;
 use axum::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -49,7 +46,7 @@ pub(in crate::views) struct PostTowedRollingStockQueryParams {
 }
 
 /// Create a towed rolling stock
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "rolling_stock",
@@ -61,17 +58,9 @@ pub(in crate::views) struct PostTowedRollingStockQueryParams {
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(query_params): Query<PostTowedRollingStockQueryParams>,
     Json(towed_rolling_stock_form): Json<TowedRollingStockForm>,
 ) -> Result<Json<TowedRollingStock>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
     let rolling_stock_changeset: Changeset<TowedRollingStock> = towed_rolling_stock_form.into();
 
@@ -103,16 +92,8 @@ pub(in crate::views) struct TowedRollingStockCountList {
 )]
 pub(in crate::views) async fn get_list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(page_settings): Query<PaginationQueryParams<50>>,
 ) -> Result<Json<TowedRollingStockCountList>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let settings = page_settings
         .into_selection_settings()
         .order_by(|| TowedRollingStock::ID.asc());
@@ -141,19 +122,10 @@ pub struct TowedRollingStockIdParam {
 )]
 pub(in crate::views) async fn get_by_id(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TowedRollingStockIdParam {
         towed_rolling_stock_id,
     }): Path<TowedRollingStockIdParam>,
 ) -> Result<Json<TowedRollingStock>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let towed_rolling_stock =
         TowedRollingStock::retrieve_or_fail(db_pool.get().await?, towed_rolling_stock_id, || {
             TowedRollingStockError::IdNotFound {
@@ -164,7 +136,7 @@ pub(in crate::views) async fn get_by_id(
     Ok(Json(towed_rolling_stock))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "rolling_stock",
@@ -176,20 +148,11 @@ pub(in crate::views) async fn get_by_id(
 )]
 pub(in crate::views) async fn put_by_id(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TowedRollingStockIdParam {
         towed_rolling_stock_id,
     }): Path<TowedRollingStockIdParam>,
     Json(towed_rolling_stock_form): Json<TowedRollingStockForm>,
 ) -> Result<Json<TowedRollingStock>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let new_towed_rolling_stock = db_pool
         .get()
         .await?
@@ -236,7 +199,7 @@ pub(in crate::views) struct TowedRollingStockLockedForm {
     pub locked: bool,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     patch, path = "",
     tag = "rolling_stock",
@@ -248,18 +211,9 @@ pub(in crate::views) struct TowedRollingStockLockedForm {
 )]
 pub(in crate::views) async fn patch_by_id_locked(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(towed_rolling_stock_id): Path<i64>,
     Json(TowedRollingStockLockedForm { locked }): Json<TowedRollingStockLockedForm>,
 ) -> Result<StatusCode> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     TowedRollingStock::changeset()

--- a/editoast/src/views/round_trips.rs
+++ b/editoast/src/views/round_trips.rs
@@ -1,11 +1,8 @@
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
 use crate::views::timetable::TimetableIdParam;
 use authz;
-use axum::Extension;
 use axum::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -91,7 +88,7 @@ fn schema_round_trips() -> RefOr<Schema> {
 }
 
 /// Upsert a list of round trips / one-way of train schedules
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "round_trips",
@@ -100,17 +97,8 @@ fn schema_round_trips() -> RefOr<Schema> {
 )]
 pub(in crate::views) async fn post_train_schedules(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(round_trips): Json<RoundTrips>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     if round_trips.has_duplicates() {
         return Err(RoundTripsError::DuplicateTrainIds.into());
     }
@@ -150,7 +138,7 @@ pub(in crate::views) async fn post_train_schedules(
 }
 
 /// Delete a list of round trips / one-way of train schedules
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "round_trips",
@@ -162,17 +150,8 @@ pub(in crate::views) async fn post_train_schedules(
 )]
 pub(in crate::views) async fn delete_train_schedules(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(train_schedule_ids): Json<HashSet<i64>>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     TrainScheduleRoundTrips::delete_batch_train_ids(conn, train_schedule_ids).await?;
 
@@ -188,7 +167,7 @@ pub(in crate::views) struct RoundTripsPage {
 }
 
 /// Upsert a list of round trips / one-way of train schedules
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tags = ["timetable", "round_trips"],
@@ -197,18 +176,9 @@ pub(in crate::views) struct RoundTripsPage {
 )]
 pub(in crate::views) async fn list_train_schedules(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<RoundTripsPage>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     Timetable::exists_or_fail(conn, timetable_id, || RoundTripsError::TimetableNotFound {

--- a/editoast/src/views/router.rs
+++ b/editoast/src/views/router.rs
@@ -1,5 +1,10 @@
 use std::collections::VecDeque;
 
+use axum::Extension;
+use axum::response::IntoResponse as _;
+
+use super::AuthorizationError;
+
 pub(super) struct RouteDocumentation {
     pub(super) http_methods: Vec<utoipa::openapi::path::HttpMethod>,
     pub(super) operation: utoipa::openapi::path::Operation,
@@ -10,13 +15,18 @@ pub(super) struct RouteDocumentation {
     )>,
 }
 
+pub(in crate::views) struct RouteMetadata {
+    pub(in crate::views) documentation: fn() -> RouteDocumentation,
+    pub(in crate::views) required_role: Option<authz::Role>,
+}
+
 // fn(function_type_name) -> utoipa::Path::path_item
 //
 // We can't just build a slice of tuples (&'static str, fn) because std::any::type_name_of_val
 // constness is unstable. So O(n^2) here we go...
 //
 // If this takes too long, we can always optimize it later (structure, search algorithm, featuring utoipa).
-pub(in crate::views) type OpenApiRouteSliceItem = fn(&str) -> Option<fn() -> RouteDocumentation>;
+pub(in crate::views) type OpenApiRouteSliceItem = fn(&str) -> Option<RouteMetadata>;
 
 #[linkme::distributed_slice]
 pub(in crate::views) static OPENAPI_ROUTES: [OpenApiRouteSliceItem];
@@ -105,7 +115,11 @@ impl DocumentedRouter {
             utoipa::openapi::HttpMethod,
         ),
     ) -> Self {
-        let Some(path_item) = OPENAPI_ROUTES.iter().find_map(|matcher| matcher(type_name)) else {
+        let Some(RouteMetadata {
+            documentation: path_item,
+            required_role,
+        }) = OPENAPI_ROUTES.iter().find_map(|matcher| matcher(type_name))
+        else {
             panic!("no openapi found for route {path} with type {type_name}!");
         };
         let RouteDocumentation { http_methods, .. } = path_item();
@@ -120,6 +134,18 @@ impl DocumentedRouter {
             path_segment: path,
             path_item,
         });
+        let method_router = if let Some(required_role) = required_role {
+            method_router.route_layer(axum::middleware::from_fn(
+                move |Extension(roles): Extension<Vec<authz::Role>>,
+                      Extension(authn): Extension<crate::authentication::Authentication>,
+                      req: axum::extract::Request,
+                      next: axum::middleware::Next| {
+                    verify_role(required_role, roles, authn, req, next)
+                },
+            ))
+        } else {
+            method_router
+        };
         Self {
             router: self.router.route(path, method_router),
             path_trees: self.path_trees,
@@ -135,6 +161,34 @@ impl DocumentedRouter {
         Self {
             router: self.router.nest(path, router),
             path_trees: self.path_trees,
+        }
+    }
+}
+
+#[tracing::instrument(name = "role verification", skip_all, fields(?required_role, decision = tracing::field::Empty))]
+async fn verify_role(
+    required_role: authz::Role,
+    roles: Vec<authz::Role>,
+    authn: crate::authentication::Authentication,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    match (authn, roles) {
+        (crate::authentication::Authentication::Skip { .. }, _) => {
+            tracing::Span::current().record("decision", "skip");
+            next.run(req).await
+        }
+        (_, roles) if roles.contains(&required_role) => {
+            tracing::Span::current().record("decision", "allow");
+            next.run(req).await
+        }
+        (_, roles) if roles.contains(&authz::Role::Admin) => {
+            tracing::Span::current().record("decision", "admin");
+            next.run(req).await
+        }
+        _ => {
+            tracing::Span::current().record("decision", "deny");
+            crate::error::InternalError::from(AuthorizationError::Forbidden).into_response()
         }
     }
 }

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -2,7 +2,6 @@ pub mod macro_nodes;
 pub mod macro_notes;
 
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -24,8 +23,6 @@ use utoipa::ToSchema;
 
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::operational_studies::OperationalStudiesOrderingParam;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
@@ -169,7 +166,7 @@ impl ScenarioResponse {
 }
 
 /// Create a scenario
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
@@ -180,17 +177,8 @@ impl ScenarioResponse {
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(data): Json<ScenarioCreateForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let timetable_id = data.timetable_id;
     let infra_id = data.infra_id;
     let study_id = data.study_id;
@@ -223,7 +211,7 @@ pub(in crate::views) async fn create(
 }
 
 /// Delete a scenario
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
@@ -234,17 +222,8 @@ pub(in crate::views) async fn create(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(ScenarioIdParam { scenario_id }): Path<ScenarioIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     conn.transaction(async move |conn| {
@@ -295,7 +274,7 @@ impl ScenarioPatchForm {
 }
 
 /// Update a scenario
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     patch, path = "",
     tag = "scenarios",
@@ -307,18 +286,9 @@ impl ScenarioPatchForm {
 )]
 pub(in crate::views) async fn patch(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(ScenarioIdParam { scenario_id }): Path<ScenarioIdParam>,
     Json(form): Json<ScenarioPatchForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let details = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
@@ -348,7 +318,7 @@ pub(in crate::views) async fn patch(
 }
 
 /// Return a specific scenario
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -359,17 +329,8 @@ pub(in crate::views) async fn patch(
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(ScenarioIdParam { scenario_id }): Path<ScenarioIdParam>,
 ) -> Result<Json<ScenarioResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let (details, project, study) = db_pool
         .get()
         .await?
@@ -417,7 +378,7 @@ pub(in crate::views) struct ListScenariosQueryParams {
 }
 
 /// Return a list of scenarios
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -429,19 +390,10 @@ pub(in crate::views) struct ListScenariosQueryParams {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(ListScenariosQueryParams { study_id }): Query<ListScenariosQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(OperationalStudiesOrderingParam { ordering }): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<ListScenariosResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let settings = pagination_params

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -18,8 +17,6 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -149,7 +146,7 @@ pub(in crate::views) struct ListMacroNodesQueryParams {
 }
 
 /// Get macro node list by scenario id
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -160,19 +157,10 @@ pub(in crate::views) struct ListMacroNodesQueryParams {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(ListMacroNodesQueryParams { scenario_id }): Query<ListMacroNodesQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<MacroNodeListResponse>> {
     // Checking role
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     // Ask the db
@@ -194,7 +182,7 @@ pub(in crate::views) async fn list(
 }
 
 /// Create macro nodes in batch
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
@@ -205,21 +193,12 @@ pub(in crate::views) async fn list(
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(MacroNodeBatchForm {
         macro_nodes,
         scenario_id,
     }): Json<MacroNodeBatchForm>,
 ) -> Result<impl IntoResponse> {
     // Checking role
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let created = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
@@ -246,7 +225,7 @@ pub(in crate::views) async fn create(
 }
 
 /// Retrieve a macro node by id
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -257,18 +236,9 @@ pub(in crate::views) async fn create(
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(MacroNodeIdParam { node_id }): Path<MacroNodeIdParam>,
 ) -> Result<Json<MacroNodeResponse>> {
     // Checking role
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     // Get the node
@@ -279,7 +249,7 @@ pub(in crate::views) async fn get(
 }
 
 /// Update a macro node
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "scenarios",
@@ -291,18 +261,9 @@ pub(in crate::views) async fn get(
 )]
 pub(in crate::views) async fn update(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(MacroNodeIdParam { node_id }): Path<MacroNodeIdParam>,
     Json(data): Json<MacroNodeForm>,
 ) -> Result<Json<MacroNodeResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     let updated_macro_node = conn
@@ -335,7 +296,7 @@ pub(in crate::views) async fn update(
 }
 
 /// Delete a macro node
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
@@ -346,17 +307,8 @@ pub(in crate::views) async fn update(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(MacroNodeIdParam { node_id }): Path<MacroNodeIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     conn.transaction(async move |conn| {

--- a/editoast/src/views/scenario/macro_notes.rs
+++ b/editoast/src/views/scenario/macro_notes.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -18,8 +17,6 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -136,7 +133,7 @@ pub(in crate::views) struct ListMacroNotesQueryParams {
 }
 
 /// Return a list of notes for a given scenario
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -147,18 +144,9 @@ pub(in crate::views) struct ListMacroNotesQueryParams {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(ListMacroNotesQueryParams { scenario_id }): Query<ListMacroNotesQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<MacroNoteListResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     let settings = pagination_params
@@ -177,7 +165,7 @@ pub(in crate::views) async fn list(
 }
 
 /// Create a note in batch
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "scenarios",
@@ -188,20 +176,11 @@ pub(in crate::views) async fn list(
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(MacroNoteBatchForm {
         macro_notes,
         scenario_id,
     }): Json<MacroNoteBatchForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let created = Scenario::transactional_content_update(
         db_pool.get().await?,
         scenario_id,
@@ -229,7 +208,7 @@ pub(in crate::views) async fn create(
 }
 
 /// Return a specific note
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -240,18 +219,9 @@ pub(in crate::views) async fn create(
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(MacroNoteIdParam { note_id }): Path<MacroNoteIdParam>,
 ) -> Result<Json<MacroNoteResponse>> {
     // Checking role
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     // Get the note
@@ -262,7 +232,7 @@ pub(in crate::views) async fn get(
 }
 
 /// Update a note
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "scenarios",
@@ -274,18 +244,9 @@ pub(in crate::views) async fn get(
 )]
 pub(in crate::views) async fn update(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(MacroNoteIdParam { note_id }): Path<MacroNoteIdParam>,
     Json(note_form): Json<MacroNoteForm>,
 ) -> Result<Json<MacroNoteResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     let updated_macro_note = conn
@@ -318,7 +279,7 @@ pub(in crate::views) async fn update(
 }
 
 /// Delete a note
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "scenarios",
@@ -329,17 +290,8 @@ pub(in crate::views) async fn update(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(MacroNoteIdParam { note_id }): Path<MacroNoteIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     conn.transaction(async move |conn| {

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -230,11 +230,9 @@ use search::query_into_sql;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::value::Value as JsonValue;
-use std::collections::HashSet;
 use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::pagination::PaginationQueryParams;
 use database::DbConnectionPoolV2;
@@ -340,17 +338,16 @@ struct SearchDBResult {
 )]
 pub(in crate::views) async fn search(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    Extension(roles): Extension<Vec<authz::Role>>,
+    Extension(authn): Extension<crate::authentication::Authentication>,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<1000>>,
     Json(SearchPayload { object, query, dry }): Json<SearchPayload>,
 ) -> Result<Json<serde_json::Value>> {
-    let roles: HashSet<Role> = match object.as_str() {
+    let required_role = match object.as_str() {
         "track" | "signal" | "project" | "study" | "scenario" => {
-            HashSet::from([Role::OperationalStudies])
+            Some(authz::Role::OperationalStudies)
         }
-        "trainschedule" | "operationalpoint" | "user" => {
-            HashSet::from([Role::OperationalStudies, Role::Stdcm])
-        }
+        "trainschedule" | "operationalpoint" | "user" => None,
         _ => {
             return Err(SearchApiError::ObjectType {
                 object_type: object.to_owned(),
@@ -359,11 +356,11 @@ pub(in crate::views) async fn search(
         }
     };
 
-    let authorized = auth
-        .check_roles(roles)
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    if let Some(required_role) = required_role
+        && !matches!(authn, crate::authentication::Authentication::Skip { .. })
+        && !roles.contains(&required_role)
+        && !roles.contains(&Role::Admin)
+    {
         return Err(AuthorizationError::Forbidden.into());
     }
 

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -2,7 +2,6 @@ use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -29,8 +28,6 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "stdcm_search_env")]
@@ -194,7 +191,7 @@ impl From<editoast_models::stdcm_search_environment::StdcmSearchEnvironment>
     }
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Admin)]
 #[utoipa::path(
     post, path = "",
     tag = "stdcm_search_environment",
@@ -205,23 +202,14 @@ impl From<editoast_models::stdcm_search_environment::StdcmSearchEnvironment>
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(form): Json<StdcmSearchEnvironmentCreateForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let changeset: Changeset<StdcmSearchEnvironment> = form.into();
     Ok((StatusCode::CREATED, Json(changeset.create(conn).await?)))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Stdcm)]
 #[utoipa::path(
     get, path = "",
     tag = "stdcm_search_environment",
@@ -232,16 +220,7 @@ pub(in crate::views) async fn create(
 )]
 pub(in crate::views) async fn retrieve_latest(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
 ) -> Result<Response> {
-    let authorized = auth
-        .check_roles([Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let search_env = StdcmSearchEnvironment::retrieve_latest_enabled(conn).await;
     if let Some(search_env) = search_env {
@@ -259,7 +238,7 @@ pub(in crate::views) struct StdcmSearchEnvIdParam {
     env_id: i64,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Admin)]
 #[utoipa::path(
     delete, path = "",
     tag = "stdcm_search_environment",
@@ -270,17 +249,8 @@ pub(in crate::views) struct StdcmSearchEnvIdParam {
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(StdcmSearchEnvIdParam { env_id }): Path<StdcmSearchEnvIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     StdcmSearchEnvironment::delete_static_or_fail(conn, env_id, || StdcmSearchEnvError::NotFound {
         env_id,
@@ -299,7 +269,7 @@ pub(in crate::views) struct SdcmSearchEnvListResponse {
     stats: PaginationStats,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Admin)]
 #[utoipa::path(
     get, path = "",
     tag = "stdcm_search_environment",
@@ -310,16 +280,8 @@ pub(in crate::views) struct SdcmSearchEnvListResponse {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(page_settings): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<SdcmSearchEnvListResponse>> {
-    let authorized = auth
-        .check_roles([Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let mut conn = db_pool.get().await?;
     let settings = page_settings
         .into_selection_settings()

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -1,5 +1,4 @@
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -19,8 +18,6 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::AuthenticationExt;
-use super::AuthorizationError;
 use super::operational_studies::OperationalStudiesOrderingParam;
 use super::pagination::PaginationStats;
 use crate::error::InternalError;
@@ -162,7 +159,7 @@ impl StudyCreateForm {
 }
 
 /// Create a new study
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "studies",
@@ -173,17 +170,8 @@ impl StudyCreateForm {
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(data): Json<StudyCreateForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let study = Project::transactional_content_update(
         db_pool.get().await?,
         data.project_id,
@@ -210,7 +198,7 @@ pub(in crate::views) struct StudyIdParam {
 }
 
 /// Delete a study
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "studies",
@@ -221,17 +209,8 @@ pub(in crate::views) struct StudyIdParam {
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(StudyIdParam { study_id }): Path<StudyIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     conn.transaction(async move |conn| {
@@ -255,7 +234,7 @@ pub(in crate::views) async fn delete(
 }
 
 /// Return a specific study
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "studies",
@@ -266,17 +245,8 @@ pub(in crate::views) async fn delete(
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(StudyIdParam { study_id }): Path<StudyIdParam>,
 ) -> Result<Json<StudyResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let (study_scenarios, project) = db_pool
         .get()
         .await?
@@ -361,7 +331,7 @@ impl StudyPatchForm {
 }
 
 /// Update a study
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     patch, path = "",
     tag = "studies",
@@ -376,18 +346,9 @@ impl StudyPatchForm {
 )]
 pub(in crate::views) async fn patch(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(StudyIdParam { study_id }): Path<StudyIdParam>,
     Json(data): Json<StudyPatchForm>,
 ) -> Result<Json<StudyWithScenarioCount>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let response = Study::transactional_content_update(
         db_pool.get().await?,
         study_id,
@@ -443,7 +404,7 @@ pub(in crate::views) struct ListStudiesQueryParams {
 }
 
 /// Return a list of studies
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "studies",
@@ -454,19 +415,10 @@ pub(in crate::views) struct ListStudiesQueryParams {
 )]
 pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(ListStudiesQueryParams { project_id }): Query<ListStudiesQueryParams>,
     Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(ordering_params): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<StudyListResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let ordering = ordering_params.ordering;
     match Project::exists(&mut db_pool.get().await?, project_id).await {
         Ok(true) => (),

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -1,5 +1,4 @@
 use authz;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -18,8 +17,6 @@ use utoipa::ToSchema;
 
 use crate::error::Result;
 use crate::models;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -70,17 +67,8 @@ pub(in crate::views) struct SubCategoryPage {
 )]
 pub(in crate::views) async fn get_sub_categories(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(pagination): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<SubCategoryPage>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     let (sub_categories, stats) = editoast_models::SubCategory::list_paginated(
@@ -97,7 +85,7 @@ pub(in crate::views) async fn get_sub_categories(
     }))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::Admin)]
 #[utoipa::path(
     post, path = "",
     tag = "sub_categories",
@@ -108,16 +96,8 @@ pub(in crate::views) async fn get_sub_categories(
 )]
 pub(in crate::views) async fn create_sub_categories(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(data): Json<Vec<SubCategory>>,
 ) -> Result<Json<Vec<SubCategory>>> {
-    let authorized = auth
-        .check_roles([authz::Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = &mut db_pool.get().await?;
 
     let sub_categories: Vec<Changeset<editoast_models::SubCategory>> =
@@ -138,7 +118,7 @@ struct SubCategoryCodeParam {
     code: String,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::Admin)]
 #[utoipa::path(
     delete, path = "",
     tag = "sub_categories",
@@ -150,16 +130,7 @@ struct SubCategoryCodeParam {
 pub(in crate::views) async fn delete_sub_category(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Path(code): Path<String>,
-    Extension(auth): AuthenticationExt,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     conn.transaction(|mut tx| {

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -1,4 +1,3 @@
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -18,8 +17,6 @@ use thiserror::Error;
 use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use authz::Role;
 use editoast_models::TemporarySpeedLimit;
 use editoast_models::TemporarySpeedLimitGroup;
@@ -112,7 +109,7 @@ impl From<temporary_speed_limits::TslGroupError> for TemporarySpeedLimitError {
     }
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "temporary_speed_limits",
@@ -123,20 +120,11 @@ impl From<temporary_speed_limits::TslGroupError> for TemporarySpeedLimitError {
 )]
 pub(in crate::views) async fn create_temporary_speed_limit_group(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(TemporarySpeedLimitCreateForm {
         speed_limit_group_name,
         speed_limits,
     }): Json<TemporarySpeedLimitCreateForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     // Create the speed limits group

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -65,7 +65,6 @@ use crate::error::Result;
 use crate::models;
 use crate::models::train_schedule::OccurrenceId;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use editoast_models::Infra;
 use editoast_models::TrainScheduleSet;
@@ -113,7 +112,7 @@ pub struct TimetableIdParam {
 }
 
 /// Create a timetable
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "timetable",
@@ -123,16 +122,7 @@ pub struct TimetableIdParam {
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let timetable = Timetable::changeset().create(conn).await?;
@@ -142,7 +132,7 @@ pub(in crate::views) async fn post(
 }
 
 /// Delete a timetable
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tag = "timetable",
@@ -154,17 +144,8 @@ pub(in crate::views) async fn post(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     Timetable::delete_static_or_fail(conn, timetable_id, || TimetableError::NotFound {
         timetable_id,
@@ -183,7 +164,7 @@ pub(in crate::views) struct ListTrainSchedulesResponse {
 }
 
 /// Return a specific timetable with its associated paced trains
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "timetable",
@@ -195,18 +176,9 @@ pub(in crate::views) struct ListTrainSchedulesResponse {
 )]
 pub(in crate::views) async fn get_train_schedules(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Query(pagination_params): Query<PaginationQueryParams<200>>,
 ) -> Result<Json<ListTrainSchedulesResponse>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let timetable_exists = Timetable::exists(conn, timetable_id).await?;
@@ -323,14 +295,6 @@ pub(in crate::views) async fn conflicts(
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
 ) -> Result<Json<Vec<Conflict>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = db_pool.get().await?;
 
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || TimetableError::InfraNotFound {
@@ -473,14 +437,6 @@ pub(in crate::views) async fn requirements(
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
 ) -> Result<Json<TrainRequirementsPage>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
@@ -774,20 +730,11 @@ impl From<PhysicsConsistParameters> for PhysicsConsist {
 )]
 pub(in crate::views) async fn set_links_train_schedule_sets_to_timetable(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Json(TrainScheduleSetForm {
         train_schedule_set_ids,
     }): Json<TrainScheduleSetForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     Timetable::exists_or_fail(&mut conn, timetable_id, || TimetableError::NotFound {
@@ -821,17 +768,8 @@ pub(in crate::views) async fn set_links_train_schedule_sets_to_timetable(
 )]
 pub(in crate::views) async fn get_train_schedule_sets_from_timetable(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
 ) -> Result<Json<Vec<TrainScheduleSet>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     Timetable::exists_or_fail(&mut db_pool.get().await?, timetable_id, || {
         TimetableError::NotFound { timetable_id }
     })

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -25,7 +25,6 @@ use std::ops::Deref;
 
 use arcstr::ArcStr;
 use authz::Role;
-use axum::Extension;
 use axum::Json;
 use axum::extract::State;
 use chrono::DateTime;
@@ -47,8 +46,6 @@ use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
 
 use super::AppState;
-use super::AuthenticationExt;
-use super::AuthorizationError;
 
 // Simulation layer struct, not a view struct, to move in some mod.rs when the simulation crate will be there
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Deref)]
@@ -164,7 +161,7 @@ enum SimilarTrainsError {
     Database(editoast_models::Error),
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Stdcm)]
 #[utoipa::path(
     post, path = "",
     tags = ["similar_trains", "stdcm", "sncf"],
@@ -178,7 +175,6 @@ enum SimilarTrainsError {
     ),
 )]
 pub(in crate::views) async fn similar_trains(
-    Extension(auth): AuthenticationExt,
     State(AppState {
         db_pool,
         speed_limit_tag_ids,
@@ -190,14 +186,6 @@ pub(in crate::views) async fn similar_trains(
         waypoints,
     }): Json<Request>,
 ) -> Result<Json<Response>> {
-    let authorized = auth
-        .check_roles([Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     // Get trains traffic

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -54,7 +54,6 @@ use crate::AppState;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
@@ -181,7 +180,7 @@ pub(in crate::views) struct StdcmQueryParams {
         path_found,
     )
 )]
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::Stdcm)]
 #[utoipa::path(
     post, path = "",
     tag = "stdcm",
@@ -241,14 +240,6 @@ pub(in crate::views) async fn stdcm_handler(
     Json(request): Json<Request>,
     returned_request: &mut Option<core_client::stdcm::Request>,
 ) -> Result<Response> {
-    let authorized = auth
-        .check_roles([authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let mut conn = db_pool.get().await?;
 
     let timetable_id = id;

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -49,7 +49,6 @@ use crate::error::Result;
 use crate::models;
 use crate::models::train_schedule::OccurrenceId;
 use crate::models::train_schedule::TrainScheduleChangeset;
-use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::path::pathfinding::PathfindingResult;
@@ -146,19 +145,10 @@ pub(in crate::views) struct TrainScheduleIdParam {
 )]
 pub(in crate::views) async fn get_by_id(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TrainScheduleIdParam {
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let train_schedule =
@@ -173,7 +163,7 @@ pub(in crate::views) async fn get_by_id(
 }
 
 /// Update a paced train
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tags = ["timetable", "train_schedule"],
@@ -185,20 +175,11 @@ pub(in crate::views) async fn get_by_id(
 )]
 pub(in crate::views) async fn update_train_schedule(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TrainScheduleIdParam {
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
     Json(train_schedule_base): Json<TrainSchedule>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let train_schedule_changeset: TrainScheduleChangeset = train_schedule_base.into();
     train_schedule_changeset
@@ -216,7 +197,7 @@ pub(in crate::views) struct TrainScheduleIds {
 }
 
 /// Delete a train schedule
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
     tags = ["timetable", "train_schedule"],
@@ -227,19 +208,10 @@ pub(in crate::views) struct TrainScheduleIds {
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(TrainScheduleIds {
         ids: train_schedule_ids,
     }): Json<TrainScheduleIds>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     models::TrainSchedule::delete_batch_or_fail(conn, train_schedule_ids, |count| {
         TrainScheduleError::BatchNotFound { count }
@@ -303,7 +275,7 @@ struct SimulationContext {
 
 /// Associate each train schedule id with its simulation summaries response
 /// If the simulation fails, it associates the reason: pathfinding failed or running time failed
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -326,14 +298,6 @@ pub(in crate::views) async fn simulation_summary(
         ids: train_schedule_ids,
     }): Json<SimulationBatchForm>,
 ) -> Result<Json<HashMap<i64, TrainScheduleSummaryResponse>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
@@ -620,13 +584,6 @@ pub(in crate::views) async fn get_path(
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
     Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
     let conn = db_pool.get().await?;
     let mut valkey_conn = valkey_client.get_connection().await?;
 
@@ -684,7 +641,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 }
 
 /// Retrieve the space, speed and time curve of a given train
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule",
@@ -711,14 +668,6 @@ pub(in crate::views) async fn simulation(
     }): Query<ElectricalProfileSetIdQueryParam>,
     Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
 ) -> Result<Json<simulation::Response>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Retrieve infra or fail
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
@@ -800,14 +749,6 @@ pub(in crate::views) async fn etcs_braking_curves(
     }): Query<ElectricalProfileSetIdQueryParam>,
     Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
 ) -> Result<Json<core_client::etcs_braking_curves::Response>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // Retrieve infra or fail
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
@@ -940,7 +881,7 @@ pub struct ProjectPathTrainScheduleResult {
 ///     - train schedules for which the simulation fails
 /// - Trains that have a simulation but that does not honor their schedule, use their schedule with straight lines
 ///   between the known points.
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -968,14 +909,6 @@ pub(in crate::views) async fn project_path(
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
-
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
 
     auth.check_authorization(async |authorizer| {
         authorizer
@@ -1104,14 +1037,6 @@ pub(in crate::views) async fn project_path_op(
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
-
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
 
     auth.check_authorization(async |authorizer| {
         authorizer
@@ -1254,7 +1179,7 @@ pub struct OccupancyBlocksTrainScheduleResult {
 /// - train schedules for which pathfinding fails
 /// - train schedules for which the simulation fails
 /// - train schedules for which the simulation does not respect schedule times
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -1279,14 +1204,6 @@ pub(in crate::views) async fn occupancy_blocks(
         electrical_profile_set_id,
     }): Json<OccupancyBlockForm>,
 ) -> Result<Json<HashMap<i64, OccupancyBlocksTrainScheduleResult>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     auth.check_authorization(async |authorizer| {
         authorizer
             .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
@@ -1404,7 +1321,7 @@ pub(in crate::views) struct TrackSectionOccupancy {
     trains: Vec<TrackOccupancy>,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule",
@@ -1431,14 +1348,6 @@ pub(in crate::views) async fn track_occupancy(
         use_simulation,
     }): Json<TrackOccupancyForm>,
 ) -> Result<Json<Vec<TrackSectionOccupancy>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     auth.check_authorization(async |authorizer| {
         authorizer
             .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
@@ -1707,7 +1616,7 @@ pub(in crate::views) struct MoveTrainSchedulesForm {
     pub train_schedule_set_id: i64,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     patch, path = "",
     tag = "train_schedule",
@@ -1718,20 +1627,11 @@ pub(in crate::views) struct MoveTrainSchedulesForm {
 )]
 pub(in crate::views) async fn move_train_schedules_to_another_train_schedule_set(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(MoveTrainSchedulesForm {
         train_schedule_ids,
         train_schedule_set_id,
     }): Json<MoveTrainSchedulesForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     TrainScheduleSet::exists_or_fail(&mut db_pool.get().await?, train_schedule_set_id, || {
         TrainScheduleError::TrainScheduleSetNotFound {
             train_schedule_set_id,

--- a/editoast/src/views/timetable/train_schedule_exceptions.rs
+++ b/editoast/src/views/timetable/train_schedule_exceptions.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use authz;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
@@ -21,10 +20,8 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::AuthenticationExt;
 use crate::error::Result;
 use crate::models;
-use crate::views::AuthorizationError;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "train_schedule_exception")]
@@ -84,7 +81,7 @@ impl From<TrainScheduleExceptionForm> for TrainScheduleExceptionChangeset {
 }
 
 /// Create a train schedule exception
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tags = ["train_schedule_exceptions"],
@@ -96,18 +93,9 @@ impl From<TrainScheduleExceptionForm> for TrainScheduleExceptionChangeset {
 )]
 pub(in crate::views) async fn create_train_schedule_exception(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Json(train_schedule_exception_form): Json<TrainScheduleExceptionForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     Timetable::exists_or_fail(conn, timetable_id, || {
@@ -144,7 +132,7 @@ pub(in crate::views) async fn create_train_schedule_exception(
 }
 
 /// Delete train schedule exceptions
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tags = ["train_schedule_exceptions"],
@@ -158,17 +146,8 @@ pub(in crate::views) async fn create_train_schedule_exception(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(ExceptionIdsParam { ids: exception_ids }): Json<ExceptionIdsParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     editoast_models::TrainScheduleException::delete_batch_or_fail(conn, exception_ids, |count| {
@@ -180,7 +159,7 @@ pub(in crate::views) async fn delete(
 }
 
 /// Update a train schedule exception
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tags = ["train_schedule_exceptions"],
@@ -192,18 +171,9 @@ pub(in crate::views) async fn delete(
 )]
 pub(in crate::views) async fn update(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(ExceptionIdParam { id: exception_id }): Path<ExceptionIdParam>,
     Json(train_schedule_exception_form): Json<TrainScheduleExceptionForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let train_schedule_id = train_schedule_exception_form.train_schedule_id;

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -12,10 +12,7 @@ use utoipa::ToSchema;
 use crate::error::Result;
 use crate::models;
 use crate::models::train_schedule::TrainScheduleChangeset;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::timetable::train_schedule::TrainScheduleResponse;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
@@ -82,7 +79,7 @@ pub(in crate::views) struct TrainScheduleSetIdParam {
     id: i64,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "train_schedule_set",
@@ -93,17 +90,8 @@ pub(in crate::views) struct TrainScheduleSetIdParam {
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(train_schedule_set_create_form): Json<TrainScheduleSetForm>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let changeset = train_schedule_set_create_form.into_changeset();
     let train_schedule_set = changeset.create(conn).await?;
@@ -124,7 +112,7 @@ pub(in crate::views) struct TrainScheduleSetQueryParams {
     published: Option<bool>,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule_set",
@@ -136,19 +124,10 @@ pub(in crate::views) struct TrainScheduleSetQueryParams {
 )]
 pub(in crate::views) async fn get_by_id(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TrainScheduleSetIdParam {
         id: train_schedule_set_id,
     }): Path<TrainScheduleSetIdParam>,
 ) -> Result<Json<TrainScheduleSetResponse>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let train_schedule_set =
         TrainScheduleSet::retrieve_or_fail(db_pool.get().await?, train_schedule_set_id, || {
             TrainScheduleSetError::NotFound {
@@ -162,7 +141,7 @@ pub(in crate::views) async fn get_by_id(
     Ok(Json(train_schedule_set_response))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule_set",
@@ -173,20 +152,11 @@ pub(in crate::views) async fn get_by_id(
 )]
 pub(in crate::views) async fn get(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Query(TrainScheduleSetQueryParams {
         catalog_entry_id,
         published,
     }): Query<TrainScheduleSetQueryParams>,
 ) -> Result<Json<Vec<TrainScheduleSetResponse>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let mut settings = SelectionSettings::new();
@@ -213,7 +183,7 @@ pub(in crate::views) async fn get(
     Ok(Json(results))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "train_schedule_set",
@@ -226,20 +196,11 @@ pub(in crate::views) async fn get(
 )]
 pub(in crate::views) async fn put(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TrainScheduleSetIdParam {
         id: train_schedule_set_id,
     }): Path<TrainScheduleSetIdParam>,
     Json(train_schedule_set_form): Json<TrainScheduleSetForm>,
 ) -> Result<Json<TrainScheduleSetResponse>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let changeset = train_schedule_set_form.into_changeset();
     let train_schedule_set = changeset
@@ -256,7 +217,7 @@ pub(in crate::views) async fn put(
     Ok(Json(train_schedule_set_response))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     delete, path = "",
         tag = "train_schedule_set",
@@ -268,19 +229,10 @@ pub(in crate::views) async fn put(
 )]
 pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TrainScheduleSetIdParam {
         id: train_schedule_set_id,
     }): Path<TrainScheduleSetIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     TrainScheduleSet::delete_static_or_fail(
         &mut db_pool.get().await?,
         train_schedule_set_id,
@@ -294,7 +246,7 @@ pub(in crate::views) async fn delete(
 }
 
 /// Create train schedules by batch
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tags = ["train_schedule_set", "train_schedule"],
@@ -306,20 +258,11 @@ pub(in crate::views) async fn delete(
 )]
 pub(in crate::views) async fn post_train_schedule(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TrainScheduleSetIdParam {
         id: train_schedule_set_id,
     }): Path<TrainScheduleSetIdParam>,
     Json(train_schedules): Json<Vec<TrainSchedule>>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let train_schedule_set_exists = TrainScheduleSet::exists(conn, train_schedule_set_id).await?;
@@ -344,7 +287,7 @@ pub(in crate::views) async fn post_train_schedule(
 }
 
 /// List train schedules for a train schedule set
-#[editoast_derive::route]
+#[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tags = ["train_schedule_set", "train_schedule"],
@@ -356,19 +299,10 @@ pub(in crate::views) async fn post_train_schedule(
 )]
 pub(in crate::views) async fn get_train_schedules(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(TrainScheduleSetIdParam {
         id: train_schedule_set_id,
     }): Path<TrainScheduleSetIdParam>,
 ) -> Result<Json<Vec<TrainScheduleResponse>>> {
-    let authorized = auth
-        .check_roles([authz::Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let train_schedule_set_exists = TrainScheduleSet::exists(conn, train_schedule_set_id).await?;

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -1,14 +1,11 @@
 use super::pagination::PaginatedList;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
-use crate::views::AuthorizationError;
 use crate::views::operational_studies::Ordering;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
 use crate::views::path::projection::Intersection;
 use crate::views::path::projection::PathProjection;
 use authz::Role;
-use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -140,7 +137,6 @@ pub(in crate::views) struct WorkScheduleCreateResponse {
 )]
 pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(WorkScheduleCreateForm {
         work_schedule_group_name,
         work_schedules,
@@ -149,7 +145,6 @@ pub(in crate::views) async fn create(
     // Create the group (using the method for the create group endpoint)
     let work_schedule_group = create_group(
         State(db_pool.clone()),
-        Extension(auth),
         Json(WorkScheduleGroupCreateForm {
             work_schedule_group_name: Some(work_schedule_group_name),
         }),
@@ -214,20 +209,11 @@ pub(in crate::views) struct WorkScheduleProjection {
 )]
 pub(in crate::views) async fn project_path(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(WorkScheduleProjectForm {
         work_schedule_group_id,
         path_track_ranges,
     }): Json<WorkScheduleProjectForm>,
 ) -> Result<Json<Vec<WorkScheduleProjection>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     // get all work_schedule of the group
     let conn = &mut db_pool.get().await?;
     let settings: SelectionSettings<WorkSchedule> = SelectionSettings::new()
@@ -279,7 +265,7 @@ pub(in crate::views) struct WorkScheduleGroupCreateResponse {
     work_schedule_group_id: i64,
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Stdcm)]
 #[utoipa::path(
     post, path = "",
     tag = "work_schedules",
@@ -290,19 +276,10 @@ pub(in crate::views) struct WorkScheduleGroupCreateResponse {
 )]
 pub(in crate::views) async fn create_group(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Json(WorkScheduleGroupCreateForm {
         work_schedule_group_name,
     }): Json<WorkScheduleGroupCreateForm>,
 ) -> Result<Json<WorkScheduleGroupCreateResponse>> {
-    let authorized = auth
-        .check_roles([Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     let group_name = work_schedule_group_name.unwrap_or(Uuid::new_v4().to_string());
 
@@ -319,7 +296,7 @@ pub(in crate::views) async fn create_group(
     }))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::Stdcm)]
 #[utoipa::path(
     delete, path = "",
     tag = "work_schedules",
@@ -331,17 +308,8 @@ pub(in crate::views) async fn create_group(
 )]
 pub(in crate::views) async fn delete_group(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(WorkScheduleGroupIdParam { id: group_id }): Path<WorkScheduleGroupIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
     WorkScheduleGroup::delete_static_or_fail(conn, group_id, || {
         WorkScheduleError::WorkScheduleGroupNotFound { id: group_id }
@@ -361,16 +329,7 @@ pub(in crate::views) async fn delete_group(
 )]
 pub(in crate::views) async fn list_groups(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<i64>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     let selection_setting = SelectionSettings::new();
@@ -383,7 +342,7 @@ pub(in crate::views) async fn list_groups(
     Ok(Json(work_schedule_group_ids))
 }
 
-#[editoast_derive::route]
+#[editoast_derive::route(Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "work_schedules",
@@ -396,18 +355,9 @@ pub(in crate::views) async fn list_groups(
 )]
 pub(in crate::views) async fn put_in_group(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(WorkScheduleGroupIdParam { id: group_id }): Path<WorkScheduleGroupIdParam>,
     Json(work_schedules): Json<Vec<WorkScheduleItemForm>>,
 ) -> Result<Json<Vec<WorkSchedule>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let conn = &mut db_pool.get().await?;
 
     conn.transaction(|conn| {
@@ -461,19 +411,10 @@ pub struct WorkScheduleOrderingParam {
 )]
 pub(in crate::views) async fn get_group(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
     Path(WorkScheduleGroupIdParam { id: group_id }): Path<WorkScheduleGroupIdParam>,
     Query(pagination_params): Query<PaginationQueryParams<100>>,
     Query(ordering_params): Query<WorkScheduleOrderingParam>,
 ) -> Result<Json<GroupContentResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let ordering = ordering_params.ordering;
     let settings = pagination_params
         .into_selection_settings()

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -16,7 +16,6 @@ use utoipa::ToSchema;
 use super::AuthenticationExt;
 use crate::AppState;
 use crate::error::Result;
-use crate::views::AuthorizationError;
 use editoast_models::Infra;
 use editoast_models::timetable::Timetable;
 
@@ -85,14 +84,6 @@ pub(in crate::views) async fn worker_load(
         timetable_id,
     }): Json<WorkerLoadForm>,
 ) -> Result<Json<WorkerStatus>> {
-    // Check user roles
-    let has_role = auth
-        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
-        .await?;
-    if !has_role {
-        return Err(AuthorizationError::Forbidden.into());
-    }
-
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         WorkerLoadError::InfraNotFound { infra_id }
     })


### PR DESCRIPTION
Removes usages of `Authentication::check_roles` in all endpoints by a declaration of the role to check (if any) in the `route` derive macro. When adding the handler in the router, a role checking middleware is injected if needed.

> [!TIP]
> Review commit by commit, have fun with the second one. 