### PR TITLE
 front: handle RaiMI errors with forwarded status 

### DIFF
--- a/front/src/utils/error.ts
+++ b/front/src/utils/error.ts
@@ -34,9 +34,20 @@ export function getErrorMessage(error: unknown, defaultValue?: string): string {
         const i18nId = type.split(':').join('.');
         return i18n.t(i18nId, i18nMsg, { ...context, ns: 'errors' });
       }
+
       if ('message' in error.data) return `${error.data.message}`;
-      if ('detail' in error.data) return `${error.data.detail}`; // Format used by some implems of railway-manager-interface
+
+      // Format used by some implems of railway-manager-interface
+      if ('detail' in error.data) {
+        const detail = error.data.detail;
+        if (!isObject(detail)) return `${detail}`;
+
+        const message = 'error' in detail ? detail.error : defaultMessage;
+        if ('status_code' in detail) return `${message} (${detail.status_code})`; // Forwarded status, differs from the main error status
+        return `${message}`;
+      }
     }
+
     if (typeof error.data === 'string') {
       // API returned a plaintext error instead of a JSON payload
       return error.data;


### PR DESCRIPTION
Close #14865

We handled most of RaiMI errors correctly, as they were of the form `"detail": string`.

However when RaiMI was forwarding a status it received to the front, it instead uses the format `"detail": {"error": string, "status_code": number}`, which we did not handle well.

Before this pr:
<img width="367" height="82" alt="image" src="https://github.com/user-attachments/assets/8a848ba2-3b8e-4fa7-b527-8e9b71878375" />


After this pr (please don't pay attention to the language of the header or the error box size, only to the error message): 
<img width="452" height="131" alt="image" src="https://github.com/user-attachments/assets/f1f9439b-8511-4b16-8a5c-743ac8fba88a" />
