### PR TITLE
front: fix track name for track_offset path steps tied to an OP

### DIFF
--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -278,8 +278,7 @@ const useTimesStopsTableData = (
         // the stableOPs fallback never applies for those since it requires 'operational_point' in location.
         const trackName =
           pathStepLocation.type === 'track_offset'
-            ? pathStepOp?.parts.find((part) => part.track === pathStepLocation.track)
-                ?.local_track_name
+            ? trackSections[pathStepLocation.track]?.extensions?.sncf?.track_name
             : (pathStepLocation.local_track_name ?? undefined);
 
         const hasRequestedTrack =


### PR DESCRIPTION
closes #16663

I used the [same logic](https://github.com/OpenRailAssociation/osrd/blob/4e5d66171757c0c6e4748289d33f8d5519544c15/front/src/modules/timesStops/hooks/useOutputTableData.ts#L85) in` useOutputTableData.ts`, which was missing handling for the requested points