### PR TITLE
front: fix delete all exceptions when cadence or time window changes

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/hooks/useUpdateTimetableItem.ts
@@ -233,11 +233,28 @@ const useUpdateTimetableItem = (
 
     // Reconcile existing exceptions with the new paced train settings and newly added ones
     // Note: exceptions are reset by the backend when cadence/interval changes
+    const cadenceChanged =
+      trainSchedule.paced.interval !== originalPacedTrain.paced.interval.toISOString() ||
+      trainSchedule.paced.time_window !== originalPacedTrain.paced.timeWindow.toISOString();
+
+    // When cadence or time window changes, all existing exceptions are invalid
+    if (cadenceChanged) {
+      const idsToDelete = originalPacedExceptions.filter((e) => e.id != null).map((e) => e.id!);
+      if (idsToDelete.length > 0) {
+        await deleteExceptions(dispatch, idsToDelete);
+      }
+    }
+
+    // Reconcile remaining exceptions with the new paced train settings and newly added ones
     const {
       exceptions: reconciledExceptions,
       modifiedExceptions: exceptionsToUpdate,
       exceptionsToDeleteIds,
-    } = checkChangeGroups(trainSchedule, trainSchedule.paced, originalPacedExceptions);
+    } = checkChangeGroups(
+      trainSchedule,
+      trainSchedule.paced,
+      cadenceChanged ? [] : originalPacedExceptions
+    );
 
     if (exceptionsToDeleteIds.length > 0) {
       await deleteExceptions(dispatch, exceptionsToDeleteIds);


### PR DESCRIPTION
fixing this [comment](https://github.com/OpenRailAssociation/osrd/pull/15653#issuecomment-4370857386) part: critical (the back was supposed to handle that ?) : changing the cadence of the paced train displays the warning popup but doesn't delete the exceptions