### PR TITLE
nix: update the flake for playwright

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1777538343,
-        "narHash": "sha256-tW6Szt8/FmRTEi3KdB2TAwZZ3jEwjDD74zIL7uGLsgk=",
+        "lastModified": 1778576139,
+        "narHash": "sha256-nJkJFr16RFsCTRw6l2fhjA9H20wBRpCH/XiCTvJrNnQ=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "298b12d701ef0d12c0f2e4858d4208bee24d14e5",
+        "rev": "d551111fcbc4ffa5c3ec9d842bf00d3dd3918b88",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777505090,
-        "narHash": "sha256-0Hgm1PJpZXQDUvzr/KDKqoBNvBRzWSJ1cE/uTFY8gTE=",
+        "lastModified": 1778486429,
+        "narHash": "sha256-RCXX2yVDIOXyrU3aTQ6wCoEweQBE9cCnRVfgbCc8M6c=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "34f1c5f1c600f3373589868e9416a0236ccfb07d",
+        "rev": "7c3fc8671f83f6e46305358b98354f0611ebb3cd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
 
           RUSTFLAGS = if stdenv.isDarwin then "" else "-C link-arg=-fuse-ld=mold";
 
+          # https://wiki.nixos.org/wiki/Playwright
           shellHook = ''
             export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
             export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -45,6 +45,13 @@ npx playwright install --with-deps
 
 ℹ️ If you use nix and the `flake.nix` of the current repository, you won’t need to `npm playwright install`.
 
+> [!WARNING]
+> When using `nix shell env`, you must ensure that the browser’s drivers are in
+> the matching version of the `playwright` dependency as documented
+> [here](https://wiki.nixos.org/wiki/Playwright). If it doesn’t work, you may
+> try to update the flake with `nix flake update`. If the `flake.lock` changes,
+> then you can test that it fixes your problem, and create a Pull Request.
+
 ## Run E2E tests
 
 ```bash
@@ -337,7 +344,7 @@ Open a trace locally with:
 ```bash
 npx playwright show-trace path/to/trace.zip
 ```
-You can also inspect traces in the browser by following [this url](https://trace.playwright.dev/)  
+You can also inspect traces in the browser by following [this url](https://trace.playwright.dev/)
 
 In the CI those files are available as artifacts. You can view them in the Github summary.
 


### PR DESCRIPTION
When browser drivers are not in the matching version of the `playwright` dependency, then launching `playwright` locally doesn’t work. It is well documented in https://wiki.nixos.org/wiki/Playwright.