### PR TITLE
editoast, front: clean up stdcm api following consist schedule changes

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3433,7 +3433,6 @@ paths:
               description: An STDCM request
               required:
               - steps
-              - rolling_stock_id
               - comfort
               - consist_schedule
               properties:
@@ -3456,10 +3455,6 @@ paths:
                   - integer
                   - 'null'
                   format: int64
-                loading_gauge_type:
-                  oneOf:
-                  - type: 'null'
-                  - $ref: '#/components/schemas/LoadingGaugeType'
                 margin:
                   type:
                   - string
@@ -3468,14 +3463,6 @@ paths:
                   example:
                   - 5%
                   - 2min/100km
-                max_speed:
-                  type:
-                  - number
-                  - 'null'
-                  format: double
-                  description: |2-
-                     Maximum speed of the consist in km/h
-                    Velocity in m·s⁻¹
                 maximum_departure_delay:
                   type:
                   - integer
@@ -3494,14 +3481,6 @@ paths:
                     Specifies how long the total run time can be in milliseconds
                     Deprecated, first step data should be used instead
                   minimum: 0
-                rolling_stock_id:
-                  type: integer
-                  format: int64
-                speed_limit_tags:
-                  type:
-                  - string
-                  - 'null'
-                  description: Train categories for speed limits
                 start_time:
                   type:
                   - string
@@ -3535,27 +3514,6 @@ paths:
                     Enforces that the path used by the train should be free and
                     available at least that many milliseconds before its passage.
                   minimum: 0
-                total_length:
-                  type:
-                  - number
-                  - 'null'
-                  format: double
-                  description: |2-
-                     Total length of the consist in meters
-                    Length in m
-                total_mass:
-                  type:
-                  - number
-                  - 'null'
-                  format: double
-                  description: |2-
-                     Total mass of the consist
-                    Mass in kg
-                towed_rolling_stock_id:
-                  type:
-                  - integer
-                  - 'null'
-                  format: int64
                 work_schedule_group_id:
                   type:
                   - integer
@@ -5181,6 +5139,7 @@ components:
           type:
           - string
           - 'null'
+          description: Train categories for speed limits
         total_length:
           type:
           - number
@@ -5218,7 +5177,7 @@ components:
             $ref: '#/components/schemas/ConsistConfiguration'
           description: |-
             Consist configuration for each segment
-            It should contains one more element than boundaries
+            It should contain one more element than boundaries
     ConstraintDistributionChangeGroup:
       type: object
       required:
@@ -6298,6 +6257,7 @@ components:
       - $ref: '#/components/schemas/EditoastStdcmErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastStdcmErrorInvalidConsistLength'
       - $ref: '#/components/schemas/EditoastStdcmErrorInvalidConsistMass'
+      - $ref: '#/components/schemas/EditoastStdcmErrorInvalidConsistMaxSpeed'
       - $ref: '#/components/schemas/EditoastStdcmErrorInvalidPathItems'
       - $ref: '#/components/schemas/EditoastStdcmErrorTimetableNotFound'
       - $ref: '#/components/schemas/EditoastStdcmErrorTowedRollingStockNotFound'
@@ -7970,6 +7930,34 @@ components:
           type: string
           enum:
           - editoast:stdcm:InvalidConsistMass
+    EditoastStdcmErrorInvalidConsistMaxSpeed:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastStdcmErrorInvalidConsistMaxSpeedContext
+          required:
+          - expected_max
+          - provided_consist_max_speed
+          properties:
+            expected_max:
+              type: number
+            provided_consist_max_speed:
+              type: number
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:stdcm:InvalidConsistMaxSpeed
     EditoastStdcmErrorInvalidPathItems:
       type: object
       required:

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -41,10 +41,10 @@ use editoast_models::timetable::Timetable;
 use editoast_models::timetable::TimetableWithTrains;
 use itertools::Itertools;
 use itertools::izip;
-use schemas::rolling_stock::EtcsBrakeParams;
 use schemas::rolling_stock::RollingResistance;
 use schemas::rolling_stock::RollingStock;
 use schemas::rolling_stock::TowedRollingStock;
+use schemas::rolling_stock::{EtcsBrakeParams, LoadingGaugeType};
 use schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use serde::Serialize;
@@ -543,6 +543,8 @@ pub struct PhysicsConsistParameters {
     pub total_mass: Option<Mass>,
     pub total_length: Option<Length>,
     pub max_speed: Option<Velocity>,
+    pub speed_limit_tag: Option<String>,
+    pub loading_gauge_type: Option<LoadingGaugeType>,
     pub towed_rolling_stock: Option<TowedRollingStock>,
     pub traction_engine: RollingStock,
 }
@@ -553,6 +555,8 @@ impl PhysicsConsistParameters {
             max_speed: None,
             total_length: None,
             total_mass: None,
+            speed_limit_tag: None,
+            loading_gauge_type: None,
             towed_rolling_stock: None,
             traction_engine,
         }
@@ -1010,7 +1014,7 @@ mod tests {
             .and_hms_opt(9, 0, 0)
             .unwrap()
             .and_utc();
-        let paced_interval = chrono::Duration::try_hours(1).unwrap();
+        let paced_interval = Duration::try_hours(1).unwrap();
 
         let train_ids = vec![
             OccurrenceId::new_base(paced_train_id, 0),
@@ -1128,6 +1132,8 @@ mod tests {
             total_length: Some(units::meter::new(100.0)),
             total_mass: Some(units::kilogram::new(50000.0)),
             max_speed: Some(units::meter_per_second::new(22.0)),
+            speed_limit_tag: None,
+            loading_gauge_type: Some(simple_rolling_stock().loading_gauge),
             towed_rolling_stock: Some(towed_rolling_stock()),
             traction_engine: simple_rolling_stock(),
         }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -140,6 +140,13 @@ enum StdcmError {
         provided_consist_length: f64,
         expected_min: f64,
     },
+    #[error(
+        "Invalid consist max speed {provided_consist_max_speed}: it should be positive and lower than {expected_max}"
+    )]
+    InvalidConsistMaxSpeed {
+        provided_consist_max_speed: f64,
+        expected_max: f64,
+    },
     #[error(transparent)]
     #[from(forward)]
     #[serde(skip)]
