### PR TITLE
editoast, front: make geographic position optional

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -13615,11 +13615,12 @@ components:
       - main_code
       - name
       - is_passenger_station
-      - geographic
       - track_sections
       properties:
         geographic:
-          $ref: '#/components/schemas/GeoJsonPoint'
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/GeoJsonPoint'
         infra_id:
           type: integer
           format: int64

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -431,7 +431,7 @@ pub(super) struct SearchResultItemTrack {
     migration(src_table = "infra_object_operational_point"),
     joins = "
         INNER JOIN infra_object_operational_point AS OP ON OP.id = search_operational_point.id
-        INNER JOIN infra_layer_operational_point AS lay ON OP.obj_id = lay.obj_id AND OP.infra_id = lay.infra_id",
+        LEFT JOIN infra_layer_operational_point AS lay ON OP.obj_id = lay.obj_id AND OP.infra_id = lay.infra_id",
     column(
         name = "obj_id",
         data_type = "varchar(255)",
@@ -495,8 +495,8 @@ pub(super) struct SearchResultItemOperationalPoint {
     #[search(sql = "OP.data#>>'{secondary_name}'")]
     secondary_name: Option<String>,
     #[search(sql = "ST_AsGeoJSON(ST_Transform(lay.geographic, 4326))::json")]
-    #[schema(value_type = GeoJsonPoint)]
-    geographic: Geometry,
+    #[schema(value_type = Option<GeoJsonPoint>)]
+    geographic: Option<Geometry>,
     #[search(sql = "OP.data->'parts'")]
     track_sections: Vec<SearchResultItemOperationalPointTrackSections>,
 }

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -424,7 +424,8 @@ pub(super) struct SearchResultItemTrack {
     line_code: i64,
 }
 
-#[derive(Search, Serialize, ToSchema)]
+#[derive(Search, Serialize, ToSchema, Debug)]
+#[cfg_attr(test, derive(serde::Deserialize))]
 #[search(
     table = "search_operational_point",
     distinct_on = "(infra_id, obj_id)",
@@ -500,7 +501,8 @@ pub(super) struct SearchResultItemOperationalPoint {
     #[search(sql = "OP.data->'parts'")]
     track_sections: Vec<SearchResultItemOperationalPointTrackSections>,
 }
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, ToSchema, Debug)]
+#[cfg_attr(test, derive(serde::Deserialize))]
 pub(super) struct SearchResultItemOperationalPointTrackSections {
     track: String,
     position: f64,
@@ -794,14 +796,23 @@ pub struct SearchConfigFinder;
 
 #[cfg(test)]
 pub mod tests {
+    use editoast_models::infra_objects::SchemaModel as _;
+    use editoast_models::prelude::CreateBatch;
     use pretty_assertions::assert_eq;
 
+    use schemas::infra::OperationalPoint;
+    use schemas::primitives::Identifier;
+    use schemas::primitives::NonBlankString;
     use serde_json::json;
 
     use super::*;
     use crate::fixtures::create_simple_paced_train;
+    use crate::fixtures::create_small_infra;
     use crate::fixtures::create_train_schedule_set;
+    use crate::generated_data::InfraGeneratedData;
+    use crate::infra_cache::InfraCache;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn search_trainschedule_post_found() {
@@ -856,5 +867,165 @@ pub mod tests {
             .json();
 
         assert_eq!(response.len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn search_operational_point_found_all() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let mut infra = create_small_infra(&mut pool.get_ok()).await;
+        let cache = InfraCache::load(&mut pool.get_ok(), &infra).await.unwrap();
+        let user = app
+            .user("test", "Test")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, authz::InfraGrant::Reader)
+            .create()
+            .await;
+
+        assert!(infra.refresh(pool, false, &cache).await.unwrap());
+        // The body
+        let response: Vec<SearchResultItemOperationalPoint> = app
+            .post("/search")
+            .by_user(user.as_ref())
+            .json(&json!({
+                "object": "operationalpoint",
+                "query": ["and", ["ilike", ["main_code"], "%s%"],
+                                 ["=", ["infra_id"], infra.id]]
+            }))
+            .await
+            .assert_status_ok()
+            .json();
+
+        assert_eq!(response.len(), 8);
+        assert!(
+            response
+                .iter()
+                .all(|operational_point| operational_point.geographic.is_some())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn search_operational_point_found_some() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let mut infra = create_small_infra(&mut pool.get_ok()).await;
+        let cache = InfraCache::load(&mut pool.get_ok(), &infra).await.unwrap();
+        let user = app
+            .user("test", "Test")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, authz::InfraGrant::Reader)
+            .create()
+            .await;
+
+        assert!(infra.refresh(pool, false, &cache).await.unwrap());
+        // The body
+        let response: Vec<SearchResultItemOperationalPoint> = app
+            .post("/search")
+            .by_user(user.as_ref())
+            .json(&json!({
+                "object": "operationalpoint",
+                "query": ["and", ["ilike", ["main_code"], "%w%"],
+                                 ["=", ["infra_id"], infra.id]],
+            }))
+            .await
+            .assert_status_ok()
+            .json();
+
+        for item in response.iter() {
+            dbg!(item);
+        }
+        assert_eq!(response.len(), 3);
+        assert!(
+            response
+                .iter()
+                .all(|operational_point| operational_point.geographic.is_some())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn search_operational_point_not_found() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let mut infra = create_small_infra(&mut pool.get_ok()).await;
+        let cache = InfraCache::load(&mut pool.get_ok(), &infra).await.unwrap();
+        let user = app
+            .user("test", "Test")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, authz::InfraGrant::Reader)
+            .create()
+            .await;
+
+        assert!(infra.refresh(pool, false, &cache).await.unwrap());
+        let response: Vec<SearchResultItemOperationalPoint> = app
+            .post("/search")
+            .by_user(user.as_ref())
+            .json(&json!({
+                "object": "operationalpoint",
+                "query": ["and", ["like", ["main_code"], "ml"],
+                                 ["=", ["infra_id"], infra.id]],
+            }))
+            .await
+            .assert_status_ok()
+            .json();
+
+        assert_eq!(response.len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn search_operational_point_without_geographic() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let mut infra = create_small_infra(&mut pool.get_ok()).await;
+        let cache = InfraCache::load(&mut pool.get_ok(), &infra).await.unwrap();
+        let user = app
+            .user("test", "Test")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, authz::InfraGrant::Reader)
+            .create()
+            .await;
+
+        // Create an operational point without any part and so without geographic
+        let op_without_geo = OperationalPoint {
+            id: Identifier("Lost_station".to_string()),
+            parts: vec![],
+            weight: None,
+            name: NonBlankString("Lost_station".to_string()),
+            uic: None,
+            plc: None,
+            country_code: NonBlankString("FR".to_string()),
+            main_code: NonBlankString("LS".to_string()),
+            secondary_code: Some(NonBlankString("BV".to_string())),
+            is_passenger_station: true,
+            secondary_name: Some(NonBlankString("0".to_string())),
+        };
+
+        // clone to use it in the search request below
+        let op_main_code = op_without_geo.main_code.clone();
+        // Add the previous operational point to the infra
+        editoast_models::OperationalPointModel::create_batch::<_, Vec<_>>(
+            &mut pool.get_ok(),
+            [
+                editoast_models::OperationalPointModel::new_from_schema(op_without_geo)
+                    .infra_id(infra.id),
+            ],
+        )
+        .await
+        .unwrap();
+
+        assert!(infra.refresh(pool, false, &cache).await.unwrap());
+        let response: Vec<SearchResultItemOperationalPoint> = app
+            .post("/search")
+            .by_user(user.as_ref())
+            .json(&json!({
+                "object": "operationalpoint",
+                "query": ["and", ["=", ["main_code"], op_main_code],
+                                 ["=", ["infra_id"], infra.id]],
+            }))
+            .await
+            .assert_status_ok()
+            .json();
+
+        assert_eq!(response.len(), 1);
+        assert_eq!(response[0].geographic, None);
     }
 }

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
@@ -29,7 +29,7 @@ const stdcmOpFromSearchResult = (searchResult: SearchResultItemOperationalPoint)
     mainCode: searchResult.main_code,
     secondaryCode: searchResult.secondary_code,
     name: searchResult.name,
-    coordinates: searchResult.geographic.coordinates as [number, number],
+    coordinates: searchResult.geographic!.coordinates as [number, number],
   };
 };
 

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -228,7 +228,7 @@ export enum StdcmStopTypes {
 export type StdcmLinkedTrainExtremity = {
   secondary_code: string;
   date: string;
-  geographic: GeoJsonPoint;
+  geographic?: GeoJsonPoint | null;
   arrivalDate: Date;
   name: string;
   obj_id: string;

--- a/front/src/common/Map/Search/MapSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/MapSearchOperationalPoint.tsx
@@ -135,28 +135,38 @@ const MapSearchOperationalPoint = ({ closeMapSearchPopUp }: MapSearchOperational
       <div className="search-results">
         {searchResults.length > 0 &&
           searchResults.length <= MAX_DISPLAYABLE_RESULTS &&
-          searchResultsFilteredBySecondaryCode.map((searchResult, index) => (
-            <button
-              id={`result-${index}`}
-              type="button"
-              className={cx('search-result-item', {
-                main: searchResult.is_passenger_station,
-                selected: index === selectedResultIndex,
-              })}
-              key={`mapSearchOperationalPoint-${searchResult.obj_id}`}
-              onClick={() => onResultClick(searchResult)}
-              tabIndex={-1}
-            >
-              <span className="main-code">{searchResult.main_code}</span>
-              <span className="name">
-                {searchResult.name}
-                {!searchResult.is_passenger_station && (
-                  <span className="secondary-code">{searchResult.secondary_code ?? ''}</span>
+          searchResultsFilteredBySecondaryCode.map((searchResult, index) => {
+            const hasNoGeo = searchResult.geographic === null;
+            return (
+              <button
+                id={`result-${index}`}
+                type="button"
+                className={cx('search-result-item', {
+                  main: searchResult.is_passenger_station,
+                  selected: index === selectedResultIndex,
+                })}
+                key={`mapSearchOperationalPoint-${searchResult.obj_id}`}
+                onClick={() => onResultClick(searchResult)}
+                tabIndex={-1}
+                disabled={hasNoGeo}
+              >
+                <span className="main-code">{searchResult.main_code}</span>
+                <span className="name">
+                  {searchResult.name}
+                  {!searchResult.is_passenger_station && (
+                    <span className="secondary-code">{searchResult.secondary_code ?? ''}</span>
+                  )}
+                </span>
+                <span className="uic">{searchResult.uic}</span>
+                {hasNoGeo && (
+                  <div className="error-line">
+                    <i className="icons-warning" />
+                    <span>Geographical position unavailable</span>
+                  </div>
                 )}
-              </span>
-              <span className="uic">{searchResult.uic}</span>
-            </button>
-          ))}
+              </button>
+            );
+          })}
       </div>
     </div>
   );

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4257,7 +4257,7 @@ export type SearchResultItemOperationalPointTrackSections = {
   track: string;
 };
 export type SearchResultItemOperationalPoint = {
-  geographic: GeoJsonPoint;
+  geographic?: null | GeoJsonPoint;
   infra_id: number;
   is_passenger_station: boolean;
   main_code: string;

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -276,6 +276,10 @@ export const stdcmConfSlice = createSlice({
       const { name, secondary_code, geographic, arrivalDate, date, time, main_code, uic, obj_id } =
         pathStep;
 
+      if (!geographic) {
+        throw new Error('Path step does not have geographic position');
+      }
+
       const coordinates: [number, number] = [geographic.coordinates[0], geographic.coordinates[1]];
 
       const newPathStep = {

--- a/front/src/styles/scss/common/map/_mapSearch.scss
+++ b/front/src/styles/scss/common/map/_mapSearch.scss
@@ -12,7 +12,9 @@
 
     .search-result-item {
       all: unset;
-      display: flex;
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      column-gap: 8px;
       align-items: center;
       padding: 0 4px;
       border-radius: var(--border-radius);
@@ -28,9 +30,7 @@
         flex-shrink: 0;
       }
       .name {
-        padding: 4px 0 0 8px;
-        flex-grow: 1;
-        flex-shrink: 1;
+        padding: 4px 0 0 0;
         .secondary-code {
           margin-left: 4px;
           font-size: 0.9rem;
@@ -43,6 +43,20 @@
         color: var(--primary);
         flex-grow: 0;
         flex-shrink: 0;
+      }
+      .error-line {
+        grid-row: 2;
+        grid-column: 1/4;
+        grid-template-columns: subgrid;
+        display: grid;
+        font-size: 14px;
+        padding-bottom: 4px;
+        color: var(--warning60);
+
+        i {
+          place-self: center end;
+          color: var(--warning30);
+        }
       }
       &:hover {
         background-color: var(--coolgray1);

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -5168,7 +5168,7 @@ class SearchResultItemOperationalPoint(BaseModel):
 
     """
 
-    geographic: GeoJsonPoint
+    geographic: GeoJsonPoint | None = None
     infra_id: int
     is_passenger_station: bool
     main_code: str


### PR DESCRIPTION
# Description and goal
Currently we skip OPs without a geographic position when searching for an OP. We should instead return these OPs alongside a null position

Ref https://github.com/OpenRailAssociation/osrd/pull/12477#discussion_r2221908599