### PR TITLE
ci: e2e: disable firefox tests in the merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -919,8 +919,7 @@ jobs:
       - name: Run Playwright tests
         run: |
           # Determine the Playwright projects to run
-          if [[ "${{ github.event_name }}" == "merge_group"  ||
-                "${{ github.ref }}" == "refs/heads/dev" ||
+          if [[ "${{ github.ref }}" == "refs/heads/dev" ||
                 "${{ github.ref }}" == "refs/heads/staging" ]]; then
             TEST_PROJECT="" # Run all browsers
             echo "Running Playwright tests on both Chromium and Firefox"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -919,8 +919,7 @@ jobs:
       - name: Run Playwright tests
         run: |
           # Determine the Playwright projects to run
-          if [[ "${{ github.ref }}" == "refs/heads/dev" ||
-                "${{ github.ref }}" == "refs/heads/staging" ]]; then
+          if [[ "${{ github.ref }}" == "refs/heads/staging" ]]; then
             TEST_PROJECT="" # Run all browsers
             echo "Running Playwright tests on both Chromium and Firefox"
           else


### PR DESCRIPTION
They are currently causing a lot of flakiness, and more generally cost a lot of build time for limited benefits.

We could instead rely on running those tests locally against staging before releasing, or just looking at the build status of the `dev`/`staging` branch (they will still run there)