### PR TITLE
editoast: make stdcm core pathfinding input creation method take a consist as a parameter

### DIFF
--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use ordered_float::OrderedFloat;
 use schemas::infra::Direction;
@@ -15,8 +15,7 @@ use crate::Json;
 use crate::RawError;
 use crate::WorkerKey;
 
-#[derive(Debug, educe::Educe, Serialize)]
-#[educe(Hash)]
+#[derive(Debug, Hash, Serialize)]
 pub struct PathfindingRequest {
     /// Infrastructure id
     pub infra: i64,
@@ -30,11 +29,9 @@ pub struct PathfindingRequest {
     pub rolling_stock_is_thermal: bool,
     /// List of supported electrification modes.
     /// Empty if does not support any electrification
-    #[educe(Hash(method(common::hashing_hash_set_string)))]
-    pub rolling_stock_supported_electrifications: HashSet<String>,
+    pub rolling_stock_supported_electrifications: BTreeSet<String>,
     /// List of supported signaling systems
-    #[educe(Hash(method(common::hashing_hash_set_string)))]
-    pub rolling_stock_supported_signaling_systems: HashSet<String>,
+    pub rolling_stock_supported_signaling_systems: BTreeSet<String>,
     /// Maximum speed of the rolling stock
     pub rolling_stock_maximum_speed: OrderedFloat<f64>,
     /// Rolling stock length in meters:

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 
 use chrono::DateTime;
@@ -120,13 +121,11 @@ pub struct UndirectedTrackRange {
 }
 
 /// Represents a physics consist.
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, educe::Educe, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
 #[schema(as = CoreConsistConfiguration)]
-#[educe(Hash)]
 pub struct ConsistConfiguration {
     /// List of supported signaling systems
-    #[educe(Hash(method(common::hashing_hash_set_string)))]
-    pub supported_signaling_systems: HashSet<String>,
+    pub supported_signaling_systems: BTreeSet<String>,
     pub speed_limit_tag: Option<String>,
     /// The loading gauge of the rolling stock
     pub loading_gauge_type: LoadingGaugeType,

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -1,5 +1,5 @@
+use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher as _;
@@ -152,19 +152,16 @@ where
     }
 }
 
-#[derive(Debug, educe::Educe, PartialEq, Eq)]
-#[educe(Hash)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(test, derive(Clone))]
 pub struct PathfindingConsist {
     pub loading_gauge: LoadingGaugeType,
     /// Can the consist run on non-electrified tracks
     pub thermal: bool,
     /// Supported electrification modes (leave empty for unelectrified consists)
-    #[educe(Hash(method(common::hashing_hash_set_string)))]
-    pub supported_electrifications: HashSet<String>,
+    pub supported_electrifications: BTreeSet<String>,
     /// A list of supported signaling systems
-    #[educe(Hash(method(common::hashing_hash_set_string)))]
-    pub supported_signaling_systems: HashSet<String>,
+    pub supported_signaling_systems: BTreeSet<String>,
     pub maximum_speed: OrderedFloat<f64>,
     /// Consist length in meters
     pub length: OrderedFloat<f64>,
@@ -459,8 +456,8 @@ pub(crate) mod test_data {
         PathfindingConsist {
             loading_gauge: LoadingGaugeType::GB,
             thermal: true,
-            supported_electrifications: HashSet::new(),
-            supported_signaling_systems: HashSet::from(["BAPR".to_owned()]),
+            supported_electrifications: BTreeSet::new(),
+            supported_signaling_systems: BTreeSet::from(["BAPR".to_owned()]),
             maximum_speed: OrderedFloat::from(100.0),
             length: OrderedFloat::from(id as f64),
             speed_limit_tag: Some("MA100".to_owned()),

--- a/editoast/schemas/src/rolling_stock.rs
+++ b/editoast/schemas/src/rolling_stock.rs
@@ -55,6 +55,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use utoipa::ToSchema;
@@ -120,7 +121,7 @@ pub struct RollingStock {
 }
 
 impl RollingStock {
-    pub fn supported_signaling_systems(&self) -> HashSet<String> {
+    pub fn supported_signaling_systems(&self) -> BTreeSet<String> {
         self.supported_signaling_systems
             .iter()
             .map(|s| s.to_string())

--- a/editoast/schemas/src/rolling_stock/effort_curves.rs
+++ b/editoast/schemas/src/rolling_stock/effort_curves.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use std::collections::BTreeMap;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use utoipa::ToSchema;
 
 use crate::train_schedule::Comfort;
@@ -28,7 +28,7 @@ impl EffortCurves {
         self.has_electric_curves()
     }
 
-    pub fn supported_electrification(&self) -> HashSet<String> {
+    pub fn supported_electrification(&self) -> BTreeSet<String> {
         self.modes
             .iter()
             .filter(|(_, mode)| mode.is_electric)

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -7,7 +7,7 @@ use crate::views::projection::interpolate_arrival_time;
 use crate::views::rolling_stock::RollingStockError;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
-use crate::views::timetable::simulation::train_simulation_batch;
+use crate::views::timetable::simulation::train_simulation_ordered_batch;
 use editoast_models::Infra;
 use editoast_models::LevelCrossingModel;
 use editoast_models::TrainSchedule;
@@ -164,7 +164,7 @@ pub(in crate::views) async fn occupancy(
         .map(|(_, train_schedule)| train_schedule.clone())
         .collect_vec();
 
-    let simulations_result = train_simulation_batch(
+    let simulations_result = train_simulation_ordered_batch(
         conn,
         valkey_client,
         core_client,

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -1,5 +1,5 @@
+use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -43,8 +43,7 @@ use editoast_models::rolling_stock::RollingStock;
 
 /// Path input is described by some rolling stock information
 /// and a list of path waypoints
-#[derive(Deserialize, Clone, Debug, educe::Educe, ToSchema)]
-#[educe(Hash)]
+#[derive(Deserialize, Clone, Debug, Hash, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]
 pub(in crate::views) struct PathfindingInput {
     /// The loading gauge of the rolling stock
@@ -53,11 +52,9 @@ pub(in crate::views) struct PathfindingInput {
     rolling_stock_is_thermal: bool,
     /// List of supported electrification modes.
     /// Empty if does not support any electrification
-    #[educe(Hash(method(common::hashing_hash_set_string)))]
-    rolling_stock_supported_electrifications: HashSet<String>,
+    rolling_stock_supported_electrifications: BTreeSet<String>,
     /// List of supported signaling systems
-    #[educe(Hash(method(common::hashing_hash_set_string)))]
-    rolling_stock_supported_signaling_systems: HashSet<String>,
+    rolling_stock_supported_signaling_systems: BTreeSet<String>,
     /// List of waypoints given to the pathfinding
     path_items: Vec<PathItemLocation>,
     /// Rolling stock maximum speed
@@ -512,7 +509,7 @@ pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
 
 #[cfg(test)]
 pub mod tests {
-    use std::collections::HashSet;
+    use std::collections::BTreeSet;
 
     use axum::http::StatusCode;
     use core_client::mocking::MockingClient;
@@ -536,8 +533,11 @@ pub mod tests {
         PathfindingInput {
             rolling_stock_loading_gauge: LoadingGaugeType::G1,
             rolling_stock_is_thermal: true,
-            rolling_stock_supported_electrifications: HashSet::new(),
-            rolling_stock_supported_signaling_systems: HashSet::from(["BAL".into(), "BAPR".into()]),
+            rolling_stock_supported_electrifications: BTreeSet::new(),
+            rolling_stock_supported_signaling_systems: BTreeSet::from([
+                "BAL".into(),
+                "BAPR".into(),
+            ]),
             rolling_stock_maximum_speed: 22.0.into(),
             rolling_stock_length: 26.0.into(),
             speed_limit_tag: None,

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -20,7 +20,6 @@ use core_client::pathfinding::PathfindingRequest;
 use core_client::pathfinding::PathfindingResultSuccess;
 use database::DbConnection;
 use educe::Educe;
-use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use schemas::rolling_stock::LoadingGaugeType;
 use schemas::train_schedule::PathItemLocation;
@@ -37,6 +36,7 @@ use crate::error::Result;
 use crate::views::AuthenticationExt;
 use crate::views::path::PathfindingError;
 use crate::views::path::operational_point_cache::OperationalPointCache;
+use crate::views::timetable::PhysicsConsistParameters;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
@@ -72,20 +72,23 @@ pub(in crate::views) struct PathfindingInput {
 
 impl PathfindingInput {
     pub fn from(
-        rolling_stock: &schemas::RollingStock,
+        consist: &PhysicsConsistParameters,
         train_schedule: &impl TrainScheduleLike,
     ) -> Self {
         Self {
-            rolling_stock_loading_gauge: rolling_stock.loading_gauge,
-            rolling_stock_is_thermal: rolling_stock.effort_curves.has_thermal_curves(),
-            rolling_stock_supported_electrifications: rolling_stock
+            rolling_stock_loading_gauge: consist.compute_loading_gauge(),
+            rolling_stock_is_thermal: consist.traction_engine.effort_curves.has_thermal_curves(),
+            rolling_stock_supported_electrifications: consist
+                .traction_engine
                 .effort_curves
                 .supported_electrification(),
-            rolling_stock_supported_signaling_systems: rolling_stock.supported_signaling_systems(),
+            rolling_stock_supported_signaling_systems: consist
+                .traction_engine
+                .supported_signaling_systems(),
             rolling_stock_maximum_speed: OrderedFloat(units::meter_per_second::from(
-                rolling_stock.max_speed,
+                consist.compute_max_speed(),
             )),
-            rolling_stock_length: OrderedFloat(units::meter::from(rolling_stock.length)),
+            rolling_stock_length: OrderedFloat(units::meter::from(consist.compute_length())),
             path_items: train_schedule
                 .path()
                 .iter()
@@ -432,12 +435,20 @@ pub async fn pathfinding_from_train<T: TrainScheduleLike>(
     train_schedule: T,
     app_version: Option<&str>,
 ) -> Result<PathfindingResult> {
-    let rolling_stock: Vec<_> =
+    let Some(consist) =
         RollingStock::retrieve(conn.clone(), train_schedule.rolling_stock_name().to_owned())
             .await?
-            .into_iter()
-            .map_into()
-            .collect();
+            .map(schemas::RollingStock::from)
+            .map(PhysicsConsistParameters::from_traction_engine)
+    else {
+        return Ok(PathfindingResult::Failure(
+            PathfindingFailure::PathfindingInputError(
+                PathfindingInputError::RollingStockNotFound {
+                    rolling_stock_name: train_schedule.rolling_stock_name().to_owned(),
+                },
+            ),
+        ));
+    };
 
     Ok(Arc::unwrap_or_clone(
         pathfinding_from_train_batch(
@@ -445,8 +456,10 @@ pub async fn pathfinding_from_train<T: TrainScheduleLike>(
             valkey,
             core,
             infra,
-            &[train_schedule],
-            &rolling_stock,
+            &[TrainScheduleWithConsist {
+                train_schedule,
+                consist,
+            }],
             app_version,
         )
         .await?
@@ -455,43 +468,38 @@ pub async fn pathfinding_from_train<T: TrainScheduleLike>(
     ))
 }
 
+#[derive(Debug, Clone)]
+pub struct TrainScheduleWithConsist<T: TrainScheduleLike> {
+    pub train_schedule: T,
+    pub consist: PhysicsConsistParameters,
+}
+
 /// Compute a path given a batch of trainschedule and an infrastructure.
 pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
     conn: DbConnection,
     valkey: &mut cache::Connection,
     core: Arc<CoreClient>,
     infra: &Infra,
-    train_schedules: &[T],
-    rolling_stocks: &[schemas::RollingStock],
+    train_schedules_with_consists: &[TrainScheduleWithConsist<T>],
     app_version: Option<&str>,
 ) -> Result<Vec<Arc<PathfindingResult>>> {
     let initial_value = Arc::new(PathfindingResult::Failure(
         PathfindingFailure::PathfindingInputError(PathfindingInputError::NotEnoughPathItems),
     ));
-    let mut results = vec![initial_value; train_schedules.len()];
-
-    let rolling_stocks: HashMap<_, _> = rolling_stocks
-        .iter()
-        .map(|rs| (rs.name.as_str(), rs))
-        .collect();
+    let mut results = vec![initial_value; train_schedules_with_consists.len()];
 
     let mut to_compute = vec![];
     let mut to_compute_index = vec![];
-    for (index, train_schedule) in train_schedules.iter().enumerate() {
-        // Retrieve rolling stock
-        let rolling_stock_name = train_schedule.rolling_stock_name();
-        let Some(rolling_stock) = rolling_stocks.get(rolling_stock_name) else {
-            let rolling_stock_name = rolling_stock_name.into();
-            results[index] = Arc::new(PathfindingResult::Failure(
-                PathfindingFailure::PathfindingInputError(
-                    PathfindingInputError::RollingStockNotFound { rolling_stock_name },
-                ),
-            ));
-            continue;
-        };
-
+    for (
+        index,
+        TrainScheduleWithConsist {
+            train_schedule,
+            consist,
+        },
+    ) in train_schedules_with_consists.iter().enumerate()
+    {
         // Create the path input
-        let path_input = PathfindingInput::from(rolling_stock, train_schedule);
+        let path_input = PathfindingInput::from(consist, train_schedule);
         to_compute.push(path_input);
         to_compute_index.push(index);
     }

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -29,7 +29,7 @@ use crate::views::path::projection::PathProjection;
 use crate::views::path::projection::TrackLocationFromPath;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
-use crate::views::timetable::simulation::train_simulation_batch;
+use crate::views::timetable::simulation::train_simulation_ordered_batch;
 use editoast_models::Infra;
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -352,7 +352,7 @@ pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     let mut valkey_conn = valkey_client.get_connection().await?;
 
     // 1. Get train simulations
-    let simulations = train_simulation_batch(
+    let simulations = train_simulation_ordered_batch(
         conn,
         valkey_client.clone(),
         core_client.clone(),
@@ -720,7 +720,7 @@ pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
     electrical_profile_set_id: Option<i64>,
     app_version: Option<&str>,
 ) -> Result<Vec<Arc<Vec<SpaceTimeCurve>>>> {
-    let simulations = train_simulation_batch(
+    let simulations = train_simulation_ordered_batch(
         conn,
         valkey_client.clone(),
         core_client.clone(),

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -6,6 +6,7 @@ mod track_occupancy;
 pub mod train_schedule;
 pub mod train_schedule_exceptions;
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -49,7 +50,7 @@ use schemas::rolling_stock::TowedRollingStock;
 use schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use serde::Serialize;
-use simulation::train_simulation_batch;
+use simulation::train_simulation_ordered_batch;
 use thiserror::Error;
 use train_schedule::TrainScheduleResponse;
 use utoipa::IntoParams;
@@ -374,7 +375,7 @@ pub(in crate::views) async fn conflicts(
         .flat_map(|(ts, exceptions)| ts.iter_occurrences(exceptions))
         .unzip();
 
-    let occurrence_simulations: Vec<_> = train_simulation_batch(
+    let occurrence_simulations: Vec<_> = train_simulation_ordered_batch(
         &mut db_pool.get().await?,
         valkey_client.clone(),
         core_client.clone(),
@@ -554,7 +555,7 @@ pub(in crate::views) async fn requirements(
         })
         .unzip();
 
-    let simulations = train_simulation_batch(
+    let simulations = train_simulation_ordered_batch(
         conn,
         valkey_client.clone(),
         core_client.clone(),
@@ -765,6 +766,11 @@ impl PhysicsConsistParameters {
         );
         etcs_brake_params
     }
+
+    pub fn compute_loading_gauge(&self) -> LoadingGaugeType {
+        self.loading_gauge_type
+            .unwrap_or(self.traction_engine.loading_gauge)
+    }
 }
 
 impl From<PhysicsConsistParameters> for PhysicsConsist {
@@ -794,7 +800,7 @@ impl From<PhysicsConsistParameters> for PhysicsConsist {
             etcs_brake_params,
             inertia_coefficient,
             rolling_resistance,
-            power_restrictions: traction_engine.power_restrictions.into_iter().collect(),
+            power_restrictions: BTreeMap::from_iter(traction_engine.power_restrictions),
             electrical_power_startup_time: traction_engine.electrical_power_startup_time,
             raise_pantograph_time: traction_engine.raise_pantograph_time,
         }
@@ -1094,7 +1100,7 @@ mod tests {
         // Check if the timetable has the two train schedules
         assert_eq!(list.results.len(), 2);
 
-        // Check if the first train schedule containe only his own exception
+        // Check if the first train schedule contains only his own exception
         assert_eq!(
             list.results
                 .first()

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -19,7 +19,7 @@ use utoipa::ToSchema;
 
 use crate::error::Result;
 use crate::views::timetable::simulation;
-use crate::views::timetable::simulation::train_simulation_batch;
+use crate::views::timetable::simulation::train_simulation_ordered_batch;
 use editoast_models::Infra;
 
 /// Occupancy block output is described by time-space points and blocks
@@ -137,7 +137,7 @@ pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
     let mut valkey_conn = valkey_client.get_connection().await?;
 
     // 1. Get train simulations
-    let simulations = train_simulation_batch(
+    let simulations = train_simulation_ordered_batch(
         conn,
         valkey_client.clone(),
         core_client.clone(),

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -19,6 +19,7 @@ use core_task::SimulationTrain;
 use core_task::SimulationTrainParameters;
 use core_task::SimulationWaypoint;
 use database::DbConnection;
+use itertools::Either;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use schemas::TrainOccurrence;
@@ -45,6 +46,7 @@ use crate::error::Result;
 use crate::views::CoreClient;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::path::pathfinding::PathfindingFailure;
+use crate::views::path::pathfinding::TrainScheduleWithConsist;
 use crate::views::path::pathfinding_from_train_batch;
 use crate::views::rolling_stock::RollingStockError;
 use crate::views::timetable::Infra;
@@ -360,7 +362,7 @@ impl From<PathfindingFailure> for SummaryResponse {
 ///
 /// Note: The order of the returned simulations is the same as the order of the train schedules.
 #[allow(clippy::too_many_arguments)]
-pub async fn train_simulation_batch<T: TrainScheduleLike>(
+pub async fn train_simulation_ordered_batch<T: TrainScheduleLike + Clone>(
     conn: &mut DbConnection,
     valkey_client: Arc<cache::Client>,
     core: Arc<CoreClient>,
@@ -369,32 +371,47 @@ pub async fn train_simulation_batch<T: TrainScheduleLike>(
     electrical_profile_set_id: Option<i64>,
     app_version: Option<&str>,
 ) -> Result<Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>> {
-    // Compute path
-
-    let train_batches = train_schedules.chunks(TRAIN_SIZE_BATCH);
-
     let rolling_stocks_names = train_schedules
         .iter()
         .map::<String, _>(|t| t.rolling_stock_name().to_string());
 
-    let rolling_stocks: Vec<_> =
-        RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_names)
-            .await
-            .map_err(RollingStockError::from)?;
+    let rolling_stocks: HashMap<_, _> = RollingStock::retrieve_batch_with_key_unchecked::<_, _>(
+        &mut conn.clone(),
+        rolling_stocks_names,
+    )
+    .await
+    .map_err(RollingStockError::from)?;
+    let (train_schedules_with_consists, rolling_stock_errors): (Vec<_>, Vec<_>) = train_schedules
+        .iter()
+        .enumerate()
+        // train_schedule_idx is the position of the train schedule in the original input list.
+        .partition_map(|(train_schedule_idx, train_schedule)| {
+            match rolling_stocks.get(train_schedule.rolling_stock_name()) {
+                Some(traction_engine) => Either::Left((
+                    train_schedule_idx,
+                    TrainScheduleWithConsist {
+                        train_schedule: train_schedule.clone(),
+                        consist: PhysicsConsistParameters::from_traction_engine(
+                            schemas::RollingStock::from(traction_engine.clone()),
+                        ),
+                    },
+                )),
+                None => Either::Right((
+                    train_schedule_idx,
+                    train_schedule.rolling_stock_name().to_owned(),
+                )),
+            }
+        });
 
-    let consists: Vec<PhysicsConsistParameters> = rolling_stocks
-        .into_iter()
-        .map(|rs| PhysicsConsistParameters::from_traction_engine(rs.into()))
-        .collect();
+    let train_batches = train_schedules_with_consists.chunks(TRAIN_SIZE_BATCH);
 
     let futures: Vec<_> = train_batches
         .zip(iter::repeat(conn.clone()))
         .map(|(chunk, conn)| {
             let valkey_client = valkey_client.clone();
             let core = core.clone();
-            let consists = consists.clone();
             let infra = <Infra as Clone>::clone(infra);
-            let chunk = chunk.to_vec(); // TODO: avoid cloning the chunk
+            let (train_schedule_idxs, chunk): (Vec<_>, Vec<_>) = chunk.iter().cloned().unzip(); // TODO: avoid cloning the chunk
             let app_version = app_version.map(String::from);
             tokio::spawn(
                 async move {
@@ -404,11 +421,16 @@ pub async fn train_simulation_batch<T: TrainScheduleLike>(
                         core.clone(),
                         &infra,
                         &chunk,
-                        &consists,
                         electrical_profile_set_id,
                         app_version.as_deref(),
                     )
                     .await
+                    .map(|v| {
+                        v.into_iter()
+                            .zip(train_schedule_idxs)
+                            .map(|((sim, path), index)| (index, sim, path))
+                            .collect_vec()
+                    })
                 }
                 .in_current_span(),
             )
@@ -416,21 +438,43 @@ pub async fn train_simulation_batch<T: TrainScheduleLike>(
         .collect();
 
     let results = futures::future::try_join_all(futures).await.unwrap();
-    results
+    let mut results =
+        results
+            .into_iter()
+            .flatten_ok()
+            .chain(rolling_stock_errors.into_iter().map(
+                |(train_schedule_idx, rolling_stock_name)| {
+                    let pathfinding_failure = PathfindingFailure::PathfindingInputError(
+                        PathfindingInputError::RollingStockNotFound { rolling_stock_name },
+                    );
+                    Ok((
+                        train_schedule_idx,
+                        Arc::new(simulation::Response::PathfindingFailed {
+                            pathfinding_failed: pathfinding_failure.clone(),
+                        }),
+                        Arc::new(PathfindingResult::Failure(pathfinding_failure)),
+                    ))
+                },
+            ))
+            .try_collect::<_, Vec<_>, _>()?;
+    // Since train_schedule_idx is the position of the train schedule in the original input list,
+    // sorting the results by train_schedule_idx here will guarantee that the results have the same
+    // order as the input list of train schedules.
+    results.sort_by_key(|(train_schedule_idx, _simulation, _path)| *train_schedule_idx);
+    let results = results
         .into_iter()
-        .flatten_ok()
-        .collect::<Result<Vec<_>, _>>()
+        .map(|(_train_schedule_idx, simulation, path)| (simulation, path))
+        .collect_vec();
+    Ok(results)
 }
 
-#[tracing::instrument(skip_all, fields(nb_trains = train_schedules.len()))]
-#[allow(clippy::too_many_arguments)]
+#[tracing::instrument(skip_all, fields(nb_trains = train_schedules_with_consists.len()))]
 pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     conn: &mut DbConnection,
     valkey_client: Arc<cache::Client>,
     core: Arc<CoreClient>,
     infra: &Infra,
-    train_schedules: &[T],
-    consists: &[PhysicsConsistParameters],
+    train_schedules_with_consists: &[TrainScheduleWithConsist<T>],
     electrical_profile_set_id: Option<i64>,
     app_version: Option<&str>,
 ) -> Result<Vec<(Arc<simulation::Response>, Arc<PathfindingResult>)>> {
@@ -441,26 +485,24 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
         &mut valkey_conn,
         core.clone(),
         infra,
-        train_schedules,
-        &consists
-            .iter()
-            .map(|consist| consist.traction_engine.clone())
-            .collect::<Vec<_>>(),
+        train_schedules_with_consists,
         app_version,
     )
     .await?;
 
-    let consists: HashMap<_, _> = consists
-        .iter()
-        .map(|consist| (consist.traction_engine.name.as_str(), consist))
-        .collect();
-
-    let mut simulation_results = vec![None::<Arc<simulation::Response>>; train_schedules.len()];
+    let mut simulation_results =
+        vec![None::<Arc<simulation::Response>>; train_schedules_with_consists.len()];
     let mut to_sim: HashMap<String, Vec<usize>> = HashMap::default();
     let mut sim_request_map: HashMap<String, core_client::simulation::Request> = HashMap::default();
-    for (index, (pathfinding, train_schedule)) in
-        pathfinding_results.iter().zip(train_schedules).enumerate()
+    for (index, (pathfinding, train_schedule_with_consist)) in pathfinding_results
+        .iter()
+        .zip(train_schedules_with_consists)
+        .enumerate()
     {
+        let TrainScheduleWithConsist {
+            train_schedule,
+            consist,
+        } = train_schedule_with_consist;
         let (path, path_item_positions) = match pathfinding.as_ref() {
             PathfindingResult::Success(PathfindingResultSuccess {
                 path,
@@ -477,15 +519,13 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
         };
 
         // Build simulation request
-        let physics_consist_parameters = consists[train_schedule.rolling_stock_name()].clone();
-
         let simulation_request = build_simulation_request(
             infra,
             train_schedule,
             path_item_positions,
             path,
             electrical_profile_set_id,
-            physics_consist_parameters.into(),
+            PhysicsConsist::from(consist.clone()),
         );
 
         // Compute unique hash of the simulation input
@@ -504,7 +544,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
             .or_insert(simulation_request);
     }
     info!(
-        nb_train_schedules = train_schedules.len(),
+        nb_train_schedules = train_schedules_with_consists.len(),
         nb_unique_sim = to_sim.len()
     );
     let cached_simulation_hash = to_sim.keys().collect::<Vec<_>>();

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -373,12 +373,12 @@ pub async fn train_simulation_batch<T: TrainScheduleLike>(
 
     let train_batches = train_schedules.chunks(TRAIN_SIZE_BATCH);
 
-    let rolling_stocks_ids = train_schedules
+    let rolling_stocks_names = train_schedules
         .iter()
         .map::<String, _>(|t| t.rolling_stock_name().to_string());
 
     let rolling_stocks: Vec<_> =
-        RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_ids)
+        RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_names)
             .await
             .map_err(RollingStockError::from)?;
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -638,6 +638,7 @@ mod tests {
     use rstest::rstest;
     use schemas::fixtures::simple_rolling_stock;
     use schemas::fixtures::towed_rolling_stock;
+    use schemas::rolling_stock::LoadingGaugeType;
     use schemas::rolling_stock::RollingResistance;
     use schemas::train_schedule::Comfort;
     use schemas::train_schedule::OperationalPointPartReference;
@@ -648,6 +649,8 @@ mod tests {
     use uom::si::length::meter;
     use uom::si::mass::kilogram;
     use uom::si::quantities::Mass;
+    use uom::si::velocity::Velocity;
+    use uom::si::velocity::kilometer_per_hour;
     use uuid::Uuid;
 
     use crate::error::InternalError;
@@ -724,15 +727,17 @@ mod tests {
         rolling_stock_id: i64,
         total_mass: Option<f64>,
         total_length: Option<f64>,
+        max_speed: Option<f64>,
+        loading_gauge_type: Option<LoadingGaugeType>,
     ) -> request::ConsistConfiguration {
         request::ConsistConfiguration {
             rolling_stock_id,
             towed_rolling_stock_id: None,
             total_mass: total_mass.map(Mass::new::<kilogram>),
             total_length: total_length.map(Length::new::<meter>),
-            max_speed: None,
+            max_speed: max_speed.map(Velocity::new::<kilometer_per_hour>),
             speed_limit_tag: Some("AR120".to_string()),
-            loading_gauge_type: None,
+            loading_gauge_type,
         }
     }
 
@@ -985,8 +990,13 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let consist_schedule =
-            build_single_consist(build_consist_config(rolling_stock.id, None, None));
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            None,
+            Some(400.0),
+            None,
+            None,
+        ));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
@@ -1033,8 +1043,13 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let consist_schedule =
-            build_single_consist(build_consist_config(rolling_stock.id, Some(80_000.0), None));
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(80_000.0),
+            None,
+            None,
+            None,
+        ));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
@@ -1076,8 +1091,13 @@ mod tests {
         let total_length = Some(300.0);
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let consist_schedule =
-            build_single_consist(build_consist_config(rolling_stock.id, None, total_length));
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            None,
+            total_length,
+            None,
+            None,
+        ));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
@@ -1123,6 +1143,8 @@ mod tests {
             rolling_stock.id,
             total_mass,
             total_length,
+            None,
+            None,
         ));
 
         let request = app
@@ -1167,8 +1189,13 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let consist_schedule =
-            build_single_consist(build_consist_config(rolling_stock.id, None, None));
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            None,
+            None,
+            None,
+            None,
+        ));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
@@ -1215,8 +1242,13 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let consist_schedule =
-            build_single_consist(build_consist_config(rolling_stock.id, None, None));
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            None,
+            None,
+            None,
+            None,
+        ));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
@@ -1283,8 +1315,13 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let consist_schedule =
-            build_single_consist(build_consist_config(rolling_stock.id, None, None));
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            None,
+            None,
+            None,
+            None,
+        ));
 
         let request = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
@@ -1370,8 +1407,8 @@ mod tests {
             ConsistSchedule {
                 boundaries: vec![1, 2],
                 values: vec![
-                    build_consist_config(1, None, None),
-                    build_consist_config(2, None, None),
+                    build_consist_config(1, None, None, None, None),
+                    build_consist_config(2, None, None, None, None),
                 ],
             },
         );
@@ -1388,8 +1425,8 @@ mod tests {
             ConsistSchedule {
                 boundaries: vec![0],
                 values: vec![
-                    build_consist_config(1, None, None),
-                    build_consist_config(2, None, None),
+                    build_consist_config(1, None, None, None, None),
+                    build_consist_config(2, None, None, None, None),
                 ],
             },
         );
@@ -1406,8 +1443,8 @@ mod tests {
             ConsistSchedule {
                 boundaries: vec![2],
                 values: vec![
-                    build_consist_config(1, None, None),
-                    build_consist_config(2, None, None),
+                    build_consist_config(1, None, None, None, None),
+                    build_consist_config(2, None, None, None, None),
                 ],
             },
         );
@@ -1424,9 +1461,9 @@ mod tests {
             ConsistSchedule {
                 boundaries: vec![5, 3],
                 values: vec![
-                    build_consist_config(1, None, None),
-                    build_consist_config(2, None, None),
-                    build_consist_config(3, None, None),
+                    build_consist_config(1, None, None, None, None),
+                    build_consist_config(2, None, None, None, None),
+                    build_consist_config(3, None, None, None, None),
                 ],
             },
         );
@@ -1484,10 +1521,14 @@ mod tests {
                         first_rolling_stock.id,
                         total_mass_first_rolling_stock,
                         None,
+                        None,
+                        None,
                     ),
                     build_consist_config(
                         second_rolling_stock.id,
                         total_mass_second_rolling_stock,
+                        None,
+                        None,
                         None,
                     ),
                 ],
@@ -1571,9 +1612,9 @@ mod tests {
             ConsistSchedule {
                 boundaries: vec![1, 2],
                 values: vec![
-                    build_consist_config(first_rolling_stock.id, None, None),
-                    build_consist_config(second_rolling_stock.id, None, None),
-                    build_consist_config(third_rolling_stock.id, None, None),
+                    build_consist_config(first_rolling_stock.id, None, None, None, None),
+                    build_consist_config(second_rolling_stock.id, None, None, None, None),
+                    build_consist_config(third_rolling_stock.id, None, None, None, None),
                 ],
             },
         );

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -54,6 +54,7 @@ use crate::AppState;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
+use crate::views::path::pathfinding::TrainScheduleWithConsist;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
@@ -509,23 +510,21 @@ impl VirtualTrainRun {
     ) -> Result<Vec<Self>> {
         // Doesn't matter for now, but eventually it will affect tmp speed limits
         let approx_start_time = stdcm_request.get_earliest_step_time();
-        let mut train_schedules = vec![];
-
-        for ((start, end), consist_parameters) in itertools::chain!(
+        let train_schedules_with_consists = itertools::chain!(
             std::iter::once(0),
             stdcm_request.consist_schedule.boundaries.clone(),
             std::iter::once(stdcm_request.steps.len() - 1)
         )
         .tuple_windows()
-        .zip(consists_parameters.iter())
-        {
+        .zip(consists_parameters)
+        .map(|((start, end), consist)| {
             let path = convert_steps(&stdcm_request.steps[start..=end]);
             let last_step = path.last().expect("empty step list");
 
-            train_schedules.push(TrainOccurrence {
+            let train_occurrence = TrainOccurrence {
                 train_name: "".to_string(),
                 labels: vec![],
-                rolling_stock_name: consist_parameters.traction_engine.name.clone(),
+                rolling_stock_name: consist.traction_engine.name.clone(),
                 start_time: approx_start_time,
                 schedule: vec![ScheduleItem {
                     // Make the train stop at the end
@@ -539,15 +538,20 @@ impl VirtualTrainRun {
                 comfort: stdcm_request.comfort,
                 path,
                 constraint_distribution: Default::default(),
-                speed_limit_tag: consist_parameters
+                speed_limit_tag: consist
                     .speed_limit_tag
                     .clone()
                     .map(schemas::primitives::NonBlankString::from),
                 power_restrictions: vec![],
                 options: Default::default(),
                 category: None,
-            });
-        }
+            };
+            TrainScheduleWithConsist {
+                train_schedule: train_occurrence,
+                consist: consist.clone(),
+            }
+        })
+        .collect_vec();
 
         // Compute simulation of a train schedule
         let simulations: Vec<Self> = consist_train_simulation_batch(
@@ -555,8 +559,7 @@ impl VirtualTrainRun {
             valkey_client,
             core_client,
             infra,
-            &train_schedules,
-            consists_parameters,
+            &train_schedules_with_consists,
             None,
             app_version,
         )
@@ -567,7 +570,7 @@ impl VirtualTrainRun {
         })
         .collect();
 
-        if simulations.len() != train_schedules.len() {
+        if simulations.len() != train_schedules_with_consists.len() {
             return Err(StdcmError::TrainSimulationFail.into());
         }
 
@@ -644,13 +647,16 @@ mod tests {
     use schemas::train_schedule::OperationalPointPartReference;
     use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::PathItemLocation;
+    use serde_json::json;
     use std::str::FromStr;
+    use uom::si::SI;
     use uom::si::length::Length;
     use uom::si::length::meter;
     use uom::si::mass::kilogram;
     use uom::si::quantities::Mass;
     use uom::si::velocity::Velocity;
     use uom::si::velocity::kilometer_per_hour;
+    use uom::si::velocity::meter_per_second;
     use uuid::Uuid;
 
     use crate::error::InternalError;
@@ -971,18 +977,72 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn stdcm_return_success() {
-        let mut core = core_mocking_client();
-        core.stub("/stdcm")
-            .response(StatusCode::OK)
-            .json(core_client::stdcm::ProgressStatus::Done {
-                result: core_client::stdcm::Response::Success {
-                    simulation: simulation_empty_response().success().unwrap(),
-                    path: pathfinding_result_success(),
-                    departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
-                        .expect("Failed to parse datetime"),
-                },
-            })
-            .finish();
+        let core = {
+            let mut core = MockingClient::new();
+            core.stub("/pathfinding/blocks")
+                .body(
+                    json!({
+                        "infra": 1,
+                        "expected_version": 0,
+                        "path_items": [
+                            {
+                                "locations": [
+                                    { "track": "TA0", "offset": 700000 },
+                                    { "track": "TA1", "offset": 500000 },
+                                    { "track": "TA2", "offset": 500000 }
+                                ],
+                                "can_backtrack": false,
+                            },
+                            {
+                                "locations": [
+                                    { "track": "TC0", "offset": 550000 },
+                                    { "track": "TC1", "offset": 550000 },
+                                    { "track": "TC2", "offset": 450000 },
+                                    { "track": "TC3", "offset": 450000 }
+                                ],
+                                "can_backtrack": false,
+                            },
+                        ],
+                        // We check the value of the consist is present, instead of the value of the traction engine
+                        "rolling_stock_loading_gauge": "GLOTT",
+                        "rolling_stock_is_thermal": true,
+                        "rolling_stock_supported_electrifications": ["25000V"],
+                        "rolling_stock_supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"],
+                        // We check the value of the consist is present, instead of the value of the traction engine
+                        "rolling_stock_maximum_speed": Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0)
+                .get::<meter_per_second>(),
+                        // We check the value of the consist is present, instead of the value of the traction engine
+                        "rolling_stock_length": Length::<SI<_>, f64>::new::<meter>(400.0)
+                .get::<meter>(),
+                        "speed_limit_tag": "AR120",
+                        "stops_at_end_of_block": false
+                    })
+                    .to_string(),
+                )
+                .response(StatusCode::OK)
+                .json(PathfindingResult::Success(pathfinding_result_success()))
+                .finish();
+            core.stub("/standalone_simulation")
+                // TODO: it would be nice to assert on the input request value
+                // but the current `MockingClient` framework impose the entire payload which is noisy
+                .response(StatusCode::OK)
+                .json(simulation_empty_response())
+                .finish();
+            core.stub("/stdcm")
+                // TODO: it would be nice to assert on the input request value
+                // but the current `MockingClient` framework impose the entire payload which is noisy
+                .response(StatusCode::OK)
+                .json(core_client::stdcm::ProgressStatus::Done {
+                    result: core_client::stdcm::Response::Success {
+                        simulation: simulation_empty_response().success().unwrap(),
+                        path: pathfinding_result_success(),
+                        departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                            .expect("Failed to parse datetime"),
+                    },
+                })
+                .finish();
+            core
+        };
 
         let app = TestAppBuilder::new().core_client(core.into()).build();
         let db_pool = app.db_pool();
@@ -992,10 +1052,10 @@ mod tests {
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
-            None,
+            Some(1000000.0),
             Some(400.0),
-            None,
-            None,
+            Some(30.0),
+            Some(LoadingGaugeType::Glott),
         ));
 
         let request = app

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -70,7 +70,7 @@ use crate::views::timetable::simulation::SummaryResponse;
 use crate::views::timetable::simulation::build_path_items_to_position;
 use crate::views::timetable::simulation::build_sim_power_restriction_items;
 use crate::views::timetable::simulation::build_sim_schedule_items;
-use crate::views::timetable::simulation::train_simulation_batch;
+use crate::views::timetable::simulation::train_simulation_ordered_batch;
 use crate::views::timetable::track_occupancy;
 use editoast_models::Infra;
 use editoast_models::TrainScheduleSet;
@@ -738,7 +738,7 @@ pub(in crate::views) async fn simulation(
     };
 
     // Compute simulation of a train schedule
-    let (simulation, _) = train_simulation_batch(
+    let (simulation, _) = train_simulation_ordered_batch(
         &mut db_pool.get().await?,
         valkey_client,
         core_client,
@@ -822,7 +822,7 @@ pub(in crate::views) async fn etcs_braking_curves(
     };
 
     // Compute simulation of a train schedule
-    let (simulation_result, pathfinding_result) = train_simulation_batch(
+    let (simulation_result, pathfinding_result) = train_simulation_ordered_batch(
         &mut db_pool.get().await?,
         valkey_client,
         core_client.clone(),
@@ -1553,7 +1553,7 @@ async fn find_track_occupancy_for_known_operational_point_with_simulation(
         app_version,
     } = simulation_params;
 
-    let simulations_result = train_simulation_batch(
+    let simulations_result = train_simulation_ordered_batch(
         conn,
         valkey_client,
         core_client,


### PR DESCRIPTION
There is a difference in behavior for the following values: loading gauge, max speed, length and mass.
- in the stdcm endpoint, the values sent to core are the consist's if it exists, and it falls back on the rolling_stock's values if not
- in the pathfinding/standalone_simulation calls made by stdcm just before the actual call, the values used are the rolling_stock's values 

This is a bug, both should be using the consist's values and fall back on the rolling_stock's values. This is the point of this PR. To fix this, consists are now forwarded all the way to the pathfinding method that creates the pathfinding input for core, and used there.

Additional api clean up changes are introduced in https://github.com/OpenRailAssociation/osrd/pull/16545.

Part of https://github.com/OpenRailAssociation/osrd/issues/16699 will by fixed.