### PR TITLE
editoast: add endpoint /search_journeys

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -3876,6 +3876,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "profile_connection_scan"
+version = "0.1.0"
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1462,6 +1462,7 @@ dependencies = [
  "petgraph",
  "postgis_diesel",
  "pretty_assertions",
+ "profile_connection_scan",
  "rand 0.10.2",
  "rangemap",
  "reqwest",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -221,6 +221,7 @@ ordered-float.workspace = true
 pathfinding = "4.14.0"
 petgraph = "0.8.2"
 postgis_diesel.workspace = true
+profile_connection_scan = { path = "./profile_connection_scan" }
 rand.workspace = true
 rangemap.workspace = true
 reqwest.workspace = true

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "fga_derive",
   "fga_migrations",
   "osm_to_railjson",
+  "profile_connection_scan",
   "schemas",
   "search",
 ]

--- a/editoast/editoast_derive/src/error.rs
+++ b/editoast/editoast_derive/src/error.rs
@@ -3,6 +3,7 @@ use darling::FromDeriveInput;
 use darling::FromVariant;
 use darling::Result;
 use proc_macro2::TokenStream;
+use quote::ToTokens as _;
 use quote::quote;
 use syn::DataEnum;
 use syn::DeriveInput;
@@ -294,7 +295,7 @@ fn extract_type(ty: &syn::Type) -> Option<String> {
                 None
             }
         }
-        _ => None,
+        _ => Some(ty.to_token_stream().to_string()),
     }
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6137,6 +6137,26 @@ components:
       enum:
       - STANDARD
       - MARECO
+    EditoastAbortJoinError:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAbortJoinErrorContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:JoinError:cancelled
     EditoastAppHealthErrorCore:
       type: object
       required:
@@ -6994,6 +7014,7 @@ components:
           - editoast:electrical_profiles:NotFound
     EditoastError:
       oneOf:
+      - $ref: '#/components/schemas/EditoastAbortJoinError'
       - $ref: '#/components/schemas/EditoastAppHealthErrorCore'
       - $ref: '#/components/schemas/EditoastAppHealthErrorDatabase'
       - $ref: '#/components/schemas/EditoastAppHealthErrorOpenfga'
@@ -7062,6 +7083,7 @@ components:
       - $ref: '#/components/schemas/EditoastOperationErrorObjectNotFound'
       - $ref: '#/components/schemas/EditoastOperationalPointProjectionErrorInvalidNumberOfDistances'
       - $ref: '#/components/schemas/EditoastOperationalPointProjectionErrorInvalidNumberOfRefs'
+      - $ref: '#/components/schemas/EditoastPanicJoinError'
       - $ref: '#/components/schemas/EditoastPathfindingErrorDatabase'
       - $ref: '#/components/schemas/EditoastPathfindingErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsEndingTrackLocationNotFound'
@@ -7150,6 +7172,7 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleExceptionErrorTrainScheduleNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleSetErrorDatabase'
       - $ref: '#/components/schemas/EditoastTrainScheduleSetErrorNotFound'
+      - $ref: '#/components/schemas/EditoastUnexpectedJoinError'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorDatabase'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorNameAlreadyUsed'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorWorkScheduleGroupNotFound'
@@ -7870,6 +7893,26 @@ components:
           type: string
           enum:
           - editoast:operationalPointProjection:InvalidNumberOfRefs
+    EditoastPanicJoinError:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastPanicJoinErrorContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:JoinError:panic
     EditoastPathfindingErrorDatabase:
       type: object
       required:
@@ -9958,6 +10001,26 @@ components:
           type: string
           enum:
           - editoast:train_schedule_set:NotFound
+    EditoastUnexpectedJoinError:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastUnexpectedJoinErrorContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:JoinError:unhandled_add_case_here
     EditoastWorkScheduleErrorDatabase:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2805,6 +2805,27 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SearchResultItem'
+  /search_journeys:
+    post:
+      tags:
+      - search_journeys
+      summary: Search possible journeys from A to B using train parts from the given timetables.
+      description: |-
+        The trains are not simulated, meaning each stop needs to be dated in order
+        to be taken into account.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneySearchQuery'
+        required: true
+      responses:
+        '200':
+          description: A list of journey proposals that match the input search query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyProposals'
   /similar_trains:
     post:
       tags:
@@ -7053,6 +7074,9 @@ components:
       - $ref: '#/components/schemas/EditoastEditionErrorSplitTrackSectionBadOffset'
       - $ref: '#/components/schemas/EditoastElectricalProfilesErrorDatabase'
       - $ref: '#/components/schemas/EditoastElectricalProfilesErrorNotFound'
+      - $ref: '#/components/schemas/EditoastErrorDatabase'
+      - $ref: '#/components/schemas/EditoastErrorInfraNotFound'
+      - $ref: '#/components/schemas/EditoastErrorInvalidInput'
       - $ref: '#/components/schemas/EditoastFontErrorsFileNotFound'
       - $ref: '#/components/schemas/EditoastGeometryErrorUnexpectedGeometry'
       - $ref: '#/components/schemas/EditoastGetObjectsErrorsDuplicateIdsProvided'
@@ -7183,6 +7207,76 @@ components:
       description: Generated error type for Editoast
       discriminator:
         propertyName: type
+    EditoastErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastErrorDatabaseContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:search_journeys:Database
+    EditoastErrorInfraNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastErrorInfraNotFoundContext
+          required:
+          - infra_id
+          properties:
+            infra_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:search_journeys:InfraNotFound
+    EditoastErrorInvalidInput:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastErrorInvalidInputContext
+          required:
+          - message
+          properties:
+            message:
+              type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:search_journeys:InvalidInput
     EditoastFontErrorsFileNotFound:
       type: object
       required:
@@ -11102,6 +11196,69 @@ components:
           type: integer
           format: int64
           description: Distance of the beginning of the intersection relative to the beginning of the path
