### PR TITLE
front: add a logic-less train header

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -497,6 +497,30 @@
     },
     "toggleTrigramSearch": "Toggle trigram search",
     "trainAdded": "Train added",
+    "trainHeader": {
+      "allowances": {
+        "linear": "Linear margin",
+        "mareco": "Mareco margin"
+      },
+      "form": {
+        "comfort": "Comfort",
+        "compositionCode": "Composition code",
+        "departureDate": "Departure date",
+        "electricalProfiles": "Electrical profiles",
+        "initialVelocity": "Initial velocity",
+        "manageExtraOccurrences": "Manage extra occurrences",
+        "recoveryMargin": "Recovery margin",
+        "rollingStock": "Rolling stock",
+        "serviceCadence": "Service cadence",
+        "serviceWindow": "Service window",
+        "tags": "Tags",
+        "trainCategory": "Train category",
+        "trainName": "Train name"
+      },
+      "itinerary": "Itinerary",
+      "serviceModelTrain": "Service model train",
+      "serviceOccurrence": "Service occurrence"
+    },
     "trainLabels": "Tags",
     "trainScheduleDepartureTime": "Departure time",
     "trainScheduleInitialSpeed": "Initial velocity",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -799,6 +799,18 @@
     "rollingResistanceFormula": "R(v) = a + bv + cv²",
     "rollingstockChoice": "Choose a rolling stock",
     "selectRollingStock": "Select",
+    "shortCategoriesOptions": {
+      "COMMUTER_TRAIN": "Commuter",
+      "FAST_FREIGHT_TRAIN": "Fast Freight",
+      "FREIGHT_TRAIN": "Freight",
+      "HIGH_SPEED_TRAIN": "High-Speed",
+      "INTERCITY_TRAIN": "Intercity",
+      "NIGHT_TRAIN": "Night",
+      "REGIONAL_TRAIN": "Regional",
+      "TOURISTIC_TRAIN": "Touristic",
+      "TRAM_TRAIN": "Tram-Train",
+      "WORK_TRAIN": "Work"
+    },
     "speed": "Velocity (km/h)",
     "startupAcceleration": "Startup acceleration",
     "startupTime": "Startup duration",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -497,6 +497,30 @@
     },
     "toggleTrigramSearch": "Basculer l'affichage de la recherche par trigramme",
     "trainAdded": "Train ajouté",
+    "trainHeader": {
+      "allowances": {
+        "linear": "Marge linéaire",
+        "mareco": "Marge Mareco"
+      },
+      "form": {
+        "comfort": "Confort",
+        "compositionCode": "Code composition",
+        "departureDate": "Date de départ",
+        "electricalProfiles": "Profils électriques",
+        "initialVelocity": "Vitesse initiale",
+        "manageExtraOccurrences": "Gérer les occurrences hors cadence",
+        "recoveryMargin": "Marge de régularité",
+        "rollingStock": "Matériel roulant",
+        "serviceCadence": "Cadence de la mission",
+        "serviceWindow": "Durée de la plage de répétition",
+        "tags": "Étiquettes",
+        "trainCategory": "Catégorie de train",
+        "trainName": "Nom du train"
+      },
+      "itinerary": "Itinéraire",
+      "serviceModelTrain": "Train modèle de mission",
+      "serviceOccurrence": "Occurrence de mission"
+    },
     "trainLabels": "Étiquettes",
     "trainScheduleDepartureTime": "Heure de départ",
     "trainScheduleInitialSpeed": "Vitesse initiale",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -799,6 +799,18 @@
     "rollingResistanceFormula": "R(v) = a + bv + cv²",
     "rollingstockChoice": "Choisissez un matériel roulant",
     "selectRollingStock": "Sélectionner",
+    "shortCategoriesOptions": {
+      "COMMUTER_TRAIN": "Banlieue",
+      "FAST_FREIGHT_TRAIN": "Fret rapide",
+      "FREIGHT_TRAIN": "Fret",
+      "HIGH_SPEED_TRAIN": "Grande vitesse",
+      "INTERCITY_TRAIN": "Interville",
+      "NIGHT_TRAIN": "Nuit",
+      "REGIONAL_TRAIN": "Régional",
+      "TOURISTIC_TRAIN": "Touristique",
+      "TRAM_TRAIN": "Tram-train",
+      "WORK_TRAIN": "Travaux"
+    },
     "speed": "Vitesse (km/h)",
     "startupAcceleration": "Accélération au démarrage",
     "startupTime": "Durée de démarrage",

