### PR TITLE
core: worker: retry if the queue doesn't exist when ALL_INFRA is set

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -27,6 +27,7 @@ import kotlin.system.exitProcess
 import kotlin.use
 import kotlinx.serialization.ExperimentalSerializationApi
 import okhttp3.OkHttpClient
+import okio.IOException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -176,7 +177,20 @@ class WorkerCommand : CliCommand {
                 TimeUnit.MILLISECONDS,
                 LinkedBlockingQueue(),
             )
-        return consume(executor)
+
+        while (true) {
+            try {
+                val res = consume(executor)
+                if (!ALL_INFRA) return res
+            } catch (e: IOException) {
+                if (!ALL_INFRA) throw e
+                // On ALL_INFRA, the worker may start before the queue exists,
+                // in which case we can wait for it to be created.
+                logger.warn("Couldn't start consumer: ${e.message} ${e.cause}")
+            }
+            logger.info("Restarting consumer in 1s")
+            Thread.sleep(1000)
+        }
     }
 
     /** Load the given infra and timetable this worker is specialized on, if set. */
@@ -336,6 +350,7 @@ class WorkerCommand : CliCommand {
         factory.setSharedExecutor(executor)
         factory.setMaxInboundMessageBodySize(WORKER_MAX_MSG_SIZE)
         val connection = factory.newConnection()
+        var isCancelled = false
 
         connection.use {
             connection.createChannel().use { channel -> reportActivity(channel, "started") }
@@ -376,16 +391,17 @@ class WorkerCommand : CliCommand {
                 },
                 { _ ->
                     logger.error("consumer cancelled")
-                    exitProcess(0)
+                    isCancelled = true
                 },
                 { consumerTag, e ->
                     logger.info("consume shutdown: {}, {}", consumerTag, e.toString())
                 },
             )
 
-            while (true) {
+            logger.info("consume started")
+
+            while (!isCancelled && channel.isOpen) {
                 Thread.sleep(100)
-                if (!channel.isOpen) break
             }
 
             logger.info("consume ended")


### PR DESCRIPTION
Sometimes, especially when the queues haven't been used in a while, starting a `core` worker can result in an error where it doesn't seem to find the queue. In can be annoying when running core outside of docker compose, as it doesn't restart automatically. We generally need to put messages in the queue *before* starting the core process. 

The error is `com.rabbitmq.client.ShutdownSignalException: channel error; protocol method: #method<channel.close>(reply-code=404, reply-text=NOT_FOUND - no queue 'core-req-all'`

This PR adds a simple retry mechanism when core is running in `ALL_INFRA`. Otherwise we can rely on osrdyne to restart the worker anyway. 

---

After further investigation: osrdyne deletes the queues after 20 minutes of inactivity. If a core is connected to the queue at that time, the consumer gets "cancelled". If a core tries to start reading the queue while it doesn't exist, it crashes with the error mentioned above, but it also *triggers the queue creation*. So the second attempt works. 

The last version of this PR wraps the consume in a loop that retries, both when it fails at startup and after a cancel. 

Note: this doesn't *entirely* make it possible to start core before the rest of the stack, as the setup before `consume` can also fail. Specifically, if valkey parameters are set, it tries to connect and may crash there. 