### PR TITLE
core: stdcm: remove mareco from final simulation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -10,7 +10,6 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceRange
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance
-import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance
 import fr.sncf.osrd.envelope_sim.pipelines.SimStop
 import fr.sncf.osrd.envelope_sim.pipelines.maxEffortEnvelopeFrom
 import fr.sncf.osrd.envelope_sim.pipelines.maxSpeedEnvelopeFrom
@@ -85,7 +84,6 @@ fun buildFinalEnvelope(
     blockAvailability: BlockAvailabilityInterface,
     stops: List<TrainStop>,
     updatedTimeData: TimeData,
-    isMareco: Boolean = true,
     attempt: Int = 0,
 ): FinalEnvelopeResult {
     val fullInfraExplorer = edges.last().infraExplorerWithNewEnvelope
@@ -129,7 +127,6 @@ fun buildFinalEnvelope(
                         envelopeSimPath,
                         consistChanges.map { it.rollingStock },
                         fixedPoints,
-                        isMareco,
                         timeStep,
                         comfort,
                     )
@@ -157,7 +154,6 @@ fun buildFinalEnvelope(
                     updatedTimeData,
                     fixedPoints,
                     conflictOffset,
-                    isMareco,
                     allowanceRanges,
                     attempt,
                 )
@@ -200,28 +196,7 @@ fun buildFinalEnvelope(
             } else throw e
         }
     }
-    if (!isMareco) {
-        throw RuntimeException(
-            "Failed to compute a standard allowance that wouldn't cause conflicts"
-        )
-    } else {
-        postProcessingLogger.warn(
-            "Failed to compute a mareco standard allowance, fallback to linear allowance"
-        )
-        return buildFinalEnvelope(
-            graph,
-            edges,
-            standardAllowance,
-            envelopeSimPath,
-            consistChanges,
-            timeStep,
-            comfort,
-            blockAvailability,
-            stops,
-            updatedTimeData,
-            false,
-        )
-    }
+    throw RuntimeException("Failed to compute a standard allowance that wouldn't cause conflicts")
 }
 
 /** Initialize all fixed points at stop locations, including stop durations. */
