### PR TITLE
editoast: add --skip-if-exists to user add cli

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,7 @@ services:
       /bin/sh -c "
         fga_migrations apply &&
         diesel migration run --locked-schema &&
-        editoast user add 'Example User' 'mock/mocked' &&
+        editoast user add --skip-if-exists 'Example User' 'mock/mocked' &&
         editoast roles add 'mock/mocked' Admin &&
         exec editoast runserver"
     healthcheck:

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -202,7 +202,7 @@ services:
       /bin/sh -c "
         fga_migrations apply &&
         diesel migration run --locked-schema &&
-        editoast user add 'Example User' 'mock/mocked' &&
+        editoast user add --skip-if-exists 'Example User' 'mock/mocked' &&
         editoast roles add 'mock/mocked' Admin &&
         exec editoast runserver"
     healthcheck:

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -196,7 +196,7 @@ If your client has a direct access to editoast, an other possibility is to add t
 You can create a new user with `Admin` role by using the following commands :
 
 ```sh
-cargo run user add 'Example User' 'mock/mocked'
+cargo run user add --skip-if-exists 'Example User' 'mock/mocked'
 cargo run roles add 'mock/mocked' Admin
 ```
 
@@ -206,7 +206,7 @@ In development, the default user `mock/mocked` which is given by the gateway.
 If you run the stack with docker, you can use:
 
 ```sh
-docker exec osrd-editoast editoast user add 'Example User' 'mock/mocked'
+docker exec osrd-editoast editoast user add --skip-if-exists 'Example User' 'mock/mocked'
 docker exec osrd-editoast editoast roles add 'mock/mocked' Admin
 ```
 

--- a/editoast/justfile
+++ b/editoast/justfile
@@ -11,7 +11,7 @@ run:
     diesel migration run --locked-schema
     cargo run --package fga_migrations -- apply
     @echo 'Authorizing "mock/mocked" user. Make sure the gateway user matches.'
-    cargo run -- user add "Example User" "mock/mocked"
+    cargo run -- user add --skip-if-exists "Example User" "mock/mocked"
     cargo run -- roles add "mock/mocked" Admin
     @echo 'Starting editoast in single worker mode. If you use osrd-compose add the `sw` flag'
     EDITOAST_CORE_SINGLE_WORKER=true cargo run -- runserver

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -59,6 +59,9 @@ pub struct AddArgs {
     name: Option<String>,
     /// Identities of the user
     identities: Vec<String>,
+    /// Skip if one of the identities already exists
+    #[arg(long)]
+    skip_if_exists: bool,
 }
 
 #[derive(Debug, Args)]
@@ -130,12 +133,26 @@ pub async fn list_user(
 
 /// Add a user
 pub async fn add_user(
-    AddArgs { name, identities }: AddArgs,
+    AddArgs {
+        name,
+        identities,
+        skip_if_exists,
+    }: AddArgs,
     pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
     if identities.is_empty() {
         println!("No identities provided.");
         return Ok(());
+    }
+    if skip_if_exists {
+        for identity in &identities {
+            let conn = pool.get().await?;
+            let user = editoast_models::User::retrieve_by_identity(identity, conn).await?;
+            if user.is_some() {
+                println!("Skipped: Identity '{identity}' already exists");
+                return Ok(());
+            }
+        }
     }
     let conn = pool.get().await?;
     let created_user =


### PR DESCRIPTION
This fixes crash loop from editoast using docker compose.

Example:

```
$ editoast user add --help
Add a user

Usage: editoast user add [OPTIONS] [NAME] [IDENTITIES]...

Arguments:
  [NAME]           Name of the user
  [IDENTITIES]...  Identities of the user

Options:
  -s, --skip-if-exists  Skip if one of the identities already exists
  -h, --help            Print help
$ editoast user add -s 'Lol' 'lol2' 'mock/mocked'
Skipped: Identity mock/mocked already exists
```