+          minimum: 0
+    JourneyProposals:
+      type: object
+      required:
+      - journeys
+      properties:
+        journeys:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: '#/components/schemas/TrainSchedulePart'
+          description: Each journey is a list of train schedule parts.
+    JourneySearchQuery:
+      type: object
+      required:
+      - infra_id
+      - timetable_ids
+      - start_ms
+      - start_tolerance
+      - origin
+      - destination
+      - transfer_ms
+      properties:
+        destination:
+          $ref: '#/components/schemas/OperationalPointPartReference'
+        infra_id:
+          type: integer
+          format: int64
+        origin:
+          $ref: '#/components/schemas/OperationalPointPartReference'
+        start_ms:
+          type: integer
+          format: int32
+          description: |-
+            Amount of milliseconds from midnight UTC to the center of the start window.
+
+            The start window is defined as the time between
+            `start_sec - start_tolerance` and `start_sec + start_tolerance`.
+          minimum: 0
+        start_tolerance:
+          type: integer
+          format: int32
+          description: |-
+            Half the time of the start window in milliseconds.
+
+            The start window is defined as the time between
+            `start_sec - start_tolerance` and `start_sec + start_tolerance`.
+          minimum: 0
+        timetable_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+          uniqueItems: true
+        transfer_ms:
+          type: integer
+          format: int32
+          description: |-
+            Constant time for a transfer/footpath in the same stop in milliseconds.
+
+            The algorithm assumes that changing from one train to another in a stop
+            always take this constant time.
           minimum: 0
     LabelsChangeGroup:
       type: object
@@ -16089,6 +16246,38 @@ components:
         use_speed_limits_for_simulation:
           type: boolean
       additionalProperties: false
+    TrainSchedulePart:
+      type: object
+      description: A part of a train schedule, from one location to another.
+      required:
+      - train_schedule_id
+      - from
+      - to
+      properties:
+        from:
+          $ref: '#/components/schemas/TrainSchedulePartBound'
+        to:
+          $ref: '#/components/schemas/TrainSchedulePartBound'
+        train_schedule_id:
+          type: integer
+          format: int64
+    TrainSchedulePartBound:
+      type: object
+      required:
+      - location
+      - time_ms
+      properties:
+        location:
+          $ref: '#/components/schemas/PathItemLocation'
+          description: This location is part of the train schedule's path.
+        time_ms:
+          type: integer
+          format: int32
+          description: |-
+            Scheduled time since the start of the train schedule in milliseconds.
+
+            Used to differentiate locations in case of backtracks.
+          minimum: 0
     TrainScheduleResponse:
       allOf:
       - $ref: '#/components/schemas/TrainSchedule'

