### PR TITLE
core: avoid connection leak when editoast returns an error

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -125,6 +125,7 @@ class TimetableDownloader(
                     return response
                 } else {
                     logger.error("Error when getting ${request.url}: $response")
+                    response.close()
                 }
             } catch (e: IOException) {
                 // This block is especially important for timeout errors, but we can retry after any
@@ -137,7 +138,7 @@ class TimetableDownloader(
             // don't want the next page to immediately take over while this one is waiting.
             Thread.sleep(nextSleepDuration)
         }
-        throw UnexpectedHttpResponse(response)
+        throw RuntimeException("Can't access ${request.url}, retry count exceeded")
     }
 
     private data class PaginatedRequirements(


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16077

Tested locally by having editoast return errors randomly, it did cause these errors before but not anymore with this change. The error being `WARNING: A connection to http://localhost:8090/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
`