### PR TITLE
editoast: skip group if does not exist

### DIFF
--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -264,7 +264,8 @@ pub(in crate::views) async fn users_info(
         let roles = regulator.user_roles(&authz::User(user_id)).await?;
         let groups = groups_by_user[&user_id]
             .iter()
-            .map(|group_id| group_by_id[&group_id.0].clone())
+            // Skip group if it does not exist
+            .filter_map(|group_id| group_by_id.get(&group_id.0).cloned())
             .collect();
         results.push(UserInfo {
             id: user_id,


### PR DESCRIPTION
In editoast, the endpoint to impersonate someone (`POST https://osrd.reseau.sncf.fr/api/authz/user/info`) can fail with an error 502. 

See #15804