### PR TITLE
front, ui: fix train schedule tab toggling visibility when clicking on the checkbox

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type PropsWithChildren } from 'react';
+import { useMemo, useRef, useState, type MouseEvent, type PropsWithChildren } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
 import {
@@ -148,6 +148,8 @@ const TrainScheduleSetTab = ({
     ? t('sandbox')
     : computeTrainScheduleSetName(trainScheduleSet.name!, catalogName);
 
+  const checkboxRef: React.RefObject<HTMLInputElement | null> = useRef(null);
+
   return (
     <>
       <div
@@ -157,8 +159,9 @@ const TrainScheduleSetTab = ({
           className="train-schedule-set-tab"
           role="button"
           tabIndex={0}
-          onClick={() => {
+          onClick={(event: MouseEvent<HTMLDivElement>) => {
             if (isCheckboxDisabled && isSelectMode) return;
+            if (event.target === checkboxRef.current) return; // Don't toggle visibility on checkbox clicks
             handleClickTrainScheduleSet(trainScheduleSet.id);
           }}
         >
@@ -170,6 +173,7 @@ const TrainScheduleSetTab = ({
               disabled={isCheckboxDisabled}
               onChange={handleSelectTrainScheduleSet}
               small
+              ref={checkboxRef}
             />
           )}
           {isTrainListOpen ? (

--- a/front/ui/ui-core/src/components/Checkbox/Checkbox.tsx
+++ b/front/ui/ui-core/src/components/Checkbox/Checkbox.tsx
@@ -8,6 +8,7 @@ export type CheckboxProps = React.PropsWithChildren<
     small?: boolean;
     hint?: string;
     isIndeterminate?: boolean;
+    ref?: React.RefObject<HTMLInputElement | null>;
   }
 >;
 
@@ -21,6 +22,7 @@ const Checkbox = ({
   isIndeterminate = false,
   onClick,
   children,
+  ref,
   ...rest
 }: CheckboxProps) => {
   const handleClick = (e: MouseEvent<HTMLInputElement>) => {
@@ -44,6 +46,9 @@ const Checkbox = ({
         ref={(input) => {
           if (input) {
             input.indeterminate = isIndeterminate;
+          }
+          if (ref) {
+            ref.current = input;
           }
         }}
         onClick={handleClick}


### PR DESCRIPTION
In the operational studies module, in the train schedule set list, in select mode, when clicking on a checkbox the train schedule set's visibility would incorrectly toggle.

This commit makes the click event handler make sure that the click didn't happen on the checkbox before.

# How to test

Thank you for testing. The easiest way is to create a train, switch to the train schedule set view (with the button on the top right of the train schedule list), then enable select mode (with the button on the top left of the train schedule list), then click on the checkbox next to the sandbox. The patch also fixes with other train schedule sets than the sandbox.