### PR TITLE
Type `fga` errors properly

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1681,6 +1681,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stdext",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -29,7 +29,7 @@ pub enum Error<StorageError: std::error::Error> {
     #[error("unknown user {identity}")]
     UnknownUser { identity: String },
     #[error(transparent)]
-    OpenFga(#[from] fga::client::RequestFailure),
+    OpenFga(#[from] fga::client::Error),
     #[error(transparent)]
     Storage(StorageError),
 }

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -282,18 +282,14 @@ impl Role {
         openfga: &fga::Client,
         relation: R,
         object: &R::Object,
-    ) -> Result<Vec<Self>, fga::client::RequestFailure>
+    ) -> Result<Vec<Self>, fga::client::Error>
     where
         O: fga::model::Object,
         R: fga::model::Relation<User = Self, Object = O>,
     {
         use fga::client::Request as _;
 
-        let roles = relation
-            .query_users(object)
-            .fetch(openfga)
-            .await
-            .map_err(fga::client::QueryError::parsing_ok)?;
+        let roles = relation.query_users(object).fetch(openfga).await?;
         debug_assert!(
             roles.public_access.is_none(),
             "we don't write public accesses for roles"

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -1,8 +1,7 @@
 use std::collections::HashSet;
 use std::future::Future;
 
-use fga::client::QueryError;
-use fga::model::Relation;
+use fga::model::Relation as _;
 use tracing::Level;
 
 use crate::Authorization;
@@ -128,8 +127,7 @@ impl<S: StorageDriver> Regulator<S> {
         let groups = self
             .openfga
             .list_users(User::group().query_users(user))
-            .await
-            .map_err(QueryError::parsing_ok)?;
+            .await?;
         Ok(groups.users.into_iter().collect())
     }
 
@@ -249,8 +247,7 @@ impl<S: StorageDriver> Regulator<S> {
         let infra_list = self
             .openfga
             .list_objects(Infra::can_read().query_objects(user))
-            .await
-            .map_err(QueryError::parsing_ok)?;
+            .await?;
 
         Ok(Authorization::Granted(infra_list))
     }

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -20,7 +20,7 @@ use crate::Role;
 use crate::Subject;
 use crate::User;
 
-pub type OpenFgaError = fga::client::RequestFailure;
+pub type OpenFgaError = fga::client::Error;
 type ValueFut<'a, T> = BoxFuture<'a, Result<T, OpenFgaError>>;
 /// An alias for the type of a protected operation
 ///

--- a/editoast/authz/src/v2/group.rs
+++ b/editoast/authz/src/v2/group.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use fga::client::QueryError;
 use fga::client::UserList;
 use fga::model::Relation as _;
 use futures::FutureExt as _;
@@ -20,8 +19,7 @@ pub fn group_members(group: Group) -> Protected<Vec<User>> {
                 public_access,
             } = openfga
                 .list_users(Group::member().query_users(&group))
-                .await
-                .map_err(QueryError::parsing_ok)?;
+                .await?;
             debug_assert!(
                 public_access.is_none(),
                 "we don't write public accesses for groups"

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use fga::client::QueryError;
 use fga::client::UserList;
 use fga::model::Relation as _;
 use futures::FutureExt as _;
@@ -200,7 +199,6 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
                     }
                 }
                 .map(|UserList { users, .. }| users)
-                .map_err(QueryError::parsing_ok)
             }
             .boxed()
         })
@@ -225,7 +223,6 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
                             .await
                     }
                 }
-                .map_err(QueryError::parsing_ok)
             }
             .boxed()
         })

