### PR TITLE
core: explorer: save current block range

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -215,6 +215,7 @@ private class InfraExplorerImpl(
     private var stepTracker: StepTracker,
     private var constraints: List<PathfindingConstraint>?,
     override var isPathComplete: Boolean = false,
+    private var currentBlockRange: BlockRange? = null,
 ) : InfraExplorer {
     override fun getCurrentEdgePathProperties(offset: Offset<Block>, length: Distance?): TrainPath {
         // We re-compute the routes of the current path since the cache may be incorrect
@@ -265,6 +266,7 @@ private class InfraExplorerImpl(
             "Infra Explorer: Current edge is already the last edge: can't move forward."
         }
         currentIndex += 1
+        currentBlockRange = null
         return this
     }
 
@@ -273,10 +275,13 @@ private class InfraExplorerImpl(
     }
 
     override fun getCurrentBlockRange(): BlockRange {
+        currentBlockRange?.let {
+            return it
+        }
         assert(currentIndex < blockRanges.size) {
             "InfraExplorer: currentBlockIndex is out of bounds."
         }
-        return blockRanges[currentIndex]
+        return blockRanges[currentIndex].also { currentBlockRange = it }
     }
 
     override fun isLookaheadEmpty(): Boolean {
@@ -317,6 +322,7 @@ private class InfraExplorerImpl(
             this.stepTracker.clone(),
             this.constraints,
             this.isPathComplete,
+            this.currentBlockRange,
         )
     }
 


### PR DESCRIPTION
Small easy optimization. We often call `getCurrentBlock` / `getCurrentBlockRange`, but we actually go through the linked list starting at the end of the lookahead when doing that. 


| | time_old | time_new | time_diff |
|---|---|---|---|
| count | 22.000000 | 22.000000 | 22.000000 |
| mean | 47.092409 | 45.362318 | -1.730091 |
| std | 69.140368 | 67.946983 | 3.344054 |
| min | 1.220000 | 1.123000 | -11.812000 |
| 25% | 2.699250 | 2.480000 | -1.389500 |
| 50% | 5.555000 | 5.003000 | -0.431000 |
| 75% | 100.572750 | 90.895500 | -0.170500 |
| max | 181.976000 | 181.780000 | -0.049000 |

| | mb_old | mb_new | mb_diff |
|---|---|---|---|
| count | 22.000000 | 22.000000 | 22.000000 |
| mean | 4189.227273 | 3841.909091 | -347.318182 |
| std | 2028.313091 | 1584.024378 | 1401.895533 |
| min | 2152.000000 | 1906.000000 | -4838.000000 |
| 25% | 2546.250000 | 2805.500000 | -571.000000 |
| 50% | 3463.000000 | 3407.500000 | -111.500000 |
| 75% | 5918.500000 | 4086.750000 | 493.750000 |
| max | 7923.000000 | 8063.000000 | 1130.000000 |

No change in outputs