### PR TITLE
front: remove part field from projection data operational points

### DIFF
--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -9,7 +9,6 @@ import { useSelector } from 'react-redux';
 import {
   osrdEditoastApi,
   type PathfindingResult,
-  type PathProperties,
   type OperationalPointReference,
   type TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
@@ -28,7 +27,7 @@ import {
   isPacedTrainId,
 } from 'utils/trainId';
 
-import type { PathProjectionResult } from '../types';
+import type { PathProjectionResult, PathProjectionResultOperationalPoint } from '../types';
 
 /**
  * Generates a display name for a virtual operational point based on available reference data.
@@ -61,7 +60,7 @@ const createVirtualOp = (
   position: number,
   weight: number,
   t: TFunction<'operational-studies'>
-): PathProperties['operational_points'][0] => {
+): PathProjectionResultOperationalPoint => {
   const virtualName = getVirtualOpName(opRef, index, totalCount, t);
   const virtualId = `virtual_op_${virtualName}`;
 
@@ -80,7 +79,6 @@ const createVirtualOp = (
         trigram: opRef.type === 'trigram' ? opRef.trigram : '',
       },
     },
-    part: { track: '', position: 0, local_track_name: 'V1' },
     position,
     weight,
   };
@@ -230,7 +228,7 @@ const usePathProjection = (
     // 1. For each point in the path, try to match with infrastructure data
     // 2. If a point is matched → use matched data with full extensions
     // 3. If a point is not matched (e.g., NGE) → create a virtual point from the reference
-    const normalizedOps: PathProperties['operational_points'] = [];
+    const normalizedOps: PathProjectionResultOperationalPoint[] = [];
 
     opRefs.forEach((opRef, index) => {
       const matchedOp = matchedOperationalPoints?.related_operational_points[index];
@@ -245,18 +243,13 @@ const usePathProjection = (
         normalizedOps.push({
           id: matchedOp.id,
           extensions: matchedOp.extensions,
-          part: matchedOp.parts.at(0) || {
-            track: '',
-            position: 0,
-            local_track_name: 'V1',
-            extensions: undefined,
-          },
           position,
           weight,
         });
       } else {
         // NOT MATCHED: Point doesn't exist in infrastructure (e.g., NGE point)
         // Create virtual point from the reference
+        // TODO : change this logic when implementing the non computation creation feature with the new opRef format
         normalizedOps.push(createVirtualOp(opRef, index, opRefs.length, position, weight, t));
       }
     });

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -176,9 +176,17 @@ export type ItineraryPathProperties = PathProperties & {
   length: number;
   incompatibleConstraints?: CoreIncompatibleConstraints;
 };
+
+export type PathProjectionResultOperationalPoint = Omit<
+  PathProperties['operational_points'][number],
+  'part'
+>;
+
 export type PathProjectionResult = {
   path: PathItem[];
-  operationalPoints: PathProperties['operational_points'];
+  // Remove the part field as it won't be used anywhere in the app.
+  // This avoid us to have to add hardcoded data in it.
+  operationalPoints: PathProjectionResultOperationalPoint[];
   operationalPointDistances: number[];
   operationalPointReferences: OperationalPointReference[];
 } & (

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -58,10 +58,6 @@ function getOperationalPointReference(
   op: PathOperationalPoint | undefined
 ): OperationalPointReference | undefined {
   if (!op) return undefined;
-  // Only use the opId when it refers to a real infra OP. Virtual OPs (unrecognised, created
-  // by usePathProjection when pathfinding fails) have a synthetic id like "virtual_op_Zürich"
-  // and an empty part.track — they must be matched by trigram/uic instead.
-  if (op.opId && op.part?.track) return { type: 'id', operational_point: op.opId };
   // Normalize empty string ch to null — virtual OPs store ch as '' when the original
   // secondary_code was null (see usePathProjection createVirtualOp), and passing ''
   // to the backend would filter for OPs with an empty secondary_code rather than any.
@@ -69,7 +65,11 @@ function getOperationalPointReference(
   const trigram = op.extensions?.sncf?.trigram;
   if (trigram) return { type: 'trigram', trigram, secondary_code: ch };
   const uic = op.extensions?.identifier?.uic;
-  if (uic != null) return { type: 'uic', uic, secondary_code: ch };
+  if (uic) return { type: 'uic', uic, secondary_code: ch }; // uic is defaulted to 0
+  // Only use the opId when it refers to a real infra OP. Virtual OPs (unrecognised, created
+  // by usePathProjection when pathfinding fails) have a synthetic id like "virtual_op_Zürich"
+  if (op.opId && !op.opId.startsWith('virtual_op'))
+    return { type: 'id', operational_point: op.opId };
   return undefined;
 }
 

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -24,10 +24,11 @@ export type EditoastPathOperationalPoint = NonNullable<
   PathProperties['operational_points']
 >[number];
 
-// This type refers to an operational point, modified to carry its own unique ID (waypointId), and
+// 1. This type refers to an operational point, modified to carry its own unique ID (waypointId), and
 // optionally an actual opId, which can be repeated along a path when a train crosses multiple time
-// the same operational point:
-export type PathOperationalPoint = Omit<EditoastPathOperationalPoint, 'id'> & {
+// the same operational point
+// 2. Remove the part field as it won't be used anywhere in the app. This avoid us to have to add hardcoded data in it.
+export type PathOperationalPoint = Omit<EditoastPathOperationalPoint, 'id' | 'part'> & {
   waypointId: string;
   opId: string | null;
 };


### PR DESCRIPTION
The data were not used anywhere and it was weird to add some hardcoded values in this field.

close #14620 