### PR TITLE
front: bump typescript-eslint from 8.58.2 to 8.59.2

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -136,7 +136,7 @@
         "tslib": "^2.8.1",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.58.2",
+        "typescript-eslint": "^8.59.2",
         "vite": "^8.0.10",
         "vite-plugin-checker": "^0.13.0",
         "vite-plugin-static-copy": "^4.1.0",
@@ -5808,7 +5808,7 @@
       "dependencies": {
         "@emnapi/core": "^1.8.1",
         "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
+        "@emnapi/wasi-threads": "^1.2.0",
         "@napi-rs/wasm-runtime": "^1.1.1",
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
@@ -6105,14 +6105,6 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
-      }
-    },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -6958,17 +6950,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -6981,7 +6973,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -6997,16 +6989,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -7022,14 +7014,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -7044,14 +7036,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7062,9 +7054,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7079,15 +7071,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -7104,9 +7096,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7118,16 +7110,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -7162,16 +7154,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7186,13 +7178,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -9884,7 +9876,9 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "4.0.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -13864,7 +13858,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16294,16 +16290,18 @@
       "license": "CC0-1.0"
     },
     "node_modules/postcss-svgo/node_modules/svgo": {
-      "version": "2.8.0",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
+        "sax": "^1.5.0",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -18543,16 +18541,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19847,7 +19845,7 @@
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-postcss": "^4.0.2",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.58.2",
+        "typescript-eslint": "^8.59.2",
         "vitest": "^4.1.5"
       },
       "engines": {

--- a/front/package.json
+++ b/front/package.json
@@ -136,7 +136,7 @@
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.58.2",
+    "typescript-eslint": "^8.59.2",
     "vite": "^8.0.10",
     "vite-plugin-checker": "^0.13.0",
     "vite-plugin-static-copy": "^4.1.0",

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -365,7 +365,7 @@ const Editor = () => {
   }, [infra]);
 
   return (
-    <EditorContext.Provider value={extendedContext as EditorContextType<unknown>}>
+    <EditorContext.Provider value={extendedContext}>
       <main
         className={cx('editor-root mastcontainer mastcontainer-map', infraID && 'infra-selected')}
       >

--- a/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
@@ -13,7 +13,6 @@ import { flattenEntity } from 'applications/editor/data/utils';
 import type {
   ElectrificationEntity,
   RangeEditionState,
-  TrackState,
 } from 'applications/editor/tools/rangeEdition/types';
 import { getTrackRangeFeatures, isOnModeMove } from 'applications/editor/tools/rangeEdition/utils';
 import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/types';
@@ -96,7 +95,7 @@ export const ElectrificationEditionLayers = () => {
             ...s,
             trackSectionsCache: {
               ...s.trackSectionsCache,
-              ...mapValues(res, (track) => ({ type: 'success', track }) as TrackState),
+              ...mapValues(res, (track) => ({ type: 'success' as const, track })),
             },
           }));
         }

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -15,7 +15,6 @@ import type {
   PslSignFeature,
   RangeEditionState,
   SpeedSectionEntity,
-  TrackState,
 } from 'applications/editor/tools/rangeEdition/types';
 import {
   generatePslSignFeatures,
@@ -167,7 +166,7 @@ export const SpeedSectionEditionLayers = () => {
             ...s,
             trackSectionsCache: {
               ...s.trackSectionsCache,
-              ...mapValues(res, (track) => ({ type: 'success', track }) as TrackState),
+              ...mapValues(res, (track) => ({ type: 'success' as const, track })),
             },
           }));
         }

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLeftPanel.tsx
@@ -21,7 +21,7 @@ import {
   speedSectionIsPsl,
   speedSectionIsSpeedRestriction,
 } from 'applications/editor/tools/rangeEdition/utils';
-import type { ExtendedEditorContextType, PartialOrReducer } from 'applications/editor/types';
+import type { ExtendedEditorContextType } from 'applications/editor/types';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import CheckboxRadioSNCF from 'common/BootstrapSNCF/CheckboxRadioSNCF';
 import { useInfraID } from 'common/osrdContext';
