### PR TITLE
editoast: authz: stop using `Regulator::get_user_id`

### DIFF
--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -34,6 +34,7 @@ pub struct Regulator<S: StorageDriver> {
 pub trait StorageDriver: Clone {
     type Error: std::error::Error;
 
+    #[deprecated(note = "use editoast_models::User::retrieve_by_identity instead")]
     fn get_user_id(
         &self,
         user_identity: &UserIdentity,
@@ -60,6 +61,7 @@ pub trait StorageDriver: Clone {
         &self,
         user_identity: &UserIdentity,
     ) -> Result<Option<UserSubject>, Self::Error> {
+        #[expect(deprecated)]
         let Some(user_id) = self.get_user_id(user_identity).await? else {
             return Ok(None);
         };

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -148,8 +148,10 @@ pub async fn exclude_group(
         let uid = if let Ok(id) = user.parse::<i64>() {
             id
         } else {
-            let uid = driver.get_user_id(user).await?;
-            uid.ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+            editoast_models::User::retrieve_by_identity(user, pool.get().await?)
+                .await?
+                .ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+                .id
         };
         authz_users.insert(authz::User(uid));
     }
@@ -189,8 +191,10 @@ pub async fn include_group(
         let uid = if let Ok(id) = user.parse::<i64>() {
             id
         } else {
-            let uid = driver.get_user_id(user).await?;
-            uid.ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+            editoast_models::User::retrieve_by_identity(user, pool.get().await?)
+                .await?
+                .ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+                .id
         };
         authz_users.insert(authz::User(uid));
     }

--- a/editoast/src/client/roles.rs
+++ b/editoast/src/client/roles.rs
@@ -122,8 +122,10 @@ async fn parse_and_fetch_subject(
     let id = if let Ok(id) = subject.parse::<i64>() {
         id
     } else {
-        let uid = driver.get_user_id(subject).await?;
-        uid.ok_or_else(|| anyhow!("No user with identity '{subject}' found"))?
+        editoast_models::User::retrieve_by_identity(subject, conn.clone())
+            .await?
+            .ok_or_else(|| anyhow!("No user with identity '{subject}' found"))?
+            .id
     };
     let subject = if let Some(info) = driver.get_user_info(id).await? {
         Subject::new_user(id, info)
@@ -141,18 +143,18 @@ pub async fn list_subject_roles(
     pool: Arc<DbConnectionPoolV2>,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
-    let conn = pool.get().await?;
-    let regulator = openfga_config.into_regulator(pool).await?;
-    let roles = match parse_and_fetch_subject(&subject, regulator.driver(), conn).await? {
-        Subject {
-            id,
-            info: SubjectInfo::User(_),
-        } => regulator.user_roles(&authz::User(id)).await?,
-        Subject {
-            id,
-            info: SubjectInfo::Group(_),
-        } => regulator.group_roles(&authz::Group(id)).await?,
-    };
+    let regulator = openfga_config.into_regulator(pool.clone()).await?;
+    let roles =
+        match parse_and_fetch_subject(&subject, regulator.driver(), pool.get().await?).await? {
+            Subject {
+                id,
+                info: SubjectInfo::User(_),
+            } => regulator.user_roles(&authz::User(id)).await?,
+            Subject {
+                id,
+                info: SubjectInfo::Group(_),
+            } => regulator.group_roles(&authz::Group(id)).await?,
+        };
     if roles.is_empty() {
         info!("{subject} has no roles assigned");
         return Ok(());
@@ -178,6 +180,7 @@ pub async fn add_roles(
     pool: Arc<DbConnectionPoolV2>,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
+    let driver = PgAuthDriver::new(pool.clone());
     let openfga = &openfga_config.into_client().await?;
     let system = SystemAuthorizer {
         openfga,
@@ -197,8 +200,7 @@ pub async fn add_roles(
             .collect_vec()
             .join(", "),
     );
-    let conn = pool.get().await?;
-    let subject = parse_and_fetch_subject(&subject, &PgAuthDriver::new(pool), conn).await?;
+    let subject = parse_and_fetch_subject(&subject, &driver, pool.get().await?).await?;
     let add_roles = authz::v2::add_roles(subject.into_authz(), roles);
     match system.authorize(add_roles).await?.access().await? {
         Ok(()) => Ok(()),
@@ -214,6 +216,7 @@ pub async fn remove_roles(
     pool: Arc<DbConnectionPoolV2>,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
+    let driver = PgAuthDriver::new(pool.clone());
     let openfga = &openfga_config.into_client().await?;
     let system = SystemAuthorizer {
         openfga,
@@ -233,8 +236,7 @@ pub async fn remove_roles(
             .collect_vec()
             .join(", "),
     );
-    let conn = pool.get().await?;
-    let subject = parse_and_fetch_subject(&subject, &PgAuthDriver::new(pool), conn).await?;
+    let subject = parse_and_fetch_subject(&subject, &driver, pool.get().await?).await?;
     let remove_roles = authz::v2::remove_roles(subject.into_authz(), roles);
     match system.authorize(remove_roles).await?.access().await? {
         Ok(()) => Ok(()),

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -7,7 +7,6 @@ use clap::Args;
 use clap::Subcommand;
 use database::DbConnectionPoolV2;
 use editoast_models::Group;
-use editoast_models::PgAuthDriver;
 use editoast_models::User;
 use editoast_models::authn::user::AddIdentitiesError;
 use editoast_models::authn::user::UserWithIdentities;
@@ -167,14 +166,16 @@ pub async fn user_info(
     openfga_config: OpenfgaConfig,
     pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
-    let regulator = openfga_config.into_regulator(pool.clone()).await?;
-    let driver = regulator.driver();
     let uid = if let Ok(id) = user.parse::<i64>() {
         id
     } else {
-        let uid = driver.get_user_id(&user).await?;
-        uid.ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+        editoast_models::User::retrieve_by_identity(&user, pool.get().await?)
+            .await?
+            .ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+            .id
     };
+    let regulator = openfga_config.into_regulator(pool.clone()).await?;
+    let driver = regulator.driver();
     let Some(UserInfo { identities, name }) = driver.get_user_info(uid).await? else {
         tracing::error!(user.id = uid, "User not found");
         return Ok(());
@@ -201,13 +202,13 @@ pub async fn delete_user(
     DeleteArgs { user }: DeleteArgs,
     pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
-    let driver = PgAuthDriver::new(pool.clone());
-
     let uid = if let Ok(id) = user.parse::<i64>() {
         id
     } else {
-        let uid = driver.get_user_id(&user).await?;
-        uid.ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+        editoast_models::User::retrieve_by_identity(&user, pool.get().await?)
+            .await?
+            .ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+            .id
     };
 
     let conn = &mut pool.get().await?;


### PR DESCRIPTION
Marked deprecated until migration completes.

refs https://github.com/osrd-project/osrd-confidential/issues/1168 