### PR TITLE
fix(i18n): correct French Import button label to Importer

### DIFF
--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -16,7 +16,7 @@
   "importTrainScheduleSet": {
     "cancel": "Annuler",
     "cartEmpty": "Aucune sélection",
-    "import": "Import",
+    "import": "Importer",
     "importType": {
       "copy": "Import par copie",
       "reference": "Import par référence"


### PR DESCRIPTION
## Summary
Fixes #16059 — corrects the French translation of the "Import" button in the operational studies UI.

## Change
- `front/public/locales/fr/operational-studies.json`: changed `"import": "Import"` → `"import": "Importer"`

## Why
In French UI conventions, button action labels use the infinitive verb form. The cancel button already uses `"Annuler"` (infinitive), but the import button was showing `"Import"` which is a noun form. `"Importer"` is the correct infinitive verb and is consistent with other action buttons.

## Type of Change
- [x] Bug fix (i18n)