### PR TITLE
core: stdcm: fix node to geo point projection

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/ProgressLogger.kt
@@ -4,10 +4,10 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.logger
+import fr.sncf.osrd.utils.toGeoPoint
 import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.seconds
 import io.opentelemetry.api.common.Attributes
@@ -51,11 +51,7 @@ data class ProgressLogger(
             return
         }
         if (progress >= thresholdDistance * nSamplesReached) {
-            val block = node.infraExplorer.getCurrentBlock()
-            val geo =
-                buildTrainPathFromBlock(graph.rawInfra, graph.blockInfra, block)
-                    .getGeo()
-                    .getPoints()[0]
+            val geo = node.toGeoPoint(graph.rawInfra, graph.blockInfra)
             val str =
                 "node sample for progress $nSamplesReached/$nStepsProgress: " +
                     "time=${node.timeData.earliestReachableTime.toInt()}s, " +
@@ -97,9 +93,7 @@ data class ProgressLogger(
     }
 
     fun logNode(node: STDCMNode): STDCMProgress {
-        val block = node.infraExplorer.getCurrentBlock()
-        val geo =
-            buildTrainPathFromBlock(graph.rawInfra, graph.blockInfra, block).getGeo().getPoints()[0]
+        val geo = node.toGeoPoint(graph.rawInfra, graph.blockInfra)
         val bestTravelTime =
             (node.timeData.earliestReachableTime + node.remainingTimeEstimation).toLong()
         val data =

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
@@ -5,7 +5,6 @@ import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.stdcm.graph.STDCMNode
-import fr.sncf.osrd.utils.units.Offset
 import java.io.BufferedWriter
 import java.io.File
 
@@ -50,11 +49,11 @@ class CSVLogger(filename: String, private val keys: List<String>) {
 
 /** Return the geo coordinates of a node. */
 fun STDCMNode.toGeoPoint(rawInfra: RawInfra, blockInfra: BlockInfra): Point {
-    val block = infraExplorer.getCurrentBlock()
-    val geo = buildTrainPathFromBlock(rawInfra, blockInfra, block).getGeo()
-    val blockLength = blockInfra.getBlockLength(block)
-    val offset = locationOnEdge ?: Offset.zero()
-    var p = geo.interpolateNormalized(offset.meters / blockLength.meters)
+    val blockRange = infraExplorer.getCurrentBlockRange()
+    val geo = buildTrainPathFromBlock(rawInfra, blockInfra, blockRange.value).getGeo()
+    val blockLength = blockInfra.getBlockLength(blockRange.value)
+    val blockOffset = blockRange.offsetFromTrainPath(infraExplorer.getSimulatedLength())
+    var p = geo.interpolateNormalized(blockOffset.meters / blockLength.meters)
     if (p.lat.isNaN() || p.lon.isNaN()) p = geo.getPoints().first()
     return p
 }


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16635

Fix in two parts:

1. Reuse the existing method that converts nodes to geo points
2. Fix said method, it failed to properly project the simulated length onto the block geometry