### PR TITLE
Fix itinerary modal error icon

### DIFF
--- a/front/src/common/AlertBox.tsx
+++ b/front/src/common/AlertBox.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Alert, Stop, X } from '@osrd-project/ui-icons';
+import { Alert, Blocked, X } from '@osrd-project/ui-icons';
 
 type AlertType = 'warning' | 'error';
 
@@ -12,7 +12,7 @@ type AlertBoxProps = {
 
 const iconByType = {
   warning: <Alert variant="fill" size="lg" className="alert-box-icon warning" />,
-  error: <Stop size="lg" className="alert-box-icon error" />,
+  error: <Blocked size="lg" variant="fill" className="alert-box-icon error" />,
 };
 
 const AlertBox = ({ type = 'warning', message, closeable }: AlertBoxProps) => {

--- a/front/src/styles/scss/common/components/_alertBox.scss
+++ b/front/src/styles/scss/common/components/_alertBox.scss
@@ -28,7 +28,7 @@
     }
 
     &.error {
-      color: var(--error30);
+      color: var(--error60);
     }
   }
 


### PR DESCRIPTION
Fix the displayed icon when errors are prensent in the itinerary modal
<img width="264" height="176" alt="image" src="https://github.com/user-attachments/assets/4e25e4d8-af0e-46f9-afb0-8257de5bc7bb" />

Closes https://github.com/OpenRailAssociation/osrd/issues/15764 