### PR TITLE
front: fix path steps not always visible in manchette

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
@@ -154,7 +154,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           local_track_name: 'V1',
         },
         position: 9246000,
-        weight: 100,
+        weight: null,
         location: {
           type: 'track_offset',
           track: 'TA6',
@@ -275,7 +275,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           local_track_name: 'V1',
         },
         position: 0,
-        weight: 100,
+        weight: null,
         location: {
           type: 'track_offset',
           track: 'TA6',
@@ -321,7 +321,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           local_track_name: 'V1',
         },
         position: 4198000,
-        weight: 100,
+        weight: null,
         location: {
           type: 'track_offset',
           track: 'TC0',
@@ -343,7 +343,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           local_track_name: 'V1',
         },
         position: 4402000,
-        weight: 100,
+        weight: null,
         location: {
           type: 'track_offset',
           track: 'TC0',
@@ -400,7 +400,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           local_track_name: 'V1',
         },
         position: 0,
-        weight: 100,
+        weight: null,
         location: {
           type: 'track_offset',
           track: 'TA6',
@@ -422,7 +422,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           local_track_name: 'V1',
         },
         position: 1748000,
-        weight: 100,
+        weight: null,
         location: {
           type: 'track_offset',
           track: 'TA6',

--- a/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
@@ -1,7 +1,8 @@
 import type { TFunction } from 'i18next';
 import { describe, it, expect } from 'vitest';
 
-import type { PathItem, PathProperties } from 'common/api/osrdEditoastApi';
+import type { PathItem } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 
 import { upsertMapWaypointsInOperationalPoints } from '../helpers/upsertMapWaypointsInOperationalPoints';
 
@@ -19,9 +20,11 @@ type Op = {
   positionOnPath: number;
 };
 
-const getOperationalPoints = (inputs: Op[]): NonNullable<PathProperties['operational_points']> =>
+const getOperationalPoints = (inputs: Op[]): PathWaypoint[] =>
   inputs.map((op) => ({
-    id: op.name,
+    waypointId: op.name,
+    opId: null,
+    pathItemId: null,
     name: op.name,
     uic: op.uic,
     country_code: '??',
@@ -34,6 +37,13 @@ const getOperationalPoints = (inputs: Op[]): NonNullable<PathProperties['operati
     },
     position: op.positionOnPath,
     weight: null,
+    location: {
+      type: 'operational_point_part_reference',
+      operational_point: {
+        type: 'uic',
+        uic: op.uic,
+      },
+    },
   }));
 
 const OPERATIONAL_POINTS = getOperationalPoints([
@@ -97,16 +107,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 9246000, 26500000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
-      'EditoastPathOperationalPoint',
+      'path',
       pathSteps,
       pathItemPositions,
       OPERATIONAL_POINTS,
       tMock
     );
 
-    expect(operationalPointsWithAllWaypoints).toEqual([
+    const expectedOps: PathWaypoint[] = [
       {
-        id: 'West_station',
+        opId: null,
+        waypointId: 'West_station',
+        pathItemId: null,
         name: 'West_station',
         uic: 2,
         country_code: '??',
@@ -119,9 +131,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 0,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: {
+            type: 'uic',
+            uic: 2,
+          },
+        },
       },
       {
-        id: '2',
+        opId: null,
+        waypointId: 'pathitem-2',
+        pathItemId: '2',
         name: 't_requestedPoint',
         uic: 0,
         country_code: '??',
@@ -134,9 +155,16 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 9246000,
         weight: 100,
+        location: {
+          type: 'track_offset',
+          track: 'TA6',
+          offset: 7746000,
+        },
       },
       {
-        id: 'Mid_West_station',
+        opId: null,
+        waypointId: 'Mid_West_station',
+        pathItemId: null,
         name: 'Mid_West_station',
         uic: 3,
         country_code: '??',
@@ -149,9 +177,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 12050000,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: {
+            type: 'uic',
+            uic: 3,
+          },
+        },
       },
       {
-        id: 'Mid_East_station',
+        opId: null,
+        waypointId: 'Mid_East_station',
+        pathItemId: null,
         name: 'Mid_East_station',
         uic: 4,
         country_code: '??',
@@ -164,8 +201,17 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 26500000,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: {
+            type: 'uic',
+            uic: 4,
+          },
+        },
       },
-    ]);
+    ];
+
+    expect(operationalPointsWithAllWaypoints).toEqual(expectedOps);
   });
 
   it('should add waypoints properly even when the last two come from map clicks', () => {
@@ -198,7 +244,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 4198000, 4402000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
-      'EditoastPathOperationalPoint',
+      'path',
       pathSteps,
       pathItemPositions,
       getOperationalPoints([
@@ -213,9 +259,11 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
       tMock
     );
 
-    expect(operationalPointsWithAllWaypoints).toEqual([
+    const expectedOps: PathWaypoint[] = [
       {
-        id: '1',
+        opId: null,
+        waypointId: 'pathitem-1',
+        pathItemId: '1',
         name: 't_requestedOrigin',
         uic: 0,
         country_code: '??',
@@ -228,9 +276,16 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 0,
         weight: 100,
+        location: {
+          type: 'track_offset',
+          track: 'TA6',
+          offset: 6481000,
+        },
       },
       {
-        id: 'Mid_West_station',
+        opId: null,
+        waypointId: 'Mid_West_station',
+        pathItemId: null,
         name: 'Mid_West_station',
         uic: 3,
         country_code: '??',
@@ -243,9 +298,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 4069000,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: {
+            type: 'uic',
+            uic: 3,
+          },
+        },
       },
       {
-        id: '2',
+        opId: null,
+        waypointId: 'pathitem-2',
+        pathItemId: '2',
         name: 't_requestedPoint',
         uic: 0,
         country_code: '??',
@@ -258,9 +322,16 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 4198000,
         weight: 100,
+        location: {
+          type: 'track_offset',
+          track: 'TC0',
+          offset: 679000,
+        },
       },
       {
-        id: '3',
+        opId: null,
+        waypointId: 'pathitem-3',
+        pathItemId: '3',
         name: 't_requestedDestination',
         uic: 0,
         country_code: '??',
@@ -273,8 +344,15 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 4402000,
         weight: 100,
+        location: {
+          type: 'track_offset',
+          track: 'TC0',
+          offset: 883000,
+        },
       },
-    ]);
+    ];
+
+    expect(operationalPointsWithAllWaypoints).toEqual(expectedOps);
   });
 
   it('should add waypoints properly when there is no op on path', () => {
@@ -299,16 +377,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 1748000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
-      'EditoastPathOperationalPoint',
+      'path',
       pathSteps,
       pathItemPositions,
       [],
       tMock
     );
 
-    expect(operationalPointsWithAllWaypoints).toEqual([
+    const expectedOps: PathWaypoint[] = [
       {
-        id: '1',
+        opId: null,
+        waypointId: 'pathitem-1',
+        pathItemId: '1',
         name: 't_requestedOrigin',
         uic: 0,
         country_code: '??',
@@ -321,9 +401,16 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 0,
         weight: 100,
+        location: {
+          type: 'track_offset',
+          track: 'TA6',
+          offset: 6481000,
+        },
       },
       {
-        id: '2',
+        opId: null,
+        waypointId: 'pathitem-2',
+        pathItemId: '2',
         name: 't_requestedDestination',
         uic: 0,
         country_code: '??',
@@ -336,8 +423,15 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 1748000,
         weight: 100,
+        location: {
+          type: 'track_offset',
+          track: 'TA6',
+          offset: 4733000,
+        },
       },
-    ]);
+    ];
+
+    expect(operationalPointsWithAllWaypoints).toEqual(expectedOps);
   });
 
   it('should return the same array if there is no waypoints added by map click', () => {
@@ -379,16 +473,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 12050000, 26500000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
-      'EditoastPathOperationalPoint',
+      'path',
       pathSteps,
       pathItemPositions,
       OPERATIONAL_POINTS,
       tMock
     );
 
-    expect(operationalPointsWithAllWaypoints).toEqual([
+    const expectedOps: PathWaypoint[] = [
       {
-        id: 'West_station',
+        opId: null,
+        waypointId: 'West_station',
+        pathItemId: null,
         name: 'West_station',
         uic: 2,
         country_code: '??',
@@ -401,9 +497,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 0,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: {
+            type: 'uic',
+            uic: 2,
+          },
+        },
       },
       {
-        id: 'Mid_West_station',
+        opId: null,
+        waypointId: 'Mid_West_station',
+        pathItemId: null,
         name: 'Mid_West_station',
         uic: 3,
         country_code: '??',
@@ -416,9 +521,18 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 12050000,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: {
+            type: 'uic',
+            uic: 3,
+          },
+        },
       },
       {
-        id: 'Mid_East_station',
+        opId: null,
+        waypointId: 'Mid_East_station',
+        pathItemId: null,
         name: 'Mid_East_station',
         uic: 4,
         country_code: '??',
@@ -431,7 +545,16 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
         },
         position: 26500000,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: {
+            type: 'uic',
+            uic: 4,
+          },
+        },
       },