@@ -270,21 +277,9 @@ pub(in crate::views) async fn stdcm_handler(
     let work_schedules = request.get_work_schedules(&mut conn).await?;
 
     // 3. Get RollingStock
-    let consist_configs = if request.consist_schedule.values.is_empty() {
-        vec![request::ConsistConfiguration {
-            rolling_stock_id: request.rolling_stock_id,
-            towed_rolling_stock_id: request.towed_rolling_stock_id,
-            total_mass: request.total_mass,
-            total_length: request.total_length,
-            max_speed: request.max_speed,
-            speed_limit_tag: request.speed_limit_tags.clone(),
-            loading_gauge_type: request.loading_gauge_type,
-        }]
-    } else {
-        request.consist_schedule.values.clone()
-    };
-
-    let rolling_stock_ids: Vec<i64> = consist_configs
+    let rolling_stock_ids: Vec<i64> = request
+        .consist_schedule
+        .values
         .iter()
         .map(|consist_config| consist_config.rolling_stock_id)
         .collect();
@@ -311,7 +306,9 @@ pub(in crate::views) async fn stdcm_handler(
         rolling_stocks_models.into_iter().map(Into::into).collect();
 
     let mut physics_consists_parameters = vec![];
-    for (consist, rolling_stock) in consist_configs.iter().zip(rolling_stocks) {
+    for (consist, rolling_stock) in
+        itertools::izip!(&request.consist_schedule.values, rolling_stocks)
+    {
         let towed_rolling_stock = consist
             .get_towed_rolling_stock(&mut conn)
             .await?
@@ -322,6 +319,8 @@ pub(in crate::views) async fn stdcm_handler(
             max_speed: consist.max_speed,
             total_length: consist.total_length,
             total_mass: consist.total_mass,
+            speed_limit_tag: consist.speed_limit_tag.clone(),
+            loading_gauge_type: consist.loading_gauge_type,
             towed_rolling_stock,
             traction_engine: rolling_stock,
         });
@@ -363,21 +362,18 @@ pub(in crate::views) async fn stdcm_handler(
     let earliest_departure_time = request.get_earliest_departure_time(total_simulation_run_time);
     let latest_simulation_end = request.get_latest_simulation_end(total_simulation_run_time);
 
-    let stdcm_consist_schedule_values = consist_configs
+    let stdcm_consist_schedule_values = physics_consists_parameters
         .iter()
-        .zip(physics_consists_parameters.iter())
-        .map(
-            |(consist_config, physics_consist_param)| ConsistConfiguration {
-                loading_gauge_type: consist_config
-                    .loading_gauge_type
-                    .unwrap_or(physics_consist_param.traction_engine.loading_gauge),
-                supported_signaling_systems: physics_consist_param
-                    .traction_engine
-                    .supported_signaling_systems(),
-                speed_limit_tag: consist_config.speed_limit_tag.clone(),
-                physics_consist: physics_consist_param.clone().into(),
-            },
-        )
+        .map(|physics_consist_param| ConsistConfiguration {
+            loading_gauge_type: physics_consist_param
+                .loading_gauge_type
+                .unwrap_or(physics_consist_param.traction_engine.loading_gauge),
+            supported_signaling_systems: physics_consist_param
+                .traction_engine
+                .supported_signaling_systems(),
+            speed_limit_tag: physics_consist_param.speed_limit_tag.clone(),
+            physics_consist: physics_consist_param.clone().into(),
+        })
         .collect_vec();
 
     // 5. Build STDCM request
@@ -543,8 +539,8 @@ impl VirtualTrainRun {
                 comfort: stdcm_request.comfort,
                 path,
                 constraint_distribution: Default::default(),
-                speed_limit_tag: stdcm_request
-                    .speed_limit_tags
+                speed_limit_tag: consist_parameters
+                    .speed_limit_tag
                     .clone()
                     .map(schemas::primitives::NonBlankString::from),
                 power_restrictions: vec![],
@@ -670,10 +666,7 @@ mod tests {
     use super::*;
 
     fn get_stdcm_payload(
-        rolling_stock_id: i64,
         work_schedule_group_id: Option<i64>,
-        total_mass: Option<f64>,
-        total_length: Option<f64>,
         consist_schedule: ConsistSchedule,
     ) -> Request {
         Request {
@@ -713,22 +706,15 @@ mod tests {
                     timing_data: None,
                 },
             ],
-            rolling_stock_id,
-            towed_rolling_stock_id: None,
             electrical_profile_set_id: None,
             work_schedule_group_id,
             temporary_speed_limit_group_id: None,
             comfort: Comfort::Standard,
             maximum_departure_delay: None,
             maximum_run_time: None,
-            speed_limit_tags: Some("AR120".to_string()),
             time_gap_before: 35000,
             time_gap_after: 35000,
             margin: Some(MarginValue::MinPer100Km(4.5)),
-            total_mass: total_mass.map(Mass::new::<kilogram>),
-            total_length: total_length.map(Length::new::<meter>),
-            max_speed: None,
-            loading_gauge_type: None,
             allowed_track_sections: None,
             consist_schedule,
         }
@@ -737,15 +723,23 @@ mod tests {
     fn build_consist_config(
         rolling_stock_id: i64,
         total_mass: Option<f64>,
+        total_length: Option<f64>,
     ) -> request::ConsistConfiguration {
         request::ConsistConfiguration {
             rolling_stock_id,
             towed_rolling_stock_id: None,
             total_mass: total_mass.map(Mass::new::<kilogram>),
-            total_length: None,
+            total_length: total_length.map(Length::new::<meter>),
             max_speed: None,
-            speed_limit_tag: None,
+            speed_limit_tag: Some("AR120".to_string()),
             loading_gauge_type: None,
+        }
+    }
+
+    fn build_single_consist(consist_config: request::ConsistConfiguration) -> ConsistSchedule {
+        ConsistSchedule {
+            boundaries: vec![],
+            values: vec![consist_config],
         }
     }
 
@@ -753,12 +747,11 @@ mod tests {
         PathfindingItem {
             duration: Some(0),
             location: PathItemLocation::OperationalPointPartReference(
-                schemas::train_schedule::OperationalPointPartReference {
-                    operational_point:
-                        schemas::train_schedule::OperationalPointReference::Trigram {
-                            trigram: trigram.into(),
-                            secondary_code: Some("BV".to_string()),
-                        },
+                OperationalPointPartReference {
+                    operational_point: OperationalPointReference::Trigram {
+                        trigram: trigram.into(),
+                        secondary_code: Some("BV".to_string()),
+                    },
                     local_track_name: None,
                 },
             ),
@@ -814,6 +807,8 @@ mod tests {
             total_length: None,
             max_speed: None,
             total_mass: Some(total_mass),
+            speed_limit_tag: None,
+            loading_gauge_type: Some(rolling_stock.loading_gauge),
             towed_rolling_stock: Some(towed_rolling_stock.clone()),
             traction_engine: rolling_stock,
         };
@@ -841,6 +836,8 @@ mod tests {
             total_mass: Some(units::kilogram::new(123.0)),
             total_length: Some(units::meter::new(455.0)),
             max_speed: Some(units::meter_per_second::new(10.0)),
+            speed_limit_tag: None,
+            loading_gauge_type: Some(simple_rolling_stock().loading_gauge),
             towed_rolling_stock: None,
             traction_engine: simple_rolling_stock(),
         };
@@ -882,6 +879,8 @@ mod tests {
             total_length: None,
             total_mass: None,
             towed_rolling_stock: Some(towed_rolling_stock.clone()),
+            speed_limit_tag: None,
+            loading_gauge_type: Some(simple_rolling_stock().loading_gauge),
             traction_engine: rolling_stock,
         };
 
@@ -911,6 +910,8 @@ mod tests {
             max_speed: None,
             total_length: None,
             total_mass: None,
+            speed_limit_tag: None,
+            loading_gauge_type: Some(simple_rolling_stock().loading_gauge),
             towed_rolling_stock: Some(towed_rolling_stock()),
             traction_engine: simple_rolling_stock(),
         };
@@ -948,6 +949,8 @@ mod tests {
             total_mass: None,
             total_length: None,
             max_speed: Some(units::meter_per_second::new(30.0)),
+            speed_limit_tag: None,
+            loading_gauge_type: Some(simple_rolling_stock().loading_gauge),
             towed_rolling_stock: None,
             traction_engine: simple_rolling_stock(),
         };
@@ -981,16 +984,12 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let consist_schedule =
+            build_single_consist(build_consist_config(rolling_stock.id, None, None));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(
-                rolling_stock.id,
-                None,
-                None,
-                None,
-                ConsistSchedule::default(),
-            ));
+            .json(&get_stdcm_payload(None, consist_schedule));
 
         let stdcm_response: StdcmProgression = app
             .fetch(request)
@@ -1033,17 +1032,12 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let consist_schedule =
+            build_single_consist(build_consist_config(rolling_stock.id, Some(80_000.0), None));
 
-        let total_mass = Some(80_000.0);
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(
-                rolling_stock.id,
-                None,
-                total_mass,
-                None,
-                ConsistSchedule::default(),
-            ));
+            .json(&get_stdcm_payload(None, consist_schedule));
 
         let stdcm_response: InternalError = app
             .fetch(request)
@@ -1078,19 +1072,15 @@ mod tests {
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let total_length = Some(300.0);
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let consist_schedule =
+            build_single_consist(build_consist_config(rolling_stock.id, None, total_length));
 
-        let total_length = Some(300.0);
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(
-                rolling_stock.id,
-                None,
-                None,
-                total_length,
-                ConsistSchedule::default(),
-            ));
+            .json(&get_stdcm_payload(None, consist_schedule));
 
         let stdcm_response: InternalError = app
             .fetch(request)
@@ -1124,20 +1114,19 @@ mod tests {
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let total_mass = Some(910_000.0);
+        let total_length = Some(410.0);
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            total_mass,
+            total_length,
+        ));
 
-        let total_length = Some(410.0);
-        let total_mass = Some(910_000.0);
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(
-                rolling_stock.id,
-                None,
-                total_mass,
-                total_length,
-                ConsistSchedule::default(),
-            ));
+            .json(&get_stdcm_payload(None, consist_schedule));
 
         let stdcm_response: StdcmProgression = app
             .fetch(request)
@@ -1177,16 +1166,12 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let consist_schedule =
+            build_single_consist(build_consist_config(rolling_stock.id, None, None));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(
-                rolling_stock.id,
-                None,
-                None,
-                None,
-                ConsistSchedule::default(),
-            ));
+            .json(&get_stdcm_payload(None, consist_schedule));
 
         let stdcm_response: StdcmProgression = app
             .fetch(request)
@@ -1229,16 +1214,12 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let consist_schedule =
+            build_single_consist(build_consist_config(rolling_stock.id, None, None));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(
-                rolling_stock.id,
-                None,
-                None,
-                None,
-                ConsistSchedule::default(),
-            ));
+            .json(&get_stdcm_payload(None, consist_schedule));
 
         let stdcm_response: Vec<StdcmProgression> = app
             .fetch(request)
@@ -1301,16 +1282,12 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let consist_schedule =
+            build_single_consist(build_consist_config(rolling_stock.id, None, None));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(
-                rolling_stock.id,
-                None,
-                None,
-                None,
-                ConsistSchedule::default(),
-            ));
+            .json(&get_stdcm_payload(None, consist_schedule));
 
         let stdcm_response: Vec<StdcmProgression> = app
             .fetch(request)
@@ -1382,19 +1359,19 @@ mod tests {
             .collect();
 
         // THEN
-        assert!(filtered.is_empty() == filtered_out);
+        assert_eq!(filtered.is_empty(), filtered_out);
     }
 
     #[test]
     fn consist_schedule_reject_same_len_values_and_boundaries() {
         let req = get_stdcm_payload(
-            1,
-            None,
-            None,
             None,
             ConsistSchedule {
                 boundaries: vec![1, 2],
-                values: vec![build_consist_config(1, None), build_consist_config(2, None)],
+                values: vec![
+                    build_consist_config(1, None, None),
+                    build_consist_config(2, None, None),
+                ],
             },
         );
 
@@ -1406,13 +1383,13 @@ mod tests {
     #[test]
     fn consist_schedule_reject_has_boundary_zero() {
         let req = get_stdcm_payload(
-            1,
-            None,
-            None,
             None,
             ConsistSchedule {
                 boundaries: vec![0],
-                values: vec![build_consist_config(1, None), build_consist_config(2, None)],
+                values: vec![
+                    build_consist_config(1, None, None),
+                    build_consist_config(2, None, None),
+                ],
             },
         );
 
@@ -1424,13 +1401,13 @@ mod tests {
     #[test]
     fn consist_schedule_reject_has_boundary_last_step() {
         let req = get_stdcm_payload(
-            1,
-            None,
-            None,
             None,
             ConsistSchedule {
                 boundaries: vec![2],
-                values: vec![build_consist_config(1, None), build_consist_config(2, None)],
+                values: vec![
+                    build_consist_config(1, None, None),
+                    build_consist_config(2, None, None),
+                ],
             },
         );
 
@@ -1442,16 +1419,13 @@ mod tests {
     #[test]
     fn consist_schedule_reject_decreasing_boundaries() {
         let req = get_stdcm_payload(
-            1,
-            None,
-            None,
             None,
             ConsistSchedule {
                 boundaries: vec![5, 3],
                 values: vec![
-                    build_consist_config(1, None),
-                    build_consist_config(2, None),
-                    build_consist_config(3, None),
+                    build_consist_config(1, None, None),
+                    build_consist_config(2, None, None),
+                    build_consist_config(3, None, None),
                 ],
             },
         );
@@ -1501,15 +1475,20 @@ mod tests {
         let total_mass_second_rolling_stock = Some(50_000.0);
 
         let mut payload = get_stdcm_payload(
-            first_rolling_stock.id,
-            None,
-            None,
             None,
             ConsistSchedule {
                 boundaries: vec![1],
                 values: vec![
-                    build_consist_config(first_rolling_stock.id, total_mass_first_rolling_stock),
-                    build_consist_config(second_rolling_stock.id, total_mass_second_rolling_stock),
+                    build_consist_config(
+                        first_rolling_stock.id,
+                        total_mass_first_rolling_stock,
+                        None,
+                    ),
+                    build_consist_config(
+                        second_rolling_stock.id,
+                        total_mass_second_rolling_stock,
+                        None,
+                    ),
                 ],
             },
         );
@@ -1587,16 +1566,13 @@ mod tests {
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
 
         let mut payload = get_stdcm_payload(
-            first_rolling_stock.id,
-            None,
-            None,
             None,
             ConsistSchedule {
                 boundaries: vec![1, 2],
                 values: vec![
-                    build_consist_config(first_rolling_stock.id, None),
-                    build_consist_config(second_rolling_stock.id, None),
-                    build_consist_config(third_rolling_stock.id, None),
+                    build_consist_config(first_rolling_stock.id, None, None),
+                    build_consist_config(second_rolling_stock.id, None, None),
+                    build_consist_config(third_rolling_stock.id, None, None),
                 ],
             },
         );

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -20,6 +20,7 @@ use serde::Serializer;
 use units::quantities;
 use uom::si::length::meter;
 use uom::si::mass::kilogram;
+use uom::si::velocity::meter_per_second;
 use utoipa::ToSchema;
 
 use crate::error::Result;
@@ -54,6 +55,8 @@ pub(crate) struct ConsistConfiguration {
     pub(crate) total_length: Option<quantities::Length>,
     #[serde(default, with = "units::meter_per_second::option")]
     pub(crate) max_speed: Option<quantities::Velocity>,
+    /// Train categories for speed limits
+    // TODO: rename the field and its description
     pub(crate) speed_limit_tag: Option<String>,
     pub(crate) loading_gauge_type: Option<LoadingGaugeType>,
 }
@@ -65,7 +68,7 @@ pub(crate) struct ConsistSchedule {
     /// It should not contain 0 and len(steps) and should be increasing
     pub(crate) boundaries: Vec<usize>,
     /// Consist configuration for each segment
-    /// It should contains one more element than boundaries
+    /// It should contain one more element than boundaries
     pub(crate) values: Vec<ConsistConfiguration>,
 }
 
@@ -98,8 +101,6 @@ pub(crate) struct Request {
     /// Deprecated, first step arrival time should be used instead
     pub(crate) start_time: Option<DateTime<Utc>>,
     pub(crate) steps: Vec<PathfindingItem>,
-    pub(crate) rolling_stock_id: i64,
-    pub(crate) towed_rolling_stock_id: Option<i64>,
     pub(crate) electrical_profile_set_id: Option<i64>,
     pub(crate) work_schedule_group_id: Option<i64>,
     pub(crate) temporary_speed_limit_group_id: Option<i64>,
@@ -110,9 +111,6 @@ pub(crate) struct Request {
     /// Specifies how long the total run time can be in milliseconds
     /// Deprecated, first step data should be used instead
     pub(crate) maximum_run_time: Option<u64>,
-    /// Train categories for speed limits
-    // TODO: rename the field and its description
-    pub(crate) speed_limit_tags: Option<String>,
     /// Margin before the train passage in seconds
     ///
     /// Enforces that the path used by the train should be free and
@@ -129,16 +127,6 @@ pub(crate) struct Request {
     #[serde(default)]
     #[schema(value_type = Option<String>, example = json!(["5%", "2min/100km"]))]
     pub(crate) margin: Option<MarginValue>,
-    /// Total mass of the consist
-    #[serde(default, with = "units::kilogram::option")]
-    pub(crate) total_mass: Option<quantities::Mass>,
-    /// Total length of the consist in meters
-    #[serde(default, with = "units::meter::option")]
-    pub(crate) total_length: Option<quantities::Length>,
-    /// Maximum speed of the consist in km/h
-    #[serde(default, with = "units::meter_per_second::option")]
-    pub(crate) max_speed: Option<quantities::Velocity>,
-    pub(crate) loading_gauge_type: Option<LoadingGaugeType>,
     /// Set of authorized track section ids for the current loading gauge,
     /// None value means no zone restriction.
     pub(crate) allowed_track_sections: Option<HashSet<String>>,
@@ -339,6 +327,7 @@ impl ConsistConfiguration {
     ) -> Result<()> {
         self.validate_consist_mass(traction_engine, towed_rolling_stock)?;
         self.validate_consist_length(traction_engine, towed_rolling_stock)?;
+        self.validate_consist_max_speed(traction_engine, towed_rolling_stock)?;
         Ok(())
     }
 
@@ -388,6 +377,33 @@ impl ConsistConfiguration {
 
         Ok(())
     }
+
+    fn validate_consist_max_speed(
+        &self,
+        traction_engine: &RollingStock,
+        towed_rolling_stock: Option<&schemas::TowedRollingStock>,
+    ) -> Result<()> {
+        let consist_max_speed = quantities::Velocity::min(
+            traction_engine.max_speed,
+            towed_rolling_stock
+                .and_then(|t| t.max_speed)
+                .unwrap_or(quantities::Velocity::new::<meter_per_second>(f64::INFINITY)),
+        );
+        let consist_max_speed = consist_max_speed.floor::<meter_per_second>();
+
+        if let Some(request_max_speed) = self.max_speed
+            && request_max_speed < quantities::Velocity::new::<meter_per_second>(0.0)
+            && request_max_speed > consist_max_speed
+        {
+            return Err(StdcmError::InvalidConsistMaxSpeed {
+                provided_consist_max_speed: request_max_speed.value,
+                expected_max: consist_max_speed.value,
+            }
+            .into());
+        }
+
+        Ok(())
+    }
 }
 
 impl<'de> Deserialize<'de> for Request {
@@ -396,32 +412,10 @@ impl<'de> Deserialize<'de> for Request {
         D: Deserializer<'de>,
     {
         let request = Request::deserialize(deserializer)?;
-        if let Some(mass) = request.total_mass
-            && mass <= units::kilogram::new(0.0)
-        {
-            return Err(serde::de::Error::custom(
-                "the total mass must be strictly positive",
-            ));
-        }
-
-        if let Some(total_length) = request.total_length
-            && total_length <= units::meter::new(0.0)
-        {
-            return Err(serde::de::Error::custom(
-                "the length mass must be strictly positive",
-            ));
-        }
-
-        if let Some(max_speed) = request.max_speed
-            && max_speed <= units::meter_per_second::new(0.0)
-        {
-            return Err(serde::de::Error::custom(
-                "the max_speed must be strictly positive",
-            ));
-        }
-
         let consist_schedule = &request.consist_schedule;
-        if !consist_schedule.values.is_empty() {
+        if consist_schedule.values.is_empty() {
+            return Err(serde::de::Error::custom("consist values cannot be empty"));
+        } else {
             if consist_schedule.boundaries.len() + 1 != consist_schedule.values.len() {
                 return Err(serde::de::Error::custom(
                     "the boundaries should have one less element than values",

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -231,6 +231,7 @@
       "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
       "InvalidConsistLength": "Invalid consist length {{provided_consist_length}}: it should be greater than '{{expected_min}}'",
       "InvalidConsistMass": "Invalid consist mass {{provided_consist_mass}}: it should be greater than '{{expected_min}}'",
+      "InvalidConsistMaxSpeed": "Invalid consist max speed {{provided_consist_max_speed}}: it should be positive  and lower than '{{expected_max}}'",
       "InvalidPathItems": "Invalid waypoint(s) {{items}}",
       "TimetableNotFound": "Timetable '{{timetable_id}}' does not exist",
       "TowedRollingStockNotFound": "Towed rolling stock {towed_rolling_stock_id} does not exist",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -231,6 +231,7 @@
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "InvalidConsistLength": "Longueur du convoi invalide {{provided_consist_length}} : doit être supérieure à '{{expected_min}}'",
       "InvalidConsistMass": "Masse du convoi invalide {{provided_consist_mass}} : elle doit être supérieure à '{{expected_min}}",
+      "InvalidConsistMaxSpeed": "Vitesse max. du convoi invalide {{provided_consist_max_speed}} : elle doit être positive et inférieure à '{{expected_max}}",
       "InvalidPathItems": "Point(s) de passage {{items}} invalide(s)",
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",
       "TowedRollingStockNotFound": "Matériel roulant remorqué {towed_rolling_stock_id} non trouvé",

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -4,7 +4,6 @@ import type { Dispatch } from 'redux';
 
 import type {
   ConsistSchedule,
-  LoadingGaugeType,
   PathfindingItem,
   PostTimetableByIdStdcmApiArg,
 } from 'common/api/osrdEditoastApi';
@@ -18,16 +17,9 @@ import { StdcmStopTypes } from '../types';
 import createMargin from './createMargin';
 
 type ValidStdcmConfig = {
-  rollingStockId: number;
-  towedRollingStockID?: number;
   timetableId: number;
   infraId: number;
   path: PathfindingItem[];
-  speedLimitByTag?: string;
-  totalMass?: number;
-  totalLength?: number;
-  maxSpeed?: number;
-  loadingGauge?: LoadingGaugeType;
   margin?: StandardAllowance;
   gridMarginBefore?: Duration;
   gridMarginAfter?: Duration;
@@ -239,15 +231,8 @@ export const checkStdcmConf = (
 
   return {
     infraId: infraID!,
-    rollingStockId: rollingStockID!,
     timetableId: timetableID!,
     path,
-    speedLimitByTag,
-    totalMass: initialConsist.total_mass,
-    totalLength,
-    maxSpeed: initialConsist.max_speed,
-    loadingGauge,
-    towedRollingStockID,
     margin: standardAllowance,
     gridMarginBefore,
     gridMarginAfter,
@@ -268,19 +253,12 @@ export const formatStdcmPayload = (
   body: {
     comfort: 'STANDARD',
     margin: createMargin(validConfig.margin),
-    rolling_stock_id: validConfig.rollingStockId,
-    towed_rolling_stock_id: validConfig.towedRollingStockID,
-    speed_limit_tags: validConfig.speedLimitByTag,
-    total_mass: validConfig.totalMass,
-    max_speed: validConfig.maxSpeed,
-    total_length: validConfig.totalLength,
     steps: validConfig.path,
     time_gap_after: validConfig.gridMarginBefore?.ms,
     time_gap_before: validConfig.gridMarginAfter?.ms,
     work_schedule_group_id: validConfig.workScheduleGroupId,
     temporary_speed_limit_group_id: validConfig.temporarySpeedLimitGroupId,
     electrical_profile_set_id: validConfig.electricalProfileSetId,
-    loading_gauge_type: validConfig.loadingGauge,
     allowed_track_sections: validConfig.allowedTrackSections,
     consist_schedule: validConfig.consistSchedule,
   },

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2438,21 +2438,14 @@ export type PostTimetableByIdStdcmApiArg = {
     comfort: Comfort;
     consist_schedule: ConsistSchedule;
     electrical_profile_set_id?: number | null;
-    loading_gauge_type?: null | LoadingGaugeType;
     /** Can be a percentage `X%`, a time in minutes per 100 kilometer `Xmin/100km` */
     margin?: string | null;
-    /**  Maximum speed of the consist in km/h
-        Velocity in m·s⁻¹ */
-    max_speed?: number | null;
     /** By how long we can shift the departure time in milliseconds
         Deprecated, first step data should be used instead */
     maximum_departure_delay?: number | null;
     /** Specifies how long the total run time can be in milliseconds
         Deprecated, first step data should be used instead */
     maximum_run_time?: number | null;
-    rolling_stock_id: number;
-    /** Train categories for speed limits */
-    speed_limit_tags?: string | null;
     /** Deprecated, first step arrival time should be used instead */
     start_time?: string | null;
     steps: PathfindingItem[];
@@ -2467,13 +2460,6 @@ export type PostTimetableByIdStdcmApiArg = {
         Enforces that the path used by the train should be free and
         available at least that many milliseconds before its passage. */
     time_gap_before?: number;
-    /**  Total length of the consist in meters
-        Length in m */
-    total_length?: number | null;
-    /**  Total mass of the consist
-        Mass in kg */
-    total_mass?: number | null;
-    towed_rolling_stock_id?: number | null;
     work_schedule_group_id?: number | null;
   };
 };
@@ -4542,6 +4528,7 @@ export type ConsistConfiguration = {
   /** Velocity in m·s⁻¹ */
   max_speed?: number | null;
   rolling_stock_id: number;
+  /** Train categories for speed limits */
   speed_limit_tag?: string | null;
   /** Length in m */
   total_length?: number | null;
@@ -4554,7 +4541,7 @@ export type ConsistSchedule = {
     It should not contain 0 and len(steps) and should be increasing */
   boundaries: number[];
   /** Consist configuration for each segment
-    It should contains one more element than boundaries */
+    It should contain one more element than boundaries */
   values: ConsistConfiguration[];
 };
 export type CoreStepTimingData = {

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -335,7 +335,6 @@ def _make_stdcm_payload(path: list[tuple[str, float]], rolling_stock: int) -> di
     Creates a payload for an STDCM request
     """
     res = {
-        "rolling_stock_id": rolling_stock,
         "start_time": _make_random_time(),
         "maximum_departure_delay": random.randint(0, 3_600_000 * 4),
         "maximum_run_time": random.randint(3_600_000 * 5, 3_600_000 * 10),
@@ -344,7 +343,14 @@ def _make_stdcm_payload(path: list[tuple[str, float]], rolling_stock: int) -> di
         "steps": [_convert_stop_stdcm(stop) for stop in path],
         "comfort": "STANDARD",
         "margin": "0%",
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": rolling_stock,
+                }
+            ],
+        },
     }
     res["steps"][-1]["duration"] = 1  # Force a stop at the end
     allowance_value = _make_random_margin_value()

--- a/tests/fuzzer/fuzzer_stdcm_single_timetable.py
+++ b/tests/fuzzer/fuzzer_stdcm_single_timetable.py
@@ -212,14 +212,20 @@ def _make_stdcm_payload(
     Generate a random stdcm payload
     """
     res = {
-        "rolling_stock_id": rolling_stock,
         "steps": _make_steps(op_list, timetable_range),
         "comfort": "STANDARD",
         "margin": "5%",
-        "total_length": random.randint(400, 750),  # 400 to 750m
-        "total_mass": random.randint(500_000, 2_500_000),  # 500 to 2500t
-        "max_speed": random.randint(22, 38),  # 80 to 140 km/h
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": rolling_stock,
+                    "total_length": random.randint(400, 750),  # 400 to 750m
+                    "total_mass": random.randint(500_000, 2_500_000),  # 500 to 2500t
+                    "max_speed": random.randint(22, 38),  # 80 to 140 km/h
+                }
+            ],
+        },
     }
     if towed_rs and random.randint(0, 5) > 0:
         res["towed_rolling_stock_id"] = random.choice(towed_rs)

--- a/tests/tests/regression_tests_data/coasting_not_intersecting_v2.json
+++ b/tests/tests/regression_tests_data/coasting_not_intersecting_v2.json
@@ -4,7 +4,6 @@
     "error": "{\"status\":500,\"type\":\"core:assert_error\",\"context\":{\"stack_trace\":[\"CoastingGenerator.java:71\",\"AcceleratingSlopeCoast.java:120\",\"MarecoAllowance.java:95\",\"AbstractAllowanceWithRanges.java:341\",\"AbstractAllowanceWithRanges.java:300\",\"AbstractAllowanceWithRanges.java:267\",\"AbstractAllowanceWithRanges.java:195\",\"AbstractAllowanceWithRanges.java:131\",\"StandaloneSimulation.kt:326\",\"StandaloneSimulation.kt:91\",\"SimulationEndpoint.kt:56\",\"FkRegex.java:153\",\"FkRegex.java:217\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:84\",\"TkFallback.java:66\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:123\",\"BkBasic.java:99\",\"BkSafe.java:46\",\"BkWrap.java:51\",\"BkParallel.java:81\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:840\"],\"url\":\"http://localhost:8080//standalone_simulation\",\"file_location\":\"CoastingGenerator.java:71\"},\"message\":\"assert check failed\"}",
     "infra_name": "small_infra",
     "stdcm_payload": {
-        "rolling_stock_id": 609,
         "start_time": "2024-01-01T02:32:30+00:00",
         "maximum_departure_delay": 9665962,
         "maximum_run_time": 19401222,
@@ -56,7 +55,7 @@
         "margin": "0%",
         "consist_schedule": {
             "boundaries": [],
-            "values": []
+            "values": [{"rolling_stock_id": 609}]
         }
     },
     "prelude": [

--- a/tests/tests/regression_tests_data/stdcm_conflict_in_result.json
+++ b/tests/tests/regression_tests_data/stdcm_conflict_in_result.json
@@ -4,7 +4,6 @@
     "error": "{\"status\":500,\"type\":\"core:assert_error\",\"context\":{\"assert_message\":\"STDCM result is conflicting with the scheduled timetable\",\"stack_trace\":[\"STDCMEndpointV2.kt:281\",\"STDCMEndpointV2.kt:1\",\"STDCMEndpointV2.kt:129\",\"WorkerCommand.kt:182\",\"AutorecoveringChannel.java:642\",\"ConsumerDispatcher.java:149\",\"ConsumerWorkService.java:111\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:840\"],\"url\":\"/v2/stdcm\",\"file_location\":\"STDCMEndpointV2.kt:281\"},\"message\":\"assert check failed\"}",
     "infra_name": "small_infra",
     "stdcm_payload": {
-        "rolling_stock_id": 474,
         "start_time": "2024-01-01T20:31:01+00:00",
         "maximum_departure_delay": 12554857,
         "maximum_run_time": 24293806,
@@ -56,7 +55,7 @@
         "margin": "0%",
         "consist_schedule": {
             "boundaries": [],
-            "values": []
+            "values": [{"rolling_stock_id": 474}]
         }
     },
     "prelude": [

--- a/tests/tests/regression_tests_data/stdcm_timetable_conflict.json
+++ b/tests/tests/regression_tests_data/stdcm_timetable_conflict.json
@@ -4,7 +4,6 @@
     "error": "{\"status\":500,\"type\":\"core:assert_error\",\"context\":{\"stack_trace\":[\"STDCMEndpointV2.kt:172\",\"STDCMEndpointV2.kt:1\",\"STDCMEndpointV2.kt:116\",\"FkRegex.java:153\",\"FkRegex.java:217\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:84\",\"TkFallback.java:66\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:123\",\"BkBasic.java:99\",\"BkSafe.java:46\",\"BkWrap.java:51\",\"BkParallel.java:81\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:840\"],\"url\":\"http://localhost:8080//stdcm\",\"assert_message\":\"STDCM result is conflicting with the scheduled timetable\",\"file_location\":\"STDCMEndpointV2.kt:172\"},\"message\":\"assert check failed\"}",
     "infra_name": "small_infra",
     "stdcm_payload": {
-        "rolling_stock_id": 470,
         "start_time": "2024-01-01T23:02:27+00:00",
         "maximum_departure_delay": 5251097,
         "maximum_run_time": 31681873,
@@ -48,7 +47,7 @@
         "margin": "0%",
         "consist_schedule": {
             "boundaries": [],
-            "values": []
+            "values": [{"rolling_stock_id": 470}]
         }
     },
     "prelude": [

--- a/tests/tests/regression_tests_data/stdcm_zone_transition_near_start.json
+++ b/tests/tests/regression_tests_data/stdcm_zone_transition_near_start.json
@@ -4,7 +4,6 @@
     "error": "{\"status\":500,\"type\":\"core:unknown_error\",\"context\":{\"exception_type\":\"class java.lang.RuntimeException\",\"message\":\"Failed to compute a standard allowance that wouldn't cause conflicts\",\"url\":\"http://host.docker.internal:8080//stdcm\",\"stack_trace\":[\"PostProcessingSimulation.kt:124\",\"PostProcessingSimulation.kt:129\",\"PostProcessingSimulation.kt:54\",\"STDCMPostProcessing.kt:69\",\"STDCMPathfinding.kt:125\",\"STDCMPathfinding.kt:59\",\"STDCMEndpointV2.kt:67\",\"FkRegex.java:153\",\"FkRegex.java:217\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:84\",\"TkFallback.java:66\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:123\",\"BkBasic.java:99\",\"BkSafe.java:46\",\"BkWrap.java:51\",\"BkParallel.java:81\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"]},\"message\":\"An unknown exception was thrown\"}",
     "infra_name": "small_infra",
     "stdcm_payload": {
-        "rolling_stock_id": 500,
         "start_time": "2024-01-01T08:39:11+00:00",
         "maximum_departure_delay": 4735183,
         "maximum_run_time": 24187328,
@@ -49,7 +48,7 @@
         "standard_allowance": "14%",
         "consist_schedule": {
             "boundaries": [],
-            "values": []
+            "values": [{"rolling_stock_id": 500}]
         }
     },
     "prelude": [

--- a/tests/tests/test_regressions.py
+++ b/tests/tests/test_regressions.py
@@ -62,7 +62,7 @@ def _update_stdcm_payload(payload, rolling_stock_id: int):
     """
     Edit the given stdcm payload to replace the ids for the rolling stock.
     """
-    payload["rolling_stock_id"] = rolling_stock_id
+    payload["consist_schedule"]["values"][0]["rolling_stock_id"] = rolling_stock_id
 
 
 def _check_result(editoast_url: str, schedule_id: int, infra_id: int, session: Session):

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -71,7 +71,6 @@ def test_empty_timetable(
     op_study = create_op_study(EDITOAST_URL, foo_project_id, session)
     _, timetable, _ = create_scenario(EDITOAST_URL, small_infra.id, op_study, session)
     payload = {
-        "rolling_stock_id": fast_rolling_stock,
         "timetable_id": timetable,
         "margin": "0%",
         "start_time": "2024-08-13T21:26:05.793Z",
@@ -82,7 +81,14 @@ def test_empty_timetable(
         "comfort": "STANDARD",
         "maximum_departure_delay": 7200000,
         "maximum_run_time": 43200000,
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": fast_rolling_stock,
+                }
+            ],
+        },
     }
     r = session.post(
         EDITOAST_URL + f"/timetable/{timetable}/stdcm?infra={small_infra.id}",
@@ -101,7 +107,6 @@ def test_empty_timetable_with_stop(
     op_study = create_op_study(EDITOAST_URL, foo_project_id, session)
     _, timetable, _ = create_scenario(EDITOAST_URL, small_infra.id, op_study, session)
     payload = {
-        "rolling_stock_id": fast_rolling_stock,
         "timetable_id": timetable,
         "margin": "0%",
         "start_time": "2024-08-13T21:26:05.793Z",
@@ -113,7 +118,10 @@ def test_empty_timetable_with_stop(
         "comfort": "STANDARD",
         "maximum_departure_delay": 7200000,
         "maximum_run_time": 43200000,
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [{"rolling_stock_id": fast_rolling_stock}],
+        },
     }
     r = session.post(
         EDITOAST_URL + f"/timetable/{timetable}/stdcm?infra={small_infra.id}",
@@ -142,7 +150,6 @@ def test_between_trains(
         session,
     )
     payload = {
-        "rolling_stock_id": fast_rolling_stock,
         "timetable_id": small_scenario.timetable,
         "margin": "0%",
         "start_time": "2024-08-13T21:26:05.793Z",
@@ -154,7 +161,14 @@ def test_between_trains(
         "comfort": "STANDARD",
         "maximum_departure_delay": 7200000,
         "maximum_run_time": 43200000,
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": fast_rolling_stock,
+                }
+            ],
+        },
     }
     r = session.post(
         EDITOAST_URL
@@ -193,7 +207,6 @@ def test_work_schedules(
     work_schedules_response = work_schedules_r.json()
 
     payload = {
-        "rolling_stock_id": fast_rolling_stock,
         "start_time": "2024-01-05T13:00:00+00:00",
         "maximum_departure_delay": 7200000,
         "maximum_run_time": 43200000,
@@ -206,7 +219,14 @@ def test_work_schedules(
         "comfort": "STANDARD",
         "margin": "0%",
         "work_schedule_group_id": work_schedules_response["work_schedule_group_id"],
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": fast_rolling_stock,
+                }
+            ],
+        },
     }
     url = f"{EDITOAST_URL}timetable/{small_scenario.timetable}/stdcm/?infra={small_scenario.infra}"
     r = session.post(url, json=payload)
@@ -235,7 +255,6 @@ def test_mrsp_sources(
 ):
     stdcm_payload = {
         "start_time": "2024-05-22T10:00:00.000Z",
-        "rolling_stock_id": fast_rolling_stock,
         "comfort": "STANDARD",
         "maximum_departure_delay": 86400000,
         "maximum_run_time": 86400000,
@@ -246,12 +265,19 @@ def test_mrsp_sources(
                 "location": {"type": "track_offset", "track": "TH1", "offset": 5000000},
             },
         ],
-        "speed_limit_tags": "E32C",
         "time_gap_before": 3600000,
         "time_gap_after": 3600000,
         "margin": "0%",
         "standard_allowance": "3%",
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": fast_rolling_stock,
+                    "speed_limit_tag": "E32C",
+                }
+            ],
+        },
     }
 
     content = _get_stdcm_response(small_infra, timetable_id, stdcm_payload, session)
@@ -270,7 +296,7 @@ def test_mrsp_sources(
         ],
     }
 
-    stdcm_payload["speed_limit_tags"] = "MA80"
+    stdcm_payload["consist_schedule"]["values"][0]["speed_limit_tag"] = "MA80"
     content = _get_stdcm_response(small_infra, timetable_id, stdcm_payload, session)
     assert content["simulation"]["mrsp"] == {
         "boundaries": [3680000, 4580000],
@@ -347,7 +373,6 @@ def test_max_running_time(
     work_schedules_response = work_schedules_r.json()
 
     payload = {
-        "rolling_stock_id": fast_rolling_stock,
         "start_time": "2024-01-01T07:30:00+00:00",
         "maximum_departure_delay": 3600 * 10,
         "time_gap_before": 0,
@@ -359,7 +384,14 @@ def test_max_running_time(
         "comfort": "STANDARD",
         "margin": "0%",
         "work_schedule_group_id": work_schedules_response["work_schedule_group_id"],
-        "consist_schedule": {"boundaries": [], "values": []},
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": fast_rolling_stock,
+                }
+            ],
+        },
     }
     url = f"{EDITOAST_URL}timetable/{small_scenario.timetable}/stdcm/?infra={small_scenario.infra}"
     r = session.post(url, json=payload)


### PR DESCRIPTION
Remove unused fields in stdcm endpoint post consist changes. These are all the information concerning the first rolling_stock, which are already contained in the list of consists in `consist_schedule`.

Front: I only cleaned up the api and the inputs closest to the call to the editoast endpoint. Further cleaning up is needed and will be done by @DucNg. This will probably entail changes in `OsrdStdcmConfState` and `ValidStdcmConf` at minimum.