### PR TITLE
front: stdcm: display stop types and consist changes in rmi modal

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -151,6 +151,12 @@
         "close": "Close",
         "comment": "Observations",
         "compositionCode": "composition code",
+        "consistChange": {
+          "length": "Length: → {{length}}m",
+          "mass": "Mass: → {{mass}}t",
+          "rsEngine": "Traction engine: → {{rsEngine}}",
+          "towedRs": "Towed rolling stock: → {{towedRs}}"
+        },
         "convoy": "CONVOY",
         "createRailManagerRequest": "Create the GESICO request",
         "csCode": "CS code",
@@ -176,7 +182,14 @@
         "retainedSimulation": "RETAINED SIMULATION",
         "rollingStock": "towed rolling stock",
         "selectPathType": "Select",
-        "stop": "Stop of {{minutes}} at {{stopAt}}",
+        "stop": "Stop at {{stopAt}} for {{stopType}} — {{minutes}}",
+        "stopType": {
+          "consistChange": "a consist change",
+          "driverSwitch": "a driver switch",
+          "overtake": "an overtake",
+          "passageTime": "passage time",
+          "serviceStop": "a service stop"
+        },
         "successMessage": "Request <requestNumber/> received by GESICO",
         "toleranceAfter": "Future tolerance",
         "toleranceBefore": "Past tolerance",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -151,6 +151,12 @@
         "close": "Fermer",
         "comment": "Commentaire",
         "compositionCode": "code de composition",
+        "consistChange": {
+          "length": "Longueur : → {{length}}m",
+          "mass": "Masse : → {{mass}}t",
+          "rsEngine": "Engin de traction : → {{rsEngine}}",
+          "towedRs": "Matériel remorqué : → {{towedRs}}"
+        },
         "convoy": "CONVOI",
         "createRailManagerRequest": "Créer la demande GESICO",
         "csCode": "Code CS",
@@ -176,7 +182,14 @@
         "retainedSimulation": "SIMULATION RETENUE",
         "rollingStock": "matériel remorqué",
         "selectPathType": "Choisir",
-        "stop": "Arrêt de {{minutes}} à {{stopAt}}",
+        "stop": "Arrêt {{stopAt}} pour {{stopType}} — {{minutes}}",
+        "stopType": {
+          "consistChange": "changement de convoi",
+          "driverSwitch": "relève conducteur",
+          "overtake": "dépassement",
+          "passageTime": "passage",
+          "serviceStop": "arrêt de service"
+        },
         "successMessage": "Demande <requestNumber/> reçue par GESICO",
         "toleranceAfter": "Tolérance aval",
         "toleranceBefore": "Tolérance amont",

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -14,6 +14,8 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { STDCM_REQUEST_STATUS } from 'applications/stdcm/consts';
+import useStdcmLightRollingStock from 'applications/stdcm/hooks/useStdcmLightRollingStock';
+import useStdcmTowedRollingStock from 'applications/stdcm/hooks/useStdcmTowedRollingStock';
 import { extractMarkersInfo } from 'applications/stdcm/utils';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