--- a/editoast/profile_connection_scan/Cargo.toml
+++ b/editoast/profile_connection_scan/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "profile_connection_scan"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -1,0 +1,270 @@
+//! Implementation of the [Profile Connection Scan Algorithm][csa] described in
+//! Section 4 of the linked paper.
+//!
+//! Initially ported from this implementation:
+//! https://github.com/Tristramg/csa-rust/blob/72ee6d54de6652da81bc41d53b81ab721dcef479/src/algo.rs
+//!
+//! # Definitions
+//!
+//! In order to understand the code and the APIs, here's some definitions
+//! regarding the algorithm:
+//!
+//! **Trip:** a scheduled train.
+//!
+//! **Stop:** "a position outside of a train where a traveler can stand."
+//!
+//! **Connection:** a portion of a trip from one stop to the next one (without
+//! any intermediate stops). Both stops are scheduled (with an associated time).
+//!
+//! **Footpath:** a path by foot between two stops that takes a given duration.
+//! It's also called a transfer. If a foot path exist between stop A and stop
+//! B, and other one between stop B and stop C, then there must be a footpath
+//! between stop A and stop C.
+//!
+//! **Journey:** a collection of N connections and N+1 footpaths. A journey
+//! starts and ends with a footpath, and alternates between footpaths and
+//! connections.
+//!
+//! # Implementation limitations
+//!
+//! We assume that the only footpath are those that depart and arrive on the
+//! same stop (`s^{change}` in the article). We also assume they take the same
+//! constant time.
+//!
+//! [csa]: https://arxiv.org/pdf/1703.05997
+
+/// Milliseconds since midnight.
+type TimeOfDayMs = u32;
+
+type ConnectionId = usize;
+type StopId = usize;
+type TripId = usize;
+
+/// A train connection from one station to another.
+///
+/// This represent a portion of a scheduled train from one stop to another. In
+/// the input data, it is expected that connections are from one stop to the
+/// next, without intermediate stops.
+#[derive(Clone, Copy, Debug)]
+pub struct Connection {
+    /// The ID of the scheduled train which makes this connection.
+    pub trip: TripId,
+
+    /// The ID of the station where the train departs.
+    ///
+    /// It is expected that `depature` is different from `arrival`.
+    pub departure: StopId,
+
+    /// The time of day when the train departs from `departure`.
+    ///
+    /// It is expected that `departure_ms` is strictly lower than `arrival_ms`.
+    pub departure_ms: TimeOfDayMs,
+
+    /// The ID of the station where the train arrives.
+    ///
+    /// It is expected that `depature` is different from `arrival`.
+    pub arrival: StopId,
+
+    /// The time of day when the train arrives at `arrival`.
+    ///
+    /// It is expected that `departure_ms` is strictly lower than `arrival_ms`.
+    pub arrival_ms: TimeOfDayMs,
+}
+
+/// A Profile documents part of a route travelers can take to reach the destination.
+///
+/// More specifically, at `departure_ms`, a traveler can take the train
+/// connection `out_connection` to reach the destination at `arrival_ms`.
+#[derive(Clone, Debug)]
+struct Profile {
+    /// The connection taken at the departure stop
+    out_connection: Option<ConnectionId>,
+
+    /// The departure time at a given stop.
+    departure_ms: TimeOfDayMs,
+
+    /// The arrival time at the target (of the algorithm input, not the connection).
+    arrival_ms: TimeOfDayMs,
+}
+
+impl Profile {
+    /// Whether [self] is superior to [other] both in arrival time and departure time.
+    fn dominates(&self, other: &Self) -> bool {
+        self.departure_ms >= other.departure_ms && self.arrival_ms <= other.arrival_ms
+    }
+}
+
+pub struct JourneyListParams {
+    pub stop_count: usize,
+    pub trip_count: usize,
+    pub connections: Vec<Connection>,
+    pub start_ms: u32,
+    pub start_tolerance: u32,
+    pub start: StopId,
+    pub end: StopId,
+    pub transfer_ms: u32,
+}
+
+/// This returns a list of journeys, each journey in the form of a list of connections to take.
+///
+/// Some pre-conditions are required:
+///
+/// - [`connections`] must be sorted by descending `departure_ms`
+/// - All connections' `trip`s must be strictly lower than [`trip_count`]
+/// - All connections' `departure`s and `arrival`s must be strictly lower than [`stop_count`]
+///
+/// See asserts below for more pre-conditions.
+pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Connection>> {
+    let JourneyListParams {
+        stop_count,
+        trip_count,
+        connections,
+        start_ms,
+        start_tolerance,
+        start,
+        end,
+        transfer_ms,
+    } = p;
+
+    assert!(start < stop_count);
+    assert!(end < stop_count);
+
+    // stop index -> profiles
+    // profiles are ordered by decreasing departure_ms
+    // they are also ordered by increasing arrival_ms
+    let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); stop_count];
+    profiles[end].push(Profile {
+        out_connection: None,
+        departure_ms: u32::MAX,
+        arrival_ms: 0,
+    });
+
+    // This maps trips to the earliest arrival time possible when taking this trip.
+    let mut trip_min_arrival_ms = vec![u32::MAX; trip_count];
+
+    for (connection_id, connection) in connections.iter().enumerate() {
+        let t1 = trip_min_arrival_ms[connection.trip];
+
+        let t2 = profiles[connection.arrival]
+            .iter()
+            .rfind(|profile| profile.departure_ms > connection.arrival_ms + transfer_ms)
+            .map_or(u32::MAX, |profile| {
+                if profile.out_connection.is_some() {
+                    profile.arrival_ms
+                } else {
+                    connection.arrival_ms
+                }
+            });
+
+        let t = u32::min(t1, t2);
+
+        if t == u32::MAX {
+            continue;
+        }
+
+        let candidate = Profile {
+            out_connection: Some(connection_id),
+            departure_ms: connection.departure_ms,
+            arrival_ms: t,
+        };
+
+        let profiles = &mut profiles[connection.departure];
+
+        let pivot = profiles
+            .iter()
+            .rposition(|profile| profile.departure_ms >= candidate.departure_ms);
+
+        let mut earlier_profiles = match pivot {
+            Some(position) => profiles
+                .drain(position + 1..)
+                .filter(|profile| candidate.dominates(profile))
+                .collect(),
+            None => Vec::new(),
+        };
+
+        let insert_candidate = match profiles.last() {
+            Some(profile) => !profile.dominates(&candidate),
+            None => true,
+        };
+
+        if insert_candidate {
+            profiles.push(candidate);
+            trip_min_arrival_ms[connection.trip] = t;
+        }
+
+        profiles.append(&mut earlier_profiles);
+    }
+
+    to_journey_list(&profiles, &connections, transfer_ms, start, end)
+        .filter(|journey| {
+            // TODO can filter before creating the path
+            let departure_ms = journey[0].departure_ms;
+
+            u32::abs_diff(departure_ms, start_ms) <= start_tolerance
+        })
+        .collect()
+}
+
+/// Explore the profile graph to create the list of journeys that a traveler can take to go from start to end.
+fn to_journey_list<'a>(
+    profiles: &'a [Vec<Profile>],
+    connections: &'a [Connection],
+    transfer_ms: u32,
+    start: StopId,
+    end: StopId,
+) -> impl Iterator<Item = Vec<Connection>> + 'a {
+    profiles[start].iter().flat_map(move |profile| {
+        let Some(out_connection) = profile.out_connection else {
+            return Vec::new();
+        };
+        to_journey_list_rec(
+            profiles,
+            connections,
+            transfer_ms,
+            end,
+            vec![connections[out_connection]],
+        )
+    })
+}
+
+fn to_journey_list_rec(
+    profiles: &[Vec<Profile>],
+    connections: &[Connection],
+    transfer_ms: u32,
+    end: StopId,
+    path: Vec<Connection>,
+) -> Vec<Vec<Connection>> {
+    let start: StopId = path.last().unwrap().arrival;
+    let time: TimeOfDayMs = path.last().unwrap().arrival_ms + transfer_ms;
+
+    if start == end {
+        return vec![path];
+    }
+
+    profiles[start]
+        .iter()
+        .flat_map(|profile| {
+            let out_conn_id = profile
+                .out_connection
+                .expect("expected start != end to imply out_connection is Some");
+
+            let out_conn = connections[out_conn_id];
+
+            let next_stop = out_conn.arrival;
+
+            if path
+                .iter()
+                .any(|connection| connection.departure == next_stop)
+                || start == next_stop
+                || out_conn.departure_ms < time
+            {
+                return Vec::new();
+            }
+
+            let mut new_path = path.clone();
+            new_path.push(out_conn);
+
+            to_journey_list_rec(profiles, connections, transfer_ms, end, new_path)
+        })
+        .collect()
+}

--- a/editoast/schemas/src/primitives/non_blank_string.rs
+++ b/editoast/schemas/src/primitives/non_blank_string.rs
@@ -117,6 +117,12 @@ impl PartialEq<NonBlankString> for &str {
     }
 }
 
+impl PartialEq<NonBlankString> for String {
+    fn eq(&self, other: &NonBlankString) -> bool {
+        self.as_str().eq(other.as_ref())
+    }
+}
+
 impl utoipa::PartialSchema for NonBlankString {
     fn schema() -> RefOr<Schema> {
         ObjectBuilder::new()

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -210,6 +210,31 @@ impl EditoastError for serde_json::Error {
     }
 }
 
+inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:JoinError:panic", "JoinError", "Panic", 500u16, r#"{}"#)
+}
+inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:JoinError:cancelled", "JoinError", "Abort", 500u16, r#"{}"#)
+}
+inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:JoinError:unhandled_add_case_here", "JoinError", "Unexpected", 500u16, r#"{}"#)
+}
+impl EditoastError for tokio::task::JoinError {
+    fn get_status(&self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    fn get_type(&self) -> &str {
+        if self.is_panic() {
+            "editoast:JoinError:panic"
+        } else if self.is_cancelled() {
+            "editoast:JoinError:cancelled"
+        } else {
+            "editoast:JoinError:unhandled_add_case_here"
+        }
+    }
+}
+
 impl EditoastError for json_patch::PatchError {
     fn get_status(&self) -> StatusCode {
         StatusCode::INTERNAL_SERVER_ERROR

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -16,6 +16,7 @@ pub mod projection;
 pub mod rolling_stock;
 pub mod round_trips;
 pub mod search;
+mod search_journeys;
 mod server;
 pub mod sprites;
 pub mod stdcm_debug;
@@ -309,6 +310,7 @@ fn service_router() -> server::router::DocumentedRouter {
                             .route("/level_order", get!(electrical_profiles::get_level_order))
                     })
             })