--- a/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
@@ -14,6 +14,7 @@ type ResizableProps = {
 
 type BoardWrapperProps = {
   children: React.ReactNode;
+  customHeader?: React.ReactNode;
   customFooter?: React.ReactNode;
   hidden?: boolean;
   name: string;
@@ -34,6 +35,7 @@ const BoardWrapper = ({
   withFooter = false,
   footerClass,
   dataTestId,
+  customHeader,
   customFooter,
   resizable,
 }: BoardWrapperProps) => {
@@ -55,6 +57,7 @@ const BoardWrapper = ({
           menuProps={{ items }}
         />
       </div>
+      {customHeader}
       <div
         className={cx('board-body', {
           'with-rounded-corners': !withFooter,

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -22,6 +22,7 @@ import useTrackOccupancy from 'modules/simulationResult/components/SpaceTimeChar
 import SpeedDistanceDiagramWrapper from 'modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper';
 import type { ProjectionData, TrainSpaceTimeData } from 'modules/simulationResult/types';
 import TimesStopsOutput from 'modules/timesStops/TimesStopsOutput';
+import TrainHeader from 'modules/trainHeader/TrainHeader';
 import { findExceptionWithOccurrenceId } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import { toggleDisplayOnlyPathSteps, updateSelectedTrain } from 'reducers/simulationResults';
@@ -350,6 +351,7 @@ const SimulationResults = ({
                 },
               },
             ]}
+            customHeader={<TrainHeader train={simulationResults.train} />}
             customFooter={
               simulationResults?.isValid && (
                 <div className="time-stop-outputs">

--- a/front/src/modules/modules.scss
+++ b/front/src/modules/modules.scss
@@ -6,3 +6,4 @@
 @use './scenario/styles/scenario.scss';
 @use './trainSchedule/styles/trainSchedule.scss';
 @use './timesStops/styles/timesStops.scss';
+@use './trainHeader/styles/trainHeader.scss';

--- a/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
+++ b/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
@@ -1,0 +1,83 @@
+import { Button } from '@osrd-project/ui-core';
+import { ChevronDown } from '@osrd-project/ui-icons';
+import { useTranslation } from 'react-i18next';
+
+import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
+import type { Train } from 'reducers/osrdconf/types';
+import { useDateTimeLocale } from 'utils/date';
+import { findExceptionInPacedTrainByOccurenceId } from 'utils/trainExceptions';
+import { isOccurrenceId } from 'utils/trainId';
+
+import {
+  getServiceInterval,
+  getServiceWindow,
+  getShortCategoryName,
+  getShortDepartureDate,
+} from './utils/trainProperties';
+
+export type CollapsedTrainOverviewProps = {
+  train: Train;
+  onExpand: () => void;
+};
+
+/**
+ * A simple line that shows an overview of the key properties of a train.
+ */
+const CollapsedTrainOverview = ({ train, onExpand }: CollapsedTrainOverviewProps) => {
+  const { t } = useTranslation(['operational-studies', 'translation']);
+  const dateTimeLocale = useDateTimeLocale();
+
+  const pacedTrain = train.paced ? (train as PacedTrainWithPaced) : null;
+  const occurenceId = isOccurrenceId(train.id) ? train.id : null;
+  const exception =
+    occurenceId && pacedTrain
+      ? findExceptionInPacedTrainByOccurenceId(occurenceId, pacedTrain)
+      : null;
+
+  return (
+    <div className="train-header collapsed-train-summary">
+      {pacedTrain && (
+        <div className="train-kind-header">
+          {occurenceId
+            ? t('manageTrainSchedule.trainHeader.serviceOccurrence')
+            : t('manageTrainSchedule.trainHeader.serviceModelTrain')}
+          {exception && ' ≠'}
+        </div>
+      )}
+      <div className="train-metadata">
+        {pacedTrain && !occurenceId && (
+          <div className="train-service-cadence">
+            {getServiceInterval(pacedTrain)}’ — {getServiceWindow(pacedTrain)}’
+          </div>
+        )}
+        <div className="train-departure-date">{getShortDepartureDate(train, dateTimeLocale)}</div>
+        <div className="train-category">{getShortCategoryName(train, t)}</div>
+        {train.rolling_stock_name && (
+          <div className="train-rolling-stock">{train.rolling_stock_name}</div>
+        )}
+        {train.speed_limit_tag && (
+          <div className="train-composition-code">{train.speed_limit_tag}</div>
+        )}
+        <div className="train-recovery-margin">
+          {train.constraint_distribution === 'MARECO'
+            ? t('manageTrainSchedule.trainHeader.allowances.mareco')
+            : t('manageTrainSchedule.trainHeader.allowances.linear')}
+        </div>
+      </div>
+      <div className="actions">
+        <Button
+          label={t('manageTrainSchedule.trainHeader.itinerary')}
+          variant="Quiet"
+          onClick={() => {}}
+          size="small"
+          isDisabled
+        />
+      </div>
+      <button className="header-toggle" onClick={() => onExpand()}>
+        <ChevronDown />
+      </button>
+    </div>
+  );
+};
+
+export default CollapsedTrainOverview;

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -1,0 +1,205 @@
+import { Button, Checkbox, Input } from '@osrd-project/ui-core';
+import { ChevronUp } from '@osrd-project/ui-icons';
+import { useTranslation } from 'react-i18next';
+
+import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
+import type { Train } from 'reducers/osrdconf/types';
+import { useDateTimeLocale } from 'utils/date';
+import { findExceptionInPacedTrainByOccurenceId } from 'utils/trainExceptions';
+import { isOccurrenceId } from 'utils/trainId';
+
+import {
+  getCategoryName,
+  getComfortType,
+  getServiceInterval,
+  getServiceWindow,
+  getShortDepartureDate,
+} from './utils/trainProperties';
+
+export type ExpandedTrainFormProps = {
+  train: Train;
+  onCollapse: () => void;
+};
+
+/**
+ * A header-shaped form that allow users to set most of the properties of a train, beside the itinerary itself.
+ */
+const ExpandedTrainForm = ({ train, onCollapse }: ExpandedTrainFormProps) => {
+  const { t } = useTranslation(['operational-studies', 'translation']);
+  const dateTimeLocale = useDateTimeLocale();
+
+  const pacedTrain = train.paced ? (train as PacedTrainWithPaced) : null;
+  const occurenceId = isOccurrenceId(train.id) ? train.id : null;
+  const exception =
+    occurenceId && pacedTrain
+      ? findExceptionInPacedTrainByOccurenceId(occurenceId, pacedTrain)
+      : null;
+
+  const toggleBand = (
+    <div className="toggle-band">
+      <button className="header-toggle" onClick={() => onCollapse()}>
+        <ChevronUp />
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="train-header expanded-train-form">
+      {pacedTrain && (
+        <div className="train-service">
+          {toggleBand}
+          {occurenceId ? (
+            <div className="train-occurrence">
+              <div className="train-paced-kind">
+                {t('manageTrainSchedule.trainHeader.serviceOccurrence')}
+                {exception && ' ≠'}
+              </div>
+            </div>
+          ) : (
+            <div className="train-service-form">
+              <div className="train-paced-kind">
+                {t('manageTrainSchedule.trainHeader.serviceModelTrain')}
+              </div>
+              <div className="train-service-cadence">
+                <Input
+                  id="train-header-service-cadence-input"
+                  small
+                  label={t('manageTrainSchedule.trainHeader.form.serviceCadence')}
+                  value={`${getServiceInterval(pacedTrain) ?? 0} min`}
+                  disabled
+                />
+              </div>
+              <div className="train-service-window">
+                <Input
+                  id="train-header-service-window-input"
+                  small
+                  label={t('manageTrainSchedule.trainHeader.form.serviceWindow')}
+                  value={`${getServiceWindow(pacedTrain) ?? 0} min`}
+                  disabled
+                />
+              </div>
+              <div className="actions">
+                <Button
+                  label={t('manageTrainSchedule.trainHeader.form.manageExtraOccurrences')}
+                  variant="Quiet"
+                  onClick={() => {}}
+                  size="small"
+                  isDisabled
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+      {!pacedTrain && toggleBand}
+      <div className="train-form">
+        <div className="train-name">
+          <Input
+            id="train-header-name-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.trainName')}
+            value={train.train_name ?? ''}
+            disabled
+          />
+        </div>
+        <div className="train-departure-date">
+          <Input
+            id="train-header-departure-date-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.departureDate')}
+            value={getShortDepartureDate(train, dateTimeLocale) ?? ''}
+            disabled
+          />
+        </div>
+        <div className="train-initial-velocity">
+          <Input
+            id="train-header-initial-velocity-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.initialVelocity')}
+            value={train.initial_speed ?? ''}
+            disabled
+          />
+        </div>
+        <div className="train-category">
+          <Input
+            id="train-header-category-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.trainCategory')}
+            value={getCategoryName(train, t) ?? ''}
+            disabled
+          />
+        </div>
+        <div className="train-rolling-stock">
+          <Input
+            id="train-header-rolling-stock-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.rollingStock')}
+            value={train.rolling_stock_name ?? ''}
+            disabled
+          />
+        </div>
+        <div className="train-composition-code">
+          <Input
+            id="train-header-composition-code-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.compositionCode')}
+            value={train.speed_limit_tag ?? ''}
+            disabled
+          />
+        </div>
+        <div className="train-recovery-margin">
+          <Input
+            id="train-header-recovery-margin-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.recoveryMargin')}
+            value={
+              train.constraint_distribution === 'MARECO'
+                ? t('manageTrainSchedule.allowances.distribution-mareco')
+                : t('manageTrainSchedule.allowances.distribution-linear')
+            }
+            disabled
+          />
+        </div>
+        <div className="train-comfort">
+          <Input
+            id="train-header-comfort-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.comfort')}
+            value={getComfortType(train, t) ?? ''}
+            disabled
+          />
+        </div>
+        <div className="train-electric-profile loose-field">
+          <Checkbox
+            id="train-header-electric-profile-input"
+            checked={train?.options?.use_electrical_profiles}
+            disabled
+          >
+            {t('manageTrainSchedule.trainHeader.form.electricalProfiles')}
+          </Checkbox>
+        </div>
+        <div className="train-tags">
+          <Input
+            id="train-header-tags-input"
+            small
+            label={t('manageTrainSchedule.trainHeader.form.tags')}
+            value={train?.labels?.join(', ') ?? ''}
+            disabled
+          />
+        </div>
+
+        <div className="actions">
+          <Button
+            label={t('manageTrainSchedule.trainHeader.itinerary')}
+            variant="Quiet"
+            onClick={() => {}}
+            size="small"
+            isDisabled
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExpandedTrainForm;

--- a/front/src/modules/trainHeader/TrainHeader.tsx
+++ b/front/src/modules/trainHeader/TrainHeader.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+import type { Train } from 'reducers/osrdconf/types';
+
+import CollapsedTrainOverview from './CollapsedTrainOverview';
+import ExpandedTrainForm from './ExpandedTrainForm';
+
+export type TrainHeaderProps = {
+  train: Train;
+};
+
+/**
+ * A dual-purpose header that shows either a collapsed overview on some key train characteristics,
+ * or an expanded form that allow the user to edit every data about the train outside of the train
+ * stops themselves or its itinerary.
+ */
+const TrainHeader = ({ train }: TrainHeaderProps) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (expanded) {
+    return (
+      <ExpandedTrainForm
+        train={train}
+        onCollapse={() => {
+          setExpanded(false);
+        }}
+      />
+    );
+  }
+
+  return (
+    <CollapsedTrainOverview
+      train={train}
+      onExpand={() => {
+        setExpanded(true);
+      }}
+    />
+  );
+};
+
+export default TrainHeader;

--- a/front/src/modules/trainHeader/styles/collapsed.scss
+++ b/front/src/modules/trainHeader/styles/collapsed.scss
@@ -1,0 +1,65 @@
+.collapsed-train-summary {
+  display: grid;
+  grid-template-areas: 'metadata actions toggle';
+  grid-template-columns: 1fr auto auto;
+  font-size: 0.875rem;
+  color: var(--grey50);
+  padding: 2px 8px 4px 12px;
+  min-height: 32px;
+  border-bottom: 1px solid var(--black25);
+  background-color: var(--ambientB5);
+  align-items: center;
+  box-shadow: inset 0 1px 0 var(--white100);
+
+  &:has(.train-kind-header) {
+    grid-template-areas: 'kind metadata actions toggle';
+    grid-template-columns: auto 1fr auto auto;
+  }
+
+  .train-metadata {
+    grid-area: metadata;
+    display: flex;
+    flex-flow: row wrap;
+    column-gap: 32px;
+    row-gap: 4px;
+    margin-top: -2px;
+    justify-self: start;
+  }
+
+  .train-kind-header {
+    grid-area: kind;
+    font-style: italic;
+    color: var(--info60);
+    margin-left: 12px;
+    margin-right: 32px;
+    margin-top: -2px;
+  }
+
+  .header-toggle {
+    grid-area: toggle;
+    margin-left: 24px;
+  }
+
+  .actions {
+    grid-area: actions;
+    justify-self: end;
+    margin-left: 24px;
+  }
+}
+
+@container board-wrapper (width < 800px) {
+  .collapsed-train-summary {
+    grid-template-areas:
+      'actions actions toggle'
+      'metadata metadata metadata';
+
+    &:has(.train-kind-header) {
+      grid-template-areas: 'kind metadata actions toggle';
+      grid-template-columns: auto 1fr auto auto;
+    }
+
+    .train-kind-header ~ .train-metadata {
+      margin-left: 12px;
+    }
+  }
+}

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -1,0 +1,127 @@
+.expanded-train-form {
+  background-color: var(--white100);
+  border-bottom: 1px solid var(--black25);
+  font-size: 14px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(200px, 1fr)) 1fr [end-column];
+
+  :where(& > *) {
+    grid-column: 1 / end-column;
+  }
+
+  .toggle-band {
+    display: grid;
+    place-items: start end;
+    padding-top: 3px;
+    margin-right: 8px;
+    margin-bottom: -28px;
+  }
+
+  .train-form {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-auto-flow: column;
+    padding: 24px 16px 16px 16px;
+
+    :where(& > *) {
+      margin-top: -8px;
+    }
+
+    label {
+      margin-bottom: unset;
+    }
+
+    .loose-field {
+      align-content: center;
+      padding: 32px 16px 16px 16px;
+    }
+
+    .actions {
+      place-self: end end;
+      margin-bottom: 16px;
+      margin-right: 8px;
+      grid-row: 3;
+      grid-column: end-column;
+    }
+  }
+
+  .train-service {
+    background-color: var(--ambientB10);
+    display: grid;
+    grid-template-columns: subgrid;
+    padding-inline: 16px;
+    border-bottom: 1px solid var(--black10);
+
+    .toggle-band {
+      justify-self: end;
+      z-index: 1;
+      margin-right: -8px;
+    }
+
+    :where(& > *) {
+      grid-column: 1 / end-column;
+    }
+  }
+
+  .train-paced-kind {
+    background-color: var(--black5);
+    color: var(--info60);
+    font-weight: 600;
+    margin: 16px 14px 0 16px;
+    align-self: center;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-style: italic;
+    border-radius: 3px;
+    white-space: nowrap;
+    padding-inline: 16px;
+  }
+
+  .train-occurrence {
+    display: grid;
+    grid-template-columns: subgrid;
+    padding-bottom: 16px;
+
+    .train-paced-kind {
+      background-color: var(--white50);
+    }
+  }
+
+  .train-service-form {
+    display: grid;
+    grid-template-columns: subgrid;
+
+    label {
+      margin-bottom: unset;
+    }
+
+    .actions {
+      align-self: end;
+      margin-left: 16px;
+      margin-bottom: 18px;
+    }
+  }
+}
+
+@container board-wrapper (width < 800px) {
+  .expanded-train-form {
+    overflow-x: auto;
+    grid-template-columns: repeat(3, minmax(200px, 1fr)) [end-column];
+    justify-content: space-between;
+
+    .train-form {
+      .train-tags {
+        grid-row: 4;
+        grid-column: 1 / 3;
+      }
+
+      .actions {
+        grid-row: 4;
+        grid-column: end-column;
+      }
+    }
+  }
+}

--- a/front/src/modules/trainHeader/styles/trainHeader.scss
+++ b/front/src/modules/trainHeader/styles/trainHeader.scss
@@ -1,0 +1,32 @@
+@use './collapsed.scss';
+@use './expanded.scss';
+
+.train-header {
+  .header-toggle {
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-content: center;
+    border-radius: 4px;
+    outline: none;
+    color: var(--grey50);
+    z-index: 1;
+  }
+
+  .header-toggle:hover,
+  .header-toggle:focus-visible {
+    color: var(--color-grey-80);
+    background-color: var(--white100);
+    box-shadow:
+      0 1px 2px 0 rgba(0, 0, 0, 0.16),
+      0 2px 2px -1px rgba(255, 171, 88, 0.27);
+  }
+
+  .header-toggle:focus-visible {
+    outline: auto;
+  }
+
+  .header-toggle span {
+    display: contents;
+  }
+}

--- a/front/src/modules/trainHeader/utils/trainProperties.ts
+++ b/front/src/modules/trainHeader/utils/trainProperties.ts
@@ -1,0 +1,33 @@
+import type { TFunction } from 'i18next';
+
+import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
+import type { Train } from 'reducers/osrdconf/types';
+import { Duration } from 'utils/duration';
+
+export const getShortDepartureDate = (train: Train, locale?: Intl.Locale) =>
+  train && train.start_time
+    ? new Date(train.start_time).toLocaleDateString(locale, {
+        day: 'numeric',
+        month: 'numeric',
+        year: 'numeric',
+      })
+    : null;
+
+export const getShortCategoryName = (train: Train, t: TFunction<'translation'>): string | null =>
+  train.category && 'main_category' in train.category
+    ? t(`translation:rollingStock.shortCategoriesOptions.${train.category.main_category}`)
+    : null;
+
+export const getCategoryName = (train: Train, t: TFunction<'translation'>): string | null =>
+  train.category && 'main_category' in train.category
+    ? t(`translation:rollingStock.categoriesOptions.${train.category.main_category}`)
+    : null;
+
+export const getComfortType = (train: Train, t: TFunction<'translation'>): string | null =>
+  train.comfort ? t(`translation:rollingStock.comfortTypes.${train.comfort}`) : '';
+
+export const getServiceInterval = (train: PacedTrainWithPaced): number =>
+  Duration.parse(train.paced.interval).total('minute');
+
+export const getServiceWindow = (train: PacedTrainWithPaced): number =>
+  Duration.parse(train.paced.time_window).total('minute');

--- a/front/src/styles/scss/applications/operationalStudies/_boardWrapper.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_boardWrapper.scss
@@ -1,4 +1,7 @@
 .board-wrapper {
+  container-name: board-wrapper;
+  container-type: inline-size;
+
   box-shadow:
     0 1px 2px 0 rgba(0, 0, 0, 0.16),
     0 2px 2px -1px rgba(255, 171, 88, 0.27);

--- a/front/src/utils/trainExceptions.ts
+++ b/front/src/utils/trainExceptions.ts
@@ -1,0 +1,21 @@
+import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
+import type { OccurrenceId } from 'reducers/osrdconf/types';
+
+import {
+  extractExceptionIdFromOccurrenceId,
+  extractOccurrenceIndexFromOccurrenceId,
+  isAddedExceptionId,
+} from './trainId';
+
+/**
+ * Given an occurrence id, find the proper exception object from a paced train.
+ */
+export const findExceptionInPacedTrainByOccurenceId = (
+  occurenceId: OccurrenceId,
+  pacedTrain: PacedTrainWithPaced
+) =>
+  pacedTrain.paced.exceptions.find((exception) =>
+    isAddedExceptionId(occurenceId)
+      ? exception.id === extractExceptionIdFromOccurrenceId(occurenceId)
+      : exception.occurrence_index === extractOccurrenceIndexFromOccurrenceId(occurenceId)
+  );

--- a/front/ui/ui-core/src/styles/main.css
+++ b/front/ui/ui-core/src/styles/main.css
@@ -27,6 +27,28 @@
   font-weight: 900;
 }
 
+/* ITALIC */
+@font-face {
+  font-family: 'IBM Plex Sans';
+  src: inline('./fonts/IBMPlexSans-Italic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  src: inline('./fonts/IBMPlexSans-SemiBoldItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 600;
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  src: inline('./fonts/IBMPlexSans-BoldItalic.ttf') format('truetype');
+  font-style: italic;
+  font-weight: 900;
+}
+
 /* SERIF */
 @font-face {
   font-family: 'IBM Plex Serif', serif;


### PR DESCRIPTION
Part of (but not all of) #16526.

As a first step of our "train header" initiative, this commit add a simple collapsable form that allow users to set key properties of a train directly on top of the train stops times table.

For now, all the inputs are disabled, as they will be updated with properly wired fields of the right kind later.

https://github.com/user-attachments/assets/6cf1a099-e859-422e-966a-cf81f7f34ffc

--- 

This is the "logic-less" part of what is needed to properly close #16526; I still need to properly explore how we should wire our fields in a read-write manner, but that can be split into another pull request to be done and reviewed later.