### PR TITLE
ui-charts: implement drag-and-drop for track occupancy zones

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -20886,6 +20886,7 @@
         "lodash": "^4.18.1"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/chroma-js": "^3.1.2",
         "@types/d3-selection": "^3.0.11",
         "@types/d3-zoom": "^3.0.0",

--- a/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/interactions.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/interactions.stories.tsx
@@ -1,0 +1,88 @@
+import React, { useMemo, useState, useCallback } from 'react';
+
+import {
+  TrackOccupancyStandalone,
+  type SpaceTimeChartProps,
+  isOccupancyPickingElement,
+} from '@osrd-project/ui-charts';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import OCCUPANCY_ZONES from './assets/occupancyZones';
+import TRACKS from './assets/tracks';
+
+import './styles/track-occupancy.css';
+
+const TrackOccupancyDiagramStory = () => {
+  const [allOccupancyZones, setAllOccupancyZones] = useState(OCCUPANCY_ZONES);
+  const [hoveredTrainId, setHoveredTrainId] = useState<string>();
+  const [hoveredTrackId, setHoveredTrackId] = useState<string>();
+  const [draggingTrainId, setDraggingTrainId] = useState<string>();
+
+  const { occupancyZones, draggingOccupancyZones } = useMemo(
+    () => ({
+      occupancyZones: allOccupancyZones.filter((zone) => zone.trainId !== draggingTrainId),
+      draggingOccupancyZones: allOccupancyZones.filter((zone) => zone.trainId === draggingTrainId),
+    }),
+    [allOccupancyZones, draggingTrainId]
+  );
+
+  const handleHoveredChildUpdate: SpaceTimeChartProps['onHoveredChildUpdate'] = useCallback(
+    ({ item }) => {
+      setHoveredTrainId(
+        item && isOccupancyPickingElement(item.element) ? item.element.pathId : undefined
+      );
+    },
+    []
+  );
+
+  const handleMouseDown = useCallback(() => {
+    setDraggingTrainId(hoveredTrainId);
+  }, [hoveredTrainId]);
+
+  const handleMouseUp = useCallback(() => {
+    if (draggingTrainId && hoveredTrackId) {
+      setAllOccupancyZones((prev) =>
+        prev.map((zone) =>
+          zone.trainId === draggingTrainId ? { ...zone, trackId: hoveredTrackId } : zone
+        )
+      );
+    }
+
+    setDraggingTrainId(undefined);
+  }, [draggingTrainId, hoveredTrackId]);
+
+  return (
+    <div
+      id="track-occupancy-diagram-base-story"
+      className="bg-ambientB-10"
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+    >
+      <TrackOccupancyStandalone
+        tracks={TRACKS}
+        occupancyZones={occupancyZones}
+        draggingOccupancyZones={draggingOccupancyZones}
+        onHoveredChildUpdate={handleHoveredChildUpdate}
+        onDragOver={setHoveredTrackId}
+        height={500}
+      />
+    </div>
+  );
+};
+
+/**
+ * Track occupancy diagram interactions.
+ *
+ * Occupancy zones can be dragged and dropped to a new track.
+ */
+const meta: Meta<typeof TrackOccupancyDiagramStory> = {
+  title: 'TrackOccupancyDiagram/Interactions',
+  component: TrackOccupancyDiagramStory,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TrackOccupancyDiagramStory>;
+
+export const TrackOccupancyDiagramStoryDefault: Story = {};

--- a/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
@@ -9,13 +9,16 @@ import TRACKS from './assets/tracks';
 import './styles/track-occupancy.css';
 
 const SELECTED_TRAIN_ID = '5';
+const DRAGGING_OCCUPANCY_ZONES = [OCCUPANCY_ZONES[2]];
 
 const TrackOccupancyDiagramStory = ({
   trainId,
   autoHeight,
+  isDragging,
 }: {
   trainId: number;
   autoHeight?: boolean;
+  isDragging?: boolean;
 }) => {
   const [selectedTrainId, setSelectedTrainId] = useState<string>();
 
@@ -30,6 +33,7 @@ const TrackOccupancyDiagramStory = ({
       <TrackOccupancyStandalone
         tracks={TRACKS}
         occupancyZones={OCCUPANCY_ZONES}
+        draggingOccupancyZones={isDragging ? DRAGGING_OCCUPANCY_ZONES : undefined}
         selectedTrainId={selectedTrainId}
         onSelectedTrainIdChange={setSelectedTrainId}
         height={autoHeight ? undefined : 500}
@@ -68,5 +72,6 @@ export const TrackOccupancyDiagramStoryDefault: Story = {
   args: {
     trainId: 5,
     autoHeight: false,
+    isDragging: false,
   },
 };

--- a/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
@@ -9,7 +9,7 @@ import TRACKS from './assets/tracks';
 import './styles/track-occupancy.css';
 
 const SELECTED_TRAIN_ID = '5';
-const DRAGGING_OCCUPANCY_ZONES = [OCCUPANCY_ZONES[2]];
+const DRAGGING_OCCUPANCY_ZONES = [OCCUPANCY_ZONES[0], OCCUPANCY_ZONES[2]];
 
 const TrackOccupancyDiagramStory = ({
   trainId,

--- a/front/ui/ui-charts/package.json
+++ b/front/ui/ui-charts/package.json
@@ -50,6 +50,7 @@
     "lodash": "^4.18.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/chroma-js": "^3.1.2",
     "@types/d3-selection": "^3.0.11",
     "@types/d3-zoom": "^3.0.0",

--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -105,6 +105,7 @@ const useManchetteWithSpaceTimeChart = ({
     handleXZoomOnWheelEvent,
     yZoomHelpers: { zoomYIn, zoomYOut, resetZoom },
     basicOnPan,
+    panTo,
   } = useSyncManchette({
     manchetteWithSpaceTimeChartRef,
     diagramRef: spaceTimeChartRef,
@@ -429,6 +430,13 @@ const useManchetteWithSpaceTimeChart = ({
     };
   }, [spaceOrigin, spaceScales, height, splitPoints, waypointsToDisplay]);
 
+  const pan = useCallback(
+    ({ dx = 0, dy = 0 }: { dx?: number; dy?: number }) => {
+      setSyncManchetteState((prev) => panTo({ x: prev.xOffset + dx, y: prev.yOffset + dy }, prev));
+    },
+    [setSyncManchetteState, panTo]
+  );
+
   return useMemo<{
     manchetteProps: ManchetteProps;
     spaceTimeChartProps: SpaceTimeChartProps;
@@ -441,6 +449,7 @@ const useManchetteWithSpaceTimeChart = ({
     timeScale: number;
     spaceScale: number;
     setTimeOrigin: (v: number) => void;
+    pan: (args: { dx?: number; dy?: number }) => void;
   }>(
     () => ({
       manchetteProps: {
@@ -538,6 +547,7 @@ const useManchetteWithSpaceTimeChart = ({
       timeScale: zoomValueToTimeScale(xZoom),
       spaceScale: zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, yZoom),
       setTimeOrigin,
+      pan,
     }),
     [
       manchetteContents,
@@ -567,6 +577,7 @@ const useManchetteWithSpaceTimeChart = ({
       minZoomMillimeterPerPx,
       maxZoomMillimeterPerPx,
       setTimeOrigin,
+      pan,
       setSyncManchetteState,
       basicOnPan,
       handleRectZoomEnd,

--- a/front/ui/ui-charts/src/manchette/hooks/useSyncManchette.ts
+++ b/front/ui/ui-charts/src/manchette/hooks/useSyncManchette.ts
@@ -188,12 +188,34 @@ const useSyncManchette = ({
     }
   }, [scrollTo, manchetteWithSpaceTimeChartRef]);
 
+  const panTo = useCallback(
+    ({ x, y }: { y?: number; x?: number }, prev: SyncManchetteState): SyncManchetteState => {
+      const manchette = manchetteWithSpaceTimeChartRef.current;
+
+      let newYOffset = prev.yOffset;
+      if (y !== undefined && y !== newYOffset) {
+        newYOffset = Math.max(y, 0);
+        if (manchette) {
+          newYOffset = Math.min(newYOffset, manchette.scrollHeight - manchette.offsetHeight);
+          manchette.scrollTop = newYOffset;
+        }
+      }
+
+      return {
+        ...prev,
+        xOffset: x ?? prev.xOffset,
+        yOffset: newYOffset,
+      };
+    },
+    [manchetteWithSpaceTimeChartRef]
+  );
+
   // =========== On Pan ===========
   const basicOnPan = useCallback(
     (
       payload: Parameters<NonNullable<SpaceTimeChartProps['onPan']>>[0],
       prev: SyncManchetteState
-    ) => {
+    ): SyncManchetteState => {
       if (!payload.isPanning) {
         return {
           ...prev,
@@ -209,23 +231,11 @@ const useSyncManchette = ({
         };
       }
 
-      const newState = { ...prev };
       const { initialOffset } = prev.panning;
       const diff = getDistance(payload.initialPosition, payload.position);
-      const manchette = manchetteWithSpaceTimeChartRef.current;
-
-      newState.xOffset = initialOffset.x + diff.x;
-      let newYOffset = initialOffset.y - diff.y;
-      newYOffset = Math.max(newYOffset, 0);
-      if (manchette) {
-        newYOffset = Math.min(newYOffset, manchette.scrollHeight - manchette.offsetHeight);
-        manchette.scrollTop = newYOffset;
-      }
-      newState.yOffset = newYOffset;
-
-      return newState;
+      return panTo({ x: initialOffset.x + diff.x, y: initialOffset.y - diff.y }, prev);
     },
-    [manchetteWithSpaceTimeChartRef]
+    [panTo]
   );
 
   return useMemo(

--- a/front/ui/ui-charts/src/manchette/hooks/useSyncManchette.ts
+++ b/front/ui/ui-charts/src/manchette/hooks/useSyncManchette.ts
@@ -247,6 +247,7 @@ const useSyncManchette = ({
       handleXZoomOnWheelEvent,
       yZoomHelpers: { zoomYIn, zoomYOut, resetZoom: resetYZoom },
       basicOnPan,
+      panTo,
     }),
     [
       state,
@@ -257,6 +258,7 @@ const useSyncManchette = ({
       zoomYOut,
       resetYZoom,
       basicOnPan,
+      panTo,
     ]
   );
 };

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -103,6 +103,7 @@ const TrackOccupancyCanvas = ({
         topPadding={topPadding}
         drawBorders={!hideBorders}
         highlightedTrackId={highlightedTrackId}
+        showTicks={!draggingOccupancyZones?.length}
       />
       <OccupancyZonesLayer
         tracks={tracks}

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useEffect } from 'react';
 
 import { X } from '@osrd-project/ui-icons';
 
@@ -39,6 +39,7 @@ const TrackOccupancyCanvas = ({
   draggingOccupancyZones,
   selectedTrainId,
   onClose,
+  onDragOver,
   topPadding = 0,
   hideBorders = false,
 }: {
@@ -48,6 +49,7 @@ const TrackOccupancyCanvas = ({
   draggingOccupancyZones?: OccupancyZone[];
   selectedTrainId?: string;
   onClose?: () => void;
+  onDragOver?: (trackId: string | undefined) => void;
   topPadding?: number;
   hideBorders?: boolean;
 }) => {
@@ -88,6 +90,10 @@ const TrackOccupancyCanvas = ({
     topPadding,
     getSpacePixel,
   ]);
+
+  useEffect(() => {
+    if (onDragOver) onDragOver(highlightedTrackId);
+  }, [onDragOver, highlightedTrackId]);
 
   return (
     <>

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -1,12 +1,17 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 
 import { X } from '@osrd-project/ui-icons';
 
 import { SpaceTimeChartContext } from '../../spaceTimeChart';
+import { MouseContext } from '../../spaceTimeChart/lib/context';
+import { CANVAS_PADDING, TRACK_HEIGHT_CONTAINER } from '../lib/consts';
 import type { OccupancyZone, Track } from '../lib/types';
 import DraggingOccupancyZonesLayer from './layers/DraggingOccupancyZonesLayer';
 import OccupancyZonesLayer from './layers/OccupancyZonesLayer';
 import TracksLayer from './layers/TracksLayer';
+
+/** Distance in pixels to snap to a track while dragging an occupancy zone */
+const DROP_SNAP_DISTANCE = 16;
 
 const CloseButton = ({ position, onClose }: { position: number; onClose: () => void }) => {
   const { getSpacePixel } = useContext(SpaceTimeChartContext);
@@ -45,26 +50,67 @@ const TrackOccupancyCanvas = ({
   onClose?: () => void;
   topPadding?: number;
   hideBorders?: boolean;
-}) => (
-  <>
-    <TracksLayer
-      position={position}
-      tracks={tracks}
-      topPadding={topPadding}
-      drawBorders={!hideBorders}
-    />
-    <OccupancyZonesLayer
-      tracks={tracks}
-      position={position}
-      topPadding={topPadding}
-      occupancyZones={occupancyZones}
-      selectedTrainId={selectedTrainId}
-    />
-    {draggingOccupancyZones && (
-      <DraggingOccupancyZonesLayer occupancyZones={draggingOccupancyZones} />
-    )}
-    {onClose && <CloseButton position={position} onClose={onClose} />}
-  </>
-);
+}) => {
+  const { getSpacePixel } = useContext(SpaceTimeChartContext);
+  const mouseContext = useContext(MouseContext);
+
+  const highlightedTrackId = useMemo(() => {
+    if (!draggingOccupancyZones?.length) {
+      return undefined;
+    }
+    if (isNaN(mouseContext.position.y)) {
+      return undefined; // mouse is outside of the canvas
+    }
+    // Vertical position relative to the middle of the first track
+    const y =
+      mouseContext.position.y -
+      getSpacePixel(position) -
+      topPadding -
+      CANVAS_PADDING -
+      TRACK_HEIGHT_CONTAINER / 2;
+    // Each track is vertically centered in a container with a fixed height, we
+    // can divide by that height to find the closest track index
+    const index = Math.round(y / TRACK_HEIGHT_CONTAINER);
+    // If the mouse is close enough to a track, snap to that track
+    if (
+      index < 0 ||
+      index >= tracks.length ||
+      Math.abs(y - index * TRACK_HEIGHT_CONTAINER) > DROP_SNAP_DISTANCE
+    ) {
+      return undefined;
+    }
+    return tracks[index].id;
+  }, [
+    mouseContext.position.y,
+    draggingOccupancyZones,
+    position,
+    tracks,
+    topPadding,
+    getSpacePixel,
+  ]);
+
+  return (
+    <>
+      <TracksLayer
+        position={position}
+        tracks={tracks}
+        topPadding={topPadding}
+        drawBorders={!hideBorders}
+        highlightedTrackId={highlightedTrackId}
+      />
+      <OccupancyZonesLayer
+        tracks={tracks}
+        position={position}
+        topPadding={topPadding}
+        occupancyZones={occupancyZones}
+        selectedTrainId={selectedTrainId}
+      />
+      {draggingOccupancyZones && (
+        <DraggingOccupancyZonesLayer occupancyZones={draggingOccupancyZones} />
+      )}
+      {onClose && <CloseButton position={position} onClose={onClose} />}
+    </>
+  );
+};
 
 export default TrackOccupancyCanvas;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -4,6 +4,7 @@ import { X } from '@osrd-project/ui-icons';
 
 import { SpaceTimeChartContext } from '../../spaceTimeChart';
 import type { OccupancyZone, Track } from '../lib/types';
+import DraggingOccupancyZonesLayer from './layers/DraggingOccupancyZonesLayer';
 import OccupancyZonesLayer from './layers/OccupancyZonesLayer';
 import TracksLayer from './layers/TracksLayer';
 
@@ -30,6 +31,7 @@ const TrackOccupancyCanvas = ({
   position,
   tracks,
   occupancyZones,
+  draggingOccupancyZones,
   selectedTrainId,
   onClose,
   topPadding = 0,
@@ -38,6 +40,7 @@ const TrackOccupancyCanvas = ({
   position: number;
   tracks: Track[];
   occupancyZones: OccupancyZone[];
+  draggingOccupancyZones?: OccupancyZone[];
   selectedTrainId?: string;
   onClose?: () => void;
   topPadding?: number;
@@ -57,6 +60,9 @@ const TrackOccupancyCanvas = ({
       occupancyZones={occupancyZones}
       selectedTrainId={selectedTrainId}
     />
+    {draggingOccupancyZones && (
+      <DraggingOccupancyZonesLayer occupancyZones={draggingOccupancyZones} />
+    )}
     {onClose && <CloseButton position={position} onClose={onClose} />}
   </>
 );

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyManchette.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyManchette.tsx
@@ -1,14 +1,24 @@
 import React, { type PropsWithChildren } from 'react';
 
+import cx from 'classnames';
+
 import { TRACK_HEIGHT_CONTAINER } from '../lib/consts';
 import type { Track } from '../lib/types';
 
-const TrackOccupancyManchette = ({ tracks, children }: PropsWithChildren<{ tracks: Track[] }>) => (
+const TrackOccupancyManchette = ({
+  tracks,
+  activeTrackId,
+  children,
+}: PropsWithChildren<{ tracks: Track[]; activeTrackId?: string }>) => (
   <div data-testid="track-occupancy-manchette" className="track-occupancy-manchette">
     {children}
     {tracks.map((track) => (
       // height is shared between manchette and canvas components
-      <div className="track" key={track.id} style={{ height: TRACK_HEIGHT_CONTAINER }}>
+      <div
+        className={cx('track', { active: activeTrackId === track.id })}
+        key={track.id}
+        style={{ height: TRACK_HEIGHT_CONTAINER }}
+      >
         <span className="track-line">{track.line}</span>
         <div className="track-name">{track.name}</div>
         <div className="track-rail" />

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -97,6 +97,8 @@ const TrackOccupancyStandalone = ({
     },
   });
 
+  const isDragging = Boolean(draggingOccupancyZones?.length);
+
   return (
     <div className="track-occupancy-standalone flex flex-col">
       <div className="bg-ambientB-5 flex flex-col justify-center main-container-header grow-0 shrink-0">
@@ -108,7 +110,7 @@ const TrackOccupancyStandalone = ({
           ref={manchetteWithSpaceTimeChartRef}
           className="manchette flex h-100"
           onScroll={handleScroll}
-          style={{ height, cursor: draggingOccupancyZones?.length ? 'ns-resize' : undefined }}
+          style={{ height, cursor: isDragging ? 'ns-resize' : undefined }}
         >
           <Manchette {...manchetteProps} />
           <div className="space-time-chart-container w-full sticky" ref={spaceTimeChartRef}>
@@ -127,6 +129,7 @@ const TrackOccupancyStandalone = ({
                   }
                 })
               }
+              onPan={isDragging ? undefined : spaceTimeChartProps.onPan}
             >
               <TimeCaptions />
             </SpaceTimeChart>

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { KebabHorizontal } from '@osrd-project/ui-icons';
 
@@ -36,6 +36,7 @@ const TrackOccupancyStandalone = ({
     // Take first round hour before minTime:
     return Math.floor(minTime / HOUR) * HOUR;
   }, [occupancyZones]);
+  const [highlightedTrackId, setHighlightedTrackId] = useState<string>();
 
   // To make SpaceTimeChart and Manchette work, we have to provide them some dummy data:
   const waypoints = useMemo(
@@ -64,13 +65,16 @@ const TrackOccupancyStandalone = ({
             occupancyZones={occupancyZones}
             draggingOccupancyZones={draggingOccupancyZones}
             selectedTrainId={selectedTrainId}
+            onDragOver={setHighlightedTrackId}
             hideBorders
           />
         ),
-        manchetteNode: <TrackOccupancyManchette tracks={tracks} />,
+        manchetteNode: (
+          <TrackOccupancyManchette tracks={tracks} activeTrackId={highlightedTrackId} />
+        ),
       },
     ],
-    [height, tracks, occupancyZones, draggingOccupancyZones, selectedTrainId]
+    [height, tracks, occupancyZones, draggingOccupancyZones, selectedTrainId, highlightedTrackId]
   );
 
   /**

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState, useCallback } from 'react';
 
 import { KebabHorizontal } from '@osrd-project/ui-icons';
 
 import { HOUR } from '../../common/consts';
 import { TimeCaptions } from '../../common/layers/TimeCaptions';
 import { Manchette, useManchetteWithSpaceTimeChart, BASE_WAYPOINT_HEIGHT } from '../../manchette';
-import { DEFAULT_THEME, SpaceTimeChart } from '../../spaceTimeChart';
+import { DEFAULT_THEME, SpaceTimeChart, type SpaceTimeChartProps } from '../../spaceTimeChart';
 import useEdgePan from '../hooks/useEdgePan';
 import { TRACK_HEIGHT_CONTAINER } from '../lib/consts';
 import type { OccupancyZone, Track } from '../lib/types';
@@ -19,6 +19,8 @@ const TrackOccupancyStandalone = ({
   draggingOccupancyZones,
   selectedTrainId,
   onSelectedTrainIdChange,
+  onHoveredChildUpdate,
+  onDragOver,
   height = TRACK_HEIGHT_CONTAINER * tracks.length + DEFAULT_THEME.timeCaptionsSize,
 }: {
   tracks: Track[];
@@ -26,6 +28,8 @@ const TrackOccupancyStandalone = ({
   draggingOccupancyZones?: OccupancyZone[];
   selectedTrainId?: string;
   onSelectedTrainIdChange?: (selectedTrainId?: string) => void;
+  onHoveredChildUpdate?: SpaceTimeChartProps['onHoveredChildUpdate'];
+  onDragOver?: (trackId: string | undefined) => void;
   height?: number;
 }) => {
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
@@ -38,6 +42,14 @@ const TrackOccupancyStandalone = ({
     return Math.floor(minTime / HOUR) * HOUR;
   }, [occupancyZones]);
   const [highlightedTrackId, setHighlightedTrackId] = useState<string>();
+
+  const handleDragOver = useCallback(
+    (trackId: string | undefined) => {
+      setHighlightedTrackId(trackId);
+      onDragOver?.(trackId);
+    },
+    [onDragOver]
+  );
 
   // To make SpaceTimeChart and Manchette work, we have to provide them some dummy data:
   const waypoints = useMemo(
@@ -66,7 +78,7 @@ const TrackOccupancyStandalone = ({
             occupancyZones={occupancyZones}
             draggingOccupancyZones={draggingOccupancyZones}
             selectedTrainId={selectedTrainId}
-            onDragOver={setHighlightedTrackId}
+            onDragOver={handleDragOver}
             hideBorders
           />
         ),
@@ -75,7 +87,15 @@ const TrackOccupancyStandalone = ({
         ),
       },
     ],
-    [height, tracks, occupancyZones, draggingOccupancyZones, selectedTrainId, highlightedTrackId]
+    [
+      height,
+      tracks,
+      occupancyZones,
+      draggingOccupancyZones,
+      selectedTrainId,
+      highlightedTrackId,
+      handleDragOver,
+    ]
   );
 
   /**
@@ -136,6 +156,7 @@ const TrackOccupancyStandalone = ({
               }
               onPan={isDragging ? undefined : spaceTimeChartProps.onPan}
               onMouseMove={onMouseMove}
+              onHoveredChildUpdate={onHoveredChildUpdate}
             >
               <TimeCaptions />
             </SpaceTimeChart>

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -6,6 +6,7 @@ import { HOUR } from '../../common/consts';
 import { TimeCaptions } from '../../common/layers/TimeCaptions';
 import { Manchette, useManchetteWithSpaceTimeChart, BASE_WAYPOINT_HEIGHT } from '../../manchette';
 import { DEFAULT_THEME, SpaceTimeChart } from '../../spaceTimeChart';
+import useEdgePan from '../hooks/useEdgePan';
 import { TRACK_HEIGHT_CONTAINER } from '../lib/consts';
 import type { OccupancyZone, Track } from '../lib/types';
 import { isOccupancyPickingElement } from './layers/OccupancyZonesLayer';
@@ -81,23 +82,27 @@ const TrackOccupancyStandalone = ({
    * We now use useManchetteWithSpaceTimeChart, to get proper pan along the time (and space axis if
    * the container is smaller than the contents):
    */
-  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart({
-    waypoints,
-    manchetteWithSpaceTimeChartRef,
-    height,
-    spaceTimeChartRef,
-    splitPoints,
-    defaultTimeOrigin,
-    verticalPadding: 0,
-    options: {
-      displayTimeCaptions: true,
-      enableTimePan: true,
-      enableSpacePan: true,
-      enableTimeZoom: false,
-    },
-  });
+  const { manchetteProps, spaceTimeChartProps, handleScroll, pan } = useManchetteWithSpaceTimeChart(
+    {
+      waypoints,
+      manchetteWithSpaceTimeChartRef,
+      height,
+      spaceTimeChartRef,
+      splitPoints,
+      defaultTimeOrigin,
+      verticalPadding: 0,
+      options: {
+        displayTimeCaptions: true,
+        enableTimePan: true,
+        enableSpacePan: true,
+        enableTimeZoom: false,
+      },
+    }
+  );
 
   const isDragging = Boolean(draggingOccupancyZones?.length);
+
+  const { onMouseMove } = useEdgePan({ enableY: isDragging, spaceTimeChartProps, pan });
 
   return (
     <div className="track-occupancy-standalone flex flex-col">
@@ -130,6 +135,7 @@ const TrackOccupancyStandalone = ({
                 })
               }
               onPan={isDragging ? undefined : spaceTimeChartProps.onPan}
+              onMouseMove={onMouseMove}
             >
               <TimeCaptions />
             </SpaceTimeChart>

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -108,7 +108,7 @@ const TrackOccupancyStandalone = ({
           ref={manchetteWithSpaceTimeChartRef}
           className="manchette flex h-100"
           onScroll={handleScroll}
-          style={{ height }}
+          style={{ height, cursor: draggingOccupancyZones?.length ? 'ns-resize' : undefined }}
         >
           <Manchette {...manchetteProps} />
           <div className="space-time-chart-container w-full sticky" ref={spaceTimeChartRef}>

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -15,12 +15,14 @@ import TrackOccupancyManchette from './TrackOccupancyManchette';
 const TrackOccupancyStandalone = ({
   tracks,
   occupancyZones,
+  draggingOccupancyZones,
   selectedTrainId,
   onSelectedTrainIdChange,
   height = TRACK_HEIGHT_CONTAINER * tracks.length + DEFAULT_THEME.timeCaptionsSize,
 }: {
   tracks: Track[];
   occupancyZones: OccupancyZone[];
+  draggingOccupancyZones?: OccupancyZone[];
   selectedTrainId?: string;
   onSelectedTrainIdChange?: (selectedTrainId?: string) => void;
   height?: number;
@@ -60,6 +62,7 @@ const TrackOccupancyStandalone = ({
             tracks={tracks}
             topPadding={BASE_WAYPOINT_HEIGHT * 1.5}
             occupancyZones={occupancyZones}
+            draggingOccupancyZones={draggingOccupancyZones}
             selectedTrainId={selectedTrainId}
             hideBorders
           />
@@ -67,7 +70,7 @@ const TrackOccupancyStandalone = ({
         manchetteNode: <TrackOccupancyManchette tracks={tracks} />,
       },
     ],
-    [height, tracks, occupancyZones, selectedTrainId]
+    [height, tracks, occupancyZones, draggingOccupancyZones, selectedTrainId]
   );
 
   /**

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZones.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZones.ts
@@ -34,7 +34,7 @@ const ARROW_WIDTH = 4.5;
 const ARROW_TOP_Y = 3.5;
 const ARROW_BOTTOM_Y = 6.5;
 
-const drawThroughTrain = (ctx: CanvasRenderingContext2D, x: number, y: number) => {
+export const drawThroughTrain = (ctx: CanvasRenderingContext2D, x: number, y: number) => {
   // Through trains are materialized by converging arrows like the following ones
   //  ___
   //  \_/

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTrack.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTrack.ts
@@ -3,25 +3,27 @@ import { sum } from 'lodash';
 import { TRACK_HEIGHT_CONTAINER, COLORS, TICKS_PATTERN } from '../../../lib/consts';
 import { getTickPattern } from '../../utils';
 
-const { WHITE_100, WHITE_50, GREY_20, RAIL_TICK } = COLORS;
+const { WHITE_100, WHITE_50, GREY_20, PRIMARY_5, PRIMARY_30, RAIL_TICK } = COLORS;
 
 const drawRails = ({
   xStart,
   yStart,
   width,
-  stroke = GREY_20,
+  fill,
+  stroke,
   ctx,
 }: {
   xStart: number;
   yStart: number;
   width: number;
-  stroke?: string;
+  fill: string;
+  stroke: string;
   ctx: CanvasRenderingContext2D;
 }) => {
   ctx.fillStyle = WHITE_100;
   ctx.fillRect(xStart, yStart, width, 9);
 
-  ctx.fillStyle = WHITE_50;
+  ctx.fillStyle = fill;
   ctx.strokeStyle = stroke;
   ctx.lineWidth = 1;
   ctx.beginPath();
@@ -59,14 +61,28 @@ type DrawTrackProps = {
   width: number;
   getTimePixel: (time: number) => number;
   labelMarks: Record<number, { level: number; rangeIndex: number }>;
+  highlighted?: boolean;
 };
 
-export const drawTrack = ({ ctx, width, getTimePixel, labelMarks }: DrawTrackProps) => {
+export const drawTrack = ({
+  ctx,
+  width,
+  getTimePixel,
+  labelMarks,
+  highlighted,
+}: DrawTrackProps) => {
   ctx.fillStyle = WHITE_50;
 
   ctx.save();
 
-  drawRails({ xStart: -1, yStart: TRACK_HEIGHT_CONTAINER / 2 - 4, width: width + 1, ctx });
+  drawRails({
+    ctx,
+    xStart: -1,
+    yStart: TRACK_HEIGHT_CONTAINER / 2 - 4,
+    width: width + 1,
+    fill: highlighted ? PRIMARY_5 : WHITE_50,
+    stroke: highlighted ? PRIMARY_30 : GREY_20,
+  });
 
   for (const t in labelMarks) {
     const date = new Date(+t);

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTracks.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTracks.ts
@@ -22,12 +22,14 @@ export const drawTracks = (
     drawBorders,
     topPadding = 0,
     highlightedTrackId,
+    showTicks = true,
   }: {
     position: number;
     tracks: Track[];
     drawBorders: boolean;
     topPadding: number;
     highlightedTrackId?: string;
+    showTicks?: boolean;
   }
 ) => {
   const {
@@ -45,7 +47,9 @@ export const drawTracks = (
   const timeEnd = getTime(width);
   const pixelsPerMinute = (1 / timeScale) * MINUTE;
 
-  const labelLevels = getLabelLevels(breakpoints, pixelsPerMinute, TICKS_PRIORITIES);
+  const labelLevels = showTicks
+    ? getLabelLevels(breakpoints, pixelsPerMinute, TICKS_PRIORITIES)
+    : [];
   const labelMarks = getLabelMarks(timeRanges, timeStart, timeEnd, labelLevels);
 
   // Draw backgrounds:

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTracks.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawTracks.ts
@@ -21,11 +21,13 @@ export const drawTracks = (
     tracks,
     drawBorders,
     topPadding = 0,
+    highlightedTrackId,
   }: {
     position: number;
     tracks: Track[];
     drawBorders: boolean;
     topPadding: number;
+    highlightedTrackId?: string;
   }
 ) => {
   const {
@@ -60,7 +62,7 @@ export const drawTracks = (
   // Draw actual tracks:
   ctx.save();
   ctx.translate(0, yStart + topPadding);
-  tracks?.forEach((_, index) => {
+  tracks?.forEach((track, index) => {
     const trackTranslate = index === 0 ? CANVAS_PADDING : TRACK_HEIGHT_CONTAINER;
     ctx.translate(0, trackTranslate);
     drawTrack({
@@ -68,6 +70,7 @@ export const drawTracks = (
       width,
       getTimePixel,
       labelMarks,
+      highlighted: highlightedTrackId === track.id,
     });
   });
   ctx.restore();

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/DraggingOccupancyZonesLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/DraggingOccupancyZonesLayer.tsx
@@ -9,6 +9,7 @@ import {
 import { MouseContext } from '../../../spaceTimeChart/lib/context';
 import { COLORS } from '../../lib/consts';
 import type { OccupancyZone } from '../../lib/types';
+import { drawThroughTrain } from '../helpers/drawElements/drawOccupancyZones';
 
 const DraggingOccupancyZonesLayer = ({ occupancyZones }: { occupancyZones: OccupancyZone[] }) => {
   const mouseContext = useContext(MouseContext);
@@ -19,11 +20,15 @@ const DraggingOccupancyZonesLayer = ({ occupancyZones }: { occupancyZones: Occup
         const xStart = getTimePixel(zone.startTime);
         const xEnd = getTimePixel(zone.endTime);
 
-        const height = 5;
-        const radius = 2;
-        const rectY = mouseContext.position.y - height / 2;
-        ctx.beginPath();
-        ctx.roundRect(xStart, rectY, xEnd - xStart, height, radius);
+        if (zone.startTime === zone.endTime) {
+          drawThroughTrain(ctx, xStart, mouseContext.position.y);
+        } else {
+          const height = 5;
+          const radius = 2;
+          const rectY = mouseContext.position.y - height / 2;
+          ctx.beginPath();
+          ctx.roundRect(xStart, rectY, xEnd - xStart, height, radius);
+        }
 
         // Draw zone box
         ctx.save();
@@ -48,7 +53,7 @@ const DraggingOccupancyZonesLayer = ({ occupancyZones }: { occupancyZones: Occup
         ctx.lineCap = 'round';
         ctx.strokeStyle = COLORS.PRIMARY_50;
         ctx.setLineDash([0, 4]);
-        const verticalLineSpacing = 2.5;
+        const verticalLineSpacing = zone.startTime === zone.endTime ? 7 : 2.5;
         ctx.beginPath();
         ctx.moveTo(xStart - verticalLineSpacing, 0);
         ctx.lineTo(xStart - verticalLineSpacing, viewportHeight);

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/DraggingOccupancyZonesLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/DraggingOccupancyZonesLayer.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useContext } from 'react';
+
+import { useDraw } from '../../../common/hooks/useCanvas';
+import type { DrawingFunction } from '../../../common/types';
+import {
+  SpaceTimeChartCanvasContext,
+  type SpaceTimeChartContextType,
+} from '../../../spaceTimeChart';
+import { MouseContext } from '../../../spaceTimeChart/lib/context';
+import { COLORS } from '../../lib/consts';
+import type { OccupancyZone } from '../../lib/types';
+
+const DraggingOccupancyZonesLayer = ({ occupancyZones }: { occupancyZones: OccupancyZone[] }) => {
+  const mouseContext = useContext(MouseContext);
+
+  const draw = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
+    (ctx, { getTimePixel, height: viewportHeight }) => {
+      for (const zone of occupancyZones) {
+        const xStart = getTimePixel(zone.startTime);
+        const xEnd = getTimePixel(zone.endTime);
+
+        const height = 5;
+        const radius = 2;
+        const rectY = mouseContext.position.y - height / 2;
+        ctx.beginPath();
+        ctx.roundRect(xStart, rectY, xEnd - xStart, height, radius);
+
+        // Draw zone box
+        ctx.save();
+        ctx.fillStyle = COLORS.PRIMARY_80;
+        ctx.shadowBlur = 8;
+        ctx.shadowOffsetX = 0;
+        ctx.shadowOffsetY = 5;
+        ctx.shadowColor = 'rgba(60, 138, 255, 0.55)';
+        ctx.fill();
+        ctx.restore();
+
+        // Draw shadow under the zone box
+        ctx.save();
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = 'rgb(105, 255, 254)';
+        ctx.stroke();
+        ctx.restore();
+
+        // Draw two vertical dashed lines around the zone box
+        ctx.save();
+        ctx.lineWidth = 1.5;
+        ctx.lineCap = 'round';
+        ctx.strokeStyle = COLORS.PRIMARY_50;
+        ctx.setLineDash([0, 4]);
+        const verticalLineSpacing = 2.5;
+        ctx.beginPath();
+        ctx.moveTo(xStart - verticalLineSpacing, 0);
+        ctx.lineTo(xStart - verticalLineSpacing, viewportHeight);
+        ctx.moveTo(xEnd + verticalLineSpacing, 0);
+        ctx.lineTo(xEnd + verticalLineSpacing, viewportHeight);
+        ctx.stroke();
+        ctx.restore();
+      }
+    },
+    [occupancyZones, mouseContext.position.y]
+  );
+
+  useDraw(SpaceTimeChartCanvasContext, 'overlay', draw);
+
+  return null;
+};
+
+export default DraggingOccupancyZonesLayer;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
@@ -69,7 +69,7 @@ const OccupancyZonesLayer = ({
 
     if (!tracks || !occupancyZones || occupancyZones.length === 0) return instructions;
 
-    const sortedOccupancyZones = occupancyZones.sort((a, b) => a.startTime - b.startTime);
+    const sortedOccupancyZones = occupancyZones.toSorted((a, b) => a.startTime - b.startTime);
 
     tracks.forEach((track, index) => {
       const trackY = topPadding + CANVAS_PADDING + index * TRACK_HEIGHT_CONTAINER;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/TracksLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/TracksLayer.tsx
@@ -14,17 +14,25 @@ const TracksLayer = ({
   position,
   topPadding,
   drawBorders,
+  highlightedTrackId,
 }: {
   tracks: Track[];
   position: number;
   topPadding: number;
   drawBorders: boolean;
+  highlightedTrackId?: string;
 }) => {
   const drawingFunction = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
     (ctx, stcContext) => {
-      drawTracks(ctx, stcContext, { position, topPadding, tracks, drawBorders });
+      drawTracks(ctx, stcContext, {
+        position,
+        topPadding,
+        tracks,
+        drawBorders,
+        highlightedTrackId,
+      });
     },
-    [drawBorders, position, topPadding, tracks]
+    [drawBorders, position, topPadding, tracks, highlightedTrackId]
   );
 
   useDraw(SpaceTimeChartCanvasContext, 'background', drawingFunction);

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/TracksLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/TracksLayer.tsx
@@ -15,12 +15,14 @@ const TracksLayer = ({
   topPadding,
   drawBorders,
   highlightedTrackId,
+  showTicks,
 }: {
   tracks: Track[];
   position: number;
   topPadding: number;
   drawBorders: boolean;
   highlightedTrackId?: string;
+  showTicks?: boolean;
 }) => {
   const drawingFunction = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
     (ctx, stcContext) => {
@@ -30,9 +32,10 @@ const TracksLayer = ({
         tracks,
         drawBorders,
         highlightedTrackId,
+        showTicks,
       });
     },
-    [drawBorders, position, topPadding, tracks, highlightedTrackId]
+    [drawBorders, position, topPadding, tracks, highlightedTrackId, showTicks]
   );
 
   useDraw(SpaceTimeChartCanvasContext, 'background', drawingFunction);

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/__tests__/useEdgePan.spec.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/__tests__/useEdgePan.spec.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { SpaceTimeChartProps, SpaceTimeChartContextType } from '../../../spaceTimeChart';
+import useEdgePan, { PAN_INTERVAL_MS } from '../useEdgePan';
+
+describe('useEdgePan', () => {
+  let y = 0; // current vertical offset
+  const pan = ({ dy }: { dy: number }) => {
+    y += dy;
+  };
+
+  const spaceTimeChartProps: SpaceTimeChartProps = {
+    operationalPoints: [],
+    spaceOrigin: 0,
+    spaceScales: [],
+    timeOrigin: 0,
+    timeScale: 1,
+  };
+
+  const initialProps = {
+    enableY: true,
+    spaceTimeChartProps,
+    pan,
+  };
+
+  // TODO: feed a complete chart context to the hook
+  const context: SpaceTimeChartContextType = {
+    width: 700,
+    height: 500,
+  } as SpaceTimeChartContextType;
+
+  // Create parameters for onMouseMove
+  const moveMouseTo = (mouseY: number) => ({
+    position: { x: 0, y: mouseY },
+    data: { time: 0, position: mouseY },
+    isHover: false,
+    hoveredItem: null,
+    context,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    y = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should do nothing when sitting in the middle of the chart', () => {
+    const { result } = renderHook((value) => useEdgePan(value), {
+      initialProps,
+    });
+
+    y = 100;
+    result.current.onMouseMove(moveMouseTo(250));
+    vi.advanceTimersByTime(PAN_INTERVAL_MS);
+    expect(y).toBe(100);
+  });
+
+  it('should pan up when reaching for the top edge', () => {
+    const { result } = renderHook((value) => useEdgePan(value), {
+      initialProps,
+    });
+
+    y = 100;
+    result.current.onMouseMove(moveMouseTo(20));
+    vi.advanceTimersByTime(PAN_INTERVAL_MS);
+    expect(y).toBe(95);
+    vi.advanceTimersByTime(PAN_INTERVAL_MS);
+    expect(y).toBe(90);
+
+    // Stop when moving far enough from the top edge
+    result.current.onMouseMove(moveMouseTo(200));
+    vi.advanceTimersByTime(PAN_INTERVAL_MS);
+    expect(y).toBe(90);
+  });
+
+  it('should pan down when reaching for the bottom edge', () => {
+    const { result } = renderHook((value) => useEdgePan(value), {
+      initialProps,
+    });
+
+    y = 100;
+    result.current.onMouseMove(moveMouseTo(490));
+    vi.advanceTimersByTime(PAN_INTERVAL_MS);
+    expect(y).toBe(105);
+    vi.advanceTimersByTime(PAN_INTERVAL_MS);
+    expect(y).toBe(110);
+
+    // Stop when moving far enough from the bottom edge
+    result.current.onMouseMove(moveMouseTo(350));
+    vi.advanceTimersByTime(PAN_INTERVAL_MS);
+    expect(y).toBe(110);
+  });
+});

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/useEdgePan.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/useEdgePan.ts
@@ -5,7 +5,7 @@ import { DEFAULT_THEME, type SpaceTimeChartProps } from '../../spaceTimeChart';
 /** How close to the edge we should start panning */
 const PAN_EDGE_DISTANCE = 50;
 /** How much time to wait between each pan */
-const PAN_INTERVAL_MS = 50;
+export const PAN_INTERVAL_MS = 50;
 /** How many pixels to pan each interval */
 const PAN_STEP = 5;
 

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/useEdgePan.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/useEdgePan.ts
@@ -1,0 +1,83 @@
+import { useCallback, useRef, useEffect } from 'react';
+
+import { DEFAULT_THEME, type SpaceTimeChartProps } from '../../spaceTimeChart';
+
+/** How close to the edge we should start panning */
+const PAN_EDGE_DISTANCE = 50;
+/** How much time to wait between each pan */
+const PAN_INTERVAL_MS = 50;
+/** How many pixels to pan each interval */
+const PAN_STEP = 5;
+
+type State = {
+  intervalID: number | null;
+  dy: number;
+};
+
+/**
+ * Pan when the mouse approaches the edge of the chart. Useful for navigating
+ * the chart during drag-and-drop operations.
+ */
+const useEdgePan = ({
+  enableY,
+  spaceTimeChartProps,
+  pan,
+}: {
+  enableY?: boolean;
+  spaceTimeChartProps: SpaceTimeChartProps;
+  pan: (pos: { dy: number }) => void;
+}) => {
+  const timeCaptionsSize = spaceTimeChartProps.hideTimeCaptions
+    ? 0
+    : (spaceTimeChartProps.theme?.timeCaptionsSize ?? DEFAULT_THEME.timeCaptionsSize);
+
+  const stateRef = useRef<State>({
+    intervalID: null,
+    dy: 0,
+  });
+
+  const start = useCallback(() => {
+    if (!stateRef.current.intervalID) {
+      stateRef.current.intervalID = setInterval(() => {
+        pan({ dy: stateRef.current.dy });
+      }, PAN_INTERVAL_MS);
+    }
+  }, [pan]);
+
+  const stop = useCallback(() => {
+    if (stateRef.current.intervalID) {
+      clearInterval(stateRef.current.intervalID);
+    }
+    stateRef.current.intervalID = null;
+  }, []);
+
+  const onMouseMove: SpaceTimeChartProps['onMouseMove'] = useCallback(
+    ({ position: { y }, context: { height } }) => {
+      if (!enableY) return;
+
+      let delta = 0;
+      if (y < PAN_EDGE_DISTANCE) {
+        delta = -PAN_STEP;
+      }
+      if (y > height - PAN_EDGE_DISTANCE - timeCaptionsSize) {
+        delta = PAN_STEP;
+      }
+
+      stateRef.current.dy = delta;
+      if (delta !== 0) {
+        start();
+      } else {
+        stop();
+      }
+    },
+    [enableY, timeCaptionsSize, start, stop]
+  );
+
+  // Interrupt current setInterval() when enableY changes or when the
+  // component is unmounted
+  useEffect(() => stop, [enableY, stop]);
+
+  return { onMouseMove };
+};
+
+export default useEdgePan;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/index.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/index.ts
@@ -6,3 +6,4 @@ export { isOccupancyPickingElement } from './components/layers/OccupancyZonesLay
 export { default as TrackOccupancyCanvas } from './components/TrackOccupancyCanvas';
 export { default as TrackOccupancyManchette } from './components/TrackOccupancyManchette';
 export { default as TrackOccupancyStandalone } from './components/TrackOccupancyStandalone';
+export { default as useEdgePan } from './hooks/useEdgePan';

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/lib/consts.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/lib/consts.ts
@@ -23,6 +23,8 @@ export const COLORS = {
   SELECTION_20: 'rgb(255, 242, 179)',
   WHITE_50: 'rgba(255, 255, 255, 0.5)',
   WHITE_100: 'rgb(255, 255, 255)',
+  PRIMARY_50: 'rgb(37, 106, 250)',
+  PRIMARY_80: 'rgb(31, 15, 150)',
 };
 
 export const TICKS_PATTERN = {

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/lib/consts.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/lib/consts.ts
@@ -23,6 +23,8 @@ export const COLORS = {
   SELECTION_20: 'rgb(255, 242, 179)',
   WHITE_50: 'rgba(255, 255, 255, 0.5)',
   WHITE_100: 'rgb(255, 255, 255)',
+  PRIMARY_5: 'rgb(227, 237, 252)',
+  PRIMARY_30: 'rgb(114, 168, 247)',
   PRIMARY_50: 'rgb(37, 106, 250)',
   PRIMARY_80: 'rgb(31, 15, 150)',
 };

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
@@ -55,9 +55,10 @@
       height: 24px;
       @apply bg-grey-70;
       border-radius: 4px;
+      --outer-border-color: rgb(182, 178, 175);
       box-shadow:
-        0 0 0 2px rgb(255, 255, 255),
-        0 0 0 2.5px rgb(182, 178, 175);
+        0 0 0 2px white,
+        0 0 0 2.5px var(--outer-border-color);
       padding: 2px 6px;
       font-weight: 600;
       font-size: 14px;
@@ -74,6 +75,18 @@
       @apply bg-white-50;
       border-top: solid 1px rgb(211, 209, 207);
       border-bottom: solid 1px rgb(211, 209, 207);
+    }
+
+    &.active {
+      .track-name {
+        @apply bg-primary-40;
+        --outer-border-color: var(--color-primary-50);
+      }
+
+      .track-rail {
+        @apply bg-primary-5;
+        border-color: var(--color-primary-30);
+      }
     }
   }
 }

--- a/front/ui/ui-charts/vitest.config.mts
+++ b/front/ui/ui-charts/vitest.config.mts
@@ -4,5 +4,6 @@ export default defineConfig({
   mode: 'benchmark',
   test: {
     include: ['**/*.spec.ts'],
+    environment: 'jsdom',
   },
 });


### PR DESCRIPTION
_See individual commits._

This is the ui-charts part of https://github.com/osrd-project/osrd-confidential/issues/677

To test, open the TOD story and switch `isDragging` to `true`.

What's in the box:

- Everything from the mockup, except the repeated track names on the left of the first occupancy zone being dragged (I'm challenging this, and since it's a purely incremental addition, I'm leaving this for later).
- Basic vertical drag
- Snapping to closest track
- Scroll when approaching the edge of the chart (and mouse wheel works as usual)

~~Depends on https://github.com/OpenRailAssociation/osrd/pull/16792~~  
~~Depends on https://github.com/OpenRailAssociation/osrd/pull/16794~~  