### PR TITLE
front: fix turning a paced train with exception into a unique train

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
@@ -216,6 +216,11 @@ const useUpdateTimetableItem = (
 
     // ========== user is converting a paced train to a unique train ==========
     if (!trainSchedule.paced) {
+      // TODO_EXCEPTION: remove `!` when using TrainScheduleException type
+      const exceptionsToDelete = (originalPacedTrain.paced?.exceptions ?? []).map((e) => e.id!);
+      if (exceptionsToDelete.length > 0) {
+        await deleteExceptions(dispatch, exceptionsToDelete);
+      }
       await storePacedTrain(
         timetableItemId,
         {


### PR DESCRIPTION
closes part of https://github.com/OpenRailAssociation/osrd/pull/15653#issuecomment-4369373737.

(major : turning a paced train with exception into a unique train doesn't delete the exceptions)