### PR TITLE
Introduce CurveStyle type for shared STD/TOD styling

### DIFF
--- a/front/ui/ui-charts/src/common/index.ts
+++ b/front/ui/ui-charts/src/common/index.ts
@@ -5,6 +5,7 @@ export { usePicking, useDraw } from './hooks/useCanvas';
 export { getCrispLineCoordinate } from './helpers/time';
 
 export type {
+  CurveStyle,
   HoveredItem,
   DrawingFunction,
   PickingDrawingFunction,

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -1,6 +1,6 @@
 import { type HTMLProps } from 'react';
 
-import { type SpaceTimeChartTheme } from '../spaceTimeChart';
+import type { PathLevel, SpaceTimeChartTheme } from '../spaceTimeChart';
 import type { DataPoint, Handler, PointToData, DataToPoint } from '../spaceTimeChart/lib/types';
 import type { LAYERS, PICKING_LAYERS } from './consts';
 
@@ -23,6 +23,32 @@ export type RGBAColor = [number, number, number, number];
 // CANVAS SPECIFIC TYPES:
 export type PickingLayerType = (typeof PICKING_LAYERS)[number];
 export type LayerType = (typeof LAYERS)[number];
+
+/**
+ * Visual style of a curve, computed by the shared curve-style helper
+ * and used by STD (PathLayer) and TOD (OccupancyBlockLayer).
+ *
+ * TODO: reuse this type in PathLayerProps when integrating drag and drop in STD/TOD.
+ */
+export type CurveStyle = {
+  color: string;
+  opacity: number;
+  level?: PathLevel;
+  outline?: {
+    /** Offset compared to the curve */
+    offset: number;
+    /** Color of the outline */
+    color: string;
+    /** Thickness of the outline */
+    width?: number;
+    /** Won't be used most of the time, color will be used */
+    backgroundColor?: string;
+  };
+  label?: {
+    border?: { color: string; width: number };
+    fontWeight?: number;
+  };
+};
 
 // PICKING SPECIFIC TYPES:
 export type PickingElement = { type: string };


### PR DESCRIPTION
This PR adds the `CurveStyle` type to the simulation result types.

It is the output of the shared curve-style helper that will style curves in both STD (PathLayer) and TOD (OccupancyBlockLayer).

It is added first so that other developers can start to work on STD, TOD and ui changes in parallel, before the helper itself is ready.
