### PR TITLE
gateway: fix map viewer disabling decompression on gateway side

### DIFF
--- a/gateway/actix_proxy/src/lib.rs
+++ b/gateway/actix_proxy/src/lib.rs
@@ -463,6 +463,8 @@ impl InnerProxyService {
             modifier.modify_http_request(req, &mut back_request)?;
         }
 
+        back_request = back_request.no_decompress();
+
         {
             // forward request headers
             let header_classifier = HeaderClassifier::from_headermap(req.headers());


### PR DESCRIPTION
This fixes maps.

The new way to compress tiles was working when editoast was running without docker, cause:
- With docker, the frontend was using `localhost:4000/api/layer/...`, which is the gateway
- Without docker, the frontend was using `localhost:8090/layer/...`, which is editoast.

What was happening, editoast was sending a compressed payload to the gateway an the gateway was:
1. Decompressing the payload
2. Keeping the header

From the frontend point of view the body was not gziped as expected.


> [!IMPORTANT]
> The fact that we did not trigger this bug before explicitely sending compressed payload from editoast means that all other payload sent by editoast are probably never compressed :exploding_head: 
> If that's the case, it's a problem for performance and networking...