### PR TITLE
editoast: stop inlining some named schemas in openapi

### DIFF
--- a/editoast/core_client/src/etcs_braking_curves.rs
+++ b/editoast/core_client/src/etcs_braking_curves.rs
@@ -44,24 +44,17 @@ pub struct Response {
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
 #[schema(as = CoreETCSCurves)]
 pub struct ETCSCurves {
-    #[schema(inline)]
     pub indication: Option<SimpleEnvelope>,
-    #[schema(inline)]
     pub permitted_speed: SimpleEnvelope,
-    #[schema(inline)]
     pub guidance: SimpleEnvelope,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
 #[schema(as = CoreETCSConflictCurves)]
 pub struct ETCSConflictCurves {
-    #[schema(inline)]
     pub indication: SimpleEnvelope,
-    #[schema(inline)]
     pub permitted_speed: SimpleEnvelope,
-    #[schema(inline)]
     pub guidance: SimpleEnvelope,
-    #[schema(inline)]
     pub conflict_type: ConflictType,
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4984,19 +4984,7 @@ components:
       - position
       properties:
         extensions:
-          type: object
-          properties:
-            sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - kp
-                properties:
-                  kp:
-                    type: string
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/BufferStopExtension'
         id:
           type: string
           maxLength: 255
@@ -5008,6 +4996,22 @@ components:
           type: string
           maxLength: 255
           minLength: 1
+      additionalProperties: false
+    BufferStopExtension:
+      type: object
+      properties:
+        sncf:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/BufferStopSncfExtension'
+      additionalProperties: false
+    BufferStopSncfExtension:
+      type: object
+      required:
+      - kp
+      properties:
+        kp:
+          type: string
       additionalProperties: false
     CatalogEntry:
       type: object
@@ -5056,11 +5060,7 @@ components:
       - requirements
       properties:
         conflict_type:
-          oneOf:
-          - type: string
-            enum:
-            - Spacing
-            - Routing
+          $ref: '#/components/schemas/CoreConflictType'
           description: Type of the conflict
         end_time:
           type: string
@@ -5247,6 +5247,11 @@ components:
           format: date-time
         zone:
           type: string
+    CoreConflictType:
+      type: string
+      enum:
+      - Spacing
+      - Routing
     CoreConsistConfiguration:
       type: object
       description: Represents a physics consist.
@@ -5388,97 +5393,13 @@ components:
       - conflict_type
       properties:
         conflict_type:
-          type: string
-          enum:
-          - Spacing
-          - Routing
+          $ref: '#/components/schemas/CoreConflictType'
         guidance:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
+          $ref: '#/components/schemas/CoreSimpleEnvelope'
         indication:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
+          $ref: '#/components/schemas/CoreSimpleEnvelope'
         permitted_speed:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
+          $ref: '#/components/schemas/CoreSimpleEnvelope'
     CoreETCSCurves:
       type: object
       required:
@@ -5486,94 +5407,13 @@ components:
       - guidance
       properties:
         guidance:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
+          $ref: '#/components/schemas/CoreSimpleEnvelope'
         indication:
           oneOf:
           - type: 'null'
-          - type: object
-            required:
-            - positions
-            - times
-            - speeds
-            properties:
-              positions:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: |-
-                  List of positions of a train
-                  Both positions (in mm) and times (in ms) must have the same length
-              speeds:
-                type: array
-                items:
-                  type: number
-                  format: double
-                description: List of speeds (in m/s) associated to a position
-              times:
-                type: array
-                items:
-                  type: integer
-                  format: int64
-                  minimum: 0
-                description: List of times (in ms) associated to a position
+          - $ref: '#/components/schemas/CoreSimpleEnvelope'
         permitted_speed:
-          type: object
-          required:
-          - positions
-          - times
-          - speeds
-          properties:
-            positions:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of positions of a train
-                Both positions (in mm) and times (in ms) must have the same length
-            speeds:
-              type: array
-              items:
-                type: number
-                format: double
-              description: List of speeds (in m/s) associated to a position
-            times:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: List of times (in ms) associated to a position
+          $ref: '#/components/schemas/CoreSimpleEnvelope'
     CoreIncompatibleConstraints:
       type: object
       required:
@@ -5999,6 +5839,35 @@ components:
           format: int64
           description: The aspects start being displayed at this time (number of ms since `departure_time`)
           minimum: 0
+    CoreSimpleEnvelope:
+      type: object
+      required:
+      - positions
+      - times
+      - speeds
+      properties:
+        positions:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            List of positions of a train
+            Both positions (in mm) and times (in ms) must have the same length
+        speeds:
+          type: array
+          items:
+            type: number
+            format: double
+          description: List of speeds (in m/s) associated to a position
+        times:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: List of times (in ms) associated to a position
     CoreSpacingRequirement:
       type: object
       required:
@@ -6331,19 +6200,7 @@ components:
       - position
       properties:
         extensions:
-          type: object
-          required:
-          - sncf
-          properties:
-            sncf:
-              type: object
-              required:
-              - kp
-              properties:
-                kp:
-                  type: string
-              additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/DetectorExtension'
         id:
           type: string
           maxLength: 255
@@ -6355,6 +6212,22 @@ components:
           type: string
           maxLength: 255
           minLength: 1
+      additionalProperties: false
+    DetectorExtension:
+      type: object
+      required:
+      - sncf
+      properties:
+        sncf:
+          $ref: '#/components/schemas/DetectorSncfExtension'
+      additionalProperties: false
+    DetectorSncfExtension:
+      type: object
+      required:
+      - kp
+      properties:
+        kp:
+          type: string
       additionalProperties: false
     Direction:
       type: string
@@ -11558,34 +11431,7 @@ components:
           items:
             $ref: '#/components/schemas/DirectionalTrackRange'
         extensions:
-          type: object
-          properties:
-            neutral_sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - announcement
-                - exe
-                - end
-                - rev
-                properties:
-                  announcement:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Sign'
-                  end:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Sign'
-                  exe:
-                    $ref: '#/components/schemas/Sign'
-                  rev:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Sign'
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/NeutralSectionExtensions'
         id:
           type: string
           maxLength: 255
@@ -11596,6 +11442,37 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DirectionalTrackRange'
+      additionalProperties: false
+    NeutralSectionExtensions:
+      type: object
+      properties:
+        neutral_sncf:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/NeutralSectionNeutralSncfExtension'
+      additionalProperties: false
+    NeutralSectionNeutralSncfExtension:
+      type: object
+      required:
+      - announcement
+      - exe
+      - end
+      - rev
+      properties:
+        announcement:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sign'
+        end:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sign'
+        exe:
+          $ref: '#/components/schemas/Sign'
+        rev:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sign'
       additionalProperties: false
     NewDocumentResponse:
       type: object
@@ -11749,50 +11626,7 @@ components:
       - parts
       properties:
         extensions:
-          type: object
-          properties:
-            identifier:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - name
-                - uic
-                properties:
-                  name:
-                    type: string
-                    minLength: 1
-                  uic:
-                    type: integer
-                    format: int32
-                    minimum: 0
-                additionalProperties: false
-            sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - ci
-                - ch
-                - ch_short_label
-                - ch_long_label
-                - trigram
-                properties:
-                  ch:
-                    type: string
-                  ch_long_label:
-                    type: string
-                    minLength: 1
-                  ch_short_label:
-                    type: string
-                    minLength: 1
-                  ci:
-                    type: integer
-                    format: int64
-                  trigram:
-                    type: string
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/OperationalPointExtensions'
         id:
           type: string
           maxLength: 255
@@ -11835,28 +11669,7 @@ components:
         sncf:
           oneOf:
           - type: 'null'
-          - type: object
-            required:
-            - ci
-            - ch
-            - ch_short_label
-            - ch_long_label
-            - trigram
-            properties:
-              ch:
-                type: string
-              ch_long_label:
-                type: string
-                minLength: 1
-              ch_short_label:
-                type: string
-                minLength: 1
-              ci:
-                type: integer
-                format: int64
-              trigram:
-                type: string
-            additionalProperties: false
+          - $ref: '#/components/schemas/OperationalPointSncfExtension'
       additionalProperties: false
     OperationalPointPart:
       type: object
@@ -11866,19 +11679,7 @@ components:
       - local_track_name
       properties:
         extensions:
-          type: object
-          properties:
-            sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - kp
-                properties:
-                  kp:
-                    type: string
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/OperationalPointPartExtension'
         local_track_name:
           $ref: '#/components/schemas/NonBlankString'
         position:
@@ -11889,6 +11690,14 @@ components:
           type: string
           maxLength: 255
           minLength: 1
+      additionalProperties: false
+    OperationalPointPartExtension:
+      type: object
+      properties:
+        sncf:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/OperationalPointPartSncfExtension'
       additionalProperties: false
     OperationalPointPartReference:
       type: object
@@ -11902,6 +11711,14 @@ components:
             minLength: 1
         operational_point:
           $ref: '#/components/schemas/OperationalPointReference'
+    OperationalPointPartSncfExtension:
+      type: object
+      required:
+      - kp
+      properties:
+        kp:
+          type: string
+      additionalProperties: false
     OperationalPointReference:
       oneOf:
       - type: object
@@ -11960,6 +11777,29 @@ components:
             format: int32
             description: The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
             minimum: 0
+    OperationalPointSncfExtension:
+      type: object
+      required:
+      - ci
+      - ch
+      - ch_short_label
+      - ch_long_label
+      - trigram
+      properties:
+        ch:
+          type: string
+        ch_long_label:
+          type: string
+          minLength: 1
+        ch_short_label:
+          type: string
+          minLength: 1
+        ci:
+          type: integer
+          format: int64
+        trigram:
+          type: string
+      additionalProperties: false
     OptionsChangeGroup:
       type: object
       required:
@@ -12969,50 +12809,7 @@ components:
       - parts
       properties:
         extensions:
-          type: object
-          properties:
-            identifier:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - name
-                - uic
-                properties:
-                  name:
-                    type: string
-                    minLength: 1
-                  uic:
-                    type: integer
-                    format: int32
-                    minimum: 0
-                additionalProperties: false
-            sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - ci
-                - ch
-                - ch_short_label
-                - ch_long_label
-                - trigram
-                properties:
-                  ch:
-                    type: string
-                  ch_long_label:
-                    type: string
-                    minLength: 1
-                  ch_short_label:
-                    type: string
-                    minLength: 1
-                  ci:
-                    type: integer
-                    format: int64
-                  trigram:
-                    type: string
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/OperationalPointExtensions'
         geo:
           oneOf:
           - type: 'null'
@@ -14231,24 +14028,7 @@ components:
         direction:
           $ref: '#/components/schemas/Direction'
         extensions:
-          type: object
-          properties:
-            sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - label
-                - kp
-                properties:
-                  kp:
-                    type: string
-                  label:
-                    type: string
-                  side:
-                    $ref: '#/components/schemas/Side'
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/SignalExtensions'
         id:
           type: string
           maxLength: 255
@@ -14315,6 +14095,27 @@ components:
           type: string
           maxLength: 255
           minLength: 1
+      additionalProperties: false
+    SignalExtensions:
+      type: object
+      properties:
+        sncf:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/SignalSncfExtension'
+      additionalProperties: false
+    SignalSncfExtension:
+      type: object
+      required:
+      - label
+      - kp
+      properties:
+        kp:
+          type: string
+        label:
+          type: string
+        side:
+          $ref: '#/components/schemas/Side'
       additionalProperties: false
     SimilarTrainWaypoint:
       type: object
@@ -14772,29 +14573,7 @@ components:
       - track_ranges
       properties:
         extensions:
-          type: object
-          properties:
-            psl_sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - announcement
-                - z
-                - r
-                properties:
-                  announcement:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Sign'
-                  r:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Sign'
-                  z:
-                    $ref: '#/components/schemas/Sign'
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/SpeedSectionExtensions'
         id:
           type: string
           maxLength: 255
@@ -14824,6 +14603,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ApplicableDirectionsTrackRange'
+      additionalProperties: false
+    SpeedSectionExtensions:
+      type: object
+      properties:
+        psl_sncf:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/SpeedSectionPslSncfExtension'
+      additionalProperties: false
+    SpeedSectionPslSncfExtension:
+      type: object
+      required:
+      - announcement
+      - z
+      - r
+      properties:
+        announcement:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sign'
+        r:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sign'
+        z:
+          $ref: '#/components/schemas/Sign'
       additionalProperties: false
     StartTimeChangeGroup:
       type: object
@@ -15446,20 +15251,7 @@ components:
       - ports
       properties:
         extensions:
-          type: object
-          properties:
-            sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - label
-                properties:
-                  label:
-                    type: string
-                    minLength: 1
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/SwitchExtensions'
         group_change_delay:
           type: number
           format: double
@@ -15480,6 +15272,14 @@ components:
           maxLength: 255
           minLength: 1
       additionalProperties: false
+    SwitchExtensions:
+      type: object
+      properties:
+        sncf:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/SwitchSncfExtension'
+      additionalProperties: false
     SwitchPortConnection:
       type: object
       required:
@@ -15493,6 +15293,15 @@ components:
         src:
           type: string
           maxLength: 255
+          minLength: 1
+      additionalProperties: false
+    SwitchSncfExtension:
+      type: object
+      required:
+      - label
+      properties:
+        label:
+          type: string
           minLength: 1
       additionalProperties: false
     SwitchType:
@@ -15749,47 +15558,7 @@ components:
           items:
             $ref: '#/components/schemas/Curve'
         extensions:
-          type: object
-          properties:
-            sncf:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - line_code
-                - line_name
-                - track_number
-                - track_name
-                properties:
-                  line_code:
-                    type: integer
-                    format: int32
-                  line_name:
-                    type: string
-                    minLength: 1
-                  track_name:
-                    type: string
-                    minLength: 1
-                  track_number:
-                    type: integer
-                    format: int32
-                additionalProperties: false
-            source:
-              oneOf:
-              - type: 'null'
-              - type: object
-                required:
-                - name
-                - id
-                properties:
-                  id:
-                    type: string
-                    minLength: 1
-                  name:
-                    type: string
-                    minLength: 1
-                additionalProperties: false
-          additionalProperties: false
+          $ref: '#/components/schemas/TrackSectionExtensions'
         geo:
           $ref: '#/components/schemas/GeoJsonLineString'
         id:
@@ -15807,6 +15576,50 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Slope'
+      additionalProperties: false
+    TrackSectionExtensions:
+      type: object
+      properties:
+        sncf:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/TrackSectionSncfExtension'
+        source:
+          oneOf:
+          - type: 'null'
+          - type: object
+            required:
+            - name
+            - id
+            properties:
+              id:
+                type: string
+                minLength: 1
+              name:
+                type: string
+                minLength: 1
+            additionalProperties: false
+      additionalProperties: false
+    TrackSectionSncfExtension:
+      type: object
+      required:
+      - line_code
+      - line_name
+      - track_number
+      - track_name
+      properties:
+        line_code:
+          type: integer
+          format: int32
+        line_name:
+          type: string
+          minLength: 1
+        track_name:
+          type: string
+          minLength: 1
+        track_number:
+          type: integer
+          format: int32
       additionalProperties: false
     TrainCategory:
       oneOf:

--- a/editoast/schemas/src/infra/buffer_stop.rs
+++ b/editoast/schemas/src/infra/buffer_stop.rs
@@ -19,7 +19,6 @@ pub struct BufferStop {
     pub track: Identifier,
     pub position: f64,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: BufferStopExtension,
 }
 
@@ -38,7 +37,6 @@ impl OSRDIdentified for BufferStop {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BufferStopExtension {
-    #[schema(inline)]
     pub sncf: Option<BufferStopSncfExtension>,
 }
 

--- a/editoast/schemas/src/infra/detector.rs
+++ b/editoast/schemas/src/infra/detector.rs
@@ -19,7 +19,6 @@ pub struct Detector {
     pub track: Identifier,
     pub position: f64,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: DetectorExtension,
 }
 
@@ -38,7 +37,6 @@ impl OSRDIdentified for Detector {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DetectorExtension {
-    #[schema(inline)]
     pub sncf: DetectorSncfExtension,
 }
 

--- a/editoast/schemas/src/infra/neutral_section.rs
+++ b/editoast/schemas/src/infra/neutral_section.rs
@@ -23,14 +23,12 @@ pub struct NeutralSection {
     pub track_ranges: Vec<DirectionalTrackRange>,
     pub lower_pantograph: bool, // Whether the trains need to lower their pantograph to cross this section
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: NeutralSectionExtensions,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct NeutralSectionExtensions {
-    #[schema(inline)]
     pub neutral_sncf: Option<NeutralSectionNeutralSncfExtension>,
 }
 

--- a/editoast/schemas/src/infra/operational_point.rs
+++ b/editoast/schemas/src/infra/operational_point.rs
@@ -17,7 +17,6 @@ pub struct OperationalPoint {
     pub id: Identifier,
     pub parts: Vec<OperationalPointPart>,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: OperationalPointExtensions,
     #[serde(default)]
     pub weight: Option<u8>,
@@ -36,14 +35,12 @@ pub struct OperationalPointPart {
     pub position: f64,
     pub local_track_name: NonBlankString,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: OperationalPointPartExtension,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct OperationalPointPartExtension {
-    #[schema(inline)]
     pub sncf: Option<OperationalPointPartSncfExtension>,
 }
 
@@ -56,7 +53,6 @@ pub struct OperationalPointPartSncfExtension {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct OperationalPointExtensions {
-    #[schema(inline)]
     pub sncf: Option<OperationalPointSncfExtension>,
     #[schema(inline)]
     pub identifier: Option<OperationalPointIdentifierExtension>,

--- a/editoast/schemas/src/infra/signal.rs
+++ b/editoast/schemas/src/infra/signal.rs
@@ -31,7 +31,6 @@ pub struct Signal {
     #[schema(inline)]
     pub logical_signals: Vec<LogicalSignal>,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: SignalExtensions,
 }
 
@@ -58,7 +57,6 @@ pub struct ConditionalParameters {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SignalExtensions {
-    #[schema(inline)]
     pub sncf: Option<SignalSncfExtension>,
 }
 

--- a/editoast/schemas/src/infra/speed_section.rs
+++ b/editoast/schemas/src/infra/speed_section.rs
@@ -32,7 +32,6 @@ pub struct SpeedSection {
     #[schema(inline)]
     pub on_routes: Option<Vec<Identifier>>,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: SpeedSectionExtensions,
 }
 
@@ -56,7 +55,6 @@ impl<'de> Deserialize<'de> for Speed {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SpeedSectionExtensions {
-    #[schema(inline)]
     pub psl_sncf: Option<SpeedSectionPslSncfExtension>,
 }
 

--- a/editoast/schemas/src/infra/switch.rs
+++ b/editoast/schemas/src/infra/switch.rs
@@ -21,14 +21,12 @@ pub struct Switch {
     pub group_change_delay: f64,
     pub ports: HashMap<Identifier, TrackEndpoint>,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: SwitchExtensions,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SwitchExtensions {
-    #[schema(inline)]
     sncf: Option<SwitchSncfExtension>,
 }
 

--- a/editoast/schemas/src/infra/track_section.rs
+++ b/editoast/schemas/src/infra/track_section.rs
@@ -32,7 +32,6 @@ pub struct TrackSection {
     #[schema(value_type = GeoJsonLineString)]
     pub geo: Geometry,
     #[serde(default)]
-    #[schema(inline)]
     pub extensions: TrackSectionExtensions,
 }
 

--- a/editoast/schemas/src/infra/track_section_extensions.rs
+++ b/editoast/schemas/src/infra/track_section_extensions.rs
@@ -8,7 +8,6 @@ use crate::infra::TrackSectionSourceExtension;
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct TrackSectionExtensions {
-    #[schema(inline)]
     pub sncf: Option<TrackSectionSncfExtension>,
     #[schema(inline)]
     pub source: Option<TrackSectionSourceExtension>,

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -681,7 +681,6 @@ struct RelatedOperationalPoint {
     id: Identifier,
     parts: Vec<RelatedOperationalPointPart>,
     #[serde(default)]
-    #[schema(inline)]
     extensions: OperationalPointExtensions,
     #[serde(default)]
     weight: Option<u8>,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -255,7 +255,6 @@ pub struct Conflict {
     /// Datetime of the end of the conflict
     pub end_time: DateTime<Utc>,
     /// Type of the conflict
-    #[schema(inline)]
     pub conflict_type: ConflictType,
     /// List of requirements causing the conflict
     pub requirements: Vec<ConflictRequirement>,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2904,22 +2904,26 @@ export type Infra = {
   railjson_version: string;
   version: number;
 };
+export type BufferStopSncfExtension = {
+  kp: string;
+};
+export type BufferStopExtension = {
+  sncf?: null | BufferStopSncfExtension;
+};
 export type BufferStop = {
-  extensions?: {
-    sncf?: null | {
-      kp: string;
-    };
-  };
+  extensions?: BufferStopExtension;
   id: string;
   position: number;
   track: string;
 };
+export type DetectorSncfExtension = {
+  kp: string;
+};
+export type DetectorExtension = {
+  sncf: DetectorSncfExtension;
+};
 export type Detector = {
-  extensions?: {
-    sncf: {
-      kp: string;
-    };
-  };
+  extensions?: DetectorExtension;
   id: string;
   position: number;
   track: string;
@@ -2979,46 +2983,52 @@ export type Sign = {
   type: string;
   value: string;
 };
+export type NeutralSectionNeutralSncfExtension = {
+  announcement: Sign[];
+  end: Sign[];
+  exe: Sign;
+  rev: Sign[];
+};
+export type NeutralSectionExtensions = {
+  neutral_sncf?: null | NeutralSectionNeutralSncfExtension;
+};
 export type NeutralSection = {
   announcement_track_ranges: DirectionalTrackRange[];
-  extensions?: {
-    neutral_sncf?: null | {
-      announcement: Sign[];
-      end: Sign[];
-      exe: Sign;
-      rev: Sign[];
-    };
-  };
+  extensions?: NeutralSectionExtensions;
   id: string;
   lower_pantograph: boolean;
   track_ranges: DirectionalTrackRange[];
 };
+export type OperationalPointSncfExtension = {
+  ch: string;
+  ch_long_label: string;
+  ch_short_label: string;
+  ci: number;
+  trigram: string;
+};
+export type OperationalPointExtensions = {
+  identifier?: null | {
+    name: string;
+    uic: number;
+  };
+  sncf?: null | OperationalPointSncfExtension;
+};
+export type OperationalPointPartSncfExtension = {
+  kp: string;
+};
+export type OperationalPointPartExtension = {
+  sncf?: null | OperationalPointPartSncfExtension;
+};
 export type NonBlankString = string;
 export type OperationalPointPart = {
-  extensions?: {
-    sncf?: null | {
-      kp: string;
-    };
-  };
+  extensions?: OperationalPointPartExtension;
   local_track_name: NonBlankString;
   /** Offset on the track section, in m */
   position: number;
   track: string;
 };
 export type OperationalPoint = {
-  extensions?: {
-    identifier?: null | {
-      name: string;
-      uic: number;
-    };
-    sncf?: null | {
-      ch: string;
-      ch_long_label: string;
-      ch_short_label: string;
-      ci: number;
-      trigram: string;
-    };
-  };
+  extensions?: OperationalPointExtensions;
   id: string;
   parts: OperationalPointPart[];
   plc?: null | NonBlankString;
@@ -3043,15 +3053,17 @@ export type Route = {
     [key: string]: string;
   };
 };
+export type SignalSncfExtension = {
+  kp: string;
+  label: string;
+  side?: Side;
+};
+export type SignalExtensions = {
+  sncf?: null | SignalSncfExtension;
+};
 export type Signal = {
   direction: Direction;
-  extensions?: {
-    sncf?: null | {
-      kp: string;
-      label: string;
-      side?: Side;
-    };
-  };
+  extensions?: SignalExtensions;
   id: string;
   logical_signals?: {
     conditional_parameters: {
@@ -3073,14 +3085,16 @@ export type Signal = {
   sight_distance: number;
   track: string;
 };
+export type SpeedSectionPslSncfExtension = {
+  announcement: Sign[];
+  r: Sign[];
+  z: Sign;
+};
+export type SpeedSectionExtensions = {
+  psl_sncf?: null | SpeedSectionPslSncfExtension;
+};
 export type SpeedSection = {
-  extensions?: {
-    psl_sncf?: null | {
-      announcement: Sign[];
-      r: Sign[];
-      z: Sign;
-    };
-  };
+  extensions?: SpeedSectionExtensions;
   id: string;
   on_routes?: string[] | null;
   speed_limit?: null | number;
@@ -3089,17 +3103,19 @@ export type SpeedSection = {
   };
   track_ranges: ApplicableDirectionsTrackRange[];
 };
+export type SwitchSncfExtension = {
+  label: string;
+};
+export type SwitchExtensions = {
+  sncf?: null | SwitchSncfExtension;
+};
 export type Endpoint = 'BEGIN' | 'END';
 export type TrackEndpoint = {
   endpoint: Endpoint;
   track: string;
 };
 export type Switch = {
-  extensions?: {
-    sncf?: null | {
-      label: string;
-    };
-  };
+  extensions?: SwitchExtensions;
   group_change_delay: number;
   id: string;
   ports: {
@@ -3111,6 +3127,19 @@ export type Curve = {
   begin: number;
   end: number;
   radius: number;
+};
+export type TrackSectionSncfExtension = {
+  line_code: number;
+  line_name: string;
+  track_name: string;
+  track_number: number;
+};
+export type TrackSectionExtensions = {
+  sncf?: null | TrackSectionSncfExtension;
+  source?: null | {
+    id: string;
+    name: string;
+  };
 };
 export type GeoJsonPointValue = number[];
 export type GeoJsonLineStringValue = GeoJsonPointValue[];
@@ -3140,18 +3169,7 @@ export type Slope = {
 };
 export type TrackSection = {
   curves: Curve[];
-  extensions?: {
-    sncf?: null | {
-      line_code: number;
-      line_name: string;
-      track_name: string;
-      track_number: number;
-    };
-    source?: null | {
-      id: string;
-      name: string;
-    };
-  };
+  extensions?: TrackSectionExtensions;
   geo: GeoJsonLineString;
   id: string;
   length: number;
@@ -3417,19 +3435,7 @@ export type RelatedOperationalPointPart = OperationalPointPart & {
   geo?: null | GeoJsonPoint;
 };
 export type RelatedOperationalPoint = {
-  extensions?: {
-    identifier?: null | {
-      name: string;
-      uic: number;
-    };
-    sncf?: null | {
-      ch: string;
-      ch_long_label: string;
-      ch_short_label: string;
-      ci: number;
-      trigram: string;
-    };
-  };
+  extensions?: OperationalPointExtensions;
   geo?: null | GeoJsonPoint;
   id: string;
   parts: RelatedOperationalPointPart[];
@@ -3486,19 +3492,6 @@ export type InfraObjectWithGeometry = {
   geographic: GeoJson;
   obj_id: string;
   railjson: object;
-};
-export type OperationalPointExtensions = {
-  identifier?: null | {
-    name: string;
-    uic: number;
-  };
-  sncf?: null | {
-    ch: string;
-    ch_long_label: string;
-    ch_short_label: string;
-    ci: number;
-    trigram: string;
-  };
 };
 export type PathProperties = {
   /** Curves along the path */
@@ -4461,6 +4454,7 @@ export type SubCategoryPage = PaginationStats & {
 export type TimetableResult = {
   timetable_id: number;
 };
+export type CoreConflictType = 'Spacing' | 'Routing';
 export type CoreConflictRequirement = {
   end_time: string;
   start_time: string;
@@ -4468,7 +4462,7 @@ export type CoreConflictRequirement = {
 };
 export type Conflict = {
   /** Type of the conflict */
-  conflict_type: 'Spacing' | 'Routing';
+  conflict_type: CoreConflictType;
   /** Datetime of the end of the conflict */
   end_time: string;
   /** List of requirements causing the conflict */
@@ -5075,64 +5069,25 @@ export type TrainScheduleSimulationSummaryResult = {
   };
   train_schedule: SimulationSummaryResult;
 };
+export type CoreSimpleEnvelope = {
+  /** List of positions of a train
+    Both positions (in mm) and times (in ms) must have the same length */
+  positions: number[];
+  /** List of speeds (in m/s) associated to a position */
+  speeds: number[];
+  /** List of times (in ms) associated to a position */
+  times: number[];
+};
 export type CoreEtcsConflictCurves = {
-  conflict_type: 'Spacing' | 'Routing';
-  guidance: {
-    /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
-    positions: number[];
-    /** List of speeds (in m/s) associated to a position */
-    speeds: number[];
-    /** List of times (in ms) associated to a position */
-    times: number[];
-  };
-  indication: {
-    /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
-    positions: number[];
-    /** List of speeds (in m/s) associated to a position */
-    speeds: number[];
-    /** List of times (in ms) associated to a position */
-    times: number[];
-  };
-  permitted_speed: {
-    /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
-    positions: number[];
-    /** List of speeds (in m/s) associated to a position */
-    speeds: number[];
-    /** List of times (in ms) associated to a position */
-    times: number[];
-  };
+  conflict_type: CoreConflictType;
+  guidance: CoreSimpleEnvelope;
+  indication: CoreSimpleEnvelope;
+  permitted_speed: CoreSimpleEnvelope;
 };
 export type CoreEtcsCurves = {
-  guidance: {
-    /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
-    positions: number[];
-    /** List of speeds (in m/s) associated to a position */
-    speeds: number[];
-    /** List of times (in ms) associated to a position */
-    times: number[];
-  };
-  indication?: null | {
-    /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
-    positions: number[];
-    /** List of speeds (in m/s) associated to a position */
-    speeds: number[];
-    /** List of times (in ms) associated to a position */
-    times: number[];
-  };
-  permitted_speed: {
-    /** List of positions of a train
-        Both positions (in mm) and times (in ms) must have the same length */
-    positions: number[];
-    /** List of speeds (in m/s) associated to a position */
-    speeds: number[];
-    /** List of times (in ms) associated to a position */
-    times: number[];
-  };
+  guidance: CoreSimpleEnvelope;
+  indication?: null | CoreSimpleEnvelope;
+  permitted_speed: CoreSimpleEnvelope;
 };
 export type CoreEtcsBrakingCurvesResponse = {
   /** List of ETCS conflict braking curves associated to the train schedule's ETCS signals.

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -66,28 +66,11 @@ class BoundingBox(BaseModel):
     min_lon: float
 
 
-class Sncf(BaseModel):
+class BufferStopSncfExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     kp: str
-
-
-class Extensions(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    sncf: Sncf | None = None
-
-
-class BufferStop(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    extensions: Extensions | None = None
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    position: float
-    track: Annotated[str, Field(max_length=255, min_length=1)]
 
 
 class CatalogEntry(BaseModel):
@@ -103,15 +86,6 @@ class Comfort(Enum):
     STANDARD = "STANDARD"
     AIR_CONDITIONING = "AIR_CONDITIONING"
     HEATING = "HEATING"
-
-
-class ConflictType(Enum):
-    """
-    Type of the conflict
-    """
-
-    Spacing = "Spacing"
-    Routing = "Routing"
 
 
 class OccurrenceIdBase(BaseModel):
@@ -179,126 +153,9 @@ class CoreConflictRequirement(BaseModel):
     zone: str
 
 
-class ConflictType1(Enum):
+class CoreConflictType(Enum):
     Spacing = "Spacing"
     Routing = "Routing"
-
-
-class Position(RootModel[int]):
-    root: Annotated[int, Field(ge=0)]
-
-
-class Time(RootModel[int]):
-    root: Annotated[int, Field(ge=0)]
-
-
-class Guidance(BaseModel):
-    positions: list[Position]
-    """
-    List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length
-    """
-    speeds: list[float]
-    """
-    List of speeds (in m/s) associated to a position
-    """
-    times: list[Time]
-    """
-    List of times (in ms) associated to a position
-    """
-
-
-class Indication(BaseModel):
-    positions: list[Position]
-    """
-    List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length
-    """
-    speeds: list[float]
-    """
-    List of speeds (in m/s) associated to a position
-    """
-    times: list[Time]
-    """
-    List of times (in ms) associated to a position
-    """
-
-
-class PermittedSpeed(BaseModel):
-    positions: list[Position]
-    """
-    List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length
-    """
-    speeds: list[float]
-    """
-    List of speeds (in m/s) associated to a position
-    """
-    times: list[Time]
-    """
-    List of times (in ms) associated to a position
-    """
-
-
-class CoreETCSConflictCurves(BaseModel):
-    conflict_type: ConflictType1
-    guidance: Guidance
-    indication: Indication
-    permitted_speed: PermittedSpeed
-
-
-class Guidance1(BaseModel):
-    positions: list[Position]
-    """
-    List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length
-    """
-    speeds: list[float]
-    """
-    List of speeds (in m/s) associated to a position
-    """
-    times: list[Time]
-    """
-    List of times (in ms) associated to a position
-    """
-
-
-class Indication1(BaseModel):
-    positions: list[Position]
-    """
-    List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length
-    """
-    speeds: list[float]
-    """
-    List of speeds (in m/s) associated to a position
-    """
-    times: list[Time]
-    """
-    List of times (in ms) associated to a position
-    """
-
-
-class PermittedSpeed1(BaseModel):
-    positions: list[Position]
-    """
-    List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length
-    """
-    speeds: list[float]
-    """
-    List of speeds (in m/s) associated to a position
-    """
-    times: list[Time]
-    """
-    List of times (in ms) associated to a position
-    """
-
-
-class CoreETCSCurves(BaseModel):
-    guidance: Guidance1
-    indication: Indication1 | None = None
-    permitted_speed: PermittedSpeed1
 
 
 class CoreObjectRange(BaseModel):
@@ -351,6 +208,14 @@ class PathItemPosition(RootModel[int]):
 
 
 class PathItemTime(RootModel[int]):
+    root: Annotated[int, Field(ge=0)]
+
+
+class Position(RootModel[int]):
+    root: Annotated[int, Field(ge=0)]
+
+
+class Time(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
@@ -442,6 +307,22 @@ class CoreSignalUpdate(BaseModel):
     time_start: Annotated[int, Field(ge=0)]
     """
     The aspects start being displayed at this time (number of ms since `departure_time`)
+    """
+
+
+class CoreSimpleEnvelope(BaseModel):
+    positions: list[Position]
+    """
+    List of positions of a train
+    Both positions (in mm) and times (in ms) must have the same length
+    """
+    speeds: list[float]
+    """
+    List of speeds (in m/s) associated to a position
+    """
+    times: list[Time]
+    """
+    List of times (in ms) associated to a position
     """
 
 
@@ -541,21 +422,11 @@ class Curve(BaseModel):
     radius: float
 
 
-class Extensions1(BaseModel):
+class DetectorSncfExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    sncf: Sncf
-
-
-class Detector(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    extensions: Extensions1 | None = None
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    position: float
-    track: Annotated[str, Field(max_length=255, min_length=1)]
+    kp: str
 
 
 class Direction(Enum):
@@ -2604,16 +2475,6 @@ class InfraGrant(Enum):
     OWNER = "OWNER"
 
 
-class InfraObjectDetector(BaseModel):
-    obj_type: Literal["Detector"]
-    railjson: Detector
-
-
-class InfraObjectBufferStop(BaseModel):
-    obj_type: Literal["BufferStop"]
-    railjson: BufferStop
-
-
 class InfraObjectElectrification(BaseModel):
     obj_type: Literal["Electrification"]
     railjson: Electrification
@@ -2780,62 +2641,15 @@ class Identifier1(BaseModel):
     uic: Annotated[int, Field(ge=0)]
 
 
-class Sncf2(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    ch: str
-    ch_long_label: Annotated[str, Field(min_length=1)]
-    ch_short_label: Annotated[str, Field(min_length=1)]
-    ci: int
-    trigram: str
+class LocalTrackName(RootModel[str]):
+    root: Annotated[str, Field(min_length=1)]
 
 
-class Extensions3(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    identifier: Identifier1 | None = None
-    sncf: Sncf2 | None = None
-
-
-class OperationalPointExtensions(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    identifier: Identifier1 | None = None
-    sncf: Sncf2 | None = None
-
-
-class Sncf4(BaseModel):
+class OperationalPointPartSncfExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     kp: str
-
-
-class Extensions4(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    sncf: Sncf4 | None = None
-
-
-class OperationalPointPart(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    extensions: Extensions4 | None = None
-    local_track_name: Annotated[str, Field(min_length=1)]
-    position: float
-    """
-    Offset on the track section, in m
-    """
-    track: Annotated[str, Field(max_length=255, min_length=1)]
-
-
-class LocalTrackName(RootModel[str]):
-    root: Annotated[str, Field(min_length=1)]
 
 
 class OperationalPointReferenceId(BaseModel):
@@ -2868,6 +2682,17 @@ class OperationalPointReferenceUic(BaseModel):
     """
     The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
     """
+
+
+class OperationalPointSncfExtension(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    ch: str
+    ch_long_label: Annotated[str, Field(min_length=1)]
+    ch_short_label: Annotated[str, Field(min_length=1)]
+    ci: int
+    trigram: str
 
 
 class PaginationStats(BaseModel):
@@ -3011,33 +2836,6 @@ class Electrifications(BaseModel):
     """
 
 
-class OperationalPoint2(BaseModel):
-    """
-    Operational point along a path.
-    """
-
-    extensions: OperationalPointExtensions | None = None
-    """
-    Extensions associated to the operational point
-    """
-    id: str
-    """
-    Id of the operational point
-    """
-    part: OperationalPointPart
-    """
-    The part along the path
-    """
-    position: Annotated[int, Field(ge=0)]
-    """
-    Distance from the beginning of the path in mm
-    """
-    weight: Annotated[int | None, Field(ge=0, le=100)] = None
-    """
-    Importance of the operational point
-    """
-
-
 class Slopes(BaseModel):
     """
     Property f64 values along a path. Each value is associated to a range of the path.
@@ -3174,25 +2972,6 @@ class RefillLaw(BaseModel):
     )
     soc_ref: Annotated[float, Field(ge=0.0, le=1.0)]
     tau: Annotated[float, Field(ge=0.0)]
-
-
-class Sncf5(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    ch: str
-    ch_long_label: Annotated[str, Field(min_length=1)]
-    ch_short_label: Annotated[str, Field(min_length=1)]
-    ci: int
-    trigram: str
-
-
-class Extensions5(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    identifier: Identifier1 | None = None
-    sncf: Sncf5 | None = None
 
 
 class RemoveOperation(BaseModel):
@@ -3491,22 +3270,6 @@ class Sign(BaseModel):
     value: str
 
 
-class Sncf6(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    kp: str
-    label: str
-    side: Side | None = None
-
-
-class Extensions6(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    sncf: Sncf6 | None = None
-
-
 class ConditionalParameter(BaseModel):
     on_route: Annotated[str, Field(min_length=1)]
     parameters: dict[str, str]
@@ -3520,17 +3283,13 @@ class LogicalSignal(BaseModel):
     signaling_system: str
 
 
-class Signal(BaseModel):
+class SignalSncfExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    direction: Direction
-    extensions: Extensions6 | None = None
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    logical_signals: list[LogicalSignal] | None = None
-    position: float
-    sight_distance: float
-    track: Annotated[str, Field(max_length=255, min_length=1)]
+    kp: str
+    label: str
+    side: Side | None = None
 
 
 class SimilarTrainWaypoint(BaseModel):
@@ -3769,36 +3528,17 @@ class SpeedLimits(BaseModel):
     speed_limit_tags: dict[str, int]
 
 
-class PslSncf(BaseModel):
+class OnRoute(RootModel[str]):
+    root: Annotated[str, Field(max_length=255, min_length=1)]
+
+
+class SpeedSectionPslSncfExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     announcement: list[Sign]
     r: list[Sign]
     z: Sign
-
-
-class Extensions7(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    psl_sncf: PslSncf | None = None
-
-
-class OnRoute(RootModel[str]):
-    root: Annotated[str, Field(max_length=255, min_length=1)]
-
-
-class SpeedSection(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    extensions: Extensions7 | None = None
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    on_routes: list[OnRoute] | None = None
-    speed_limit: float | None = None
-    speed_limit_by_tag: dict[str, float]
-    track_ranges: list[ApplicableDirectionsTrackRange]
 
 
 class StartTimeChangeGroup(BaseModel):
@@ -3901,26 +3641,19 @@ class SupportedSignalingSystemTVM430(BaseModel):
     type: Literal["TVM430"]
 
 
-class Sncf7(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    label: Annotated[str, Field(min_length=1)]
-
-
-class Extensions8(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    sncf: Sncf7 | None = None
-
-
 class SwitchPortConnection(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     dst: Annotated[str, Field(max_length=255, min_length=1)]
     src: Annotated[str, Field(max_length=255, min_length=1)]
+
+
+class SwitchSncfExtension(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    label: Annotated[str, Field(min_length=1)]
 
 
 class Port(RootModel[str]):
@@ -4067,16 +3800,6 @@ class TrackRange(BaseModel):
     track: Annotated[str, Field(examples=["01234567-89ab-cdef-0123-456789abcdef"])]
 
 
-class Sncf8(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    line_code: int
-    line_name: Annotated[str, Field(min_length=1)]
-    track_name: Annotated[str, Field(min_length=1)]
-    track_number: int
-
-
 class Source(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4085,12 +3808,14 @@ class Source(BaseModel):
     name: Annotated[str, Field(min_length=1)]
 
 
-class Extensions9(BaseModel):
+class TrackSectionSncfExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    sncf: Sncf8 | None = None
-    source: Source | None = None
+    line_code: int
+    line_name: Annotated[str, Field(min_length=1)]
+    track_name: Annotated[str, Field(min_length=1)]
+    track_number: int
 
 
 class TrainCategorySub(BaseModel):
@@ -4326,6 +4051,13 @@ class SendLastMinuteRequestPostRequest(BaseModel):
     simulation_report_sheet: bytes
 
 
+class BufferStopExtension(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    sncf: BufferStopSncfExtension | None = None
+
+
 class ConditionalEffortCurve(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4335,7 +4067,7 @@ class ConditionalEffortCurve(BaseModel):
 
 
 class Conflict(BaseModel):
-    conflict_type: ConflictType
+    conflict_type: CoreConflictType
     """
     Type of the conflict
     """
@@ -4400,22 +4132,17 @@ class ConstraintDistributionChangeGroup(BaseModel):
     value: Distribution
 
 
-class CoreETCSBrakingCurvesResponse(BaseModel):
-    conflicts: list[CoreETCSConflictCurves]
-    """
-    List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
-    For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
-    For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
-    corresponding potential spacing or routing conflict.
-    """
-    slowdowns: list[CoreETCSCurves]
-    """
-    List of ETCS braking curves associated to the train schedule's ETCS slowdowns
-    """
-    stops: list[CoreETCSCurves]
-    """
-    List of ETCS braking curves associated to the train schedule's ETCS stops
-    """
+class CoreETCSConflictCurves(BaseModel):
+    conflict_type: CoreConflictType
+    guidance: CoreSimpleEnvelope
+    indication: CoreSimpleEnvelope
+    permitted_speed: CoreSimpleEnvelope
+
+
+class CoreETCSCurves(BaseModel):
+    guidance: CoreSimpleEnvelope
+    indication: CoreSimpleEnvelope | None = None
+    permitted_speed: CoreSimpleEnvelope
 
 
 class CoreIncompatibleOffsetRange(BaseModel):
@@ -4512,6 +4239,13 @@ class CoreTrainRequirementsById(BaseModel):
     """
     ID that can be used to find the train in tools other than OSRD. Used in debug traces.
     """
+
+
+class DetectorExtension(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    sncf: DetectorSncfExtension
 
 
 class EditoastError(
@@ -4951,16 +4685,6 @@ class GrantBody(BaseModel):
     subject_id: int
 
 
-class InfraObjectSignal(BaseModel):
-    obj_type: Literal["Signal"]
-    railjson: Signal
-
-
-class InfraObjectSpeedSection(BaseModel):
-    obj_type: Literal["SpeedSection"]
-    railjson: SpeedSection
-
-
 class InfraObjectSwitchType(BaseModel):
     obj_type: Literal["SwitchType"]
     railjson: SwitchType
@@ -5050,7 +4774,7 @@ class ModeEffortCurves(BaseModel):
     is_electric: bool
 
 
-class NeutralSncf(BaseModel):
+class NeutralSectionNeutralSncfExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -5058,32 +4782,6 @@ class NeutralSncf(BaseModel):
     end: list[Sign]
     exe: Sign
     rev: list[Sign]
-
-
-class Extensions2(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    neutral_sncf: NeutralSncf | None = None
-
-
-class NeutralSection(BaseModel):
-    """
-    Neutral sections are portions of track where trains aren't allowed to pull power from electrifications. They have to rely on inertia to cross such sections.
-
-    In practice, neutral sections are delimited by signs. In OSRD, neutral sections are directional to allow accounting for different sign placement depending on the direction.
-
-    For more details see [the documentation](https://osrd.fr/en/docs/explanation/neutral_sections/).
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    announcement_track_ranges: list[DirectionalTrackRange]
-    extensions: Extensions2 | None = None
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    lower_pantograph: bool
-    track_ranges: list[DirectionalTrackRange]
 
 
 class ObjectRef(BaseModel):
@@ -5102,15 +4800,19 @@ class OccupancyBlockForm(BaseModel):
     timetable_id: int
 
 
-class OperationalPoint(BaseModel):
+class OperationalPointExtensions(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    extensions: Extensions3 | None = None
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    parts: list[OperationalPointPart]
-    plc: NonBlankString | None = None
-    weight: Annotated[int | None, Field(ge=0)] = None
+    identifier: Identifier1 | None = None
+    sncf: OperationalPointSncfExtension | None = None
+
+
+class OperationalPointPartExtension(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    sncf: OperationalPointPartSncfExtension | None = None
 
 
 class OperationalPointPartReference(BaseModel):
@@ -5304,10 +5006,6 @@ class ProjectWithStudies(Project):
     studies_count: Annotated[int, Field(ge=0)]
 
 
-class RelatedOperationalPointPart(OperationalPointPart):
-    geo: GeoJsonPoint | None = None
-
-
 class Route(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5431,6 +5129,13 @@ class SearchResultItemSignal(BaseModel):
     sprite_signaling_system: str | None = None
 
 
+class SignalExtensions(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    sncf: SignalSncfExtension | None = None
+
+
 class FinalOutput(CoreReportTrain):
     """
     Simulation that takes into account the regularity margins and the schedule item times
@@ -5460,6 +5165,13 @@ class SimulationResponseSuccess(BaseModel):
     """
     Simulation that takes into account the regularity margins
     """
+
+
+class SpeedSectionExtensions(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    psl_sncf: SpeedSectionPslSncfExtension | None = None
 
 
 class StdcmProgressionEvent(BaseModel):
@@ -5558,15 +5270,19 @@ class SupportedSignalingSystemEtcsLevel2(BaseModel):
     type: Literal["ETCS_LEVEL2"]
 
 
-class Switch(BaseModel):
+class SwitchExtensions(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    extensions: Extensions8 | None = None
-    group_change_delay: float
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    ports: dict[str, TrackEndpoint]
-    switch_type: Annotated[str, Field(max_length=255, min_length=1)]
+    sncf: SwitchSncfExtension | None = None
+
+
+class TrackSectionExtensions(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    sncf: TrackSectionSncfExtension | None = None
+    source: Source | None = None
 
 
 class TrainCategoryMain(BaseModel):
@@ -5581,6 +5297,34 @@ class WorkSchedule(BaseModel):
     track_ranges: list[TrackRange]
     work_schedule_group_id: int
     work_schedule_type: WorkScheduleType
+
+
+class BufferStop(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    extensions: BufferStopExtension | None = None
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    position: float
+    track: Annotated[str, Field(max_length=255, min_length=1)]
+
+
+class CoreETCSBrakingCurvesResponse(BaseModel):
+    conflicts: list[CoreETCSConflictCurves]
+    """
+    List of ETCS conflict braking curves associated to the train schedule's ETCS signals.
+    For each non-route delimiter (F) signal, the associated spacing conflict curve is returned.
+    For each route delimiter (Nf) signal, 2 sets of curves are returned, associated to the
+    corresponding potential spacing or routing conflict.
+    """
+    slowdowns: list[CoreETCSCurves]
+    """
+    List of ETCS braking curves associated to the train schedule's ETCS slowdowns
+    """
+    stops: list[CoreETCSCurves]
+    """
+    List of ETCS braking curves associated to the train schedule's ETCS stops
+    """
 
 
 class CoreIncompatibleConstraints(BaseModel):
@@ -5732,6 +5476,16 @@ class CoreStdcmRequest(BaseModel):
     """
 
 
+class Detector(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    extensions: DetectorExtension | None = None
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    position: float
+    track: Annotated[str, Field(max_length=255, min_length=1)]
+
+
 class EffortCurves(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5880,24 +5634,19 @@ class InfraErrorType(
     )
 
 
-class InfraObjectNeutralSection(BaseModel):
-    obj_type: Literal["NeutralSection"]
-    railjson: NeutralSection
+class InfraObjectDetector(BaseModel):
+    obj_type: Literal["Detector"]
+    railjson: Detector
 
 
-class InfraObjectSwitch(BaseModel):
-    obj_type: Literal["Switch"]
-    railjson: Switch
+class InfraObjectBufferStop(BaseModel):
+    obj_type: Literal["BufferStop"]
+    railjson: BufferStop
 
 
 class InfraObjectRoute(BaseModel):
     obj_type: Literal["Route"]
     railjson: Route
-
-
-class InfraObjectOperationalPoint(BaseModel):
-    obj_type: Literal["OperationalPoint"]
-    railjson: OperationalPoint
 
 
 class InfraObjectLevelCrossing(BaseModel):
@@ -5968,6 +5717,13 @@ class MacroNoteListResponse(PaginationStats):
     results: list[MacroNoteResponse]
 
 
+class NeutralSectionExtensions(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    neutral_sncf: NeutralSectionNeutralSncfExtension | None = None
+
+
 class OperationUpdate(BaseModel):
     obj_id: str
     obj_type: ObjectType
@@ -5983,6 +5739,19 @@ class OperationUpdate(BaseModel):
     Representation of JSON Patch (list of patch operations)
     """
     operation_type: Literal["UPDATE"]
+
+
+class OperationalPointPart(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    extensions: OperationalPointPartExtension | None = None
+    local_track_name: Annotated[str, Field(min_length=1)]
+    position: float
+    """
+    Offset on the track section, in m
+    """
+    track: Annotated[str, Field(max_length=255, min_length=1)]
 
 
 class Patch(
@@ -6032,6 +5801,33 @@ class PathItem(BaseModel):
     """
 
 
+class OperationalPoint2(BaseModel):
+    """
+    Operational point along a path.
+    """
+
+    extensions: OperationalPointExtensions | None = None
+    """
+    Extensions associated to the operational point
+    """
+    id: str
+    """
+    Id of the operational point
+    """
+    part: OperationalPointPart
+    """
+    The part along the path
+    """
+    position: Annotated[int, Field(ge=0)]
+    """
+    Distance from the beginning of the path in mm
+    """
+    weight: Annotated[int | None, Field(ge=0, le=100)] = None
+    """
+    Importance of the operational point
+    """
+
+
 class PathProperties(BaseModel):
     """
     Properties along a path. Each property is optional since it depends on what the user requests.
@@ -6071,12 +5867,8 @@ class PathfindingResultSuccess(CorePathfindingResultSuccess):
     status: Literal["success"]
 
 
-class RelatedOperationalPoint(BaseModel):
-    extensions: Extensions5 | None = None
+class RelatedOperationalPointPart(OperationalPointPart):
     geo: GeoJsonPoint | None = None
-    id: Annotated[str, Field(max_length=255, min_length=1)]
-    parts: list[RelatedOperationalPointPart]
-    weight: Annotated[int | None, Field(ge=0)] = None
 
 
 class RollingStock(BaseModel):
@@ -6249,6 +6041,19 @@ class SearchResultItemTrainSchedule(BaseModel):
     train_schedule_set_id: int
 
 
+class Signal(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    direction: Direction
+    extensions: SignalExtensions | None = None
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    logical_signals: list[LogicalSignal] | None = None
+    position: float
+    sight_distance: float
+    track: Annotated[str, Field(max_length=255, min_length=1)]
+
+
 class ResponseSuccess(SimulationResponseSuccess):
     status: Literal["success"]
 
@@ -6259,6 +6064,18 @@ class SummaryResponsePathfindingInputError(BaseModel):
     """
 
     status: Literal["pathfinding_input_error"]
+
+
+class SpeedSection(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    extensions: SpeedSectionExtensions | None = None
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    on_routes: list[OnRoute] | None = None
+    speed_limit: float | None = None
+    speed_limit_by_tag: dict[str, float]
+    track_ranges: list[ApplicableDirectionsTrackRange]
 
 
 class StdcmResponseSuccess(BaseModel):
@@ -6280,12 +6097,23 @@ class StdcmResponseInternalError(BaseModel):
     status: Literal["internal_error"]
 
 
+class Switch(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    extensions: SwitchExtensions | None = None
+    group_change_delay: float
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    ports: dict[str, TrackEndpoint]
+    switch_type: Annotated[str, Field(max_length=255, min_length=1)]
+
+
 class TrackSectionModel(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     curves: list[Curve]
-    extensions: Extensions9 | None = None
+    extensions: TrackSectionExtensions | None = None
     geo: GeoJsonLineString
     id: Annotated[str, Field(max_length=255, min_length=1)]
     length: float
@@ -6396,44 +6224,49 @@ class InfraObjectTrackSection(BaseModel):
     railjson: TrackSectionModel
 
 
-class InfraObject(
-    RootModel[
-        InfraObjectTrackSection
-        | InfraObjectSignal
-        | InfraObjectNeutralSection
-        | InfraObjectSpeedSection
-        | InfraObjectSwitch
-        | InfraObjectSwitchType
-        | InfraObjectDetector
-        | InfraObjectBufferStop
-        | InfraObjectRoute
-        | InfraObjectOperationalPoint
-        | InfraObjectElectrification
-        | InfraObjectLevelCrossing
-    ]
-):
-    root: (
-        InfraObjectTrackSection
-        | InfraObjectSignal
-        | InfraObjectNeutralSection
-        | InfraObjectSpeedSection
-        | InfraObjectSwitch
-        | InfraObjectSwitchType
-        | InfraObjectDetector
-        | InfraObjectBufferStop
-        | InfraObjectRoute
-        | InfraObjectOperationalPoint
-        | InfraObjectElectrification
-        | InfraObjectLevelCrossing
+class InfraObjectSignal(BaseModel):
+    obj_type: Literal["Signal"]
+    railjson: Signal
+
+
+class InfraObjectSpeedSection(BaseModel):
+    obj_type: Literal["SpeedSection"]
+    railjson: SpeedSection
+
+
+class InfraObjectSwitch(BaseModel):
+    obj_type: Literal["Switch"]
+    railjson: Switch
+
+
+class NeutralSection(BaseModel):
+    """
+    Neutral sections are portions of track where trains aren't allowed to pull power from electrifications. They have to rely on inertia to cross such sections.
+
+    In practice, neutral sections are delimited by signs. In OSRD, neutral sections are directional to allow accounting for different sign placement depending on the direction.
+
+    For more details see [the documentation](https://osrd.fr/en/docs/explanation/neutral_sections/).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
     )
+    announcement_track_ranges: list[DirectionalTrackRange]
+    extensions: NeutralSectionExtensions | None = None
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    lower_pantograph: bool
+    track_ranges: list[DirectionalTrackRange]
 
 
-class OperationCreate(BaseModel):
-    operation_type: Literal["CREATE"]
-
-
-class Operation(RootModel[OperationCreate | OperationUpdate | OperationDelete]):
-    root: OperationCreate | OperationUpdate | OperationDelete
+class OperationalPoint(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    extensions: OperationalPointExtensions | None = None
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    parts: list[OperationalPointPart]
+    plc: NonBlankString | None = None
+    weight: Annotated[int | None, Field(ge=0)] = None
 
 
 class PathAndScheduleChangeGroup(BaseModel):
@@ -6515,6 +6348,14 @@ class RailJson(BaseModel):
     """
     The version of the RailJSON format. Defaults to the current version.
     """
+
+
+class RelatedOperationalPoint(BaseModel):
+    extensions: OperationalPointExtensions | None = None
+    geo: GeoJsonPoint | None = None
+    id: Annotated[str, Field(max_length=255, min_length=1)]
+    parts: list[RelatedOperationalPointPart]
+    weight: Annotated[int | None, Field(ge=0)] = None
 
 
 class SearchResultItem(
@@ -6617,6 +6458,48 @@ class TrainScheduleSimulationSummaryResult(BaseModel):
     )
 
 
+class InfraObjectNeutralSection(BaseModel):
+    obj_type: Literal["NeutralSection"]
+    railjson: NeutralSection
+
+
+class InfraObjectOperationalPoint(BaseModel):
+    obj_type: Literal["OperationalPoint"]
+    railjson: OperationalPoint
+
+
+class InfraObject(
+    RootModel[
+        InfraObjectTrackSection
+        | InfraObjectSignal
+        | InfraObjectNeutralSection
+        | InfraObjectSpeedSection
+        | InfraObjectSwitch
+        | InfraObjectSwitchType
+        | InfraObjectDetector
+        | InfraObjectBufferStop
+        | InfraObjectRoute
+        | InfraObjectOperationalPoint
+        | InfraObjectElectrification
+        | InfraObjectLevelCrossing
+    ]
+):
+    root: (
+        InfraObjectTrackSection
+        | InfraObjectSignal
+        | InfraObjectNeutralSection
+        | InfraObjectSpeedSection
+        | InfraObjectSwitch
+        | InfraObjectSwitchType
+        | InfraObjectDetector
+        | InfraObjectBufferStop
+        | InfraObjectRoute
+        | InfraObjectOperationalPoint
+        | InfraObjectElectrification
+        | InfraObjectLevelCrossing
+    )
+
+
 class InfraObjectWithGeometry(BaseModel):
     geographic: (
         GeoJsonPoint
@@ -6631,6 +6514,14 @@ class InfraObjectWithGeometry(BaseModel):
     """
     obj_id: str
     railjson: dict[str, Any]
+
+
+class OperationCreate(BaseModel):
+    operation_type: Literal["CREATE"]
+
+
+class Operation(RootModel[OperationCreate | OperationUpdate | OperationDelete]):
+    root: OperationCreate | OperationUpdate | OperationDelete
 
 
 class PacedTrainException(BaseModel):


### PR DESCRIPTION
Several utoipa types are already declared as named openapi schemas (`CoreConflictType`, `CoreSimpleEnvelope`, and the `*Extensions` / `*SncfExtension` structs on each infra entity), but `#[schema(inline)]` on every use site was forcing utoipa to emit anonymous inline copies.
Downstream `datamodel-codegen` then produced duplicate classes in the generated python schemas: `ConflictType` / `ConflictType1` on the `conflict_type` fields, `Guidance` / `Indication` / `PermittedSpeed` (each with a "1" twin) on the `ETCSCurves` and `ETCSConflictCurves` envelopes, and `Extensions` / `Extensions1..9` plus `Sncf` / `Sncf2..8` on the infra extensions.
Drop the inline attribute everywhere so all use sites reference the named schema via `$ref` and the generated client names stay stable.