### PR TITLE
editoast: core_task: naming harmonization pass

### DIFF
--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -78,7 +78,7 @@ where
                    }| {
                 if let Some(tx) = ready_trains_tx.as_ref() {
                     let trains = runner
-                        .input_train_set(&input)
+                        .train_set(&input)
                         .expect("input provided by the Runner should be valid");
                     tx.unbounded_send(trains).ok();
                 }
@@ -112,7 +112,7 @@ where
                       data: path,
                   }| {
                 let trains = runner
-                    .input_train_set(&input)
+                    .train_set(&input)
                     .expect("input provided by the Runner should be valid");
                 Correlated::new(trains, path)
             },
@@ -258,7 +258,7 @@ where
 {
     core_env: CoreEnv,
     pub(in crate::envs) pathfinding_inputs: Arc<PathfindingEnvInputs<Train>>,
-    input_index: DashMap<PathfindingKey, TrainSet<Train>>,
+    rev: DashMap<PathfindingKey, TrainSet<Train>>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -272,30 +272,27 @@ where
     Train: TrainKey + 'static,
 {
     pub(in crate::envs) fn new(PathfindingEnv { core_env, inputs }: PathfindingEnv<Train>) -> Self {
-        let input_index = DashMap::<PathfindingKey, TrainSet<Train>>::new();
+        let rev = DashMap::<PathfindingKey, TrainSet<Train>>::new();
         for Correlated {
             correlation_key: train,
             data: input,
         } in inputs.iter()
         {
-            input_index.entry(input).or_default().insert(train);
+            rev.entry(input).or_default().insert(train);
         }
         Self {
             core_env: core_env.clone(),
             pathfinding_inputs: Arc::new(inputs),
-            input_index,
+            rev,
         }
     }
 
-    pub(in crate::envs) fn input_train_set(
-        &self,
-        input: &PathfindingKey,
-    ) -> Option<TrainSet<Train>> {
-        self.input_index.get(input).as_deref().cloned()
+    pub(in crate::envs) fn train_set(&self, input: &PathfindingKey) -> Option<TrainSet<Train>> {
+        self.rev.get(input).as_deref().cloned()
     }
 
     fn iter_keys(&self) -> impl Iterator<Item = PathfindingKey> {
-        self.input_index.iter().map(|set| set.key().clone())
+        self.rev.iter().map(|set| set.key().clone())
     }
 
     pub(in crate::envs) fn stream(

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -230,7 +230,7 @@ impl<Train> PathfindingEnvInputs<Train>
 where
     Train: TrainKey + 'static,
 {
-    fn iter(&self) -> impl Iterator<Item = Correlated<Train, Input>> {
+    fn iter(&self) -> impl Iterator<Item = Correlated<Train, PathfindingKey>> {
         self.consists.keys().map(|train| {
             let pf_key = self
                 .train_input(train)
@@ -239,10 +239,10 @@ where
         })
     }
 
-    pub(in crate::envs) fn train_input(&self, train: &Train) -> Option<Input> {
+    pub(in crate::envs) fn train_input(&self, train: &Train) -> Option<PathfindingKey> {
         let consist = self.consists.get(train)?;
         let constraints = self.constraints.get(train)?;
-        Some(Input(consist.clone(), constraints.clone()))
+        Some(PathfindingKey(consist.clone(), constraints.clone()))
     }
 }
 
@@ -258,11 +258,11 @@ where
 {
     core_env: CoreEnv,
     pub(in crate::envs) pathfinding_inputs: Arc<PathfindingEnvInputs<Train>>,
-    input_index: DashMap<Input, TrainSet<Train>>,
+    input_index: DashMap<PathfindingKey, TrainSet<Train>>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub(in crate::envs) struct Input(
+pub(in crate::envs) struct PathfindingKey(
     pub(in crate::envs) Arc<PathfindingConsist>,
     pub(in crate::envs) Arc<PathfindingConstraints>,
 );
@@ -272,7 +272,7 @@ where
     Train: TrainKey + 'static,
 {
     pub(in crate::envs) fn new(PathfindingEnv { core_env, inputs }: PathfindingEnv<Train>) -> Self {
-        let input_index = DashMap::<Input, TrainSet<Train>>::new();
+        let input_index = DashMap::<PathfindingKey, TrainSet<Train>>::new();
         for Correlated {
             correlation_key: train,
             data: input,
@@ -287,11 +287,14 @@ where
         }
     }
 
-    pub(in crate::envs) fn input_train_set(&self, input: &Input) -> Option<TrainSet<Train>> {
+    pub(in crate::envs) fn input_train_set(
+        &self,
+        input: &PathfindingKey,
+    ) -> Option<TrainSet<Train>> {
         self.input_index.get(input).as_deref().cloned()
     }
 
-    fn iter_inputs(&self) -> impl Iterator<Item = Input> {
+    fn iter_keys(&self) -> impl Iterator<Item = PathfindingKey> {
         self.input_index.iter().map(|set| set.key().clone())
     }
 
@@ -300,14 +303,14 @@ where
         vkconn: Arc<Mutex<cache::Connection>>,
     ) -> impl stream::Stream<
         Item = Correlated<
-            Input,
+            PathfindingKey,
             Result<core_client::pathfinding::PathfindingCoreResult, core_client::Error>,
         >,
     > {
         use crate::TaskStreamExt as _;
 
         let requests = self
-            .iter_inputs()
+            .iter_keys()
             .map(|input| {
                 let request = build_request(&self.core_env, &input);
                 Correlated::new(input, request)
@@ -334,7 +337,7 @@ where
 {
     inputs: Arc<PathfindingEnvInputs<Train>>,
     // optionally deduplicate similar outputs of different inputs
-    paths: Arc<DashMap<Input, PendingPathfindingResult>>,
+    paths: Arc<DashMap<PathfindingKey, PendingPathfindingResult>>,
 }
 
 /// Ready when the pathfinding result is available and stored in [PathfindingRun], pending if the task is not yet completed
@@ -348,7 +351,7 @@ where
     fn new(runner: &Runner<Train>) -> Self {
         let paths = DashMap::from_iter(
             runner
-                .iter_inputs()
+                .iter_keys()
                 .zip(std::iter::repeat_with(|| Poll::Pending)),
         );
         Self {
@@ -375,7 +378,7 @@ where
 
 fn build_request(
     core_env: &CoreEnv,
-    Input(consist, constraints): &Input,
+    PathfindingKey(consist, constraints): &PathfindingKey,
 ) -> core_client::pathfinding::PathfindingRequest {
     core_client::pathfinding::PathfindingRequest {
         infra: core_env.infra_id as i64,

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -176,7 +176,7 @@ pub struct PathfindingConsist {
 #[cfg_attr(test, derive(Clone))]
 pub struct PathfindingConstraints {
     /// An ordered list of waypoints the resulting path must pass through
-    pub path_items: Vec<PathWaypointAlternatives>,
+    pub path_items: Vec<PathItemAlternatives>,
 }
 
 /// A set of [TrackOffset]
@@ -184,15 +184,15 @@ pub struct PathfindingConstraints {
 /// The resulting path can cross any of these.
 #[derive(Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(test, derive(Clone))]
-pub struct PathWaypointAlternatives(Vec<TrackOffset>);
+pub struct PathItemAlternatives(Vec<TrackOffset>);
 
-impl FromIterator<TrackOffset> for PathWaypointAlternatives {
+impl FromIterator<TrackOffset> for PathItemAlternatives {
     fn from_iter<T: IntoIterator<Item = TrackOffset>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
-impl IntoIterator for PathWaypointAlternatives {
+impl IntoIterator for PathItemAlternatives {
     type Item = TrackOffset;
     type IntoIter = <Vec<TrackOffset> as IntoIterator>::IntoIter;
 
@@ -386,12 +386,12 @@ fn build_request(
         path_items: constraints
             .path_items
             .iter()
-            .map(|PathWaypointAlternatives(track_alternatives)| {
-                core_client::pathfinding::PathItem {
+            .map(
+                |PathItemAlternatives(track_alternatives)| core_client::pathfinding::PathItem {
                     locations: track_alternatives.clone(),
                     can_backtrack: Some(false),
-                }
-            })
+                },
+            )
             .collect(),
         rolling_stock_loading_gauge: consist.loading_gauge,
         rolling_stock_is_thermal: consist.thermal,
@@ -448,12 +448,12 @@ pub(crate) mod test_data {
     pub(crate) fn constraints(id: usize) -> PathfindingConstraints {
         PathfindingConstraints {
             path_items: vec![
-                PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
-                PathWaypointAlternatives::from_iter([
+                PathItemAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
+                PathItemAlternatives::from_iter([
                     TrackOffset::new("tr1", 100),
                     TrackOffset::new("tr1bis", 100),
                 ]),
-                PathWaypointAlternatives::from_iter([TrackOffset::new("tr2", 200)]),
+                PathItemAlternatives::from_iter([TrackOffset::new("tr2", 200)]),
             ],
         }
     }

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -429,36 +429,36 @@ pub(crate) mod test_data {
                 Default::default(),
             ),
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
             NonBlankString::from("start"),
-            SimulationWaypoint::PathItem,
+            ScheduleItem::PathItem,
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("a", 42)]),
             NonBlankString::from("a"),
-            SimulationWaypoint::ScheduleItem {
+            ScheduleItem::ScheduleItem {
                 arrival_at: Some(1200),
                 stop_for: Some(60),
                 reception_signal: Default::default(),
             },
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             pathfinding::PathItemAlternatives::from_iter([
                 TrackOffset::new("b", 43),
                 TrackOffset::new("bis", 34),
             ]),
             NonBlankString::from("b"),
-            SimulationWaypoint::ScheduleItem {
+            ScheduleItem::ScheduleItem {
                 arrival_at: None,
                 stop_for: Some(120),
                 reception_signal: Default::default(),
             },
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("finish", 44)]),
             NonBlankString::from("finish"),
-            SimulationWaypoint::ScheduleItem {
+            ScheduleItem::ScheduleItem {
                 arrival_at: Some(2400),
                 stop_for: Some(0),
                 reception_signal: Default::default(),

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -430,12 +430,12 @@ pub(crate) mod test_data {
             ),
         );
         builder.push_waypoint(
-            pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
+            pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
             NonBlankString::from("start"),
             SimulationWaypoint::PathItem,
         );
         builder.push_waypoint(
-            pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("a", 42)]),
+            pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("a", 42)]),
             NonBlankString::from("a"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(1200),
@@ -444,7 +444,7 @@ pub(crate) mod test_data {
             },
         );
         builder.push_waypoint(
-            pathfinding::PathWaypointAlternatives::from_iter([
+            pathfinding::PathItemAlternatives::from_iter([
                 TrackOffset::new("b", 43),
                 TrackOffset::new("bis", 34),
             ]),
@@ -456,7 +456,7 @@ pub(crate) mod test_data {
             },
         );
         builder.push_waypoint(
-            pathfinding::PathWaypointAlternatives::from_iter([TrackOffset::new("finish", 44)]),
+            pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("finish", 44)]),
             NonBlankString::from("finish"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(2400),

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -181,7 +181,7 @@ where
         pathfinding_key: &pathfinding::PathfindingKey,
     ) -> impl Iterator<Item = SimulationKey> {
         self.pathfinding_runner
-            .input_train_set(pathfinding_key)
+            .train_set(pathfinding_key)
             .into_iter()
             .flatten()
             .filter_map(|train| {
@@ -213,7 +213,7 @@ where
                         correlation_key: pf_key,
                         data: Ok(core_client::pathfinding::PathfindingCoreResult::Success(path)),
                     } => {
-                        let trains = runner.pathfinding_runner.input_train_set(&pf_key).expect("input provided by the runner should be valid");
+                        let trains = runner.pathfinding_runner.train_set(&pf_key).expect("input provided by the runner should be valid");
                         (trains, path)
                     }
                     Correlated {

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -432,12 +432,12 @@ pub(crate) mod test_data {
         builder.push_schedule_item(
             pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
             NonBlankString::from("start"),
-            ScheduleItem::PathItem,
+            ScheduleItem::pass_by(),
         );
         builder.push_schedule_item(
             pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("a", 42)]),
             NonBlankString::from("a"),
-            ScheduleItem::ScheduleItem {
+            ScheduleItem {
                 arrival_at: Some(1200),
                 stop_for: Some(60),
                 reception_signal: Default::default(),
@@ -449,7 +449,7 @@ pub(crate) mod test_data {
                 TrackOffset::new("bis", 34),
             ]),
             NonBlankString::from("b"),
-            ScheduleItem::ScheduleItem {
+            ScheduleItem {
                 arrival_at: None,
                 stop_for: Some(120),
                 reception_signal: Default::default(),
@@ -458,7 +458,7 @@ pub(crate) mod test_data {
         builder.push_schedule_item(
             pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("finish", 44)]),
             NonBlankString::from("finish"),
-            ScheduleItem::ScheduleItem {
+            ScheduleItem {
                 arrival_at: Some(2400),
                 stop_for: Some(0),
                 reception_signal: Default::default(),

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -135,7 +135,7 @@ where
 pub(in crate::envs) struct SimulationKey(
     Arc<SimulationConsist>,
     Arc<SimulationTrainParameters>,
-    pathfinding::Input,
+    pathfinding::PathfindingKey,
 );
 
 impl<Train> Runner<Train>
@@ -178,7 +178,7 @@ where
     /// do not necessarily share the same simulation key (simulation inputs differ).
     fn simulation_keys_of_pathfinding_key(
         &self,
-        pathfinding_key: &pathfinding::Input,
+        pathfinding_key: &pathfinding::PathfindingKey,
     ) -> impl Iterator<Item = SimulationKey> {
         self.pathfinding_runner
             .input_train_set(pathfinding_key)

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -56,16 +56,18 @@ pub struct SimulationTrainParameters {
 }
 
 /// Schedule information attached to a path item
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum ScheduleItem {
-    /// No specific requirement
-    PathItem,
-    /// The train must stop at this item
-    ScheduleItem {
-        stop_for: Option<u64>,
-        arrival_at: Option<u64>,
-        reception_signal: ReceptionSignal,
-    },
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
+pub struct ScheduleItem {
+    pub stop_for: Option<u64>,
+    pub arrival_at: Option<u64>,
+    pub reception_signal: ReceptionSignal,
+}
+
+impl ScheduleItem {
+    /// Just a passing point without any particular scheduling requirements
+    pub fn pass_by() -> Self {
+        Self::default()
+    }
 }
 
 impl SimulationTrainParameters {

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -18,7 +18,7 @@ use crate::PathfindingConsist;
 use crate::PathfindingConstraints;
 use crate::PathfindingTrain;
 use crate::TrainKey;
-use crate::envs::pathfinding::PathWaypointAlternatives;
+use crate::envs::pathfinding::PathItemAlternatives;
 
 #[derive(Debug)]
 pub(crate) struct SimulationInputs<Train>
@@ -215,7 +215,7 @@ impl SimulationTrain {
     /// The label can be reused for [Self::set_power_restriction] and [Self::set_margin].
     pub fn push_waypoint(
         &mut self,
-        path_constraint: PathWaypointAlternatives,
+        path_constraint: PathItemAlternatives,
         label: NonBlankString,
         point: SimulationWaypoint,
     ) {

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -146,11 +146,11 @@ where
     ) -> Option<super::SimulationKey> {
         let consist = self.consists.get(train)?;
         let params = self.parameters.get(train)?;
-        let pf_input = pathfinding_inputs.train_input(train)?;
+        let pf_key = pathfinding_inputs.train_input(train)?;
         Some(super::SimulationKey(
             consist.clone(),
             params.clone(),
-            pf_input,
+            pf_key,
         ))
     }
 }

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -42,9 +42,9 @@ pub struct SimulationConsist(pub PhysicsConsist);
 #[derive(Debug, educe::Educe)]
 #[educe(Hash, PartialEq, Eq)]
 pub struct SimulationTrainParameters {
-    path_items: Vec<SimulationWaypoint>,
-    power_restrictions: rangemap::RangeMap<PathWaypointIndex, String>,
-    margins: rangemap::RangeMap<PathWaypointIndex, MarginValue>,
+    schedule_items: Vec<ScheduleItem>,
+    power_restrictions: rangemap::RangeMap<ScheduleItemIndex, String>,
+    margins: rangemap::RangeMap<ScheduleItemIndex, MarginValue>,
 
     #[educe(Hash(method(common::units::meter_per_second::hash)))]
     #[educe(Eq(method(common::units::meter_per_second::eq)))]
@@ -55,12 +55,12 @@ pub struct SimulationTrainParameters {
     options: TrainScheduleOptions,
 }
 
-/// Schedule information for a path waypoint
+/// Schedule information attached to a path item
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum SimulationWaypoint {
+pub enum ScheduleItem {
     /// No specific requirement
     PathItem,
-    /// The train must stop at this waypoint
+    /// The train must stop at this item
     ScheduleItem {
         stop_for: Option<u64>,
         arrival_at: Option<u64>,
@@ -77,7 +77,7 @@ impl SimulationTrainParameters {
         options: TrainScheduleOptions,
     ) -> Self {
         Self {
-            path_items: Default::default(),
+            schedule_items: Default::default(),
             power_restrictions: Default::default(),
             margins: Default::default(),
             initial_speed,
@@ -88,15 +88,15 @@ impl SimulationTrainParameters {
         }
     }
 
-    pub fn schedule(&self) -> &[SimulationWaypoint] {
-        &self.path_items
+    pub fn schedule_items(&self) -> &[ScheduleItem] {
+        &self.schedule_items
     }
 
-    pub fn power_restrictions(&self) -> &rangemap::RangeMap<PathWaypointIndex, String> {
+    pub fn power_restrictions(&self) -> &rangemap::RangeMap<ScheduleItemIndex, String> {
         &self.power_restrictions
     }
 
-    pub fn margins(&self) -> &rangemap::RangeMap<PathWaypointIndex, MarginValue> {
+    pub fn margins(&self) -> &rangemap::RangeMap<ScheduleItemIndex, MarginValue> {
         &self.margins
     }
 
@@ -121,7 +121,9 @@ impl SimulationTrainParameters {
     }
 
     fn is_empty(&self) -> bool {
-        self.path_items.is_empty() && self.power_restrictions.is_empty() && self.margins.is_empty()
+        self.schedule_items.is_empty()
+            && self.power_restrictions.is_empty()
+            && self.margins.is_empty()
     }
 }
 
@@ -158,7 +160,7 @@ where
 /// The way to provide simulation and pathfinding inputs to a [SimulationEnv]
 ///
 /// This builder is useful to ensure the following things are consistent:
-/// - pathfinding waypoints and schedule information ([SimulationWaypointSchedule])
+/// - pathfinding path items and simulation schedule items ([ScheduleItem])
 /// - power restrictions ranges
 /// - margin ranges
 ///
@@ -169,10 +171,10 @@ pub struct SimulationTrain {
     pub(super) pathfinding_consist: PathfindingConsist,
     pub(super) parameters: SimulationTrainParameters,
     pub(super) path_constraints: PathfindingConstraints,
-    path_item_to_index: HashMap<NonBlankString, PathWaypointIndex>,
+    schedule_item_to_index: HashMap<NonBlankString, ScheduleItemIndex>,
 }
 
-type PathWaypointIndex = usize;
+type ScheduleItemIndex = usize;
 
 impl SimulationTrain {
     pub fn new(
@@ -191,13 +193,13 @@ impl SimulationTrain {
             path_constraints: PathfindingConstraints {
                 path_items: Vec::new(),
             },
-            path_item_to_index: HashMap::default(),
+            schedule_item_to_index: HashMap::default(),
         }
     }
 
-    fn waypoints(&self) -> usize {
+    fn schedule_items(&self) -> usize {
         let n = self.path_constraints.path_items.len();
-        debug_assert_eq!(n, self.parameters.path_items.len());
+        debug_assert_eq!(n, self.parameters.schedule_items.len());
         debug_assert!(
             self.parameters
                 .power_restrictions
@@ -210,46 +212,46 @@ impl SimulationTrain {
         n
     }
 
-    /// Adds a waypoint to the train's path with simulation schedule information
+    /// Adds a schedule item to the train's path with simulation schedule information
     ///
     /// The label can be reused for [Self::set_power_restriction] and [Self::set_margin].
-    pub fn push_waypoint(
+    pub fn push_schedule_item(
         &mut self,
         path_constraint: PathItemAlternatives,
         label: NonBlankString,
-        point: SimulationWaypoint,
+        schedule_item: ScheduleItem,
     ) {
-        let index = self.parameters.path_items.len();
-        self.parameters.path_items.push(point);
+        let index = self.parameters.schedule_items.len();
+        self.parameters.schedule_items.push(schedule_item);
         self.path_constraints.path_items.push(path_constraint);
-        self.path_item_to_index.insert(label, index);
+        self.schedule_item_to_index.insert(label, index);
     }
 
-    /// Sets a power restriction for a range of waypoints.
+    /// Sets a power restriction for a range of schedule
     ///
     /// Labels are used to define the range: they can be &NonBlankString, &String or &str.
     ///
     /// # Panics
     ///
-    /// Panics if `begin_label` or `end_label` has not been used to push a waypoint.
+    /// Panics if `begin_label` or `end_label` has not been used to push a schedule item.
     pub fn set_power_restriction<Q>(&mut self, begin_label: &Q, end_label: &Q, restriction: String)
     where
         NonBlankString: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let begin_index = self
-            .path_item_to_index
+            .schedule_item_to_index
             .get(begin_label)
             .copied()
-            .expect("only names already inserted through “push_waypoint” can be used");
+            .expect("only names already inserted through “push_schedule_item” can be used");
         let end_index = self
-            .path_item_to_index
+            .schedule_item_to_index
             .get(end_label)
             .copied()
-            .expect("only names already inserted through “push_waypoint” can be used");
-        let n = self.waypoints();
+            .expect("only names already inserted through “push_schedule_item” can be used");
+        let n = self.schedule_items();
         if begin_index >= n || end_index >= n {
-            panic!("path waypoint index out of bounds");
+            panic!("schedule item index out of bounds");
         }
         match begin_index.cmp(&end_index) {
             Ordering::Less => self
@@ -263,31 +265,31 @@ impl SimulationTrain {
         }
     }
 
-    /// Sets a margin for a range of waypoints.
+    /// Sets a margin for a range of schedule items
     ///
     /// Labels are used to define the range: they can be &NonBlankString, &String or &str.
     ///
     /// # Panics
     ///
-    /// Panics if `begin_label` or `end_label` has not been used to push a waypoint.
+    /// Panics if `begin_label` or `end_label` has not been used to push a schedule item.
     pub fn set_margin<Q>(&mut self, begin_label: &Q, end_label: &Q, margin: MarginValue)
     where
         NonBlankString: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let begin_index = self
-            .path_item_to_index
+            .schedule_item_to_index
             .get(begin_label)
             .copied()
-            .expect("only names already inserted through “push_waypoint” can be used");
+            .expect("only names already inserted through “push_schedule_item” can be used");
         let end_index = self
-            .path_item_to_index
+            .schedule_item_to_index
             .get(end_label)
             .copied()
-            .expect("only names already inserted through “push_waypoint” can be used");
-        let n = self.waypoints();
+            .expect("only names already inserted through “push_schedule_item” can be used");
+        let n = self.schedule_items();
         if begin_index >= n || end_index >= n {
-            panic!("path waypoint index out of bounds");
+            panic!("path schedule item index out of bounds");
         }
         match begin_index.cmp(&end_index) {
             Ordering::Less => self
@@ -317,7 +319,7 @@ where
                             pathfinding_consist,
                             parameters,
                             path_constraints,
-                            path_item_to_index: _,
+                            schedule_item_to_index: _,
                         },
                     )| {
                         (

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -70,21 +70,22 @@ pub(super) fn build_request(
     );
 
     let mut schedule = Vec::new();
-    for (i, point) in params.schedule_items().iter().enumerate() {
-        if let ScheduleItem::ScheduleItem {
+    for (
+        i,
+        ScheduleItem {
             arrival_at,
             stop_for,
             reception_signal,
-        } = point
-        {
-            let position = path_item_positions[i];
-            schedule.push(core_client::simulation::SimulationScheduleItem {
-                path_offset: position,
-                arrival: *arrival_at,
-                stop_for: *stop_for,
-                reception_signal: *reception_signal,
-            });
-        }
+        },
+    ) in params.schedule_items().iter().enumerate()
+    {
+        let position = path_item_positions[i];
+        schedule.push(core_client::simulation::SimulationScheduleItem {
+            path_offset: position,
+            arrival: *arrival_at,
+            stop_for: *stop_for,
+            reception_signal: *reception_signal,
+        });
     }
 
     let margin_boundaries_len = margin_boundaries.len();
@@ -200,12 +201,12 @@ mod tests {
         builder.push_schedule_item(
             path_items[0].clone(),
             NonBlankString::from("a"),
-            ScheduleItem::PathItem,
+            ScheduleItem::pass_by(),
         );
         builder.push_schedule_item(
             path_items[1].clone(),
             NonBlankString::from("b"),
-            ScheduleItem::ScheduleItem {
+            ScheduleItem {
                 arrival_at: Some(300),
                 stop_for: Some(0),
                 reception_signal: Default::default(),
@@ -224,12 +225,20 @@ mod tests {
             infra: 1,
             expected_version: 1,
             electrical_profile_set_id: None,
-            schedule: vec![core_client::simulation::SimulationScheduleItem {
-                path_offset: 10,
-                arrival: Some(300),
-                stop_for: Some(0),
-                reception_signal: Default::default(),
-            }],
+            schedule: vec![
+                core_client::simulation::SimulationScheduleItem {
+                    path_offset: 0,
+                    arrival: None,
+                    stop_for: None,
+                    reception_signal: Default::default(),
+                },
+                core_client::simulation::SimulationScheduleItem {
+                    path_offset: 10,
+                    arrival: Some(300),
+                    stop_for: Some(0),
+                    reception_signal: Default::default(),
+                },
+            ],
             margins: core_client::simulation::SimulationMargins {
                 // Core also accepts this form
                 boundaries: vec![],
@@ -299,7 +308,7 @@ mod tests {
             builder.push_schedule_item(
                 path_items[i].clone(),
                 NonBlankString::from(i.to_string()),
-                ScheduleItem::ScheduleItem {
+                ScheduleItem {
                     arrival_at: *arrival,
                     stop_for: Some(0),
                     reception_signal: Default::default(),
@@ -433,12 +442,12 @@ mod tests {
         builder.push_schedule_item(
             PathItemAlternatives::from_iter([]),
             NonBlankString::from("a"),
-            ScheduleItem::PathItem,
+            ScheduleItem::pass_by(),
         );
         builder.push_schedule_item(
             PathItemAlternatives::from_iter([]),
             NonBlankString::from("b"),
-            ScheduleItem::ScheduleItem {
+            ScheduleItem {
                 arrival_at: Some(300),
                 stop_for: Some(0),
                 reception_signal: Default::default(),

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -9,8 +9,8 @@ use crate::CoreEnv;
 use crate::Task;
 use crate::envs::pathfinding;
 
+use super::ScheduleItem;
 use super::SimulationKey;
-use super::SimulationWaypoint;
 
 pub(super) fn build_request(
     core_env: &CoreEnv,
@@ -29,7 +29,7 @@ pub(super) fn build_request(
             ?pf_consist,
             sim_params = ?params,
             pf_constraints = ?constraints,
-            waypoint_count = constraints.path_items.len(),
+            schedule_item_count = constraints.path_items.len(),
             computed_path_item_count = path_item_positions.len(),
             "Core path does not respect pathfinding constraints. Please open a bug report."
         );
@@ -70,8 +70,8 @@ pub(super) fn build_request(
     );
 
     let mut schedule = Vec::new();
-    for (i, point) in params.schedule().iter().enumerate() {
-        if let SimulationWaypoint::ScheduleItem {
+    for (i, point) in params.schedule_items().iter().enumerate() {
+        if let ScheduleItem::ScheduleItem {
             arrival_at,
             stop_for,
             reception_signal,
@@ -154,9 +154,9 @@ mod tests {
     use crate::envs::pathfinding;
     use crate::envs::pathfinding::PathItemAlternatives;
     use crate::envs::simulation;
+    use crate::envs::simulation::ScheduleItem;
     use crate::envs::simulation::SimulationTrain;
     use crate::envs::simulation::SimulationTrainParameters;
-    use crate::envs::simulation::SimulationWaypoint;
 
     /// Simple request with only schedule items
     #[test]
@@ -197,15 +197,15 @@ mod tests {
                 Default::default(),
             ),
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             path_items[0].clone(),
             NonBlankString::from("a"),
-            SimulationWaypoint::PathItem,
+            ScheduleItem::PathItem,
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             path_items[1].clone(),
             NonBlankString::from("b"),
-            SimulationWaypoint::ScheduleItem {
+            ScheduleItem::ScheduleItem {
                 arrival_at: Some(300),
                 stop_for: Some(0),
                 reception_signal: Default::default(),
@@ -296,10 +296,10 @@ mod tests {
             .iter()
             .enumerate()
         {
-            builder.push_waypoint(
+            builder.push_schedule_item(
                 path_items[i].clone(),
                 NonBlankString::from(i.to_string()),
-                SimulationWaypoint::ScheduleItem {
+                ScheduleItem::ScheduleItem {
                     arrival_at: *arrival,
                     stop_for: Some(0),
                     reception_signal: Default::default(),
@@ -430,15 +430,15 @@ mod tests {
                 Default::default(),
             ),
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             PathItemAlternatives::from_iter([]),
             NonBlankString::from("a"),
-            SimulationWaypoint::PathItem,
+            ScheduleItem::PathItem,
         );
-        builder.push_waypoint(
+        builder.push_schedule_item(
             PathItemAlternatives::from_iter([]),
             NonBlankString::from("b"),
-            SimulationWaypoint::ScheduleItem {
+            ScheduleItem::ScheduleItem {
                 arrival_at: Some(300),
                 stop_for: Some(0),
                 reception_signal: Default::default(),

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -152,7 +152,7 @@ mod tests {
 
     use super::*;
     use crate::envs::pathfinding;
-    use crate::envs::pathfinding::PathWaypointAlternatives;
+    use crate::envs::pathfinding::PathItemAlternatives;
     use crate::envs::simulation;
     use crate::envs::simulation::SimulationTrain;
     use crate::envs::simulation::SimulationTrainParameters;
@@ -176,8 +176,8 @@ mod tests {
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
         let path_items = vec![
-            PathWaypointAlternatives::from_iter([]),
-            PathWaypointAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
         ];
         let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
@@ -268,11 +268,11 @@ mod tests {
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
         let path_items = vec![
-            PathWaypointAlternatives::from_iter([]),
-            PathWaypointAlternatives::from_iter([]),
-            PathWaypointAlternatives::from_iter([]),
-            PathWaypointAlternatives::from_iter([]),
-            PathWaypointAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
         ];
         let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
@@ -431,12 +431,12 @@ mod tests {
             ),
         );
         builder.push_waypoint(
-            PathWaypointAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
             NonBlankString::from("a"),
             SimulationWaypoint::PathItem,
         );
         builder.push_waypoint(
-            PathWaypointAlternatives::from_iter([]),
+            PathItemAlternatives::from_iter([]),
             NonBlankString::from("b"),
             SimulationWaypoint::ScheduleItem {
                 arrival_at: Some(300),

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -15,7 +15,7 @@ use super::SimulationWaypoint;
 pub(super) fn build_request(
     core_env: &CoreEnv,
     electrical_profile_set_id: Option<u64>,
-    SimulationKey(sim_consist, params, pathfinding::Input(pf_consist, constraints)): &SimulationKey,
+    SimulationKey(sim_consist, params, pathfinding::PathfindingKey(pf_consist, constraints)): &SimulationKey,
     core_client::pathfinding::PathfindingResultSuccess {
         path,
         path_item_positions,
@@ -179,7 +179,7 @@ mod tests {
             PathWaypointAlternatives::from_iter([]),
             PathWaypointAlternatives::from_iter([]),
         ];
-        let pf_input = pathfinding::Input(
+        let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
             Arc::new(crate::PathfindingConstraints {
                 path_items: path_items.clone(),
@@ -274,7 +274,7 @@ mod tests {
             PathWaypointAlternatives::from_iter([]),
             PathWaypointAlternatives::from_iter([]),
         ];
-        let pf_input = pathfinding::Input(
+        let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
             Arc::new(crate::PathfindingConstraints {
                 path_items: path_items.clone(),
@@ -414,7 +414,7 @@ mod tests {
         };
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
-        let pf_input = pathfinding::Input(
+        let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
             Arc::new(crate::PathfindingConstraints { path_items: vec![] }),
         );

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -12,12 +12,12 @@ pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;
 pub use envs::pathfinding::PathfindingTrain;
+pub use envs::simulation::ScheduleItem;
 pub use envs::simulation::SimulationConsist;
 pub use envs::simulation::SimulationEnv;
 pub use envs::simulation::SimulationOutput;
 pub use envs::simulation::SimulationTrain;
 pub use envs::simulation::SimulationTrainParameters;
-pub use envs::simulation::SimulationWaypoint;
 
 use futures::stream;
 use itertools::Itertools as _;

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 // Crate-level exports
 pub use envs::TrainSet;
 pub use envs::core::CoreEnv;
-pub use envs::pathfinding::PathWaypointAlternatives;
+pub use envs::pathfinding::PathItemAlternatives;
 pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -17,7 +17,6 @@ use core_task::PathfindingConsist;
 use core_task::SimulationConsist;
 use core_task::SimulationTrain;
 use core_task::SimulationTrainParameters;
-use core_task::SimulationWaypoint;
 use database::DbConnection;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
@@ -656,8 +655,8 @@ pub fn build_simulation_train(
         .map(|schedule_item @ ScheduleItem { at, .. }| (at, schedule_item))
         .collect::<HashMap<_, _>>();
     for (track_offsets, PathItem { id, .. }) in track_offsets.iter().zip(path) {
-        let (at, simulation_waypoint) = match schedule_map.get(id) {
-            None => (id, SimulationWaypoint::PathItem),
+        let (at, simulation_schedule_item) = match schedule_map.get(id) {
+            None => (id, core_task::ScheduleItem::PathItem),
             Some(ScheduleItem {
                 at,
                 arrival,
@@ -665,17 +664,17 @@ pub fn build_simulation_train(
                 reception_signal,
             }) => (
                 at,
-                SimulationWaypoint::ScheduleItem {
+                core_task::ScheduleItem::ScheduleItem {
                     arrival_at: arrival.as_ref().map(|a| a.num_milliseconds() as u64),
                     stop_for: stop_for.as_ref().map(|s| s.num_milliseconds() as u64),
                     reception_signal: *reception_signal,
                 },
             ),
         };
-        simulation_train.push_waypoint(
+        simulation_train.push_schedule_item(
             track_offsets.iter().cloned().collect(),
             at.clone(),
-            simulation_waypoint,
+            simulation_schedule_item,
         )
     }
     debug_assert!(

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -656,7 +656,7 @@ pub fn build_simulation_train(
         .collect::<HashMap<_, _>>();
     for (track_offsets, PathItem { id, .. }) in track_offsets.iter().zip(path) {
         let (at, simulation_schedule_item) = match schedule_map.get(id) {
-            None => (id, core_task::ScheduleItem::PathItem),
+            None => (id, core_task::ScheduleItem::pass_by()),
             Some(ScheduleItem {
                 at,
                 arrival,
@@ -664,7 +664,7 @@ pub fn build_simulation_train(
                 reception_signal,
             }) => (
                 at,
-                core_task::ScheduleItem::ScheduleItem {
+                core_task::ScheduleItem {
                     arrival_at: arrival.as_ref().map(|a| a.num_milliseconds() as u64),
                     stop_for: stop_for.as_ref().map(|s| s.num_milliseconds() as u64),
                     reception_signal: *reception_signal,


### PR DESCRIPTION
Naming harmonization promised in https://github.com/OpenRailAssociation/osrd/pull/14100.

Besides obvious renaming of internals, "path item" and "waypoint" now stop being used interchangeably with the following boundary:

* "path item" is only used in `PathfindingEnv`, essentially taking a `Vec<Vec<PathItem>>`
* "waypoint" designates the path simulation constraints, a waypoint designates **one** of the path item alternatives provided to `PathfindingEnv`, with potential schedule information.

To merge before we start working heavily on https://github.com/osrd-project/osrd-confidential/issues/1469, ideally.