### PR TITLE
prevent stale exceptionId 404s by updating local state before putTrainSchedulesById

### DIFF
--- a/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
+++ b/front/src/modules/timetableItem/helpers/updateTimetableItemHelpers.ts
@@ -220,12 +220,10 @@ export async function storePacedTrain(
   dispatch: AppDispatch,
   upsertTimetableItems: (timetableItems: TimetableItem[]) => void
 ): Promise<TimetableItem> {
-  const updatedPacedTrain = await syncAndUpdatePacedTrain(
-    timetableItemIdToUpdate,
-    pacedTrain,
-    dispatch
-  );
-
+  const updatedPacedTrain = { ...pacedTrain, id: timetableItemIdToUpdate };
   upsertTimetableItems([updatedPacedTrain]);
+
+  await syncAndUpdatePacedTrain(timetableItemIdToUpdate, pacedTrain, dispatch);
+
   return updatedPacedTrain;
 }


### PR DESCRIPTION
In this [comment](https://github.com/OpenRailAssociation/osrd/pull/15653#issuecomment-4370857386), closes this line : **_minor : when updating the paced train so it sticks with one of its exceptions (easy to reproduce with category), the stale exception is properly deleted, the paced train is properly updated but we have some 404 on getPathById and getSimulationById for the exception which is not here anymore. This is probably because of invalidating the rtk-query tag not at the good moment_**