@@ -448,7 +423,6 @@ fun runSimulationWithFixedPoints(
     envelopeSimPath: PhysicsPath,
     rollingStocks: List<RollingStock>,
     fixedPoints: TreeSet<FixedTimePoint>,
-    isMareco: Boolean,
     timeStep: Double,
     comfort: Comfort?,
 ): List<Envelope> {
@@ -473,15 +447,7 @@ fun runSimulationWithFixedPoints(
         require(ranges.isNotEmpty()) {
             "There should be at least one allowance range, even if it's just a 0 allowance"
         }
-        val allowance =
-            if (isMareco)
-                MarecoAllowance(
-                    0.0,
-                    envelope.endPos,
-                    1.0, // Needs to be >0 to avoid problems when simulating low speeds
-                    ranges,
-                )
-            else LinearAllowance(0.0, envelope.endPos, 0.0, ranges)
+        val allowance = LinearAllowance(0.0, envelope.endPos, 0.0, ranges)
         val newEnvelope = allowance.apply(envelope, context)
         finalEnvelopes.add(newEnvelope)
         currentOffset += newEnvelope.endPos.meters
@@ -541,7 +507,6 @@ private fun handlePostProcessingConflict(
     updatedTimeData: TimeData,
     fixedPoints: TreeSet<FixedTimePoint>,
     conflictOffset: Offset<PhysicsPath>,
-    isMareco: Boolean,
     allowanceRanges: List<EngineeringAllowanceRange>,
     attempt: Int,
 ): FinalEnvelopeResult {
@@ -611,8 +576,7 @@ private fun handlePostProcessingConflict(
             "attempt $attempt: retrying after adding traction to rolling stock..."
         )
         postProcessingLogger.info("(reset of fixed time points)")
-        // First retry by removing mareco, then by increasing rolling stock traction
-        val scaleFactor = if (isMareco) 1.0 else 1.2
+        val scaleFactor = 1.2
         val newRollingStock =
             consistChanges.map { it.copy(rollingStock = it.rollingStock.scalePower(scaleFactor)) }
         return buildFinalEnvelope(
@@ -626,7 +590,6 @@ private fun handlePostProcessingConflict(
             blockAvailability,
             stops,
             updatedTimeData,
-            isMareco = false,
             attempt = attempt + 1,
         )
     } else {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/PostProcessingSimulationTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/PostProcessingSimulationTests.kt
@@ -84,7 +84,6 @@ class PostProcessingSimulationTests {
                 envelopeSimPath = physicsPath,
                 rollingStocks = rollingStocks,
                 fixedPoints = TreeSet(fixedPoints),
-                isMareco = true,
                 timeStep = DEFAULT_TIME_STEP.seconds,
                 comfort = null,
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
+import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockLocation
@@ -8,6 +9,8 @@ import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import kotlin.math.roundToInt
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -532,6 +535,52 @@ class StandardAllowanceTests {
 
         // We need a high tolerance because there are several binary searches
         checkAllowanceResult(res, allowance, 4 * TIME_STEP)
+    }
+
+    /**
+     * Test that the 5% standard allowance is properly distributed over the entire path: for any
+     * pair of points on the path, the added time must be within 3 and 7 extra percents (5 +- 2).
+     * These are magic number, but fit the French rules.
+     */
+    @Test
+    fun testStandardAllowanceDistribution() {
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                // Large changes in the MRSP, with blocks long enough to speed up and slow down
+                infra.addBlock("a", "b", length = 10_000.meters, allowedSpeed = 20.0),
+                infra.addBlock("b", "c", length = 10_000.meters, allowedSpeed = 50.0),
+                infra.addBlock("c", "d", length = 10_000.meters, allowedSpeed = 30.0),
+                infra.addBlock("d", "e", length = 10_000.meters, allowedSpeed = 50.0),
+                infra.addBlock("e", "f", length = 10_000.meters, allowedSpeed = 20.0),
+            )
+        val builder =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(BlockLocation(blocks[0], Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(blocks.last(), Offset(10_000.meters))))
+                .setStandardAllowance(AllowanceValue.Percentage(5.0))
+        val res = runWithAndWithoutAllowance(builder)
+        val step = 1_000
+        val envelopeWithAllowances = res.withAllowance!!.envelope
+        val fastestEnvelope = res.withoutAllowance!!.envelope
+        for (start in 0..envelopeWithAllowances.endPos.roundToInt() step step) {
+            for (end in (start + step)..envelopeWithAllowances.endPos.roundToInt() step step) {
+                fun getTime(envelope: Envelope): Double {
+                    return envelope.interpolateArrivalAtClamp(end.toDouble()) -
+                        envelope.interpolateArrivalAtClamp(start.toDouble())
+                }
+                val baseTime = getTime(fastestEnvelope)
+                val withAllowance = getTime(envelopeWithAllowances)
+
+                // between 3% and 7% for a target of 5%,
+                // these are standard values
+                val minAllowedTime = baseTime * 1.03
+                val maxAllowedTime = baseTime * 1.07
+                assertTrue { withAllowance >= minAllowedTime }
+                assertTrue { withAllowance <= maxAllowedTime }
+            }
+        }
     }
 
     companion object {

--- a/front/tests/assets/constants/stdcm/simulation-sheet-const.ts
+++ b/front/tests/assets/constants/stdcm/simulation-sheet-const.ts
@@ -77,7 +77,7 @@ const simulationSheetDetails = (): PdfSimulationContent => ({
         name: '3 Mid_East_station',
         ch: 'BV',
         track: 'V1',
-        passageTime: '20:38',
+        passageTime: '20:40',
         tonnage: '=',
         length: '=',
       },

--- a/front/tests/assets/stdcm/linked-train/posterior-linked-train-table.json
+++ b/front/tests/assets/stdcm/linked-train/posterior-linked-train-table.json
@@ -15,7 +15,7 @@
     "operationalPoint": "Mid_East_station",
     "code": "BV",
     "track": "V1",
-    "endStop": "12:38",
+    "endStop": "12:37",
     "passageStop": "3 min",
     "startStop": "12:41",
     "weight": "=",

--- a/front/tests/assets/stdcm/stdcm-with-all-via.json
+++ b/front/tests/assets/stdcm/stdcm-with-all-via.json
@@ -25,7 +25,7 @@
     "code": "BV",
     "track": "V1",
     "endStop": "",
-    "passageStop": "20:38",
+    "passageStop": "20:40",
     "startStop": "",
     "weight": "=",
     "refEngine": "="


### PR DESCRIPTION
We've been asked to make allowances more regularly distributed over the path. It will also reduce the amount of errors and the post-processing computation time. 

Also include a new unit test where we check that the allowance is within 2% for any pair of points, this test fails when using mareco.

(now I just have to fix the e2e tests)