@@ -274,11 +274,7 @@ const SpeedSectionEditionLeftPanel = () => {
         {!isSpeedRestriction && isPermanentSpeedLimit && (
           <EditPSLSection
             entity={entity as SpeedSectionPslEntity}
-            setState={
-              setState as (
-                stateOrReducer: PartialOrReducer<RangeEditionState<SpeedSectionEntity>>
-              ) => void
-            }
+            setState={setState}
             trackSectionsCache={trackSectionsCache}
           />
         )}

--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -17,7 +17,6 @@ import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { save } from 'reducers/editor/thunkActions';
 import { getNearestPoint } from 'utils/mapHelper';
 
-import type { OptionsStateType } from '../routeEdition/types';
 import type {
   HoveredExtremityState,
   HoveredSignState,
@@ -29,7 +28,6 @@ import type {
   SpeedSectionPslEntity,
   SpeedSectionEntity,
   ElectrificationEntity,
-  InteractionState,
 } from './types';
 import {
   getPslSignNewPosition,
@@ -74,9 +72,9 @@ function getRangeEditionTool<T extends EditorRange>({
       entity,
       initialEntity: entity,
       hoveredItem: null,
-      interactionState: { type: 'idle' } as InteractionState,
+      interactionState: { type: 'idle' },
       trackSectionsCache: {},
-      optionsState: { type: 'idle' } as OptionsStateType,
+      optionsState: { type: 'idle' },
       selectedSwitches: {},
       highlightedRoutes: [],
       routeElements: {},

--- a/front/src/applications/editor/tools/rangeEdition/utils.ts
+++ b/front/src/applications/editor/tools/rangeEdition/utils.ts
@@ -14,10 +14,7 @@ import {
   getTrackSectionEntityFromNearestPoint,
 } from 'applications/editor/tools/utils';
 import type { PartialOrReducer } from 'applications/editor/types';
-import type {
-  ApplicableDirections,
-  GetInfraByInfraIdRoutesTrackRangesApiResponse,
-} from 'common/api/osrdEditoastApi';
+import type { GetInfraByInfraIdRoutesTrackRangesApiResponse } from 'common/api/osrdEditoastApi';
 import { getNearestPoint } from 'utils/mapHelper';
 
 import type {
@@ -109,13 +106,11 @@ export function getNewSpeedSection(): SpeedSectionEntity {
 /** return the PSL sign type and its index (if the sign is not a Z sign) */
 export function getSignInformationFromInteractionState(
   interactionState: { type: 'moveSign' } & PslSignInformation
-) {
+): PslSignInformation {
   const { signType } = interactionState;
-  return (
-    signType === PSL_SIGN_TYPES.Z
-      ? { signType: PSL_SIGN_TYPES.Z }
-      : { signType, signIndex: interactionState.signIndex }
-  ) as PslSignInformation;
+  return signType === PSL_SIGN_TYPES.Z
+    ? { signType: PSL_SIGN_TYPES.Z }
+    : { signType, signIndex: interactionState.signIndex };
 }
 
 function getNewPslExtension(
@@ -383,7 +378,7 @@ export const makeSpeedRestrictionTrackRanges = (
   }
   const trackRangesWithBothDirections = zoneTrackRanges.map<ApplicableTrackRange>((tr) => ({
     ...tr,
-    applicable_directions: 'BOTH' as ApplicableDirections,
+    applicable_directions: 'BOTH',
   }));
   return { trackRangesWithBothDirections, returnedExtra };
 };

--- a/front/src/applications/editor/tools/routeEdition/components/RouteEditionLayers.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/RouteEditionLayers.tsx
@@ -31,7 +31,7 @@ import {
 import { colors } from 'common/Map/theme';
 import { useInfraID } from 'common/osrdContext';
 import { useAppDispatch } from 'store';
-import { NULL_GEOMETRY, type OmitLayer, type NullGeometry } from 'types';
+import { NULL_GEOMETRY, type NullGeometry } from 'types';
 
 const RouteEditionLayers = () => {
   const {
@@ -79,16 +79,18 @@ const RouteEditionLayers = () => {
    */
   const lineProps = useMemo(() => {
     const layer = getRoutesLineLayerProps({ colors: colors[mapStyle] });
+    const linePaint: LineLayerSpecification['paint'] = {
+      ...layer.paint,
+      'line-color': ['get', 'color'],
+      'line-width': 2,
+      'line-dasharray': [2, 1],
+      'line-offset': ['get', 'offset'],
+    };
+
     return {
       ...layer,
-      paint: {
-        ...layer.paint,
-        'line-color': ['get', 'color'],
-        'line-width': 2,
-        'line-dasharray': [2, 1],
-        'line-offset': ['get', 'offset'],
-      },
-    } as OmitLayer<LineLayerSpecification>;
+      paint: linePaint,
+    };
   }, [mapStyle]);
 
   /**

--- a/front/src/applications/editor/tools/trackEdition/components/TrackEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components/TrackEditionLeftPanel.tsx
@@ -149,7 +149,7 @@ const TrackEditionLeftPanel = () => {
           }
           setState({
             ...state,
-            track: checkedTrack as TrackSectionEntity,
+            track: checkedTrack,
           });
         }}
       >

--- a/front/src/applications/editor/tools/trackEdition/tool.tsx
+++ b/front/src/applications/editor/tools/trackEdition/tool.tsx
@@ -374,9 +374,8 @@ const TrackEditionTool: Tool<TrackEditionState> = {
 
     if (editionState.type === 'movePoint' && typeof editionState.draggedPointIndex === 'number') {
       const newTrack = cloneDeep(track);
-      newTrack.geometry.coordinates[editionState.draggedPointIndex] = (
-        anchorLinePoints && nearestPoint ? nearestPoint.geometry.coordinates : e.lngLat.toArray()
-      ) as [number, number];
+      newTrack.geometry.coordinates[editionState.draggedPointIndex] =
+        anchorLinePoints && nearestPoint ? nearestPoint.geometry.coordinates : e.lngLat.toArray();
 
       newState.track = entityDoUpdate(newTrack, track.geometry);
     }

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/useImportTrainSchedules.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/useImportTrainSchedules.ts
@@ -39,7 +39,7 @@ const useImportTrainSchedules = ({ upsertTrainSchedules }: ImportTrainSchedulesP
       return await locallyProcessXmlFile(fileContent);
     }
     try {
-      return (await postTransformTimetable({ body: file }).unwrap()) as TimetableJsonPayload;
+      return await postTransformTimetable({ body: file }).unwrap();
     } catch (error: unknown) {
       if (isObject(error) && 'status' in error && error.status === '415')
         return await locallyProcessXmlFile(fileContent);

--- a/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
+++ b/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
@@ -6,7 +6,7 @@ import { compact, isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import type { ConditionalEffortCurve, RollingStock, Comfort } from 'common/api/osrdEditoastApi';
+import type { RollingStock, Comfort } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import Selector from 'common/Selector';
 import {
@@ -198,7 +198,7 @@ const CurveParamSelectors = ({
     value: string | Comfort
   ) => {
     if (!effortCurves) return;
-    const condKey = title as keyof ConditionalEffortCurve['cond'];
+    const condKey = title;
 
     const updatedModesCurves = Object.keys(effortCurves).reduce((acc, mode) => {
       const cleanedList = effortCurves[mode].curves.filter(

--- a/front/src/applications/rollingStockEditor/consts.ts
+++ b/front/src/applications/rollingStockEditor/consts.ts
@@ -56,7 +56,7 @@ export const newRollingStockValues: RollingStockParametersValues = {
     unit: 'kN/(km/h)²',
     value: 0,
   },
-  loadingGauge: 'G1' as RollingStockParametersValues['loadingGauge'],
+  loadingGauge: 'G1',
   electricalPowerStartupTime: null,
   raisePantographTime: null,
   basePowerClass: null,

--- a/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
+++ b/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
@@ -37,7 +37,7 @@ const computeChartData = (
     formattedPowerRestrictions,
     simulation,
     formattedPathProperties,
-  } as SpeedDistanceDiagramData;
+  };
 };
 
 export default computeChartData;

--- a/front/src/common/IntervalsDataViz/data.ts
+++ b/front/src/common/IntervalsDataViz/data.ts
@@ -739,7 +739,7 @@ export function getFieldJsonSchema(
           },
         },
         definitions: rootSchema.definitions,
-      } as JSONSchema7;
+      };
     }
   }
   return result;

--- a/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
@@ -37,7 +37,7 @@ const IntervalsEditorMarginForm = ({
             setData(result);
           }
         }}
-        value={(interval.value as number) || 0}
+        value={Number(interval.value) || 0}
         noMargin
         sm
         textRight

--- a/front/src/common/Map/Layers/InfraObjectLayers/getKPLabelLayerProps.ts
+++ b/front/src/common/Map/Layers/InfraObjectLayers/getKPLabelLayerProps.ts
@@ -28,7 +28,7 @@ export default function getKPLabelLayerProps(params: {
   } = params;
 
   // Will have to be removed when backend will be updated with consistent fieldnames
-  const testSideExpression = (side: 'LEFT' | 'RIGHT' | 'CENTER') => [
+  const testSideExpression = (side: 'LEFT' | 'RIGHT' | 'CENTER'): ExpressionFilterSpecification => [
     'any',
     ['==', ['get', 'extensions_sncf_side'], side],
     ['==', ['get', 'side'], side],
@@ -41,17 +41,17 @@ export default function getKPLabelLayerProps(params: {
         'text-rotate': ['get', 'angle'],
         'text-anchor': [
           'case',
-          testSideExpression('LEFT') as ExpressionFilterSpecification,
+          testSideExpression('LEFT'),
           'right',
-          testSideExpression('RIGHT') as ExpressionFilterSpecification,
+          testSideExpression('RIGHT'),
           'left',
           'center',
         ],
         'text-offset': [
           'case',
-          testSideExpression('LEFT') as ExpressionFilterSpecification,
+          testSideExpression('LEFT'),
           ['literal', [-2.75, 0.2]],
-          testSideExpression('RIGHT') as ExpressionFilterSpecification,
+          testSideExpression('RIGHT'),
           ['literal', [2.75, 0.2]],
           ['literal', [0, bottomOffset]],
         ],

--- a/front/src/common/Map/Layers/useMapBlankStyle.ts
+++ b/front/src/common/Map/Layers/useMapBlankStyle.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import type { SpriteSpecification } from 'maplibre-gl';
 import type { MapProps } from 'react-map-gl/maplibre';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
@@ -57,8 +58,8 @@ const useMapBlankStyle = (): MapProps['mapStyle'] => {
     fetchData();
   }, [signalingSystems]);
 
-  const props = useMemo(() => {
-    const sprite = validSprites;
+  const props: MapProps['mapStyle'] = useMemo(() => {
+    const sprite: SpriteSpecification = validSprites;
     return {
       version: 8,
       name: 'Blank',
@@ -74,7 +75,7 @@ const useMapBlankStyle = (): MapProps['mapStyle'] => {
           },
         },
       ],
-    } as MapProps['mapStyle'];
+    };
   }, [validSprites]);
 
   return props;

--- a/front/src/common/Map/WarpedMap/core/grids.tsx
+++ b/front/src/common/Map/WarpedMap/core/grids.tsx
@@ -6,13 +6,7 @@ import length from '@turf/length';
 import type { Feature, LineString, Position } from 'geojson';
 import { clamp, cloneDeep, keyBy, meanBy } from 'lodash';
 
-import type {
-  GridFeature,
-  GridIndex,
-  Grids,
-  PointsGrid,
-  Triangle,
-} from 'common/Map/WarpedMap/core/helpers';
+import type { GridFeature, GridIndex, Grids, PointsGrid } from 'common/Map/WarpedMap/core/helpers';
 import vec, { type Vec2 } from 'common/Map/WarpedMap/core/vec-lib';
 import type { PolygonZone } from 'types';
 
@@ -53,7 +47,7 @@ export function featureToPointsGrid(grid: GridFeature, stepsCount: number): Poin
   return points;
 }
 function pointsGridToFeature(points: PointsGrid): GridFeature {
-  const grid = featureCollection([]) as GridFeature;
+  const grid: GridFeature = featureCollection([]);
   const steps = points.length - 1;
   const stripsPerSide = (Object.keys(points[0]).length - 1) / 2;
 
@@ -67,12 +61,12 @@ function pointsGridToFeature(points: PointsGrid): GridFeature {
         grid.features.push(
           polygon([[p00, p10, p01, p00]], {
             triangleId: `step:${i}/strip:${direction * (j + 1)}/inside`,
-          }) as Triangle
+          })
         );
         grid.features.push(
           polygon([[p11, p10, p01, p11]], {
             triangleId: `step:${i}/strip:${direction * (j + 1)}/outside`,
-          }) as Triangle
+          })
         );
       }
     }
@@ -130,7 +124,7 @@ export function getGrids(line: Feature<LineString>): Grids {
   const totalLength = length(line);
   const step = totalLength / (pointsCount - 1);
   const c = center(line);
-  const flatGrid = featureCollection([]) as GridFeature;
+  const flatGrid: GridFeature = featureCollection([]);
 
   /*
    * Generate flat line:

--- a/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
+++ b/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
@@ -190,7 +190,7 @@ const IncompatibleConstraints = ({
   const filteredGeojson = useMemo(() => {
     if (!geometry || filteredConstraints.length === 0)
       return featureCollection<LineString, { ids: string[] }>([]);
-    return getSegmentsConstraints(geometry as LineString, filteredConstraints);
+    return getSegmentsConstraints(geometry, filteredConstraints);
   }, [geometry, filteredConstraints]);
 
   if (total === 0) return null;

--- a/front/src/modules/rollingStock/components/RollingStockCurve.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCurve.tsx
@@ -125,7 +125,7 @@ export default function RollingStockCurve({
             isOnEditionMode
           );
           transformedCurves[curveName] = {
-            ...(curve.curve as { speeds: number[]; max_efforts: number[] }),
+            ...curve.curve,
             mode: name,
             comfort,
             electricalProfile: electrical_profile_level,

--- a/front/src/reducers/commonMap/index.ts
+++ b/front/src/reducers/commonMap/index.ts
@@ -3,7 +3,6 @@ import type { Position } from 'geojson';
 import { useSelector } from 'react-redux';
 
 import { useOsrdContext } from 'common/osrdContext';
-import type { RootState } from 'reducers';
 
 import type { LayersSettings, MapSettings, Viewport } from './types';
 
@@ -109,7 +108,7 @@ export const useMapSettings = (): MapSettings => {
     throw new Error('getMapSettings selector is not available in this context');
   }
 
-  return useSelector(selectors.getMapSettings as (state: RootState) => MapSettings);
+  return useSelector(selectors.getMapSettings);
 };
 
 export const useMapSettingsActions = () => {

--- a/front/src/reducers/editor/thunkActions.ts
+++ b/front/src/reducers/editor/thunkActions.ts
@@ -11,7 +11,7 @@ import {
   entityToUpdateOperation,
   entityToDeleteOperation,
 } from 'applications/editor/data/utils';
-import type { EditorEntity, EditorSchema } from 'applications/editor/typesEditorEntity';
+import type { EditorEntity } from 'applications/editor/typesEditorEntity';
 import type { Operation } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { setLoading, setSuccess, setFailure, setSuccessWithoutMessage } from 'reducers/main';
@@ -61,7 +61,7 @@ export function loadDataModel() {
                 ...refTarget,
                 [ref[1]]: schemaResponse[ref[1]],
               },
-            } as EditorSchema[0];
+            };
           });
         dispatch(setSuccessWithoutMessage());
         dispatch(loadDataModelAction(schema));

--- a/front/tests/utils/send-trains.ts
+++ b/front/tests/utils/send-trains.ts
@@ -61,7 +61,7 @@ const extractChangeGroups = (exception: ExceptionFormat): TrainScheduleException
       key,
       pacedException[key],
     ])
-  ) as TrainScheduleExceptionChangeGroups;
+  );
 };
 
 /**
@@ -95,7 +95,7 @@ async function sendTrains(
       if (train.paced?.exceptions) {
         exceptionsToCreate.push({
           trainIndex: index,
-          exceptions: train.paced.exceptions as ExceptionFormat[],
+          exceptions: train.paced.exceptions,
         });
       }
     });

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -5,11 +5,9 @@ import type {
   TrainSchedule,
   PostInfraRailjsonApiResponse,
   Project,
-  ProjectCreateForm,
   RailJson,
   StdcmSearchEnvironmentCreateForm,
   Study,
-  StudyCreateForm,
 } from 'common/api/osrdEditoastApi';
 
 import {
@@ -119,7 +117,7 @@ export async function createProject(projectName = globalProjectName): Promise<Pr
       ...PROJECT_DATA,
       name: projectName,
       budget: 1234567890,
-    } as ProjectCreateForm,
+    },
     undefined,
     'Failed to create project'
   );
@@ -142,7 +140,7 @@ export async function createStudy(projectId: number, studyName = globalStudyName
       project_id: projectId,
       name: studyName,
       budget: 1234567890,
-    } as StudyCreateForm,
+    },
     undefined,
     'Failed to create study'
   );

--- a/front/ui/base/package.json
+++ b/front/ui/base/package.json
@@ -33,7 +33,7 @@
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-postcss": "^4.0.2",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.58.2",
+    "typescript-eslint": "^8.59.2",
     "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
This PR bumps typescript-eslint to version ^8.59.2.

#### What was done:

- Upgraded typescript-eslint to ^8.59.2
- Removed a significant number of unnecessary casts
- Fixed resulting type errors by explicitly typing variables & functions