### PR TITLE
front: upgrade NGE with Angular v18

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.d39ba24afcec290f16002911ea46f1283beb402c",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3509,9 +3509,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4.tgz",
-      "integrity": "sha512-UNU1ofG+/JypqLrwn5lBPXbLI/JSuAGint/rQsJK4QtpAXfebXI/iWXkHgrqx8yPm2j5e+8g4uNSkAMskOVubg=="
+      "version": "0.0.0-snapshot.d39ba24afcec290f16002911ea46f1283beb402c",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.d39ba24afcec290f16002911ea46f1283beb402c.tgz",
+      "integrity": "sha512-o1mUzopRPhtWm63lA4QAPceORjXrgaJNo10Gr7No5Pja4i+NoCyqCSntNdRdQpOUFf7EwkvADZuke8V/P2dgsw=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.67f493cf2502e26b42381bb91451aa525593a7c4",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.d39ba24afcec290f16002911ea46f1283beb402c",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",

--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
@@ -1,12 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 
-/* eslint-disable import/extensions */
-import ngeMain from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/main.js?url';
-import ngePolyfills from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/polyfills.js?url';
-import ngeRuntime from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/runtime.js?url';
-import ngeStyles from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/styles.css?url';
-import ngeVendor from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/vendor.js?url';
-/* eslint-enable import/extensions */
 import { useTranslation } from 'react-i18next';
 
 import { EMPTY_DTO } from './consts';
@@ -28,11 +21,9 @@ const frameSrc = `
 <html class="sbb-lean sbb-light">
   <head>
     <base href="/netzgrafik-frontend/">
-    <link rel="stylesheet" href="${ngeStyles}"></link>
-    <script type="module" src="${ngeRuntime}"></script>
-    <script type="module" src="${ngePolyfills}"></script>
-    <script type="module" src="${ngeVendor}"></script>
-    <script type="module" src="${ngeMain}"></script>
+    <link rel="stylesheet" href="/netzgrafik-frontend/styles.css"></link>
+    <script type="module" src="/netzgrafik-frontend/polyfills.js"></script>
+    <script type="module" src="/netzgrafik-frontend/main.js"></script>
   </head>
   <body></body>
 </html>

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -50,11 +50,13 @@ export default defineConfig(({ mode }) => {
       viteStaticCopy({
         targets: [
           {
-            src: [
-              path.join(ngeBase, 'node_modules_angular_common_locales_*_mjs.js'),
-              path.join(ngeBase, 'src_assets_i18n_*_json.js'),
-            ],
+            src: [path.join(ngeBase, '*')],
             dest: 'netzgrafik-frontend/',
+            rename: { stripBase: true },
+          },
+          {
+            src: [path.join(ngeBase, 'assets/i18n/*')],
+            dest: 'netzgrafik-frontend/assets/i18n/',
             rename: { stripBase: true },
           },
         ],


### PR DESCRIPTION
Latest NGE has upgraded Angular to v18. This new version produces a different build output:

- main.js now loads a tiny chunk with an import statement. I haven't found a way to get rid of this chunk. Additionally, the chunk doesn't have a predictable filename regardless of the outputHashing: "none" Angular setting. Unfortunately for us, that means we need to load main.js from the same directory as the chunk file. We can't import it anymore.
- Translation files are no longer placed at the top-level directory. They are stored in an assets/i18n/ subdirectory. We need to keep this directory structure when copying. vite-plugin-static-copy has… a creative way to specify options, and doesn't allow one to copy a directory structure in a convenient way, e.g. like the venerable cp command does. Add a new target to work around this creativity.