-    ]);
+    ];
+
+    expect(operationalPointsWithAllWaypoints).toEqual(expectedOps);
   });
 });

--- a/front/src/applications/operationalStudies/__tests__/upsertTrackOffsetPathItemsInWaypoints.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/upsertTrackOffsetPathItemsInWaypoints.spec.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 import type { PathItem } from 'common/api/osrdEditoastApi';
 import type { PathWaypoint } from 'modules/simulationResult/types';
 
-import { upsertMapWaypointsInOperationalPoints } from '../helpers/upsertMapWaypointsInOperationalPoints';
+import { upsertTrackOffsetPathItemsInWaypoints } from '../helpers/upsertTrackOffsetPathItemsInWaypoints';
 
 /**
 Mocks the translation t function by stripping the namespace prefixes of the passed translation key and prefixing it with t_
@@ -106,7 +106,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     ];
     const pathItemPositions = [0, 9246000, 26500000];
 
-    const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+    const operationalPointsWithAllWaypoints = upsertTrackOffsetPathItemsInWaypoints(
       'path',
       pathSteps,
       pathItemPositions,
@@ -243,7 +243,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     ];
     const pathItemPositions = [0, 4198000, 4402000];
 
-    const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+    const operationalPointsWithAllWaypoints = upsertTrackOffsetPathItemsInWaypoints(
       'path',
       pathSteps,
       pathItemPositions,
@@ -376,7 +376,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     ];
     const pathItemPositions = [0, 1748000];
 
-    const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+    const operationalPointsWithAllWaypoints = upsertTrackOffsetPathItemsInWaypoints(
       'path',
       pathSteps,
       pathItemPositions,
@@ -472,7 +472,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     ];
     const pathItemPositions = [0, 12050000, 26500000];
 
-    const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+    const operationalPointsWithAllWaypoints = upsertTrackOffsetPathItemsInWaypoints(
       'path',
       pathSteps,
       pathItemPositions,

--- a/front/src/applications/operationalStudies/helpers/applyPathStepWeight.ts
+++ b/front/src/applications/operationalStudies/helpers/applyPathStepWeight.ts
@@ -1,0 +1,15 @@
+import type { PathWaypoint, ProjectionWaypoint } from 'modules/simulationResult/types';
+
+const HIGHEST_PRIORITY_WEIGHT = 100;
+
+/**
+ * For each waypoints along side the train itinerary, check if the waypoint is a path item and set its weight
+ * to the highest priority.
+ */
+export const applyPathStepWeight = <T extends PathWaypoint | ProjectionWaypoint>(
+  waypoints: T[]
+): T[] =>
+  waypoints.map((waypoint) => ({
+    ...waypoint,
+    weight: waypoint.pathItemId ? HIGHEST_PRIORITY_WEIGHT : waypoint.weight,
+  }));

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -1,10 +1,11 @@
 import type { TFunction } from 'i18next';
 
-import type { CorePathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
 import type {
-  PathOperationalPoint,
-  EditoastPathOperationalPoint,
-} from 'modules/simulationResult/types';
+  CorePathfindingResultSuccess,
+  PathProperties,
+  TrainSchedule,
+} from 'common/api/osrdEditoastApi';
+import type { PathOperationalPoint } from 'modules/simulationResult/types';
 
 const HIGHEST_PRIORITY_WEIGHT = 100;
 
@@ -22,16 +23,16 @@ export function upsertMapWaypointsInOperationalPoints(
   type: 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
-  operationalPoints: EditoastPathOperationalPoint[],
+  operationalPoints: PathProperties['operational_points'][number][],
   t: TFunction<'operational-studies'>
-): EditoastPathOperationalPoint[];
+): PathProperties['operational_points'][number][];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'PathOperationalPoint' | 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
-  operationalPoints: (PathOperationalPoint | EditoastPathOperationalPoint)[],
+  operationalPoints: (PathOperationalPoint | PathProperties['operational_points'][number])[],
   t: TFunction<'operational-studies'>
