### PR TITLE
editoast: compress tiles with gzip to optimize valkey traffic

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1310,6 +1310,7 @@ dependencies = [
  "enum-map",
  "fga",
  "fga_migrations",
+ "flate2",
  "futures 0.3.32",
  "futures-util",
  "geos",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -80,6 +80,7 @@ educe = "0.6.0"
 enum-map = "2.7.3"
 fga = { path = "./fga", features = ["test_utilities"] }
 fga_migrations = { path = "./fga_migrations" }
+flate2 = "1.1.9"
 futures = "0.3.32"
 futures-util = "0.3.30"
 geos = { version = "11.1.1", features = ["json"] }
@@ -189,6 +190,7 @@ educe.workspace = true
 enum-map.workspace = true
 fga.workspace = true
 fga_migrations.workspace = true
+flate2.workspace = true
 futures.workspace = true
 futures-util.workspace = true
 geos.workspace = true

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -4,12 +4,16 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
+use axum::http::header::CONTENT_ENCODING;
 use axum::http::header::CONTENT_TYPE;
 use axum::response::IntoResponse;
 use deadpool_redis::redis::AsyncCommands;
 use editoast_derive::EditoastError;
+use flate2::Compression;
+use flate2::write::GzEncoder;
 use serde::Deserialize;
 use serde::Serialize;
+use std::io::Write;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
@@ -185,11 +189,19 @@ pub(in crate::views) async fn cache_and_get_mvt_tile(
         (x, y, z),
     );
 
-    let mut valkey = valkey_client.get_connection().await?;
-    let cached_value: Option<Vec<u8>> = valkey.get(&cache_key).await?;
+    let cached_value: Option<Vec<u8>> = {
+        let mut valkey = valkey_client.get_connection().await?;
+        valkey.get(&cache_key).await?
+    };
 
     if let Some(value) = cached_value {
-        return Ok(([(CONTENT_TYPE, "application/x-protobuf")], value));
+        return Ok((
+            [
+                (CONTENT_TYPE, "application/x-protobuf"),
+                (CONTENT_ENCODING, "gzip"),
+            ],
+            value,
+        ));
     }
 
     let conn = &mut db_pool.get().await?;
@@ -198,12 +210,25 @@ pub(in crate::views) async fn cache_and_get_mvt_tile(
     let mvt_bytes: Vec<u8> = create_and_fill_mvt_tile(layer_slug, records)
         .to_bytes()
         .unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+    encoder
+        .write_all(&mvt_bytes)
+        .expect("Failed to write MVT bytes to GzEncoder");
+    let compressed_mvt = encoder.finish().unwrap();
+
+    let mut valkey = valkey_client.get_connection().await?;
     valkey
-        .set::<_, _, ()>(&cache_key, mvt_bytes.clone())
+        .set::<_, _, ()>(&cache_key, compressed_mvt.clone())
         .await
         .unwrap_or_else(|_| panic!("Failed to set value in valkey with key {cache_key}"));
 
-    Ok(([(CONTENT_TYPE, "application/x-protobuf")], mvt_bytes))
+    Ok((
+        [
+            (CONTENT_TYPE, "application/x-protobuf"),
+            (CONTENT_ENCODING, "gzip"),
+        ],
+        compressed_mvt,
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We keep the Valkey connection open for a shorter period of time.