### PR TITLE
editoast: fix path escape for sprites and fonts endpoints

### DIFF
--- a/editoast/src/views/fonts.rs
+++ b/editoast/src/views/fonts.rs
@@ -45,6 +45,13 @@ pub(in crate::views) async fn fonts(
         return Err(FontErrors::FileNotFound { file: file_name }.into());
     }
 
+    // Avoid path traversal attack by ensuring the path is within the dynamic assets directory
+    let canonical_path = path.canonicalize().unwrap();
+    let canonical_assets_path = config.dynamic_assets_path.canonicalize().unwrap();
+    if !canonical_path.starts_with(&canonical_assets_path) {
+        return Err(FontErrors::FileNotFound { file: file_name }.into());
+    }
+
     Ok(ServeFile::new(&path).oneshot(request).await)
 }
 

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -69,6 +69,13 @@ pub(in crate::views) async fn sprites(
         return Err(SpriteErrors::FileNotFound { file: file_name }.into());
     }
 
+    // Avoid path traversal attack by ensuring the path is within the dynamic assets directory
+    let canonical_path = path.canonicalize().unwrap();
+    let canonical_assets_path = config.dynamic_assets_path.canonicalize().unwrap();
+    if !canonical_path.starts_with(&canonical_assets_path) {
+        return Err(SpriteErrors::FileNotFound { file: file_name }.into());
+    }
+
     Ok(ServeFile::new(&path).oneshot(request).await)
 }
 


### PR DESCRIPTION
This prevent path traversal attack.

Thanks @emersion finding this issue 🙏.

```sh
curl -i 'https://demo.osrd.fr/api/sprites/TVM300/..%2F..%2F..%2Fetc%2Fpasswd'
```