@@ -141,9 +143,14 @@ const StdcmConfig = ({
   const trackSectionIdsByLoadingGauge = useSelector(getTrackSectionIdsByLoadingGauge);
   const loadingGaugeType = useSelector(getLoadingGauge);
 
+  const rollingStock = useStdcmLightRollingStock();
+  const towedRollingStock = useStdcmTowedRollingStock();
+
   const initialConsist: ConsistData = {
     rollingStockID,
+    rollingStockName: rollingStock?.name,
     towedRollingStockID,
+    towedRollingStockName: towedRollingStock?.name,
     totalMass,
     totalLength,
     maxSpeed,

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -148,8 +148,8 @@ const StdcmVias = ({
         return { ...intermediatePoints[i].consistChange };
       }
     }
-
-    return initialConsist;
+    const { maxSpeed: _maxSpeed, ...initialConsistChange } = initialConsist;
+    return initialConsistChange;
   };
 
   const addConsistChange = (viaPathStep: StdcmViaPathStep, index: number) => {

--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -5,10 +5,11 @@ import { Download, CheckCircle } from '@osrd-project/ui-icons';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import type {
-  StdcmSimulationInputs,
-  StdcmSuccessResponse,
-  SimilarTrainWithSecondaryCode,
+import {
+  type StdcmSimulationInputs,
+  type StdcmSuccessResponse,
+  type SimilarTrainWithSecondaryCode,
+  StdcmStopTypes,
 } from 'applications/stdcm/types';
 import {
   osrdRailwayManagerApi,
@@ -328,7 +329,7 @@ const SendToRailwayManagerModal = ({
         <div className="route-and-simulation">
           <section className="requested-route">
             <h3>{t('modal.requestedRoute')}</h3>
-            <ul>
+            <ul className="requested-route-content">
               <li>
                 {`${t('modal.date')} : ${realDepartureTime.toLocaleDateString(dateTimeLocale, {
                   day: '2-digit',
@@ -351,17 +352,43 @@ const SendToRailwayManagerModal = ({
                 </li>
               )}
 
-              {intermediatePoints.map(
-                (step) =>
-                  step.isVia && (
-                    <li key={step.id}>
-                      {t('modal.stop', {
-                        minutes: getStopDurationTime(step.stopFor),
-                        stopAt: `${step.operationalPoint?.name} ${step.operationalPoint?.secondaryCode}`,
-                      })}
-                    </li>
-                  )
-              )}
+              {intermediatePoints.map((step) => {
+                if (!step.isVia) return null;
+                const stopType = step.consistChange ? StdcmStopTypes.CONSIST_CHANGE : step.stopType;
+                return (
+                  <li key={step.id}>
+                    {t('modal.stop', {
+                      minutes: getStopDurationTime(step.stopFor),
+                      stopAt: `${step.operationalPoint?.name} ${step.operationalPoint?.secondaryCode}`,
+                      stopType: t(`modal.stopType.${stopType}`),
+                    })}
+                    {step.consistChange && (
+                      <ul className="consist-change">
+                        <li>
+                          {t('modal.consistChange.rsEngine', {
+                            rsEngine: step.consistChange?.rollingStockName,
+                          })}
+                        </li>
+                        <li>
+                          {t('modal.consistChange.towedRs', {
+                            towedRs: step.consistChange?.towedRollingStockName,
+                          })}
+                        </li>
+                        <li>
+                          {t('modal.consistChange.mass', {
+                            mass: step.consistChange?.totalMass,
+                          })}
+                        </li>
+                        <li>
+                          {t('modal.consistChange.length', {
+                            length: step.consistChange?.totalLength,
+                          })}
+                        </li>
+                      </ul>
+                    )}
+                  </li>
+                );
+              })}
 
               {lastStep && (
                 <li>

--- a/front/src/applications/stdcm/styles/_railwayManagerModal.scss
+++ b/front/src/applications/stdcm/styles/_railwayManagerModal.scss
@@ -73,7 +73,7 @@
     grid-template-columns: 4fr 1fr;
     gap: 32px;
 
-    ul {
+    .requested-route-content {
       background-color: var(--ambientA15);
       padding: 14px 16px 14px 40px;
       min-height: 144px;
@@ -87,6 +87,10 @@
         line-height: 0px;
         padding-bottom: 6px;
         padding-right: 5px;
+      }
+
+      .consist-change {
+        padding-left: 32px;
       }
 
       .linked-train-infos {


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/16506

To test this pr:
- make sure your front/public/overrides/overrides.json contains a value for the raimi url (for example { "railway_manager_interface_url": "/tartine" }) - a bogus value is fine, as long as it's defined
- remove `isDebugMode && ` L230 of StdcmVias.tsx (or only test in debug mode)
- remove `sendLMRAuthorizedResponse?.authorized &&` L352 of StdcmResults.tsx (or test with RaiMI up and credentials)
- remove `hasConsistChange || ` L361 of StdcmResults.tsx
- launch an lmr request with a variety of stops and at least one consist change, then open the send to RaiMI modal
- repeat in both French and English (the mockup only exists for the French version)

(The `hasConsistChange` flag will be dropped in a susbequent pr implementing the consist changes in the actual RaiMI request.)