-): (PathOperationalPoint | EditoastPathOperationalPoint)[] {
+): (PathOperationalPoint | PathProperties['operational_points'][number])[] {
   return path.reduce(
     (operationalPointsWithAllWaypoints, step, stepIndex) => {
       const location = step.location;

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -1,11 +1,7 @@
 import type { TFunction } from 'i18next';
 
-import type {
-  CorePathfindingResultSuccess,
-  PathProperties,
-  TrainSchedule,
-} from 'common/api/osrdEditoastApi';
-import type { ProjectionWaypoint } from 'modules/simulationResult/types';
+import type { CorePathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint, ProjectionWaypoint } from 'modules/simulationResult/types';
 
 const HIGHEST_PRIORITY_WEIGHT = 100;
 
@@ -13,26 +9,26 @@ const HIGHEST_PRIORITY_WEIGHT = 100;
  * Check if the train path used waypoints added by map click and add them to the operational points
  */
 export function upsertMapWaypointsInOperationalPoints(
-  type: 'ProjectionWaypoint',
+  type: 'projection',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: ProjectionWaypoint[],
   t: TFunction<'operational-studies'>
 ): ProjectionWaypoint[];
 export function upsertMapWaypointsInOperationalPoints(
-  type: 'EditoastPathOperationalPoint',
+  type: 'path',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
-  operationalPoints: PathProperties['operational_points'][number][],
+  operationalPoints: PathWaypoint[],
   t: TFunction<'operational-studies'>
-): PathProperties['operational_points'][number][];
+): PathWaypoint[];
 export function upsertMapWaypointsInOperationalPoints(
-  type: 'ProjectionWaypoint' | 'EditoastPathOperationalPoint',
+  type: 'projection' | 'path',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
-  operationalPoints: (ProjectionWaypoint | PathProperties['operational_points'][number])[],
+  operationalPoints: (ProjectionWaypoint | PathWaypoint)[],
   t: TFunction<'operational-studies'>
-): (ProjectionWaypoint | PathProperties['operational_points'][number])[] {
+): (ProjectionWaypoint | PathWaypoint)[] {
   return path.reduce(
     (operationalPointsWithAllWaypoints, step, stepIndex) => {
       const location = step.location;
@@ -49,6 +45,9 @@ export function upsertMapWaypointsInOperationalPoints(
         }
 
         const baseFormattedStep = {
+          waypointId: `pathitem-${step.id}`,
+          opId: null,
+          pathItemId: step.id,
           name: stepName,
           uic: 0,
           country_code: '??',
@@ -56,20 +55,16 @@ export function upsertMapWaypointsInOperationalPoints(
           main_code: '',
           position: positionOnPath,
           weight: HIGHEST_PRIORITY_WEIGHT,
+          location,
         };
         const formattedStep =
-          type === 'ProjectionWaypoint'
+          type === 'projection'
             ? {
                 ...baseFormattedStep,
-                waypointId: step.id,
-                opId: null,
-                pathItemId: step.id,
-                location,
               }
             : {
                 ...baseFormattedStep,
                 part: { track: location.track, position: location.offset, local_track_name: 'V1' },
-                id: step.id,
               };
 
         // If we can't find any op position greater than the current step position, we add it at the end
@@ -82,23 +77,16 @@ export function upsertMapWaypointsInOperationalPoints(
         return operationalPointsWithAllWaypoints;
       }
 
-      if (location.operational_point.type === 'uic') {
-        const matchedIndex = operationalPointsWithAllWaypoints.findIndex(
-          (op) =>
-            location.operational_point.type === 'uic' &&
-            location.operational_point.uic === op.uic &&
-            location.operational_point.secondary_code === op.secondary_code
-        );
+      const matchedIndex = operationalPointsWithAllWaypoints.findIndex(
+        (op) => step.id === op.pathItemId
+      );
 
-        if (matchedIndex !== -1) {
-          // Replace the operational point at its original index with updated weight
-          operationalPointsWithAllWaypoints[matchedIndex] = {
-            ...operationalPointsWithAllWaypoints[matchedIndex],
-            weight: HIGHEST_PRIORITY_WEIGHT,
-          };
-        }
-
-        return operationalPointsWithAllWaypoints;
+      if (matchedIndex !== -1) {
+        // Replace the operational point at its original index with updated weight
+        operationalPointsWithAllWaypoints[matchedIndex] = {
+          ...operationalPointsWithAllWaypoints[matchedIndex],
+          weight: HIGHEST_PRIORITY_WEIGHT,
+        };
       }
 
       return operationalPointsWithAllWaypoints;

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -3,8 +3,6 @@ import type { TFunction } from 'i18next';
 import type { CorePathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { PathWaypoint, ProjectionWaypoint } from 'modules/simulationResult/types';
 
-const HIGHEST_PRIORITY_WEIGHT = 100;
-
 /**
  * Check if the train path used waypoints added by map click and add them to the operational points
  */
@@ -32,61 +30,47 @@ export function upsertMapWaypointsInOperationalPoints(
   return path.reduce(
     (operationalPointsWithAllWaypoints, step, stepIndex) => {
       const location = step.location;
-      if (location.type === 'track_offset') {
-        const positionOnPath = pathItemsPositions[stepIndex];
-        const indexToInsert = operationalPointsWithAllWaypoints.findIndex(
-          (op) => op.position >= positionOnPath
-        );
-        let stepName = t('main.requestedPoint', { count: stepIndex });
-        if (stepIndex === 0) {
-          stepName = t('main.requestedOrigin');
-        } else if (stepIndex === path.length - 1) {
-          stepName = t('main.requestedDestination');
-        }
-
-        const baseFormattedStep = {
-          waypointId: `pathitem-${step.id}`,
-          opId: null,
-          pathItemId: step.id,
-          name: stepName,
-          uic: 0,
-          country_code: '??',
-          is_passenger_station: false,
-          main_code: '',
-          position: positionOnPath,
-          weight: HIGHEST_PRIORITY_WEIGHT,
-          location,
-        };
-        const formattedStep =
-          type === 'projection'
-            ? {
-                ...baseFormattedStep,
-              }
-            : {
-                ...baseFormattedStep,
-                part: { track: location.track, position: location.offset, local_track_name: 'V1' },
-              };
-
-        // If we can't find any op position greater than the current step position, we add it at the end
-        if (indexToInsert === -1) {
-          operationalPointsWithAllWaypoints.push(formattedStep);
-        } else {
-          operationalPointsWithAllWaypoints.splice(indexToInsert, 0, formattedStep);
-        }
-
+      if (location.type !== 'track_offset') {
         return operationalPointsWithAllWaypoints;
       }
 
-      const matchedIndex = operationalPointsWithAllWaypoints.findIndex(
-        (op) => step.id === op.pathItemId
+      const positionOnPath = pathItemsPositions[stepIndex];
+      const indexToInsert = operationalPointsWithAllWaypoints.findIndex(
+        (op) => op.position >= positionOnPath
       );
+      let stepName = t('main.requestedPoint', { count: stepIndex });
+      if (stepIndex === 0) {
+        stepName = t('main.requestedOrigin');
+      } else if (stepIndex === path.length - 1) {
+        stepName = t('main.requestedDestination');
+      }
 
-      if (matchedIndex !== -1) {
-        // Replace the operational point at its original index with updated weight
-        operationalPointsWithAllWaypoints[matchedIndex] = {
-          ...operationalPointsWithAllWaypoints[matchedIndex],
-          weight: HIGHEST_PRIORITY_WEIGHT,
-        };
+      const baseFormattedStep = {
+        waypointId: `pathitem-${step.id}`,
+        opId: null,
+        pathItemId: step.id,
+        name: stepName,
+        uic: 0,
+        country_code: '??',
+        is_passenger_station: false,
+        main_code: '',
+        position: positionOnPath,
+        weight: null,
+        location,
+      };
+      const formattedStep =
+        type === 'projection'
+          ? baseFormattedStep
+          : {
+              ...baseFormattedStep,
+              part: { track: location.track, position: location.offset, local_track_name: 'V1' },
+            };
+
+      // If we can't find any op position greater than the current step position, we add it at the end
+      if (indexToInsert === -1) {
+        operationalPointsWithAllWaypoints.push(formattedStep);
+      } else {
+        operationalPointsWithAllWaypoints.splice(indexToInsert, 0, formattedStep);
       }
 
       return operationalPointsWithAllWaypoints;

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -5,7 +5,7 @@ import type {
   PathProperties,
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
-import type { PathOperationalPoint } from 'modules/simulationResult/types';
+import type { ProjectionWaypoint } from 'modules/simulationResult/types';
 
 const HIGHEST_PRIORITY_WEIGHT = 100;
 
@@ -13,12 +13,12 @@ const HIGHEST_PRIORITY_WEIGHT = 100;
  * Check if the train path used waypoints added by map click and add them to the operational points
  */
 export function upsertMapWaypointsInOperationalPoints(
-  type: 'PathOperationalPoint',
+  type: 'ProjectionWaypoint',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
-  operationalPoints: PathOperationalPoint[],
+  operationalPoints: ProjectionWaypoint[],
   t: TFunction<'operational-studies'>
-): PathOperationalPoint[];
+): ProjectionWaypoint[];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
@@ -27,12 +27,12 @@ export function upsertMapWaypointsInOperationalPoints(
   t: TFunction<'operational-studies'>
 ): PathProperties['operational_points'][number][];
 export function upsertMapWaypointsInOperationalPoints(
-  type: 'PathOperationalPoint' | 'EditoastPathOperationalPoint',
+  type: 'ProjectionWaypoint' | 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
-  operationalPoints: (PathOperationalPoint | PathProperties['operational_points'][number])[],
+  operationalPoints: (ProjectionWaypoint | PathProperties['operational_points'][number])[],
   t: TFunction<'operational-studies'>
-): (PathOperationalPoint | PathProperties['operational_points'][number])[] {
+): (ProjectionWaypoint | PathProperties['operational_points'][number])[] {
   return path.reduce(
     (operationalPointsWithAllWaypoints, step, stepIndex) => {
       const location = step.location;
@@ -54,20 +54,21 @@ export function upsertMapWaypointsInOperationalPoints(
           country_code: '??',
           is_passenger_station: false,
           main_code: '',
-          part: { track: location.track, position: location.offset, local_track_name: 'V1' },
           position: positionOnPath,
           weight: HIGHEST_PRIORITY_WEIGHT,
         };
         const formattedStep =
-          type === 'PathOperationalPoint'
+          type === 'ProjectionWaypoint'
             ? {
                 ...baseFormattedStep,
                 waypointId: step.id,
                 opId: null,
+                pathItemId: step.id,
                 location,
               }
             : {
                 ...baseFormattedStep,
+                part: { track: location.track, position: location.offset, local_track_name: 'V1' },
                 id: step.id,
               };
 

--- a/front/src/applications/operationalStudies/helpers/upsertTrackOffsetPathItemsInWaypoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertTrackOffsetPathItemsInWaypoints.ts
@@ -6,21 +6,21 @@ import type { PathWaypoint, ProjectionWaypoint } from 'modules/simulationResult/
 /**
  * Check if the train path used waypoints added by map click and add them to the operational points
  */
-export function upsertMapWaypointsInOperationalPoints(
+export function upsertTrackOffsetPathItemsInWaypoints(
   type: 'projection',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: ProjectionWaypoint[],
   t: TFunction<'operational-studies'>
 ): ProjectionWaypoint[];
-export function upsertMapWaypointsInOperationalPoints(
+export function upsertTrackOffsetPathItemsInWaypoints(
   type: 'path',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
   operationalPoints: PathWaypoint[],
   t: TFunction<'operational-studies'>
 ): PathWaypoint[];
-export function upsertMapWaypointsInOperationalPoints(
+export function upsertTrackOffsetPathItemsInWaypoints(
   type: 'projection' | 'path',
   path: TrainSchedule['path'],
   pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -28,7 +28,7 @@ import {
 } from 'utils/trainId';
 
 import type { PathProjectionResult } from '../types';
-import { matchOpRefAndOp } from '../utils';
+import { matchOpRefAndWaypoint } from '../utils';
 
 /**
  * Generates a display name for a virtual operational point based on available reference data.
@@ -209,7 +209,7 @@ const usePathProjection = (
       const formattedOperationalPoints: ProjectionWaypoint[] = [];
       operationalPoints.forEach((op, index) => {
         const matchedPathItem = pathUsedForProjection.find((step) =>
-          matchOpRefAndOp(step.location, op)
+          matchOpRefAndWaypoint(step.location, op)
         );
         const formattedOp: ProjectionWaypoint = {
           ...omit(op, ['id', 'part']),

--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import type { TFunction } from 'i18next';
-import { isEqual } from 'lodash';
+import { isEqual, omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -12,6 +12,7 @@ import {
   type OperationalPointReference,
   type TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
+import type { ProjectionWaypoint } from 'modules/simulationResult/types';
 import { getExceptionFromOccurrenceId } from 'modules/trainSchedule/helpers/pacedTrain';
 import { updateProjectionType } from 'reducers/simulationResults';
 import {
@@ -26,7 +27,8 @@ import {
   isTrainScheduleId,
 } from 'utils/trainId';
 
-import type { PathProjectionResult, PathProjectionResultOperationalPoint } from '../types';
+import type { PathProjectionResult } from '../types';
+import { matchOpRefAndOp } from '../utils';
 
 /**
  * Generates a display name for a virtual operational point based on available reference data.
@@ -54,17 +56,20 @@ const FALLBACK_DISTANCE_MM = 100_000_000;
  */
 const createVirtualOp = (
   opRef: OperationalPointReference,
+  pathItemId: string,
   index: number,
   totalCount: number,
   position: number,
   weight: number,
   t: TFunction<'operational-studies'>
-): PathProjectionResultOperationalPoint => {
+): ProjectionWaypoint => {
   const virtualName = getVirtualOpName(opRef, index, totalCount, t);
   const virtualId = `virtual_op_${virtualName}`;
 
   return {
-    id: virtualId,
+    waypointId: virtualId,
+    opId: null,
+    pathItemId,
     name: virtualName,
     uic: opRef.type === 'uic' ? opRef.uic : 0,
     secondary_code: (opRef.type !== 'id' && opRef.secondary_code) || null,
@@ -73,7 +78,10 @@ const createVirtualOp = (
     weight,
     country_code: '??',
     is_passenger_station: false,
-    opRef,
+    location: {
+      type: 'operational_point_part_reference',
+      operational_point: opRef,
+    },
   };
 };
 
@@ -153,14 +161,16 @@ const usePathProjection = (
     return exception?.path_and_schedule?.path ?? trainSchedule?.path;
   }, [trainIdUsedForProjection, trainSchedulesById]);
 
-  const opRefs = useMemo(() => {
+  const { opRefs, opRefPathItemIds } = useMemo(() => {
     const refs: OperationalPointReference[] = [];
+    const refPathItemIds: string[] = [];
     pathUsedForProjection?.forEach((step) => {
       if (step.location.type === 'operational_point_part_reference') {
         refs.push(step.location.operational_point);
+        refPathItemIds.push(step.id);
       }
     });
-    return refs;
+    return { opRefs: refs, opRefPathItemIds: refPathItemIds };
   }, [pathUsedForProjection]);
 
   const { data: matchedOperationalPoints } =
@@ -196,7 +206,24 @@ const usePathProjection = (
       const { operational_points: operationalPoints } = pathProperties;
 
       const pathfindingOpRefs: OperationalPointReference[] = [];
+      const formattedOperationalPoints: ProjectionWaypoint[] = [];
       operationalPoints.forEach((op, index) => {
+        const matchedPathItem = pathUsedForProjection.find((step) =>
+          matchOpRefAndOp(step.location, op)
+        );
+        const formattedOp: ProjectionWaypoint = {
+          ...omit(op, ['id', 'part']),
+          waypointId: `op-${op.id}-${op.position}`,
+          opId: op.id,
+          pathItemId: matchedPathItem?.id ?? null,
+          location: matchedPathItem
+            ? matchedPathItem.location
+            : {
+                type: 'operational_point_part_reference',
+                operational_point: { type: 'id', operational_point: op.id },
+              },
+        };
+        formattedOperationalPoints.push(formattedOp);
         pathfindingOpRefs.push({ operational_point: op.id, type: 'id' });
         if (index > 0) {
           operationalPointDistances.push(op.position - operationalPoints[index - 1].position);
@@ -208,10 +235,7 @@ const usePathProjection = (
         pathfinding,
         path: pathUsedForProjection,
         geometry: pathProperties.geometry,
-        operationalPoints: operationalPoints.map((op, index) => ({
-          ...op,
-          opRef: pathfindingOpRefs[index],
-        })),
+        operationalPoints: formattedOperationalPoints,
         operationalPointReferences: pathfindingOpRefs,
         projectingOnSimulatedPathException,
         operationalPointDistances,
@@ -227,7 +251,7 @@ const usePathProjection = (
     // 1. For each point in the path, try to match with infrastructure data
     // 2. If a point is matched → use matched data with full extensions
     // 3. If a point is not matched (e.g., NGE) → create a virtual point from the reference
-    const normalizedOps: PathProjectionResultOperationalPoint[] = [];
+    const normalizedOps: ProjectionWaypoint[] = [];
 
     opRefs.forEach((opRef, index) => {
       const matchedOp = matchedOperationalPoints?.related_operational_points[index];
@@ -237,11 +261,19 @@ const usePathProjection = (
         operationalPointDistances.push(FALLBACK_DISTANCE_MM); // Add distance for fallback positioning
       }
 
+      const pathItemId = opRefPathItemIds.at(index);
+      if (!pathItemId) {
+        // We know there are as many opRefPathItemIds as opRefs, so this should never happens
+        throw new Error(`Path item ID not found for index ${index}`);
+      }
+
       if (matchedOp) {
         // MATCHED: Point exists in infrastructure
         normalizedOps.push({
           country_code: matchedOp.country_code,
-          id: matchedOp.id,
+          waypointId: `op-${matchedOp.id}-${position}`,
+          opId: matchedOp.id,
+          pathItemId,
           is_passenger_station: matchedOp.is_passenger_station,
           main_code: matchedOp.main_code,
           name: matchedOp.name,
@@ -249,13 +281,18 @@ const usePathProjection = (
           secondary_code: matchedOp.secondary_code,
           uic: matchedOp.uic,
           weight,
-          opRef,
+          location: {
+            type: 'operational_point_part_reference',
+            operational_point: opRef,
+          },
         });
       } else {
         // NOT MATCHED: Point doesn't exist in infrastructure (e.g., NGE point)
         // Create virtual point from the reference
         // TODO : change this logic when implementing the non computation creation feature with the new opRef format
-        normalizedOps.push(createVirtualOp(opRef, index, opRefs.length, position, weight, t));
+        normalizedOps.push(
+          createVirtualOp(opRef, pathItemId, index, opRefs.length, position, weight, t)
+        );
       }
     });
 

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -28,7 +28,7 @@ import {
 } from 'utils/trainId';
 
 import type { SimulationResults } from '../types';
-import { matchOpRefAndOp, preparePathPropertiesData } from '../utils';
+import { matchOpRefAndWaypoint, preparePathPropertiesData } from '../utils';
 import { useScenarioContext } from './useScenarioContext';
 
 /**
@@ -45,8 +45,8 @@ export const sortPathOperationalPoints = (
 ): CoreOperationalPointOnPath[] =>
   ops.toSorted((a, b) => {
     if (a.position !== b.position) return a.position - b.position;
-    const aPathIndex = path.findIndex((pathItem) => matchOpRefAndOp(pathItem.location, a));
-    const bPathIndex = path.findIndex((pathItem) => matchOpRefAndOp(pathItem.location, b));
+    const aPathIndex = path.findIndex((pathItem) => matchOpRefAndWaypoint(pathItem.location, a));
+    const bPathIndex = path.findIndex((pathItem) => matchOpRefAndWaypoint(pathItem.location, b));
     const lastIndex = path.length - 1;
     const aIsOrigin = aPathIndex === 0;
     const bIsOrigin = bPathIndex === 0;

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -21,6 +21,7 @@ import type {
   PathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
+import type { ProjectionWaypoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { Train, TrainScheduleWithPathOps } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
@@ -180,18 +181,9 @@ export type ItineraryPathProperties = PathProperties & {
   pathItemPositions?: number[];
 };
 
-export type PathProjectionResultOperationalPoint = Omit<
-  PathProperties['operational_points'][number],
-  'part'
-> & {
-  opRef: OperationalPointReference;
-};
-
 export type PathProjectionResult = {
   path: PathItem[];
-  // Remove the part field as it won't be used anywhere in the app.
-  // This avoid us to have to add hardcoded data in it.
-  operationalPoints: PathProjectionResultOperationalPoint[];
+  operationalPoints: ProjectionWaypoint[];
   operationalPointDistances: number[];
   operationalPointReferences: OperationalPointReference[];
 } & (

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -113,8 +113,8 @@ export type PathPropertiesFormatted = {
   electrifications: ElectrificationRange[];
   curves: PositionData<'radius'>[];
   slopes: PositionData<'gradient'>[];
-  operationalPoints: NonNullable<PathProperties['operational_points']>;
-  geometry: NonNullable<PathProperties['geometry']>;
+  operationalPoints: PathProperties['operational_points'];
+  geometry: PathProperties['geometry'];
   voltages: RangedValue[];
 };
 

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -21,7 +21,6 @@ import type {
   PathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
-import type { ProjectionWaypoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { Train, TrainScheduleWithPathOps } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
@@ -61,8 +60,6 @@ export type TimetableJsonPayload = {
 
 // Extraction of some required and non nullable properties from osrdEditoastApi's PathProperties type
 export type ManageTrainSchedulePathProperties = {
-  // TODO : remove this field that seems to be unused
-  manchetteOperationalPoints?: ProjectionWaypoint[];
   electrifications: NonNullable<PathProperties['electrifications']>;
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -21,7 +21,7 @@ import type {
   PathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
-import type { PathOperationalPoint } from 'modules/simulationResult/types';
+import type { ProjectionWaypoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { Train, TrainScheduleWithPathOps } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
@@ -61,7 +61,8 @@ export type TimetableJsonPayload = {
 
 // Extraction of some required and non nullable properties from osrdEditoastApi's PathProperties type
 export type ManageTrainSchedulePathProperties = {
-  manchetteOperationalPoints?: PathOperationalPoint[];
+  // TODO : remove this field that seems to be unused
+  manchetteOperationalPoints?: ProjectionWaypoint[];
   electrifications: NonNullable<PathProperties['electrifications']>;
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -21,7 +21,7 @@ import type {
   PathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
-import type { ProjectionWaypoint } from 'modules/simulationResult/types';
+import type { ProjectionWaypoint, PathWaypoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { Train, TrainScheduleWithPathOps } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
@@ -113,7 +113,7 @@ export type PathPropertiesFormatted = {
   electrifications: ElectrificationRange[];
   curves: PositionData<'radius'>[];
   slopes: PositionData<'gradient'>[];
-  operationalPoints: PathProperties['operational_points'];
+  operationalPoints: PathWaypoint[];
   geometry: PathProperties['geometry'];
   voltages: RangedValue[];
 };

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -1,8 +1,7 @@
 import type { TFunction } from 'i18next';
-import { type Dictionary, isEqual } from 'lodash';
+import { type Dictionary, isEqual, omit } from 'lodash';
 
 import type {
-  OperationalPoint,
   OperationalPointReference,
   CorePathfindingResultSuccess,
   PathItemLocation,
@@ -15,8 +14,10 @@ import type {
   ScheduleItem,
   PathItem,
   TrainScheduleResponse,
+  CoreOperationalPointOnPath,
 } from 'common/api/osrdEditoastApi';
 import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import { isPacedTrain } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { SimulationSummary } from 'modules/trainSchedule/types';
 import type { TrainScheduleWithPathOps } from 'reducers/osrdconf/types';
@@ -167,6 +168,27 @@ export const transformElectricalBoundariesToRanges = (
   return formattedData;
 };
 
+export const matchOpRefAndWaypoint = (
+  location: PathItemLocation,
+  waypoint: CoreOperationalPointOnPath
+) => {
+  if (location.type === 'track_offset') return false;
+
+  if (location.operational_point.type === 'id') {
+    return location.operational_point.operational_point === waypoint.id;
+  }
+  if (location.operational_point.type === 'uic') {
+    return (
+      location.operational_point.uic === waypoint.uic &&
+      location.operational_point.secondary_code === waypoint.secondary_code
+    );
+  }
+  return (
+    location.operational_point.trigram === waypoint.main_code &&
+    location.operational_point.secondary_code === waypoint.secondary_code
+  );
+};
+
 /**
  * Format path properties data to be used in simulation results charts
  */
@@ -191,11 +213,29 @@ export const preparePathPropertiesData = (
 
   const voltageRanges = electricalProfiles ? getPathVoltages(electrifications, length) : [];
 
+  const formattedOperationalPoints: PathWaypoint[] = operational_points.map((op) => {
+    const matchedPathItem = trainSchedulePath.find((step) =>
+      matchOpRefAndWaypoint(step.location, op)
+    );
+    return {
+      ...omit(op, 'id'),
+      waypointId: `op-${op.id}-${op.position}`,
+      opId: op.id,
+      pathItemId: matchedPathItem?.id ?? null,
+      location: matchedPathItem
+        ? matchedPathItem.location
+        : {
+            type: 'operational_point_part_reference',
+            operational_point: { type: 'id', operational_point: op.id },
+          },
+    };
+  });
+
   const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
-    'EditoastPathOperationalPoint',
+    'path',
     trainSchedulePath,
     path_item_positions,
-    operational_points,
+    formattedOperationalPoints,
     t
   );
 
@@ -402,25 +442,4 @@ export const getInvalidStepLabel = (opRef: OperationalPointReference) => {
   if (opRef.type === 'uic') return opRef.uic.toString();
   if (opRef.type === 'trigram') return opRef.trigram;
   return opRef.operational_point;
-};
-
-export const matchOpRefAndOp = (
-  location: PathItemLocation,
-  op: PathProperties['operational_points'][number] | OperationalPoint
-) => {
-  if (location.type === 'track_offset') return false;
-
-  if (location.operational_point.type === 'id') {
-    return location.operational_point.operational_point === op.id;
-  }
-  if (location.operational_point.type === 'uic') {
-    return (
-      location.operational_point.uic === op.uic &&
-      location.operational_point.secondary_code === op.secondary_code
-    );
-  }
-  return (
-    location.operational_point.trigram === op.main_code &&
-    location.operational_point.secondary_code === op.secondary_code
-  );
 };

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -25,6 +25,7 @@ import { Duration } from 'utils/duration';
 import { mmToM } from 'utils/physics';
 import { SMALL_INPUT_MAX_LENGTH } from 'utils/strings';
 
+import { applyPathStepWeight } from './helpers/applyPathStepWeight';
 import { upsertMapWaypointsInOperationalPoints } from './helpers/upsertMapWaypointsInOperationalPoints';
 import type {
   BoundariesData,
@@ -231,19 +232,21 @@ export const preparePathPropertiesData = (
     };
   });
 
-  const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+  const waypointsWithTrackOffsetPathSteps = upsertMapWaypointsInOperationalPoints(
     'path',
     trainSchedulePath,
     path_item_positions,
     formattedOperationalPoints,
     t
   );
+  // Apply max weight on path steps so they are prioritized in the SDD
+  const waypointsWithPathStepWeight = applyPathStepWeight(waypointsWithTrackOffsetPathSteps);
 
   return {
     electrifications: electrificationAndProfilesRanges,
     curves: formattedCurves,
     slopes: formattedSlopes,
-    operationalPoints: operationalPointsWithAllWaypoints,
+    operationalPoints: waypointsWithPathStepWeight,
     geometry,
     voltages: voltageRanges,
   };

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -26,7 +26,7 @@ import { mmToM } from 'utils/physics';
 import { SMALL_INPUT_MAX_LENGTH } from 'utils/strings';
 
 import { applyPathStepWeight } from './helpers/applyPathStepWeight';
-import { upsertMapWaypointsInOperationalPoints } from './helpers/upsertMapWaypointsInOperationalPoints';
+import { upsertTrackOffsetPathItemsInWaypoints } from './helpers/upsertTrackOffsetPathItemsInWaypoints';
 import type {
   BoundariesData,
   ElectricalBoundariesData,
@@ -232,7 +232,7 @@ export const preparePathPropertiesData = (
     };
   });
 
-  const waypointsWithTrackOffsetPathSteps = upsertMapWaypointsInOperationalPoints(
+  const waypointsWithTrackOffsetPathSteps = upsertTrackOffsetPathItemsInWaypoints(
     'path',
     trainSchedulePath,
     path_item_positions,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
@@ -1,4 +1,4 @@
-import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
+import { matchOpRefAndWaypoint } from 'applications/operationalStudies/utils';
 import type {
   CoreOperationalPointOnPath,
   OperationalPointReference,
@@ -92,7 +92,7 @@ export function groupOperationalPoints(
 
     // Reach a step by identity:
     const matchedIndex = collapsedSteps.findIndex(({ step }, index) => {
-      if (index <= currentGroupIndex || !matchOpRefAndOp(step.location, op)) return false;
+      if (index <= currentGroupIndex || !matchOpRefAndWaypoint(step.location, op)) return false;
       // An OP crossed twice matches both steps by identity. Pick the right
       // crossing: by position if known, else by pinned track.
       const position = positionByStepId?.get(step.id);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalMap.tsx
@@ -4,7 +4,7 @@ import type { Feature, Position } from 'geojson';
 import { useTranslation } from 'react-i18next';
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 
-import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
+import { matchOpRefAndWaypoint } from 'applications/operationalStudies/utils';
 import {
   osrdEditoastApi,
   type OperationalPoint,
@@ -362,7 +362,7 @@ const ItineraryModalMap = ({
                 coordinates = pathStepMetadata.coordinates;
               } else {
                 const matchedOp = pathProperties.operational_points.find((op) =>
-                  matchOpRefAndOp(pathStepLocation, op)
+                  matchOpRefAndWaypoint(pathStepLocation, op)
                 );
                 const trackMetadata = pathStepMetadata.parts.find(
                   (part) => part.type === 'valid' && part.trackId === matchedOp?.part.track

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/utils.ts
@@ -95,7 +95,10 @@ export const formatOperationalPoints = (
     let stepDuration: Duration | undefined;
     const correspondingStep = trainSchedule.path.find((step) =>
       matchPathStepAndOp(step.location, {
-        opId: op.id,
+        // opId won't be defined for "trackoffset" ops but matchPathStepAndOp will match them
+        // with their track as their location is of type "track_offset"
+        // TODO: find a better way to handle this
+        opId: op.opId ?? '',
         uic: op.uic,
         secondaryCode: op.secondary_code,
         mainCode: op.main_code,
@@ -120,7 +123,7 @@ export const formatOperationalPoints = (
     }
 
     const opCommonProp = {
-      id: op.id,
+      id: op.waypointId,
       name: op.name,
       duration: stepDuration,
       position: mmToM(op.position),

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -10,7 +10,6 @@ import captureMap from 'applications/operationalStudies/helpers/captureMap';
 import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
-import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
 import type {
   CorePathfindingResultSuccess,
   RelatedOperationalPoint,
@@ -96,7 +95,7 @@ const SimulationResultMap = ({
           acc.push(step.location.track);
         }
         // Get the track ids from the computed ops
-        const matchedOp = pathPropertiesOps?.find((op) => matchOpRefAndOp(step.location, op));
+        const matchedOp = pathPropertiesOps?.find((op) => step.id === op.pathItemId);
         if (matchedOp) {
           acc.push(matchedOp.part.track);
         }
@@ -154,7 +153,7 @@ const SimulationResultMap = ({
         }
 
         if (pathPropertiesOps) {
-          const matchedOp = pathPropertiesOps.find((op) => matchOpRefAndOp(location, op));
+          const matchedOp = pathPropertiesOps.find((op) => step.id === op.pathItemId);
 
           if (!matchedOp) return null;
 

--- a/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
@@ -13,7 +13,7 @@ import {
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { MovableOccupancyZone } from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones';
 import type { DeployedWaypoint } from 'modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy';
-import type { PathOperationalPoint } from 'modules/simulationResult/types';
+import type { ProjectionWaypoint } from 'modules/simulationResult/types';
 import { findTrainScheduleAndException } from 'modules/trainSchedule/helpers/pacedTrain';
 import { storeTrainSchedule } from 'modules/trainSchedule/helpers/updateTrainScheduleHelpers';
 import type {
@@ -31,13 +31,13 @@ import { Duration, startTimeToDate } from 'utils/duration';
 function upsertPathStepTrack(
   path: PathItem[],
   simulationSummary: SimulationSummary | undefined,
-  op: PathOperationalPoint,
+  op: ProjectionWaypoint,
   occupancyZoneStartOffset: Duration,
   trackName: string
 ): PathItem[] {
   // First check if the OP is already an explicit path step, if so update it
   // TODO: better matching, e.g. by making the backend return the path step ID
-  // for each PathOperationalPoint
+  // for each ProjectionWaypoint
   const pathStepIndex = path.findIndex((step) =>
     matchPathStepAndOp(step.location, {
       // If the OP is not found in the infrastructure, OP ID may be null
@@ -110,7 +110,7 @@ export default function useOccupancyZoneDrop({
 }: {
   trainSchedules: TrainScheduleResponse[];
   trainSchedulesWithDetails: TrainScheduleWithDetails[];
-  pathOperationalPoints: PathOperationalPoint[];
+  pathOperationalPoints: ProjectionWaypoint[];
   deployedWaypoints: DeployedWaypoint[];
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
 }) {

--- a/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { omit } from 'lodash';
+
 import type {
   ElectricalBoundariesData,
   ElectrificationUsage,
@@ -29,7 +31,16 @@ const DebugSpeedDistanceDiagram = ({ simData }: { simData: SimDebugData }) => {
       simData.path_properties.electrifications as ElectricalBoundariesData<ElectrificationUsage>,
       pathLength
     ),
-    operationalPoints: simData.path_properties.operational_points,
+    operationalPoints: simData.path_properties.operational_points.map((op) => ({
+      ...omit(op, 'id'),
+      opId: op.id,
+      waypointId: `${op.id}-${op.position}`,
+      pathItemId: null,
+      location: {
+        type: 'operational_point_part_reference',
+        operational_point: { type: 'id', operational_point: op.id },
+      },
+    })),
     curves: [],
     voltages: [],
     geometry: { type: 'LineString', coordinates: [] },

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -10,7 +10,7 @@ import type {
   StdcmResponseWithTraceId,
 } from 'common/api/osrdEditoastApi';
 import type {
-  PathOperationalPoint,
+  PathWaypoint,
   SpeedDistanceDiagramData,
   TrainSpaceTimeData,
 } from 'modules/simulationResult/types';
@@ -34,7 +34,7 @@ export type StdcmPathNotFound = Extract<StdcmResponseWithTraceId, { status: 'pat
 export type StdcmResponse = StdcmPathNotFound | StdcmSuccessResponse;
 
 export type StdcmPathProperties = PathProperties & {
-  manchetteOperationalPoints?: PathOperationalPoint[];
+  manchetteOperationalPoints?: PathWaypoint[];
   suggestedOperationalPoints: SuggestedOP[];
 };
 

--- a/front/src/applications/stdcm/utils/addSecondaryCodesToSimilarTrains.ts
+++ b/front/src/applications/stdcm/utils/addSecondaryCodesToSimilarTrains.ts
@@ -1,13 +1,13 @@
 import type { PostSimilarTrainsApiResponse } from 'common/api/osrdEditoastApi';
-import type { PathOperationalPoint } from 'modules/simulationResult/types';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 
 import type { SimilarTrainWithSecondaryCode } from '../types';
 
 export const addSecondaryCodesToSimilarTrains = (
   similarTrains: PostSimilarTrainsApiResponse['similar_trains'],
-  pathOP?: PathOperationalPoint[]
+  pathOP?: PathWaypoint[]
 ): SimilarTrainWithSecondaryCode[] => {
-  const opById = new Map<string, PathOperationalPoint>();
+  const opById = new Map<string, PathWaypoint>();
   pathOP?.forEach((op) => {
     if (op.opId) {
       opById.set(op.opId, op);

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -9,7 +9,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
-import type { PathOperationalPoint } from 'modules/simulationResult/types';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { AppDispatch } from 'store';
 
@@ -56,17 +56,16 @@ const fetchPathProperties = async (
       return { ...op, metadata };
     });
 
-    const operationalPointsWithUniqueIds: PathOperationalPoint[] = result.operational_points.map(
-      (op, index) => ({
-        ...omit(op, 'id'),
-        waypointId: `${op.id}-${op.position}-${index}`,
-        opId: op.id,
-        location: {
-          type: 'operational_point_part_reference' as const,
-          operational_point: { type: 'id' as const, operational_point: op.id },
-        },
-      })
-    );
+    const operationalPointsWithUniqueIds: PathWaypoint[] = result.operational_points.map((op) => ({
+      ...omit(op, 'id'),
+      waypointId: `op-${op.id}-${op.position}`,
+      opId: op.id,
+      pathItemId: null,
+      location: {
+        type: 'operational_point_part_reference' as const,
+        operational_point: { type: 'id' as const, operational_point: op.id },
+      },
+    }));
 
     const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
       operationalPointsWithMetadata,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -34,7 +34,7 @@ import getPathStyleV2 from 'modules/simulationResult/helpers/getPathStyleV2';
 import type {
   CurveStyleExceptionType,
   CurveStyleInput,
-  PathOperationalPoint,
+  ProjectionWaypoint,
   TrainSpaceTimeData,
   WaypointsPanelData,
   DraggingState,
@@ -91,7 +91,7 @@ import useWaypointMenu from './useWaypointMenu';
 import WaypointsPanel from './WaypointsPanel';
 
 type SpaceTimeChartWrapperBaseProps = {
-  operationalPoints: PathOperationalPoint[];
+  operationalPoints: ProjectionWaypoint[];
   trainScheduleProjections: TrainSpaceTimeData[];
   conflicts?: Conflict[];
   workSchedules?: PostWorkSchedulesProjectPathApiResponse;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/WaypointsPanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/WaypointsPanel.tsx
@@ -5,7 +5,7 @@ import { Alert } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import type { PathOperationalPoint, WaypointsPanelData } from 'modules/simulationResult/types';
+import type { ProjectionWaypoint, WaypointsPanelData } from 'modules/simulationResult/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { mmToKm } from 'utils/physics';
 
@@ -14,7 +14,7 @@ import { getWaypointsLocalStorageKey } from './helpers/utils';
 type WaypointsPanelProps = {
   waypointsPanelIsOpen: boolean;
   setWaypointsPanelIsOpen: (open: boolean) => void;
-  waypoints: PathOperationalPoint[];
+  waypoints: ProjectionWaypoint[];
   waypointsPanelData: WaypointsPanelData;
   hideOffsets?: boolean;
 };

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/cutSpaceTimeCurves.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/cutSpaceTimeCurves.ts
@@ -3,7 +3,7 @@ import { compact } from 'lodash';
 
 import type {
   IndividualTrainProjection,
-  PathOperationalPoint,
+  ProjectionWaypoint,
   WaypointsPanelData,
   LayerRangeData,
 } from 'modules/simulationResult/types';
@@ -42,7 +42,7 @@ export const cutSpaceTimeRect = (
 const cutSpaceTimeCurves = (
   projectedTrains: IndividualTrainProjection[],
   conflicts: Conflict[],
-  operationalPoints: PathOperationalPoint[],
+  operationalPoints: ProjectionWaypoint[],
   waypointsPanelData?: WaypointsPanelData
 ) => {
   let cutProjectedTrains = projectedTrains;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import { applyPathStepWeight } from 'applications/operationalStudies/helpers/applyPathStepWeight';
 import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
 import type {
   CorePathfindingResultSuccess,
@@ -36,7 +37,8 @@ const useGetProjectedTrainOperationalPoints = ({
     const getOperationalPoints = async () => {
       let operationalPointsWithUniqueIds =
         projectionType === 'trackProjection' && path && pathfinding
-          ? upsertMapWaypointsInOperationalPoints(
+          ? // Add track offset waypoints to the waypoints
+            upsertMapWaypointsInOperationalPoints(
               'projection',
               path,
               pathfinding.path_item_positions,
@@ -44,6 +46,8 @@ const useGetProjectedTrainOperationalPoints = ({
               t
             )
           : projectedOperationalPoints || [];
+      // Apply max weight on path steps so they are prioritized in the manchette
+      operationalPointsWithUniqueIds = applyPathStepWeight(operationalPointsWithUniqueIds);
 
       setOperationalPoints(operationalPointsWithUniqueIds);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -9,7 +9,7 @@ import type {
   CorePathfindingResultSuccess,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
-import type { PathOperationalPoint, ProjectionData } from 'modules/simulationResult/types';
+import type { ProjectionWaypoint, ProjectionData } from 'modules/simulationResult/types';
 import { getProjectionType } from 'reducers/simulationResults/selectors';
 
 import { getWaypointsLocalStorageKey } from './helpers/utils';
@@ -29,17 +29,18 @@ const useGetProjectedTrainOperationalPoints = ({
   const { t } = useTranslation('operational-studies');
   const projectionType = useSelector(getProjectionType);
 
-  const [operationalPoints, setOperationalPoints] = useState<PathOperationalPoint[]>([]);
+  const [operationalPoints, setOperationalPoints] = useState<ProjectionWaypoint[]>([]);
   const [filteredOperationalPoints, setFilteredOperationalPoints] =
-    useState<PathOperationalPoint[]>(operationalPoints);
+    useState<ProjectionWaypoint[]>(operationalPoints);
 
   useEffect(() => {
     const getOperationalPoints = async () => {
-      let operationalPointsWithUniqueIds: PathOperationalPoint[] =
+      let operationalPointsWithUniqueIds: ProjectionWaypoint[] =
         projectedOperationalPoints?.map((op, i) => ({
           ...omit(op, ['id', 'opRef']),
           waypointId: `${op.id}-${op.position}-${i}`,
           opId: op.id,
+          pathItemId: null,
           location: {
             type: 'operational_point_part_reference' as const,
             operational_point: op.opRef,
@@ -49,7 +50,7 @@ const useGetProjectedTrainOperationalPoints = ({
       operationalPointsWithUniqueIds =
         projectionType === 'trackProjection' && path && pathfinding
           ? upsertMapWaypointsInOperationalPoints(
-              'PathOperationalPoint',
+              'ProjectionWaypoint',
               path,
               pathfinding.path_item_positions,
               operationalPointsWithUniqueIds,
@@ -66,7 +67,7 @@ const useGetProjectedTrainOperationalPoints = ({
       if (stringifiedSavedWaypoints) {
         operationalPointsWithUniqueIds = JSON.parse(
           stringifiedSavedWaypoints
-        ) as PathOperationalPoint[];
+        ) as ProjectionWaypoint[];
       } else {
         // If the manchette hasn't been saved, we want to display by default only
         // the waypoints with CH BV/00/'' and the path steps (origin, destination, vias)

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 
-import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -35,28 +34,16 @@ const useGetProjectedTrainOperationalPoints = ({
 
   useEffect(() => {
     const getOperationalPoints = async () => {
-      let operationalPointsWithUniqueIds: ProjectionWaypoint[] =
-        projectedOperationalPoints?.map((op, i) => ({
-          ...omit(op, ['id', 'opRef']),
-          waypointId: `${op.id}-${op.position}-${i}`,
-          opId: op.id,
-          pathItemId: null,
-          location: {
-            type: 'operational_point_part_reference' as const,
-            operational_point: op.opRef,
-          },
-        })) || [];
-
-      operationalPointsWithUniqueIds =
+      let operationalPointsWithUniqueIds =
         projectionType === 'trackProjection' && path && pathfinding
           ? upsertMapWaypointsInOperationalPoints(
               'ProjectionWaypoint',
               path,
               pathfinding.path_item_positions,
-              operationalPointsWithUniqueIds,
+              projectedOperationalPoints || [],
               t
             )
-          : operationalPointsWithUniqueIds;
+          : projectedOperationalPoints || [];
 
       setOperationalPoints(operationalPointsWithUniqueIds);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -37,7 +37,7 @@ const useGetProjectedTrainOperationalPoints = ({
       let operationalPointsWithUniqueIds =
         projectionType === 'trackProjection' && path && pathfinding
           ? upsertMapWaypointsInOperationalPoints(
-              'ProjectionWaypoint',
+              'projection',
               path,
               pathfinding.path_item_positions,
               projectedOperationalPoints || [],

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { applyPathStepWeight } from 'applications/operationalStudies/helpers/applyPathStepWeight';
-import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
+import { upsertTrackOffsetPathItemsInWaypoints } from 'applications/operationalStudies/helpers/upsertTrackOffsetPathItemsInWaypoints';
 import type {
   CorePathfindingResultSuccess,
   TrainScheduleResponse,
@@ -38,7 +38,7 @@ const useGetProjectedTrainOperationalPoints = ({
       let operationalPointsWithUniqueIds =
         projectionType === 'trackProjection' && path && pathfinding
           ? // Add track offset waypoints to the waypoints
-            upsertMapWaypointsInOperationalPoints(
+            upsertTrackOffsetPathItemsInWaypoints(
               'projection',
               path,
               pathfinding.path_item_positions,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -340,7 +340,8 @@ const useTrackOccupancy = ({
 
         res.push({
           waypointId,
-          operationalPointId: op.opId ?? waypointId,
+          // The TOD can't be opened on a trackoffset waypoint so opId is always defined
+          operationalPointId: op.opId!,
           operationalPointPosition: op.position,
           operationalPointName: op.name,
           zones: resolvedZones,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -24,7 +24,7 @@ import {
 import { mapBy } from 'utils/types';
 
 import { usePrevious } from '../../../../utils/hooks/state';
-import type { BaseTrainProjection, PathOperationalPoint, TrainSpaceTimeData } from '../../types';
+import type { BaseTrainProjection, ProjectionWaypoint, TrainSpaceTimeData } from '../../types';
 import { EXCEPTION_SUFFIX } from './helpers/makeProjectedTrains';
 import { NO_TRACK_SPECIFIED_SYMBOL, sortTracks } from './helpers/sortTracks';
 import { batchFetchTrackOccupancy } from './helpers/utils';
@@ -56,7 +56,7 @@ function extractStationLabel(
 }
 
 function getTrackOccupancyOperationalPointReference(
-  op: PathOperationalPoint | undefined
+  op: ProjectionWaypoint | undefined
 ): OperationalPointReference | undefined {
   return op && op.location.type !== 'track_offset' ? op.location.operational_point : undefined;
 }
@@ -68,7 +68,7 @@ function getTrackOccupancyOperationalPointReference(
  * - infraId
  * - trains: An array with all visible TrainSpaceTimeData items in the SpaceTimeChart.
  * - pathOperationalPoints:
- *   An array with all PathOperationalPoint items along the current path
+ *   An array with all ProjectionWaypoint items along the current path
  *
  * It outputs:
  * - deployedWaypoints:
@@ -89,7 +89,7 @@ const useTrackOccupancy = ({
   infraId: number;
   timetableId: number;
   trainScheduleProjections: TrainSpaceTimeData[];
-  pathOperationalPoints: PathOperationalPoint[];
+  pathOperationalPoints: ProjectionWaypoint[];
 }): {
   deployedWaypoints: DeployedWaypoint[];
   toggleWaypoint: (waypointId: string, selectedState?: boolean) => void;

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/__tests__/helpers.spec.ts
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/__tests__/helpers.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 
 import type { PathPropertiesFormatted, PositionData } from 'applications/operationalStudies/types';
 import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 
 import {
   formatSpeeds,
@@ -34,10 +35,12 @@ describe('formatSpeeds', () => {
 
 describe('formatStops', () => {
   it('should format stops', () => {
-    const operationalPoints: PathPropertiesFormatted['operationalPoints'] = [
+    const operationalPoints: PathWaypoint[] = [
       {
         country_code: 'country_code',
-        id: 'id',
+        opId: null,
+        waypointId: 'id',
+        pathItemId: null,
         is_passenger_station: false,
         main_code: 'main_code',
         name: 'name',
@@ -50,6 +53,10 @@ describe('formatStops', () => {
         secondary_code: 'secondary_code',
         uic: 0,
         weight: null,
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: { type: 'uic', uic: 0 },
+        },
       },
     ];
     const expected = [

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/helpers.ts
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/helpers.ts
@@ -10,7 +10,7 @@ import type {
 import type { PathPropertiesFormatted, PositionData } from 'applications/operationalStudies/types';
 import type { CoreReportTrain, SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import { TAG_COLORS } from 'modules/simulationResult/consts';
-import type { SpeedLimitTagValue } from 'modules/simulationResult/types';
+import type { PathWaypoint, SpeedLimitTagValue } from 'modules/simulationResult/types';
 import { mmToKm, msToKmh, mToKm } from 'utils/physics';
 
 import { electricalProfilesDesignValues } from './consts';
@@ -98,7 +98,7 @@ const formatMrsp = (mrsp: SimulationResponseSuccess['mrsp']) => ({
   values: mrsp.values.map((speed) => ({ speed: msToKmh(speed.speed), isTemporary: false })),
 });
 
-export const formatStops = (operationalPoints: PathPropertiesFormatted['operationalPoints']) =>
+export const formatStops = (operationalPoints: PathWaypoint[]) =>
   operationalPoints.map(({ position, weight, name, secondary_code }) => ({
     position: {
       start: mmToKm(position),

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -26,18 +26,25 @@ import type {
 import type { SelectedTrain, SelectionSource } from 'reducers/simulationResults/types';
 import type { ArrayElement } from 'utils/types';
 
-// 1. This type refers to an operational point, modified to carry its own unique ID (waypointId), and
-// optionally an actual opId, which can be repeated along a path when a train crosses multiple time
-// the same operational point
-// 2. Remove the part field as it won't be used anywhere in the app. This avoid us to have to add hardcoded data in it.
-export type PathOperationalPoint = Omit<
-  PathProperties['operational_points'][number],
-  'id' | 'part'
-> & {
+/**
+ * This type refers to a waypoint, modified to carry its own unique ID (waypointId), and
+ * optionally an actual opId and pathStepId (for its corresponding path item), which can be repeated along a path when a train crosses multiple time
+ * the same operational point.
+ * Can hold an OP found in infra, or a track-offset
+ */
+export type PathWaypoint = Omit<PathProperties['operational_points'][number], 'id'> & {
   waypointId: string;
   opId: string | null;
+  pathItemId: string | null;
   location: PathItemLocation;
 };
+
+// TODO: adapt all params using these types to use the term waypoint instead of operational point
+//       since they can contain trackoffset waypoints and "op" refers to an infra object
+
+// Same as above, and can also hold a virtual OP
+// TODO: refactor this type to remove all the unnecessary fields
+export type ProjectionWaypoint = Omit<PathWaypoint, 'part'>;
 
 // Space Time Chart
 /**
@@ -104,8 +111,8 @@ export type ProjectionData = Omit<
 
 export type WaypointsPanelData = {
   timetableId: number | undefined;
-  filteredWaypoints: PathOperationalPoint[];
-  setFilteredWaypoints: Dispatch<SetStateAction<PathOperationalPoint[]>>;
+  filteredWaypoints: ProjectionWaypoint[];
+  setFilteredWaypoints: Dispatch<SetStateAction<ProjectionWaypoint[]>>;
   deployedWaypoints: Set<string>;
   toggleDeployedWaypoint: (waypointId: string, deployed?: boolean) => void;
   projectionPath: TrainSchedule['path'];

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -26,16 +26,14 @@ import type {
 import type { SelectedTrain, SelectionSource } from 'reducers/simulationResults/types';
 import type { ArrayElement } from 'utils/types';
 
-// This alias refers to an operational point, in the context of a given path, from Edistoast:
-export type EditoastPathOperationalPoint = NonNullable<
-  PathProperties['operational_points']
->[number];
-
 // 1. This type refers to an operational point, modified to carry its own unique ID (waypointId), and
 // optionally an actual opId, which can be repeated along a path when a train crosses multiple time
 // the same operational point
 // 2. Remove the part field as it won't be used anywhere in the app. This avoid us to have to add hardcoded data in it.
-export type PathOperationalPoint = Omit<EditoastPathOperationalPoint, 'id' | 'part'> & {
+export type PathOperationalPoint = Omit<
+  PathProperties['operational_points'][number],
+  'id' | 'part'
+> & {
   waypointId: string;
   opId: string | null;
   location: PathItemLocation;

--- a/front/src/modules/timesStops/helpers/powerRestrictionIncompatibility.ts
+++ b/front/src/modules/timesStops/helpers/powerRestrictionIncompatibility.ts
@@ -160,9 +160,10 @@ export const computePowerRestrictionWarnings = ({
 
   const pathStepPositions = new Map<string, number>();
   path.forEach((pathStep) => {
-    const matchingOp = operationalPointsOnPath?.find((op) =>
-      matchPathStepAndOp(pathStep.location, buildOpMatchParams(op))
-    );
+    const matchingOp = operationalPointsOnPath?.find((op) => {
+      const builtOp = buildOpMatchParams(op);
+      return builtOp && matchPathStepAndOp(pathStep.location, builtOp);
+    });
     if (matchingOp) pathStepPositions.set(pathStep.id, matchingOp.position);
   });
 

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -23,7 +23,6 @@ import {
   secToHoursString,
   time2sec,
 } from 'utils/timeManipulation';
-import type { ArrayElement } from 'utils/types';
 
 import { marginRegExValidation, MarginUnit } from '../consts';
 import { TableType, type TimeExtraDays, type TimesStopsInputRow } from '../types';
@@ -400,13 +399,14 @@ export const getOperationalPointName = (
 };
 
 /** Build matching parameters from an operational point for PathStep matching. */
-export const buildOpMatchParams = (
-  op: ArrayElement<PathPropertiesFormatted['operationalPoints']>
-) => ({
-  opId: op.id,
-  uic: op.uic,
-  secondaryCode: op.secondary_code,
-  mainCode: op.main_code,
-  track: op.part.track,
-  offsetOnTrack: op.part.position,
-});
+export const buildOpMatchParams = (op: PathPropertiesFormatted['operationalPoints'][number]) =>
+  op.opId
+    ? {
+        opId: op.opId,
+        uic: op.uic,
+        secondaryCode: op.secondary_code,
+        mainCode: op.main_code,
+        track: op.part.track,
+        offsetOnTrack: op.part.position,
+      }
+    : null;

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -257,7 +257,10 @@ const useTimesStopsTableData = (
         const matchingOp =
           pathStepOp ??
           ('operational_point' in pathStep.location && stableOPs
-            ? stableOPs.find((op) => matchPathStepAndOp(pathStep.location, buildOpMatchParams(op)))
+            ? stableOPs.find((op) => {
+                const builtOp = buildOpMatchParams(op);
+                return builtOp && matchPathStepAndOp(pathStep.location, builtOp);
+              })
             : undefined);
 
         const name =
@@ -345,9 +348,16 @@ const useTimesStopsTableData = (
       stableOPs.forEach((op, opIndex) => {
         const trackName = op.part.local_track_name;
 
-        const matchingPathStep = selectedTrain.path.find((pathStep) =>
-          matchPathStepAndOp(pathStep.location, buildOpMatchParams(op))
-        );
+        const matchingPathStep = selectedTrain.path.find((pathStep) => {
+          // Track-offset waypoints (opId is null) are matched by pathItemId
+          if (!op.opId) {
+            return op.pathItemId ? pathStep.id === op.pathItemId : false;
+          }
+          // TODO: now that we can match with pathItemId, we no longer need to call matchPathStepAndOp
+          // We could probably remove this function after the drop of the old interfaces is done
+          const builtOp = buildOpMatchParams(op);
+          return builtOp && matchPathStepAndOp(pathStep.location, builtOp);
+        });
 
         const matchingPathStepRow = matchingPathStep
           ? pathStepRowsById.get(matchingPathStep.id)
@@ -375,7 +385,9 @@ const useTimesStopsTableData = (
                 : undefined;
           }
 
-          const receptionSignal = scheduleByAt[op.id]?.reception_signal;
+          // TODO : the correspondance is weird. We rely on an opId to match the schedule but the db opId
+          // won't be the same as the generated one from the path steps.
+          const receptionSignal = scheduleByAt[op.opId ?? op.waypointId]?.reception_signal;
 
           const { shortSlipDistance, onStopSignal } =
             receptionSignalToSignalBooleans(receptionSignal);
@@ -387,7 +399,7 @@ const useTimesStopsTableData = (
 
           formattedRows.push({
             ...buildTableRow({
-              id: `op-${op.id}-${op.position}`,
+              id: op.waypointId,
               pathStepId: null,
               opOnPathIndex: opIndex,
               name: op.name,

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
@@ -56,7 +56,6 @@ export default function commonConfBuilder() {
     ],
 
     buildPathProperties: (): ManageTrainSchedulePathProperties => ({
-      manchetteOperationalPoints: [],
       electrifications: {
         boundaries: [84015000],
         values: [


### PR DESCRIPTION
Before the new itinerary modal, we supported only the uic format to update the weight of path steps in the manchette. The new itinerary modal introduced the use of trigram format to define an path step which was not working on the manchette. Update the logic so it supports all kind of format.

To properly fix this issue, some refacto has been done. See commits.

We also fix path steps not having prioritized in the manchette in op projection in the STD.

fix #16707 
close #16733
fix #11306 