+            .route("/search_journeys", post!(search_journeys::search_journeys))
             //
             // operational studies
             //

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -1,0 +1,389 @@
+use std::collections::HashSet;
+
+use axum::Extension;
+use axum::extract::Json;
+use axum::extract::State;
+use common::units::quantities::Offset;
+use editoast_derive::EditoastError;
+use editoast_models::Infra;
+use editoast_models::prelude::*;
+use itertools::Itertools;
+use profile_connection_scan::Connection;
+use schemas::primitives::ObjectType;
+use schemas::train_schedule::OperationalPointPartReference;
+use schemas::train_schedule::OperationalPointReference;
+use schemas::train_schedule::PathItemLocation;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::task::JoinSet;
+use tracing::Instrument as _;
+use utoipa::ToSchema;
+
+use crate::AppState;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::views::AuthenticationExt;
+use crate::views::path::operational_point_cache::OperationalPointCache;
+use crate::views::timetable::conflicts::retrieve_trains;
+
+#[derive(Debug, thiserror::Error, EditoastError)]
+#[editoast_error(base_id = "search_journeys")]
+enum Error {
+    #[error("Infra '{infra_id}' could not be found")]
+    #[editoast_error(status = 404)]
+    InfraNotFound { infra_id: i64 },
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::Error),
+
+    #[error("invalid input: {message}")]
+    #[editoast_error(status = 400)]
+    InvalidInput { message: &'static str },
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub(in crate::views) struct JourneySearchQuery {
+    infra_id: i64,
+
+    timetable_ids: HashSet<i64>,
+
+    /// Amount of milliseconds from midnight UTC to the center of the start window.
+    ///
+    /// The start window is defined as the time between
+    /// `start_sec - start_tolerance` and `start_sec + start_tolerance`.
+    start_ms: u32,
+
+    /// Half the time of the start window in milliseconds.
+    ///
+    /// The start window is defined as the time between
+    /// `start_sec - start_tolerance` and `start_sec + start_tolerance`.
+    start_tolerance: u32,
+
+    origin: OperationalPointPartReference,
+    destination: OperationalPointPartReference,
+
+    /// Constant time for a transfer/footpath in the same stop in milliseconds.
+    ///
+    /// The algorithm assumes that changing from one train to another in a stop
+    /// always take this constant time.
+    transfer_ms: u32,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct TrainSchedulePartBound {
+    /// This location is part of the train schedule's path.
+    location: PathItemLocation,
+
+    /// Scheduled time since the start of the train schedule in milliseconds.
+    ///
+    /// Used to differentiate locations in case of backtracks.
+    time_ms: u32,
+}
+
+/// A part of a train schedule, from one location to another.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct TrainSchedulePart {
+    train_schedule_id: i64,
+    from: TrainSchedulePartBound,
+    to: TrainSchedulePartBound,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub(in crate::views) struct JourneyProposals {
+    /// Each journey is a list of train schedule parts.
+    journeys: Vec<Vec<TrainSchedulePart>>,
+}
+
+/// Search possible journeys from A to B using train parts from the given timetables.
+///
+/// The trains are not simulated, meaning each stop needs to be dated in order
+/// to be taken into account.
+#[editoast_derive::route]
+#[utoipa::path(
+    post, path = "",
+    tag = "search_journeys",
+    request_body = JourneySearchQuery,
+    responses(
+        (status = 200, description = "A list of journey proposals that match the input search query", body = JourneyProposals),
+    ),
+)]
+pub(in crate::views) async fn search_journeys(
+    State(AppState { db_pool, .. }): State<AppState>,
+    Extension(auth): AuthenticationExt,
+    Json(JourneySearchQuery {
+        infra_id,
+        timetable_ids,
+        start_ms,
+        start_tolerance,
+        origin,
+        destination,
+        transfer_ms,
+    }): Json<JourneySearchQuery>,
+) -> Result<Json<JourneyProposals>> {
+    let mut train_schedule_futs = JoinSet::new();
+
+    for timetable_id in timetable_ids {
+        let db_pool = db_pool.clone();
+
+        let span = tracing::info_span!("fetching train schedules", timetable_id);
+
+        train_schedule_futs.spawn(
+            async move {
+                let conn = db_pool.get().await?;
+                let train_schedules = retrieve_trains(conn, timetable_id).await?;
+
+                Ok::<_, InternalError>(train_schedules)
+            }
+            .instrument(span),
+        );
+    }
+
+    let mut conn = db_pool.get().await?;
+
+    let infra =
+        Infra::retrieve_or_fail(conn.clone(), infra_id, || Error::InfraNotFound { infra_id })
+            .await?;
+
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .await
+    })
+    .await?;
+
+    let span = tracing::info_span!("fetching operational points");
+    let operational_point_ids = infra
+        .list_objects(&mut conn, ObjectType::OperationalPoint)
+        .instrument(span)
+        .await?;
+
+    let path_items: Vec<PathItemLocation> = operational_point_ids
+        .iter()
+        .map(|operational_point| path_item_id(operational_point))
+        .collect();
+
+    let op_cache = OperationalPointCache::load_path_items(conn, infra_id, &path_items).await?;
+
+    let origin_op = &origin.operational_point;
+    let destination_op = &destination.operational_point;
+
+    let Some(origin_op) = op_cache.get_op_ref_id(origin_op) else {
+        return Err(Error::InvalidInput {
+            message: "origin not found in the infra",
+        })?;
+    };
+
+    let Some(destination_op) = op_cache.get_op_ref_id(destination_op) else {
+        return Err(Error::InvalidInput {
+            message: "destination not found in the infra",
+        })?;
+    };
+
+    let Some(origin_index) = operational_point_ids
+        .iter()
+        .position(|operational_point_id| *operational_point_id == origin_op)
+    else {
+        return Err(Error::InvalidInput {
+            message: "origin not found in the infra",
+        })?;
+    };
+
+    let Some(destination_index) = operational_point_ids
+        .iter()
+        .position(|operational_point_id| *operational_point_id == destination_op)
+    else {
+        return Err(Error::InvalidInput {
+            message: "destination not found in the infra",
+        })?;
+    };
+
+    let mut train_schedule_ids = Vec::new();
+    let mut train_schedule_parts = Vec::new();
+    let mut train_schedule_start_times = Vec::new();
+    while let Some(ts_fut_result) = train_schedule_futs.join_next().await {
+        let (timetable_type, train_schedules) = ts_fut_result??;
+
+        let index_offset = train_schedule_ids.len();
+
+        train_schedule_ids.extend(
+            train_schedules
+                .iter()
+                .map(|train_schedule| train_schedule.id),
+        );
+
+        train_schedule_start_times.extend(
+            train_schedules
+                .iter()
+                .map(|train_schedule| datetime_millis_from_midnight(train_schedule.start_time)),
+        );
+
+        train_schedule_parts.extend(train_schedules.into_iter().zip(index_offset..).flat_map(
+            |(train_schedule, train_schedule_index)| {
+                let offset_ms = match timetable_type {
+                    schemas::timetable_type::TimetableType::Calendar => {
+                        // TODO this handles badly train schedules that span longer than a day
+                        datetime_millis_from_midnight(train_schedule.start_time)
+                    }
+                    schemas::timetable_type::TimetableType::Hourly => u32::try_from(
+                        common::units::millisecond::i64::from(train_schedule.start_time),
+                    )
+                    .unwrap(),
+                };
+
+                // avoid moving them into the filter_map closure
+                let operational_points = operational_point_ids.as_slice();
+                let op_cache = &op_cache;
+
+                train_schedule
+                    .path
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(move |(i, path_item)| {
+                        let arrival_ms: u32;
+                        let stop_for_ms: u32;
+
+                        if i == 0 {
+                            arrival_ms = offset_ms;
+                            stop_for_ms = 0;
+                        } else {
+                            let schedule_item = train_schedule
+                                .schedule
+                                .iter()
+                                .find(|schedule_item| schedule_item.at == path_item.id)?;
+
+                            arrival_ms = offset_ms
+                                + u32::try_from(schedule_item.arrival?.num_milliseconds()).unwrap();
+                            stop_for_ms =
+                                u32::try_from(schedule_item.stop_for?.num_milliseconds()).unwrap();
+                        }
+
+                        let PathItemLocation::OperationalPointPartReference(op_ref) =
+                            path_item.location
+                        else {
+                            return None;
+                        };
+
+                        let op_id = op_cache.get_op_ref_id(&op_ref.operational_point)?;
+
+                        let op_index = operational_points
+                            .iter()
+                            .position(|operational_point| &op_id == operational_point)?;
+
+                        Some((op_index, arrival_ms, stop_for_ms))
+                    })
+                    .tuple_windows()
+                    .map(
+                        move |(
+                            (start_op_index, start_op_arrival_ms, start_op_stop_for_ms),
+                            (end_op_index, end_op_arrival_ms, _end_op_stop_for_ms),
+                        )| {
+                            Connection {
+                                trip: train_schedule_index,
+                                departure: start_op_index,
+                                departure_ms: start_op_arrival_ms + start_op_stop_for_ms,
+                                arrival: end_op_index,
+                                arrival_ms: end_op_arrival_ms,
+                            }
+                        },
+                    )
+                    .filter(|connection| {
+                        // Simple filters to reduce the size of the problem.
+
+                        // The connection isn't too early for the traveler to take it
+                        let departs_late_enough = (start_ms as i64 - start_tolerance as i64)
+                            <= connection.departure_ms as i64;
+
+                        // If the connection departs from the source OP, it
+                        // doesn't depart too late for the traveler to take it
+                        let departs_early_enough = connection.departure != origin_index
+                            || connection.departure_ms <= start_ms + start_tolerance;
+
+                        departs_early_enough && departs_late_enough
+                    })
+            },
+        ));
+    }
+
+    // Sort train schedule parts by *decreasing* departure time.
+    train_schedule_parts.sort_unstable_by(|a, b| u32::cmp(&b.departure_ms, &a.departure_ms));
+
+    let journeys =
+        profile_connection_scan::journey_list(profile_connection_scan::JourneyListParams {
+            stop_count: operational_point_ids.len(),
+            trip_count: train_schedule_ids.len(),
+            connections: train_schedule_parts,
+            start_ms,
+            start_tolerance,
+            start: origin_index,
+            end: destination_index,
+            transfer_ms,
+        });
+
+    let journeys = journeys
+        .into_iter()
+        .map(|journey| {
+            dedup_connections(journey.into_iter())
+                .map(|connection| TrainSchedulePart {
+                    train_schedule_id: train_schedule_ids[connection.trip],
+                    from: TrainSchedulePartBound {
+                        location: path_item_id(&operational_point_ids[connection.departure]),
+                        time_ms: connection.departure_ms
+                            - train_schedule_start_times[connection.trip],
+                    },
+                    to: TrainSchedulePartBound {
+                        location: path_item_id(&operational_point_ids[connection.arrival]),
+                        time_ms: connection.arrival_ms
+                            - train_schedule_start_times[connection.trip],
+                    },
+                })
+                .collect()
+        })
+        .collect();
+
+    Ok(Json(JourneyProposals { journeys }))
+}
+
+/// Make a [PathItemLocation] from an operational point identifier.
+fn path_item_id(id: &str) -> PathItemLocation {
+    PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
+        operational_point: OperationalPointReference::Id {
+            operational_point: id.into(),
+        },
+        local_track_name: None,
+    })
+}
+
+/// Deduplicate connections that have the same trip in the given iterator.
+fn dedup_connections<'a, I>(mut iter: I) -> impl Iterator<Item = Connection> + 'a
+where
+    I: Iterator<Item = Connection> + 'a,
+{
+    let mut prev_connection: Option<Connection> = None;
+
+    std::iter::from_fn(move || {
+        loop {
+            let next_connection = match iter.next() {
+                Some(conn) => conn,
+                None => return prev_connection.take(),
+            };
+
+            match &mut prev_connection {
+                Some(prev_conn) => {
+                    if prev_conn.trip == next_connection.trip {
+                        prev_conn.arrival = next_connection.arrival;
+                        prev_conn.arrival_ms = next_connection.arrival_ms;
+                    } else {
+                        return prev_connection.replace(next_connection);
+                    }
+                }
+                None => prev_connection = Some(next_connection),
+            }
+        }
+    })
+}
+
+fn datetime_millis_from_midnight(t: Offset) -> u32 {
+    const MS_IN_DAY: i64 = 24 * 60 * 60 * 1000;
+    (common::units::millisecond::i64::from(t) % MS_IN_DAY) as u32
+}

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -92,7 +92,7 @@ impl Conflict {
 
 type Interval = (u64, u64);
 
-pub(super) async fn retrieve_trains(
+pub(in crate::views) async fn retrieve_trains(
     mut conn: DbConnection,
     timetable_id: i64,
 ) -> Result<(TimetableType, Vec<editoast_models::TrainSchedule>)> {

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -13,6 +13,11 @@
   "default": "An error has occurred.",
   "editoast": {
     "DatabaseAccessError": "Database access fatal error",
+    "JoinError": {
+      "cancelled": "Aborted work",
+      "panic": "Panic",
+      "unhandled_add_case_here": "Unexpected JoinError case"
+    },
     "app_health": {
       "Core": "Core is in error",
       "Database": "Database is in error",
@@ -219,6 +224,11 @@
       "UnexpectedColumn": "Unexpected column",
       "UnexpectedErsatz": "Expected value of type {{expected}}, but got ersatz '{{value}}'",
       "VariadicArgTypeMismatch": "Expected variadic argument of type {{expected}}, but got {{actual}}"
+    },
+    "search_journeys": {
+      "Database": "database error",
+      "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
+      "InvalidInput": "invalid input: {{message}}"
     },
     "single_simulation": {
       "ElectricalProfileSetNotFound": "Electrical Profile Set '{{electrical_profile_set_id}}' could not be found",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -13,6 +13,11 @@
   "default": "Une erreur est survenue.",
   "editoast": {
     "DatabaseAccessError": "Erreur fatale d'accès à la base de données",
+    "JoinError": {
+      "cancelled": "Tâche annulée",
+      "panic": "Panic",
+      "unhandled_add_case_here": "Cas de JoinError inattendu"
+    },
     "app_health": {
       "Core": "Erreur de core",
       "Database": "Erreur de base de données",
@@ -219,6 +224,11 @@
       "UnexpectedColumn": "Colonne inattendue",
       "UnexpectedErsatz": "Une valeur de type {{expected}} était attendue, mais '{{value}}' trouvé",
       "VariadicArgTypeMismatch": "Un argument variadique de type {{expected}} était attendu, mais {{actual}} trouvé"
+    },
+    "search_journeys": {
+      "Database": "database error",
+      "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
+      "InvalidInput": "données d'entrée invalides: {{message}}"
     },
     "single_simulation": {
       "ElectricalProfileSetNotFound": "Profil électrique '{{electrical_profile_set_id}}' non trouvé",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -18,6 +18,7 @@ export const addTagTypes = [
   'rolling_stock_livery',
   'round_trips',
   'search',
+  'search_journeys',
   'similar_trains',
   'stdcm',
   'sncf',
@@ -916,6 +917,14 @@ const injectedRtkApi = api
           },
         }),
         providesTags: ['search'],
+      }),
+      postSearchJourneys: build.mutation<PostSearchJourneysApiResponse, PostSearchJourneysApiArg>({
+        query: (queryArg) => ({
+          url: `/search_journeys`,
+          method: 'POST',
+          body: queryArg.journeySearchQuery,
+        }),
+        invalidatesTags: ['search_journeys'],
       }),
       postSimilarTrains: build.mutation<PostSimilarTrainsApiResponse, PostSimilarTrainsApiArg>({
         query: (queryArg) => ({
@@ -2296,6 +2305,11 @@ export type PostSearchApiArg = {
   page?: number;
   pageSize?: number;
   searchPayload: SearchPayload;
+};
+export type PostSearchJourneysApiResponse =
+  /** status 200 A list of journey proposals that match the input search query */ JourneyProposals;
+export type PostSearchJourneysApiArg = {
+  journeySearchQuery: JourneySearchQuery;
 };
 export type PostSimilarTrainsApiResponse =
   /** status 200 A combination of reference train identifiers similar to the provided train */ {
@@ -4395,6 +4409,44 @@ export type SearchPayload = {
   object: SearchObjectType;
   /** The query to run */
   query: SearchQuery;
+};
+export type TrainSchedulePartBound = {
+  /** This location is part of the train schedule's path. */
+  location: PathItemLocation;
+  /** Scheduled time since the start of the train schedule in milliseconds.
+    
+    Used to differentiate locations in case of backtracks. */
+  time_ms: number;
+};
+export type TrainSchedulePart = {
+  from: TrainSchedulePartBound;
+  to: TrainSchedulePartBound;
+  train_schedule_id: number;
+};
+export type JourneyProposals = {
+  /** Each journey is a list of train schedule parts. */
+  journeys: TrainSchedulePart[][];
+};
+export type JourneySearchQuery = {
+  destination: OperationalPointPartReference;
+  infra_id: number;
+  origin: OperationalPointPartReference;
+  /** Amount of milliseconds from midnight UTC to the center of the start window.
+    
+    The start window is defined as the time between
+    `start_sec - start_tolerance` and `start_sec + start_tolerance`. */
+  start_ms: number;
+  /** Half the time of the start window in milliseconds.
+    
+    The start window is defined as the time between
+    `start_sec - start_tolerance` and `start_sec + start_tolerance`. */
+  start_tolerance: number;
+  timetable_ids: number[];
+  /** Constant time for a transfer/footpath in the same stop in milliseconds.
+    
+    The algorithm assumes that changing from one train to another in a stop
+    always take this constant time. */
+  transfer_ms: number;
 };
 export type SimilarTrainWaypoint = {
   id: string;

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -418,6 +418,15 @@ class Distribution(Enum):
     MARECO = "MARECO"
 
 
+class EditoastAbortJoinError(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastAbortJoinErrorContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:JoinError:cancelled"]
+
+
 class EditoastAppHealthErrorCore(BaseModel):
     context: Annotated[
         dict[str, Any] | None, Field(title="EditoastAppHealthErrorCoreContext")
@@ -855,6 +864,43 @@ class EditoastElectricalProfilesErrorNotFound(BaseModel):
     type: Literal["editoast:electrical_profiles:NotFound"]
 
 
+class EditoastErrorDatabase(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastErrorDatabaseContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:search_journeys:Database"]
+
+
+class EditoastErrorInfraNotFoundContext(BaseModel):
+    infra_id: int
+
+
+class EditoastErrorInfraNotFound(BaseModel):
+    context: Annotated[
+        EditoastErrorInfraNotFoundContext | None,
+        Field(title="EditoastErrorInfraNotFoundContext"),
+    ] = None
+    message: str
+    status: Literal[404]
+    type: Literal["editoast:search_journeys:InfraNotFound"]
+
+
+class EditoastErrorInvalidInputContext(BaseModel):
+    message: dict[str, Any]
+
+
+class EditoastErrorInvalidInput(BaseModel):
+    context: Annotated[
+        EditoastErrorInvalidInputContext | None,
+        Field(title="EditoastErrorInvalidInputContext"),
+    ] = None
+    message: str
+    status: Literal[400]
+    type: Literal["editoast:search_journeys:InvalidInput"]
+
+
 class EditoastFontErrorsFileNotFoundContext(BaseModel):
     file: str
 
@@ -1231,6 +1277,15 @@ class EditoastOperationalPointProjectionErrorInvalidNumberOfRefs(BaseModel):
     message: str
     status: Literal[422]
     type: Literal["editoast:operationalPointProjection:InvalidNumberOfRefs"]
+
+
+class EditoastPanicJoinError(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastPanicJoinErrorContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:JoinError:panic"]
 
 
 class EditoastPathfindingErrorDatabase(BaseModel):
@@ -2349,6 +2404,15 @@ class EditoastTrainScheduleSetErrorNotFound(BaseModel):
     message: str
     status: Literal[404]
     type: Literal["editoast:train_schedule_set:NotFound"]
+
+
+class EditoastUnexpectedJoinError(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastUnexpectedJoinErrorContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:JoinError:unhandled_add_case_here"]
 
 
 class EditoastWorkScheduleErrorDatabase(BaseModel):
@@ -4451,7 +4515,8 @@ class DetectorExtension(BaseModel):
 
 class EditoastError(
     RootModel[
-        EditoastAppHealthErrorCore
+        EditoastAbortJoinError
+        | EditoastAppHealthErrorCore
         | EditoastAppHealthErrorDatabase
         | EditoastAppHealthErrorOpenfga
         | EditoastAppHealthErrorTimeout
@@ -4489,6 +4554,9 @@ class EditoastError(
         | EditoastEditionErrorSplitTrackSectionBadOffset
         | EditoastElectricalProfilesErrorDatabase
         | EditoastElectricalProfilesErrorNotFound
+        | EditoastErrorDatabase
+        | EditoastErrorInfraNotFound
+        | EditoastErrorInvalidInput
         | EditoastFontErrorsFileNotFound
         | EditoastGeometryErrorUnexpectedGeometry
         | EditoastGetObjectsErrorsDuplicateIdsProvided
@@ -4519,6 +4587,7 @@ class EditoastError(
         | EditoastOperationErrorObjectNotFound
         | EditoastOperationalPointProjectionErrorInvalidNumberOfDistances
         | EditoastOperationalPointProjectionErrorInvalidNumberOfRefs
+        | EditoastPanicJoinError
         | EditoastPathfindingErrorDatabase
         | EditoastPathfindingErrorInfraNotFound
         | EditoastPathfindingViewErrorsEndingTrackLocationNotFound
@@ -4607,6 +4676,7 @@ class EditoastError(
         | EditoastTrainScheduleExceptionErrorTrainScheduleNotFound
         | EditoastTrainScheduleSetErrorDatabase
         | EditoastTrainScheduleSetErrorNotFound
+        | EditoastUnexpectedJoinError
         | EditoastWorkScheduleErrorDatabase
         | EditoastWorkScheduleErrorNameAlreadyUsed
         | EditoastWorkScheduleErrorWorkScheduleGroupNotFound
@@ -4617,7 +4687,8 @@ class EditoastError(
     ]
 ):
     root: Annotated[
-        EditoastAppHealthErrorCore
+        EditoastAbortJoinError
+        | EditoastAppHealthErrorCore
         | EditoastAppHealthErrorDatabase
         | EditoastAppHealthErrorOpenfga
         | EditoastAppHealthErrorTimeout
@@ -4655,6 +4726,9 @@ class EditoastError(
         | EditoastEditionErrorSplitTrackSectionBadOffset
         | EditoastElectricalProfilesErrorDatabase
         | EditoastElectricalProfilesErrorNotFound
+        | EditoastErrorDatabase
+        | EditoastErrorInfraNotFound
+        | EditoastErrorInvalidInput
         | EditoastFontErrorsFileNotFound
         | EditoastGeometryErrorUnexpectedGeometry
         | EditoastGetObjectsErrorsDuplicateIdsProvided
@@ -4685,6 +4759,7 @@ class EditoastError(
         | EditoastOperationErrorObjectNotFound
         | EditoastOperationalPointProjectionErrorInvalidNumberOfDistances
         | EditoastOperationalPointProjectionErrorInvalidNumberOfRefs
+        | EditoastPanicJoinError
         | EditoastPathfindingErrorDatabase
         | EditoastPathfindingErrorInfraNotFound
         | EditoastPathfindingViewErrorsEndingTrackLocationNotFound
@@ -4773,6 +4848,7 @@ class EditoastError(
         | EditoastTrainScheduleExceptionErrorTrainScheduleNotFound
         | EditoastTrainScheduleSetErrorDatabase
         | EditoastTrainScheduleSetErrorNotFound
+        | EditoastUnexpectedJoinError
         | EditoastWorkScheduleErrorDatabase
         | EditoastWorkScheduleErrorNameAlreadyUsed
         | EditoastWorkScheduleErrorWorkScheduleGroupNotFound
@@ -5713,6 +5789,21 @@ class TrainCategoryMain(BaseModel):
     main_category: TrainMainCategory
 
 
+class TrainSchedulePartBound(BaseModel):
+    location: (
+        PathItemLocationTrackOffset | PathItemLocationOperationalPointPartReference
+    )
+    """
+    This location is part of the train schedule's path.
+    """
+    time_ms: Annotated[int, Field(ge=0)]
+    """
+    Scheduled time since the start of the train schedule in milliseconds.
+
+    Used to differentiate locations in case of backtracks.
+    """
+
+
 class WorkSchedule(BaseModel):
     end_date_time: AwareDatetime
     id: int
@@ -5936,6 +6027,34 @@ class InfraObjectRoute(BaseModel):
 class InfraObjectLevelCrossing(BaseModel):
     obj_type: Literal["LevelCrossing"]
     railjson: LevelCrossing
+
+
+class JourneySearchQuery(BaseModel):
+    destination: OperationalPointPartReference
+    infra_id: int
+    origin: OperationalPointPartReference
+    start_ms: Annotated[int, Field(ge=0)]
+    """
+    Amount of milliseconds from midnight UTC to the center of the start window.
+
+    The start window is defined as the time between
+    `start_sec - start_tolerance` and `start_sec + start_tolerance`.
+    """
+    start_tolerance: Annotated[int, Field(ge=0)]
+    """
+    Half the time of the start window in milliseconds.
+
+    The start window is defined as the time between
+    `start_sec - start_tolerance` and `start_sec + start_tolerance`.
+    """
+    timetable_ids: list[int]
+    transfer_ms: Annotated[int, Field(ge=0)]
+    """
+    Constant time for a transfer/footpath in the same stop in milliseconds.
+
+    The algorithm assumes that changing from one train to another in a stop
+    always take this constant time.
+    """
 
 
 class LightRollingStock(BaseModel):
@@ -6450,6 +6569,16 @@ class TrackSectionModel(BaseModel):
     slopes: list[Slope]
 
 
+class TrainSchedulePart(BaseModel):
+    """
+    A part of a train schedule, from one location to another.
+    """
+
+    from_: Annotated[TrainSchedulePartBound, Field(alias="from")]
+    to: TrainSchedulePartBound
+    train_schedule_id: int
+
+
 class TrainScheduleSimulationSummaryResult(BaseModel):
     exceptions: dict[
         str,
@@ -6584,6 +6713,13 @@ class InfraObjectSpeedSection(BaseModel):
 class InfraObjectSwitch(BaseModel):
     obj_type: Literal["Switch"]
     railjson: Switch
+
+
+class JourneyProposals(BaseModel):
+    journeys: list[list[TrainSchedulePart]]
+    """
+    Each journey is a list of train schedule parts.
+    """
 
 
 class NeutralSection(BaseModel):


### PR DESCRIPTION
This is an experimental endpoint to find paths a traveler can take to go from one Operational Point to another through one or more timetables.

The endpoint takes an infra ID (because all timetables are expected to run on the same infra), two operational points (could have more in the future? and/ore accept track offsets?), a start time and tolerance.

The train schedules in the timetables as well as the input start time are taken from midnight (until OSRD gets proper maquette support).

Trains aren't simulated, meaning only stops with a user-given arrival time are taken into account.

No frontend work to use this endpoint is planned currently.

Unsure about the response format. Currently, it's returning a Vec of journeys. Each journey is a Vec of train schedule part, and a train schedule part is a train schedule ID with a start point+time and end point+time (the times are there to account for backtracks).

# TODO

- [x] implement the algorithm
- [x] draft the endpoint
- [x] format the result to return the actual train schedules IDs
- [x] in `profile_connection_scan`, filter connections that departed too early
- [x] in the endpoint, implement error paths
- [ ] ~also import paced train occurrences~ https://github.com/OpenRailAssociation/osrd/pull/16927

# How to test

- In the operational studies module, either
    - make one or several scenarios using the same infra. Make sure all
      scheduled stops have arrival times or they won't be taken into account
      (this is a lot easier to do with the new table)
    - Import these two timetables on small infra (either on one or two scenarios): TODO
- Get the timetable IDs associated with the scenarios:
    - note the scenario ID from the URL
    - run the following SQL query (replacing 44 with the scenario ID):
      ```sql
      select timetable_id from scenario where id=44;
      ```
- Hit the `POST /search_journeys` endpoint with a JSON payload like this one
  (all fields except `timetable_ids` set according to the provided timetables):
  ```json
  {
      "infra_id": 1,
      "timetable_ids": [45, 46],
      "start_ms": 40720000,
      "start_tolerance": 3600000,
      "origin": {
          "type": "operational_point_part_reference",
          "operational_point": {
              "type": "trigram",
              "trigram": "WS",
              "secondary_code": "BV"
          }
      },
      "destination": {
          "type": "operational_point_part_reference",
          "operational_point": {
              "type": "trigram",
              "trigram": "NES",
              "secondary_code": "BV"
          }
      },
      "transfer_ms": 0
  }
  ```
  e.g. with curl and the docker compose setup:
  ```sh
  curl -i 'http://localhost:4000/api/search_journeys' -H 'Content-Type: application/json' -d'{"infra_id":1,"timetable_ids":[45,46],"start_sec":40720,"start_tolerance":3600,"path_items":[{"type":"operational_point_part_reference","operational_point":{"type":"trigram","trigram":"WS","secondary_code":"BV"}},{"type":"operational_point_part_reference","operational_point":{"type":"trigram","trigram":"NES","secondary_code":"BV"}}]}'
  ```

The result should look like this:

```json
{
  "journeys": [
    [
      {
        "train_schedule_id": 2963,
        "from": {
          "location": {
            "type": "operational_point_part_reference",
            "operational_point": {
              "type": "id",
              "operational_point": "West_station"
            },
            "local_track_name": null
          },
          "time_ms": 0
        },
        "to": {
          "location": {
            "type": "operational_point_part_reference",
            "operational_point": {
              "type": "id",
              "operational_point": "Mid_East_station"
            },
            "local_track_name": null
          },
          "time_ms": 1882000
        }
      },
      {
        "train_schedule_id": 2964,
        "from": {
          "location": {
            "type": "operational_point_part_reference",
            "operational_point": {
              "type": "id",
              "operational_point": "Mid_East_station"
            },
            "local_track_name": null
          },
          "time_ms": 0
        },
        "to": {
          "location": {
            "type": "operational_point_part_reference",
            "operational_point": {
              "type": "id",
              "operational_point": "North_East_station"
            },
            "local_track_name": null
          },
          "time_ms": 1087000
        }
      }
    ]
  ]
}
```

Closes https://github.com/OpenRailAssociation/osrd/issues/16497
Closes https://github.com/OpenRailAssociation/osrd/issues/16498

cc @Melissa-LASSAL @Tristramg @flomonster @OpenRailAssociation/osrd-core 