--- a/editoast/editoast_models/src/auth_driver.rs
+++ b/editoast/editoast_models/src/auth_driver.rs
@@ -27,7 +27,7 @@ pub enum AuthDriverError {
     #[error("Subject with id {subject_id} not found")]
     SubjectNotFound { subject_id: i64 },
     #[error(transparent)]
-    OpenFgaRequestFailure(#[from] fga::client::RequestFailure),
+    OpenFgaRequestFailure(#[from] fga::client::Error),
     #[error("The provided identity is already associated to another user: `{owner:?}`")]
     IdentityAlreadyOwned { owner: User },
 }

--- a/editoast/fga/Cargo.toml
+++ b/editoast/fga/Cargo.toml
@@ -17,6 +17,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 stdext = { workspace = true, optional = true }
+strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -1,11 +1,18 @@
 mod api;
 mod authorization_models;
+mod error;
 mod queries;
 mod stores;
 mod tuples;
 
 pub use authorization_models::AuthorizationModel;
 pub use authorization_models::StoreAuthorizationModel;
+pub use error::AuthErrorCode;
+pub use error::Error;
+pub use error::ErrorCode;
+pub use error::InternalErrorCode;
+pub use error::NotFoundErrorCode;
+pub use error::UnprocessableContentErrorCode;
 pub use queries::UserList;
 pub use stores::Store;
 pub use tuples::UntypedTuple;
@@ -91,64 +98,15 @@ pub enum Consistency {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("HTTP request to OpenFGA failed: {0}")]
-pub struct RequestFailure(#[source] reqwest::Error);
-
-#[derive(Debug, thiserror::Error)]
 pub enum InitializationError {
     #[error("Store not found: {0}")]
     NotFound(String),
     #[error(transparent)]
-    Request(#[from] RequestFailure),
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("Too many tuples provided ({provided_count}): hard limit set to {max}")]
-pub struct TooManyTuples {
-    max: usize,
-    provided_count: usize,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum QueryError {
-    #[error("Cannot parse OpenFGA value identifier as '{expected_type}': '{ident}'")]
-    Parsing {
-        ident: String,
-        expected_type: &'static str,
-    },
-    #[error(transparent)]
-    Request(#[from] RequestFailure),
-}
-
-impl QueryError {
-    pub fn parsing_ok(self) -> RequestFailure {
-        match self {
-            QueryError::Parsing {
-                ident,
-                expected_type,
-            } => {
-                tracing::error!(ident, expected_type, "failed to parse OpenFGA value");
-                panic!(
-                    "failed to parse OpenFGA value '{ident}' as '{expected_type}': a migration is probably missing",
-                );
-            }
-            QueryError::Request(request_failure) => request_failure,
-        }
-    }
-}
-
-impl From<reqwest::Error> for RequestFailure {
-    fn from(error: reqwest::Error) -> Self {
-        #[cfg(any(debug_assertions, test))]
-        let err = RequestFailure(error);
-        #[cfg(all(not(debug_assertions), not(test)))]
-        let err = RequestFailure(error.without_url());
-        err
-    }
+    Error(#[from] Error),
 }
 
 impl Client {
-    pub async fn is_healthy(&self) -> Result<bool, RequestFailure> {
+    pub async fn is_healthy(&self) -> Result<bool, Error> {
         Ok(matches!(self.get_healthz().await?, Health::Serving))
     }
 
@@ -251,15 +209,15 @@ impl Continuation {
     /// ```
     ///
     // TODO: rewrite that using async closures once rust 1.85 lands :pepoparty:
-    fn stream<F, Fut, T>(f: F) -> impl stream::TryStream<Ok = T, Error = RequestFailure>
+    fn stream<F, Fut, T>(f: F) -> impl stream::TryStream<Ok = T, Error = Error>
     where
         F: Fn(Continuation) -> Fut + Copy,
-        Fut: Future<Output = Result<(Vec<T>, Continuation), RequestFailure>>,
+        Fut: Future<Output = Result<(Vec<T>, Continuation), Error>>,
     {
         let stream = stream::try_unfold(Continuation::None, move |continuation| {
             Box::pin(async move {
                 if let Continuation::Stop = continuation {
-                    return Ok::<_, RequestFailure>(None);
+                    return Ok::<_, Error>(None);
                 }
                 let (items, continuation) = f(continuation).await?;
                 Ok(Some((items, continuation)))

--- a/editoast/fga/src/client/api.rs
+++ b/editoast/fga/src/client/api.rs
@@ -1,7 +1,28 @@
 //! Low-level mapping of the OpenFGA HTTP API
 
+use super::Error;
+
 pub(super) mod authorization_models;
 pub(super) mod healthz;
 pub(super) mod queries;
 pub(super) mod stores;
 pub(super) mod tuples;
+
+/// Helper to deserialize responses or errors from OpenFGA responses
+///
+/// We cannot just deserialize a Result because it is externally tagged by default.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum Message<T> {
+    Success(T),
+    Error(Error),
+}
+
+impl<T> Message<T> {
+    fn try_success(self) -> Result<T, Error> {
+        match self {
+            Message::Success(value) => Ok(value),
+            Message::Error(error) => Err(error),
+        }
+    }
+}

--- a/editoast/fga/src/client/api/authorization_models.rs
+++ b/editoast/fga/src/client/api/authorization_models.rs
@@ -1,5 +1,6 @@
 use super::super::Client;
-use super::super::RequestFailure;
+use super::super::Error;
+use super::Message;
 
 pub type AuthorizationModel = serde_json::Value;
 
@@ -16,7 +17,7 @@ impl Client {
         store_id: &str,
         page_size: Option<usize>,
         continuation: Option<&str>,
-    ) -> Result<(Vec<StoreAuthorizationModel>, String), RequestFailure> {
+    ) -> Result<(Vec<StoreAuthorizationModel>, String), Error> {
         #[derive(serde::Deserialize)]
         struct Response {
             authorization_models: Vec<StoreAuthorizationModel>,
@@ -37,11 +38,11 @@ impl Client {
                 .append_pair("page_size", page_size.to_string().as_str());
         }
 
-        let response = self.inner.get(url).send().await?.error_for_status()?;
+        let response = self.inner.get(url).send().await?;
         let Response {
             authorization_models,
             continuation_token,
-        } = response.json().await?;
+        } = response.json::<Message<_>>().await?.try_success()?;
 
         Ok((authorization_models, continuation_token))
     }
@@ -51,7 +52,7 @@ impl Client {
         &self,
         store_id: &str,
         authorization_model: &AuthorizationModel,
-    ) -> Result<String, RequestFailure> {
+    ) -> Result<String, Error> {
         let url = self
             .base_url()
             .join(format!("stores/{store_id}/authorization-models").as_str())
@@ -61,8 +62,7 @@ impl Client {
             .post(url)
             .json(authorization_model)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
 
         #[derive(serde::Deserialize)]
         struct Response {
@@ -70,7 +70,7 @@ impl Client {
         }
         let Response {
             authorization_model_id,
-        } = response.json().await?;
+        } = response.json::<Message<_>>().await?.try_success()?;
 
         Ok(authorization_model_id)
     }

--- a/editoast/fga/src/client/api/healthz.rs
+++ b/editoast/fga/src/client/api/healthz.rs
@@ -1,5 +1,6 @@
 use super::super::Client;
-use super::super::RequestFailure;
+use super::super::Error;
+use super::Message;
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -12,14 +13,15 @@ pub(in crate::client) enum Health {
 
 impl Client {
     #[tracing::instrument(skip(self), ret(level = "debug"), err)]
-    pub(in crate::client) async fn get_healthz(&self) -> Result<Health, RequestFailure> {
+    pub(in crate::client) async fn get_healthz(&self) -> Result<Health, Error> {
         #[derive(serde::Deserialize)]
         struct Response {
             status: Health,
         }
 
         let url = self.base_url().join("healthz").unwrap();
-        let Response { status } = self.inner.get(url).send().await?.json().await?;
+        let response = self.inner.get(url).send().await?;
+        let Response { status } = response.json::<Message<_>>().await?.try_success()?;
         Ok(status)
     }
 }

--- a/editoast/fga/src/client/api/queries.rs
+++ b/editoast/fga/src/client/api/queries.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
+use crate::client::api::Message;
 use crate::model::AsUser;
 use crate::model::Relation;
 use crate::model::Tuple;
 
 use super::super::Client;
 use super::super::Consistency;
-use super::super::RequestFailure;
+use super::super::Error;
 
 use super::tuples::RawTuple;
 
@@ -77,7 +78,7 @@ impl Client {
         checks: &[BatchCheckItem],
         authorization_model_id: Option<&str>,
         consistency: Option<Consistency>,
-    ) -> Result<HashMap<String, BatchCheckSingleResult>, RequestFailure> {
+    ) -> Result<HashMap<String, BatchCheckSingleResult>, Error> {
         assert!(
             checks.len() as u32 <= self.settings.limits.max_checks_per_batch_check,
             "OpenFGA client's checks limit per batch setting is set to {}",
@@ -112,7 +113,7 @@ impl Client {
         struct Response {
             result: HashMap<String, BatchCheckSingleResult>,
         }
-        let Response { result } = response.error_for_status()?.json().await?;
+        let Response { result } = response.json::<Message<_>>().await?.try_success()?;
         Ok(result)
     }
 
@@ -123,7 +124,7 @@ impl Client {
         tuple: RawTuple,
         contextual_tuples: Option<ContextualTuples>,
         authorization_model_id: Option<String>,
-    ) -> Result<bool, RequestFailure> {
+    ) -> Result<bool, Error> {
         #[derive(serde::Serialize)]
         struct Request {
             tuple_key: RawTuple,
@@ -152,7 +153,7 @@ impl Client {
             resolution: String,
         }
 
-        let Response { allowed, .. } = response.error_for_status()?.json::<Response>().await?;
+        let Response { allowed, .. } = response.json::<Message<_>>().await?.try_success()?;
 
         Ok(allowed)
     }
@@ -166,7 +167,7 @@ impl Client {
         user: &str,
         contextual_tuples: Option<ContextualTuples>,
         consistency: Option<Consistency>,
-    ) -> Result<Vec<String>, RequestFailure> {
+    ) -> Result<Vec<String>, Error> {
         #[derive(serde::Serialize)]
         struct Request {
             #[serde(rename = "type")]
@@ -198,7 +199,7 @@ impl Client {
             objects: Vec<String>,
         }
 
-        let Response { objects } = response.error_for_status()?.json::<Response>().await?;
+        let Response { objects } = response.json::<Message<_>>().await?.try_success()?;
 
         tracing::debug!(count = objects.len(), "objects found");
         Ok(objects)
@@ -215,7 +216,7 @@ impl Client {
         contextual_tuples: Option<ContextualTuples>,
         authorization_model_id: Option<&str>,
         consistency: Option<Consistency>,
-    ) -> Result<Vec<RawUser>, RequestFailure> {
+    ) -> Result<Vec<RawUser>, Error> {
         #[derive(serde::Serialize)]
         struct Request<'a> {
             authorization_model_id: Option<String>,
@@ -257,7 +258,7 @@ impl Client {
             users: Vec<RawUser>,
         }
 
-        let Response { users } = response.error_for_status()?.json().await?;
+        let Response { users } = response.json::<Message<_>>().await?.try_success()?;
         Ok(users)
     }
 }

--- a/editoast/fga/src/client/api/stores.rs
+++ b/editoast/fga/src/client/api/stores.rs
@@ -1,5 +1,6 @@
 use super::super::Client;
-use super::super::RequestFailure;
+use super::super::Error;
+use super::Message;
 
 #[derive(Debug, Default, Clone, serde::Deserialize)]
 pub struct Store {
@@ -16,7 +17,7 @@ impl Client {
         &self,
         page_size: Option<usize>,
         continuation: Option<&str>,
-    ) -> Result<(Vec<Store>, String), RequestFailure> {
+    ) -> Result<(Vec<Store>, String), Error> {
         #[derive(serde::Deserialize)]
         struct Response {
             stores: Vec<Store>,
@@ -38,13 +39,13 @@ impl Client {
         let Response {
             stores,
             continuation_token,
-        } = response.error_for_status()?.json::<Response>().await?;
+        } = response.json::<Message<_>>().await?.try_success()?;
 
         Ok((stores, continuation_token))
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub(in crate::client) async fn post_stores(&self, name: &str) -> Result<Store, RequestFailure> {
+    pub(in crate::client) async fn post_stores(&self, name: &str) -> Result<Store, Error> {
         #[derive(serde::Serialize)]
         struct Request {
             name: String,
@@ -57,20 +58,21 @@ impl Client {
         let url = self.base_url().join("stores").unwrap();
         let response = self.inner.post(url).json(&request).send().await?;
 
-        let store = response.error_for_status()?.json().await?;
+        let store = response.json::<Message<_>>().await?.try_success()?;
         Ok(store)
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub(in crate::client) async fn delete_stores(
-        &self,
-        store_id: &str,
-    ) -> Result<(), RequestFailure> {
+    pub(in crate::client) async fn delete_stores(&self, store_id: &str) -> Result<(), Error> {
         let url = self
             .base_url()
             .join(format!("stores/{store_id}").as_str())
             .unwrap();
-        self.inner.delete(url).send().await?.error_for_status()?;
-        Ok(())
+        let response = self.inner.delete(url).send().await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(response.json::<Error>().await?)
+        }
     }
 }

--- a/editoast/fga/src/client/api/tuples.rs
+++ b/editoast/fga/src/client/api/tuples.rs
@@ -8,7 +8,8 @@ use crate::model::Type;
 
 use super::super::Client;
 use super::super::Consistency;
-use super::super::RequestFailure;
+use super::super::Error;
+use super::Message;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(in crate::client) struct RawTuple {
@@ -120,7 +121,7 @@ impl Client {
         authorization_model_id: Option<&str>,
         consistency: Option<Consistency>,
         continuation_token: Option<String>,
-    ) -> Result<(Vec<RawTuple>, String), RequestFailure> {
+    ) -> Result<(Vec<RawTuple>, String), Error> {
         #[derive(serde::Serialize)]
         struct Request<'a> {
             #[serde(skip_serializing_if = "Option::is_none")]
@@ -153,10 +154,7 @@ impl Client {
             .join(format!("stores/{store_id}/read").as_str())
             .unwrap();
 
-        let Response {
-            tuples,
-            continuation_token,
-        } = self
+        let response = self
             .inner
             .post(url)
             .json(&Request {
@@ -167,10 +165,11 @@ impl Client {
                 continuation_token,
             })
             .send()
-            .await?
-            .error_for_status()?
-            .json()
             .await?;
+        let Response {
+            tuples,
+            continuation_token,
+        } = response.json::<Message<_>>().await?.try_success()?;
 
         let tuples = tuples.into_iter().map(|t| t.key).collect_vec();
         Ok((tuples, continuation_token))
@@ -186,7 +185,7 @@ impl Client {
         writes: &[RawTuple],
         deletes: &[RawTuple],
         authorization_model_id: Option<String>,
-    ) -> Result<(), RequestFailure> {
+    ) -> Result<(), Error> {
         #[derive(serde::Serialize)]
         struct Request<'a> {
             #[serde(skip_serializing_if = "Writes::is_empty")]
@@ -230,7 +229,8 @@ impl Client {
             .base_url()
             .join(format!("stores/{store_id}/write").as_str())
             .unwrap();
-        self.inner
+        let response = self
+            .inner
             .post(url)
             .json(&Request {
                 writes: Writes { tuple_keys: writes },
@@ -240,8 +240,11 @@ impl Client {
                 authorization_model_id,
             })
             .send()
-            .await?
-            .error_for_status()?;
-        Ok(())
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(response.json::<Error>().await?)
+        }
     }
 }

--- a/editoast/fga/src/client/authorization_models.rs
+++ b/editoast/fga/src/client/authorization_models.rs
@@ -3,7 +3,7 @@ use tracing::Instrument;
 
 use super::Client;
 use super::Continuation;
-use super::RequestFailure;
+use super::Error;
 
 pub use super::api::authorization_models::AuthorizationModel;
 pub use super::api::authorization_models::StoreAuthorizationModel;
@@ -11,7 +11,7 @@ pub use super::api::authorization_models::StoreAuthorizationModel;
 impl Client {
     pub fn authorization_models(
         &self,
-    ) -> impl stream::TryStream<Ok = StoreAuthorizationModel, Error = RequestFailure> + '_ {
+    ) -> impl stream::TryStream<Ok = StoreAuthorizationModel, Error = Error> + '_ {
         Continuation::stream(move |continuation| {
             async move {
                 let (models, continuation_str) = self
@@ -25,7 +25,7 @@ impl Client {
 
     pub async fn latest_authorization_model(
         &self,
-    ) -> Result<Option<StoreAuthorizationModel>, RequestFailure> {
+    ) -> Result<Option<StoreAuthorizationModel>, Error> {
         let models = &mut self
             .get_stores_authorization_models(&self.store.id, Some(1), None)
             .await?
@@ -35,7 +35,7 @@ impl Client {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn actualize_authorization_model(&mut self) -> Result<(), RequestFailure> {
+    pub async fn actualize_authorization_model(&mut self) -> Result<(), Error> {
         self.authorization_model_id = self
             .latest_authorization_model()
             .await?
@@ -51,7 +51,7 @@ impl Client {
     pub async fn update_authorization_model(
         &mut self,
         authorization_model: &AuthorizationModel,
-    ) -> Result<String, RequestFailure> {
+    ) -> Result<String, Error> {
         let model_id = self
             .post_stores_authorization_models(&self.store.id, authorization_model)
             .await?;

--- a/editoast/fga/src/client/error.rs
+++ b/editoast/fga/src/client/error.rs
@@ -1,0 +1,176 @@
+//! Error codes are extracted from OpenFGA Protobuf spec: https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto
+
+#[derive(Debug, thiserror::Error, serde::Deserialize)]
+#[serde(untagged)]
+pub enum Error {
+    /// Standard OpenFGA error: https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto
+    #[error("{code}[{}]: {message}", *code as u16)]
+    Auth {
+        code: AuthErrorCode,
+        message: String,
+    },
+
+    /// Standard OpenFGA error: https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto
+    #[error("{code}[{}]: {message}", *code as u16)]
+    Validation { code: ErrorCode, message: String },
+
+    /// Standard OpenFGA error: https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto
+    #[error("{code}[{}]: {message}", *code as u16)]
+    UnprocessableContent {
+        code: UnprocessableContentErrorCode,
+        message: String,
+    },
+
+    /// Standard OpenFGA error: https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto
+    #[error("{code}[{}]: {message}", *code as u16)]
+    Internal {
+        code: InternalErrorCode,
+        message: String,
+    },
+
+    /// Standard OpenFGA error: https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto
+    #[error("{code}[{}]: {message}", *code as u16)]
+    NotFound {
+        code: NotFoundErrorCode,
+        message: String,
+    },
+
+    /// Standard OpenFGA error: https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto
+    #[error("{code}: {message}")]
+    Aborted { code: String, message: String },
+
+    /// Custom error indicating we could not parse an identifier we got from OpenFGA
+    ///
+    /// Shouldn't happen and should result in a 500 or a panic.
+    #[error("Cannot parse OpenFGA value identifier as '{expected_type}': '{ident}'")]
+    #[serde(skip_deserializing)]
+    MalformedValue {
+        ident: String,
+        expected_type: String,
+    },
+
+    /// The error could not be parsed as an OpenFGA error
+    #[error("HTTP request to OpenFGA failed: {0}")]
+    #[serde(skip_deserializing)]
+    Reqwest(#[source] reqwest::Error),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        #[cfg(any(debug_assertions, test))]
+        let error = error;
+        #[cfg(all(not(debug_assertions), not(test)))]
+        let error = error.without_url();
+        Self::Reqwest(error)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, serde::Deserialize)]
+#[repr(u16)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum AuthErrorCode {
+    NoAuthError = 0,
+    AuthFailedInvalidSubject = 1001,
+    AuthFailedInvalidAudience = 1002,
+    AuthFailedInvalidIssuer = 1003,
+    InvalidClaims = 1004,
+    AuthFailedInvalidBearerToken = 1005,
+    BearerTokenMissing = 1010,
+    Unauthenticated = 1500,
+    Forbidden = 1600,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, serde::Deserialize)]
+#[repr(u16)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ErrorCode {
+    NoError = 0,
+    ValidationError = 2000,
+    AuthorizationModelNotFound = 2001,
+    AuthorizationModelResolutionTooComplex = 2002,
+    InvalidWriteInput = 2003,
+    CannotAllowDuplicateTuplesInOneRequest = 2004,
+    CannotAllowDuplicateTypesInOneRequest = 2005,
+    CannotAllowMultipleReferencesToOneRelation = 2006,
+    InvalidContinuationToken = 2007,
+    InvalidTupleSet = 2008,
+    InvalidCheckInput = 2009,
+    InvalidExpandInput = 2010,
+    UnsupportedUserSet = 2011,
+    InvalidObjectFormat = 2012,
+    WriteFailedDueToInvalidInput = 2017,
+    AuthorizationModelAssertionsNotFound = 2018,
+    LatestAuthorizationModelNotFound = 2020,
+    TypeNotFound = 2021,
+    RelationNotFound = 2022,
+    EmptyRelationDefinition = 2023,
+    InvalidUser = 2025,
+    InvalidTuple = 2027,
+    UnknownRelation = 2028,
+    StoreIdInvalidLength = 2030,
+    AssertionsTooManyItems = 2033,
+    IdTooLong = 2034,
+    AuthorizationModelIdTooLong = 2036,
+    TupleKeyValueNotSpecified = 2037,
+    TupleKeysTooManyOrTooFewItems = 2038,
+    PageSizeInvalid = 2039,
+    ParamMissingValue = 2040,
+    DifferenceBaseMissingValue = 2041,
+    SubtractBaseMissingValue = 2042,
+    ObjectTooLong = 2043,
+    RelationTooLong = 2044,
+    TypeDefinitionsTooFewItems = 2045,
+    TypeInvalidLength = 2046,
+    TypeInvalidPattern = 2047,
+    RelationsTooFewItems = 2048,
+    RelationsTooLong = 2049,
+    RelationsInvalidPattern = 2050,
+    ObjectInvalidPattern = 2051,
+    QueryStringTypeContinuationTokenMismatch = 2052,
+    ExceededEntityLimit = 2053,
+    InvalidContextualTuple = 2054,
+    DuplicateContextualTuple = 2055,
+    InvalidAuthorizationModel = 2056,
+    UnsupportedSchemaVersion = 2057,
+    Cancelled = 2058,
+    InvalidStartTime = 2059,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, serde::Deserialize)]
+#[repr(u16)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum UnprocessableContentErrorCode {
+    NoThrottledErrorCode = 0,
+    ThrottledTimeoutError = 3500,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, serde::Deserialize)]
+#[repr(u16)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum InternalErrorCode {
+    NoInternalError = 0,
+    InternalError = 4000,
+    DeadlineExceeded = 4004,
+    AlreadyExists = 4005,
+    ResourceExhausted = 4006,
+    FailedPrecondition = 4007,
+    Aborted = 4008,
+    OutOfRange = 4009,
+    Unavailable = 4010,
+    DataLoss = 4011,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, serde::Deserialize)]
+#[repr(u16)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum NotFoundErrorCode {
+    NoNotFoundError = 0,
+    UndefinedEndpoint = 5000,
+    StoreIdNotFound = 5002,
+    Unimplemented = 5004,
+}

--- a/editoast/fga/src/client/queries.rs
+++ b/editoast/fga/src/client/queries.rs
@@ -16,9 +16,8 @@ use crate::model::User;
 use crate::model::Wildcard;
 
 use super::Client;
-use super::QueryError;
+use super::Error;
 use super::Request;
-use super::RequestFailure;
 use super::api::queries::BatchCheckItem;
 use super::api::queries::BatchCheckSingleResult;
 use super::api::queries::RawUser;
@@ -26,10 +25,7 @@ use super::api::queries::UserFilter;
 use super::tuples::RawTuple;
 
 impl Client {
-    pub async fn check<R, U>(
-        &self,
-        Check { user, object }: Check<'_, R, U>,
-    ) -> Result<bool, RequestFailure>
+    pub async fn check<R, U>(&self, Check { user, object }: Check<'_, R, U>) -> Result<bool, Error>
     where
         R: Relation,
         U: AsUser<User = R::User>,
@@ -94,10 +90,7 @@ impl Client {
     /// assert!(alice_can_read && alice_can_write && !bob_can_read);
     /// # }
     /// ```
-    pub async fn checks<S: StructuredChecks>(
-        &self,
-        checks: S,
-    ) -> Result<S::Output, RequestFailure> {
+    pub async fn checks<S: StructuredChecks>(&self, checks: S) -> Result<S::Output, Error> {
         let results = checks.prepare(self).execute().await?;
         Ok(S::from_check_results(results))
     }
@@ -124,7 +117,7 @@ impl Client {
     pub async fn list_objects<R: Relation, U: AsUser<User = R::User>>(
         &self,
         QueryObjects(user, _): QueryObjects<R, U>,
-    ) -> Result<Vec<R::Object>, QueryError> {
+    ) -> Result<Vec<R::Object>, Error> {
         let objects = self
             .post_stores_list_objects(
                 &self.store.id,
@@ -143,9 +136,9 @@ impl Client {
                 };
                 R::Object::from_str(id).map_err(|_| {
                     tracing::error!(ident, type = R::Object::NAMESPACE, "failed to parse OpenFGA object");
-                    QueryError::Parsing {
+                    Error::MalformedValue {
                         ident,
-                        expected_type: R::Object::NAMESPACE,
+                        expected_type: R::Object::NAMESPACE.to_owned(),
                     }
                 })
             })
@@ -163,7 +156,7 @@ impl Client {
     pub async fn list_users<R: Relation>(
         &self,
         QueryUsers(object): QueryUsers<'_, R>,
-    ) -> Result<UserList<R::User>, QueryError> {
+    ) -> Result<UserList<R::User>, Error> {
         let raw_users = self
             .post_stores_list_users(
                 &self.store.id,
@@ -186,9 +179,9 @@ impl Client {
                         debug_assert_eq!(r#type.as_str(), R::User::NAMESPACE);
                         let user = R::User::from_str(&id).map_err(|_| {
                             tracing::error!(id, type = R::User::NAMESPACE, "failed to parse OpenFGA user");
-                            QueryError::Parsing {
+                            Error::MalformedValue {
                                 ident: id,
-                                expected_type: R::User::NAMESPACE,
+                                expected_type: R::User::NAMESPACE.to_owned(),
                             }
                         })?;
                         users.push(user);
@@ -239,7 +232,7 @@ impl Client {
     pub async fn list_usersets<R: Relation, S: Relation>(
         &self,
         QueryUsersets(object, _): QueryUsersets<'_, R, S>,
-    ) -> Result<Vec<S::Object>, QueryError> {
+    ) -> Result<Vec<S::Object>, Error> {
         let users = self
             .post_stores_list_users(
                 &self.store.id,
@@ -266,9 +259,9 @@ impl Client {
                     debug_assert_eq!(relation.as_str(), S::NAME);
                     S::Object::from_str(&id).map_err(|_| {
                         tracing::error!(id, type = S::Object::NAMESPACE, "failed to parse OpenFGA userset");
-                        QueryError::Parsing {
+                        Error::MalformedValue {
                             ident: id,
-                            expected_type: S::Object::NAMESPACE,
+                            expected_type: S::Object::NAMESPACE.to_owned(),
                         }
                     })
                 }
@@ -318,7 +311,7 @@ impl PreparedChecks<'_> {
     /// Concurrently send batch-checks requests to OpenFGA in chunks of `n` elements,
     /// with `n` the maximum number of tuple reads configured in the
     /// [super::ConnectionSettings::limits]'s [super::Limits::max_checks_per_batch_check].
-    pub async fn execute(self) -> Result<Vec<bool>, RequestFailure> {
+    pub async fn execute(self) -> Result<Vec<bool>, Error> {
         let count = self.checks.len();
 
         let (check_items, correlation_ids): (Vec<_>, HashMap<_, _>) = self
@@ -415,7 +408,7 @@ impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool, bool), R1 R2 
 impl<R: Relation, U: AsUser<User = R::User>> Request for Check<'_, R, U> {
     type Response = bool;
 
-    type Error = RequestFailure;
+    type Error = Error;
 
     async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
         client.check(self).await
@@ -429,7 +422,7 @@ where
 {
     type Response = Vec<R::Object>;
 
-    type Error = QueryError;
+    type Error = Error;
 
     async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
         client.list_objects(self).await
@@ -439,7 +432,7 @@ where
 impl<R: Relation> Request for QueryUsers<'_, R> {
     type Response = UserList<R::User>;
 
-    type Error = QueryError;
+    type Error = Error;
 
     async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
         client.list_users(self).await
@@ -449,7 +442,7 @@ impl<R: Relation> Request for QueryUsers<'_, R> {
 impl<R: Relation, S: Relation> Request for QueryUsersets<'_, R, S> {
     type Response = Vec<S::Object>;
 
-    type Error = QueryError;
+    type Error = Error;
 
     async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
         client.list_usersets(self).await
@@ -458,10 +451,10 @@ impl<R: Relation, S: Relation> Request for QueryUsersets<'_, R, S> {
 
 #[cfg(test)]
 mod tests {
-    use reqwest::StatusCode;
-
     use crate::client::Client;
     use crate::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
+    use crate::client::Error;
+    use crate::client::ErrorCode;
     use crate::client::Request as _;
     use crate::compile_model;
     use crate::defs::*;
@@ -630,7 +623,13 @@ mod tests {
             checks.push(&Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")));
         }
         let results = checks.execute().await;
-        assert!(results.is_err_and(|err| err.0.status().unwrap() == StatusCode::BAD_REQUEST));
+        assert!(results.is_err_and(|err| matches!(
+            err,
+            Error::Validation {
+                code: ErrorCode::ValidationError,
+                message,
+            } if message == "batchCheck received 51 checks, the maximum allowed is 50"
+        )));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/fga/src/client/stores.rs
+++ b/editoast/fga/src/client/stores.rs
@@ -7,8 +7,8 @@ use tracing::Instrument;
 use super::Client;
 use super::ConnectionSettings;
 use super::Continuation;
+use super::Error;
 use super::InitializationError;
-use super::RequestFailure;
 
 pub use super::api::stores::Store;
 
@@ -55,7 +55,7 @@ impl Client {
         Ok(client)
     }
 
-    pub fn stores(&self) -> impl stream::TryStream<Ok = Store, Error = RequestFailure> + '_ {
+    pub fn stores(&self) -> impl stream::TryStream<Ok = Store, Error = Error> + '_ {
         Continuation::stream(move |continuation| {
             async move {
                 let (stores, continuation_str) =
@@ -67,7 +67,7 @@ impl Client {
     }
 
     #[tracing::instrument(skip(self), err)]
-    pub async fn find_store(&self, store_name: &str) -> Result<Option<Store>, RequestFailure> {
+    pub async fn find_store(&self, store_name: &str) -> Result<Option<Store>, Error> {
         let stream = self
             .stores()
             .try_filter(|Store { name, .. }| future::ready(name == store_name));

--- a/editoast/fga/src/client/tuples.rs
+++ b/editoast/fga/src/client/tuples.rs
@@ -342,6 +342,58 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn write_tuples_limit_fail() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        let mut entities = vec![];
+        for i in 1..=client.settings.limits.max_tuples_per_write + 1 {
+            entities.push((Infra(format!("{i}")), User(format!("{i}"))));
+        }
+        let tuples = entities
+            .iter()
+            .map(|(infra, user)| Infra::reader().tuple(user, infra))
+            .collect::<Vec<_>>();
+
+        let response = client.write_tuples(&tuples).await;
+        assert!(response.is_err_and(|err| matches!(
+            err,
+            Error::Validation {
+                code: ErrorCode::ExceededEntityLimit,
+                message,
+            } if message == "The number of write operations exceeds the allowed limit of 100"
+        )));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_tuples_limit_fail() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        let mut entities = vec![];
+        for i in 1..=client.settings.limits.max_tuples_per_write + 1 {
+            entities.push((Infra(format!("{i}")), User(format!("{i}"))));
+        }
+        let tuples = entities
+            .iter()
+            .map(|(infra, user)| Infra::reader().tuple(user, infra))
+            .collect::<Vec<_>>();
+
+        let response = client.delete_tuples(&tuples).await;
+        assert!(response.is_err_and(|err| matches!(
+            err,
+            Error::Validation {
+                code: ErrorCode::ExceededEntityLimit,
+                message,
+            } if message == "The number of write operations exceeds the allowed limit of 100"
+        )));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn prepare_deletes() {
         setup_tracing();
         let model = compile_model(MODEL);

--- a/editoast/fga/src/client/tuples.rs
+++ b/editoast/fga/src/client/tuples.rs
@@ -1,5 +1,4 @@
 use futures::stream;
-use itertools::Either;
 use itertools::Itertools as _;
 use tracing::Instrument;
 
@@ -9,9 +8,8 @@ use crate::model::Tuple;
 
 use super::Client;
 use super::Continuation;
+use super::Error;
 use super::Request;
-use super::RequestFailure;
-use super::TooManyTuples;
 
 pub(in crate::client) use super::api::tuples::RawTuple;
 pub use super::api::tuples::UntypedTuple;
@@ -22,7 +20,7 @@ impl Client {
     pub async fn tuple_exists<R: Relation, U: AsUser<User = R::User>>(
         &self,
         tuple: Tuple<'_, R, U>,
-    ) -> Result<bool, RequestFailure> {
+    ) -> Result<bool, Error> {
         let (tuples, _continuation) = self
             .get_stores_read(
                 &self.store.id,
@@ -36,9 +34,7 @@ impl Client {
         Ok(!tuples.is_empty())
     }
 
-    pub fn list_tuples(
-        &self,
-    ) -> impl stream::TryStream<Ok = UntypedTuple, Error = RequestFailure> + '_ {
+    pub fn list_tuples(&self) -> impl stream::TryStream<Ok = UntypedTuple, Error = Error> + '_ {
         Continuation::stream(move |continuation| {
             async move {
                 let (tuples, continuation_str) = self
@@ -61,13 +57,7 @@ impl Client {
     pub async fn write_tuples<R: Relation, U: AsUser<User = R::User>>(
         &self,
         tuples: &[Tuple<'_, R, U>],
-    ) -> Result<(), Either<RequestFailure, TooManyTuples>> {
-        if tuples.len() > self.settings.limits.max_tuples_per_write as usize {
-            return Err(Either::Right(TooManyTuples {
-                max: self.settings.limits.max_tuples_per_write as usize,
-                provided_count: tuples.len(),
-            }));
-        }
+    ) -> Result<(), Error> {
         self.post_stores_write(
             &self.store.id,
             &tuples.iter().map_into().collect::<Vec<_>>(),
@@ -75,7 +65,6 @@ impl Client {
             self.authorization_model_id.clone(),
         )
         .await
-        .map_err(Either::Left)
     }
 
     /// Prepares multiple write requests to OpenFGA
@@ -105,15 +94,9 @@ impl Client {
     pub async fn delete_tuples<R: Relation, U: AsUser<User = R::User>>(
         &self,
         tuples: &[Tuple<'_, R, U>],
-    ) -> Result<(), Either<RequestFailure, TooManyTuples>> {
+    ) -> Result<(), Error> {
         if tuples.is_empty() {
             return Ok(());
-        }
-        if tuples.len() > self.settings.limits.max_tuples_per_write as usize {
-            return Err(Either::Right(TooManyTuples {
-                max: self.settings.limits.max_tuples_per_write as usize,
-                provided_count: tuples.len(),
-            }));
         }
         self.post_stores_write(
             &self.store.id,
@@ -122,7 +105,6 @@ impl Client {
             self.authorization_model_id.clone(),
         )
         .await
-        .map_err(Either::Left)
     }
 
     /// Prepares multiple delete requests to OpenFGA
@@ -175,7 +157,7 @@ impl PreparedWrites<'_> {
     /// the tuples written by other successful requests will remain in OpenFGA.
     /// This function also returns at the first failing request, so OpenFGA may still
     /// write some tuples **after** this function exits.
-    pub async fn execute(self) -> Result<(), RequestFailure> {
+    pub async fn execute(self) -> Result<(), Error> {
         let futs = self
             .writes
             .chunks(self.client.settings.limits.max_tuples_per_write as usize)
@@ -225,7 +207,7 @@ impl PreparedDeletes<'_> {
     /// the tuples deleted by other successful requests will remain deleted in OpenFGA.
     /// This function also returns at the first failing request, so OpenFGA may still
     /// delete some tuples **after** this function exits.
-    pub async fn execute(self) -> Result<(), RequestFailure> {
+    pub async fn execute(self) -> Result<(), Error> {
         let futs = self
             .deletes
             .chunks(self.client.settings.limits.max_tuples_per_write as usize)
@@ -248,7 +230,7 @@ impl PreparedDeletes<'_> {
 impl<R: Relation, U: AsUser<User = R::User>> Request for Tuple<'_, R, U> {
     type Response = bool;
 
-    type Error = RequestFailure;
+    type Error = Error;
 
     async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
         client.tuple_exists(self).await
@@ -257,9 +239,9 @@ impl<R: Relation, U: AsUser<User = R::User>> Request for Tuple<'_, R, U> {
 
 #[cfg(test)]
 mod tests {
-    use reqwest::StatusCode;
-
     use crate::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
+    use crate::client::Error;
+    use crate::client::ErrorCode;
     use crate::client::setup_tracing;
     use crate::compile_model;
     use crate::defs::*;
@@ -316,7 +298,13 @@ mod tests {
             writes.push(&tuple);
         }
         let response = writes.execute().await;
-        assert!(response.is_err_and(|err| err.0.status().unwrap() == StatusCode::BAD_REQUEST));
+        assert!(response.is_err_and(|err| matches!(
+            err,
+            Error::Validation {
+                code: ErrorCode::ExceededEntityLimit,
+                message,
+            } if message == "The number of write operations exceeds the allowed limit of 100"
+        )));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/fga_migrations/src/lib.rs
+++ b/editoast/fga_migrations/src/lib.rs
@@ -2,14 +2,13 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 use fga::client::Client;
+use fga::client::Error;
 use fga::client::InitializationError;
-use fga::client::RequestFailure;
 use fga::compile_model;
 use fga::model::Relation;
 use fga::model::Type;
 use indexmap::IndexMap;
 use indexmap::indexmap;
-use itertools::Either;
 use sha1::Digest;
 use sha1::Sha1;
 use tracing::info;
@@ -101,7 +100,7 @@ pub enum MigrationError {
     #[error(transparent)]
     InitializationError(#[from] InitializationError),
     #[error(transparent)]
-    RequestFailure(#[from] RequestFailure),
+    RequestFailure(#[from] Error),
     #[error("Inconsistent migrations store state")]
     InconsistantMigrationStore,
 }
@@ -145,8 +144,7 @@ pub async fn run_migrations(
     let migration = Migration(migration_number, new_model_hash.clone());
     match client_migrations
         .list_objects(Migration::apply().query_objects(&Editoast))
-        .await
-        .map_err(|err| err.parsing_ok())?
+        .await?
         .as_slice()
     {
         [current_migration] => {
@@ -160,13 +158,7 @@ pub async fn run_migrations(
             info!("Deleting existing migration tuple");
             client_migrations
                 .delete_tuples(&[Migration::apply().tuple(&Editoast, current_migration)])
-                .await
-                .map_err(|err| match err {
-                    Either::Left(request_failure) => request_failure,
-                    Either::Right(_) => {
-                        unreachable!("Removing a single tuple, it should be fine")
-                    }
-                })?;
+                .await?;
         }
         [_, _, ..] => return Err(MigrationError::InconsistantMigrationStore),
         [] => info!("No previous migration tuple found"),
@@ -181,11 +173,7 @@ pub async fn run_migrations(
 
     client_migrations
         .write_tuples(&[Migration::apply().tuple(&Editoast, &migration)])
-        .await
-        .map_err(|err| match err {
-            Either::Left(request_failure) => request_failure,
-            Either::Right(_) => unreachable!("Writing a single tuple, it should be fine"),
-        })?;
+        .await?;
     info!(
         tuple.migration.number = migration.0,
         tuple.migration.hash = migration.1,

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -321,8 +321,8 @@ impl From<crate::views::AuthorizerError> for InternalError {
     }
 }
 
-impl From<fga::client::RequestFailure> for InternalError {
-    fn from(value: fga::client::RequestFailure) -> Self {
+impl From<fga::client::Error> for InternalError {
+    fn from(value: fga::client::Error) -> Self {
         crate::views::AuthorizationError::from(value).into()
     }
 }

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -560,7 +560,7 @@ pub enum AuthorizationError {
     ImpersonatedUserNotFound { identity: String },
     #[error(transparent)]
     #[editoast_error(status = 500)]
-    #[from(AuthorizerError, fga::client::RequestFailure)]
+    #[from(AuthorizerError, fga::client::Error)]
     AuthError(AuthorizerError),
     #[error(transparent)]
     #[editoast_error(status = 500)]


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/14174

> [!TIP]
> review each commit separately

Uses [OpenFGA's protobuf specification](https://github.com/openfga/api/blob/main/openfga/v1/errors_ignore.proto) to type error responses in detail. Most errors now live in `fga::client::Error`, see commit description for more detail.

Last commit will be squashed after review. 

To merge after https://github.com/OpenRailAssociation/osrd/pull/16709
> [!IMPORTANT]
> Ready to review, only kept as a draft to avoid spamming since not mergeable atm.