### PR TITLE
front: fix std updating when delete exception

### DIFF
--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -293,6 +293,9 @@ const osrdEditoastApi = generatedEditoastApi
       putTrainScheduleExceptionById: {
         invalidatesTags: ['train_schedule_exceptions', 'train_schedule'],
       },
+      postTrainScheduleExceptionsDelete: {
+        invalidatesTags: ['train_schedule_exceptions', 'train_schedule'],
+      },
 
       postLevelCrossingOccupancy: {
         providesTags: ['level_crossing', 'train_schedule'],


### PR DESCRIPTION
closes part of https://github.com/OpenRailAssociation/osrd/pull/15653#issuecomment-4369373737.

fix : 
```
major : if reactivating an occurrence which didn't have any exception (except the disabled status), the exception is properly deleted but it doesn't come back on the STD
major : resetting an occurrence with exceptions properly delete the exception but it's not updated on the STD (easy to reproduce by changing the start time - probably some issue than previous point -)
major : removing all exceptions of a paced trains properly delete all exceptions but the STD is not updated (probably same issue as the previous ones)
```