### PR TITLE
editoast: activate compression

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -31,6 +31,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "amq-protocol"
 version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +541,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +620,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -717,9 +755,12 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
+ "brotli",
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -2612,6 +2653,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -5710,6 +5761,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -231,9 +231,9 @@ tokio.workspace = true
 tokio-stream = "0.1.18"
 tower = "0.5.2"
 tower-http = { version = "0.6.6", features = [
-  "compression-gzip",
+  "compression-full",
   "cors",
-  "decompression-gzip",
+  "decompression-full",
   "fs",
   "limit",
   "normalize-path",

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -18,8 +18,9 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Cargo chef : build #
 ######################
 FROM chef AS base_builder
-RUN apk add --no-cache build-base curl openssl openssl-dev openssl-libs-static mold libpq-dev geos-dev
+RUN apk add --no-cache build-base curl openssl openssl-dev openssl-libs-static mold libpq-dev geos-dev zstd-dev
 ENV RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=mold"
+ENV ZSTD_SYS_USE_PKG_CONFIG=1
 RUN set -eux; \
     arch="$(uname -m)"; \
     mkdir -p /cargo_editoast/bin; \

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -80,6 +80,7 @@ use editoast_derive::EditoastError;
 use thiserror::Error;
 use tokio::time::timeout;
 use tower::Layer as _;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::Any;
 use tower_http::cors::CorsLayer;
 use tower_http::decompression::RequestDecompressionLayer;
@@ -1248,6 +1249,7 @@ impl Server {
             .layer(OtelInResponseLayer)
             .layer(OtelAxumLayer::default())
             .layer(RequestDecompressionLayer::new())
+            .layer(CompressionLayer::new())
             .layer(DefaultBodyLimit::disable())
             .layer(request_payload_limit)
             .layer(cors)


### PR DESCRIPTION
Editoast was not compressing any payloads. The gateway was doing the work. In local it's not  a bit deal but in production is not ideal since the gateway and editoast can be running on different nodes. 

In addition of enabling compression, I have re-enable zstd, br and flate.
As mention in this PR: https://github.com/OpenRailAssociation/osrd/pull/16178 zstd takes a lot of time. I added `ZSTD_SYS_USE_PKG_CONFIG=1` to make it use pre-installed zstd.

> [!NOTE]
> I checked that we still don't compress payloads for stdcm since we wante live update (ref: https://github.com/OpenRailAssociation/osrd/pull/16380/changes).
> Fun fact we thought editoast was compressing but it was the gateway. 