### PR TITLE
Fix banner placing using computed arrival before requested arrival

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -638,8 +638,9 @@ const TimesStopsTable = ({
 
   const getRowDayOffset = (row: Row<TimesStopsRowNew>): number | null => {
     if (!row.original.pathStepId) return null;
-    if (!row.original.requestedArrival) return null;
-    return calculateTimeDifferenceInDays(startTime, row.original.requestedArrival);
+    const arrival = row.original.computedArrival ?? row.original.requestedArrival;
+    if (!arrival) return null;
+    return calculateTimeDifferenceInDays(startTime, arrival);
   };
 
   const tableRows = table.getRowModel().rows;
@@ -731,7 +732,7 @@ const TimesStopsTable = ({
             const rowIndex = virtualRow.index;
             const row = tableRows[rowIndex];
 
-            const rowArrivalDate = row.original.requestedArrival ?? row.original.computedArrival;
+            const rowArrivalDate = row.original.computedArrival ?? row.original.requestedArrival;
             const dayOffset = effectiveDayOffsets[rowIndex];
             const prevDayOffset = rowIndex > 0 ? effectiveDayOffsets[rowIndex - 1] : 0;
             const hasDayChanged = dayOffset > prevDayOffset;


### PR DESCRIPTION
close #16294 

The D+1 banner was placed using `requestedArrival`. 
When a pathstep had no requested arrival (only a stop duration can be set), the banner had no time reference and fell back to the previous row's day, causing it to appear in the wrong place or not at all.

We now use computedArrival  as the primary source, with requestedArrival as fallback. 