### PR TITLE
ui-charts: only draw affected layers on change

### DIFF
--- a/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
+++ b/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
@@ -10,7 +10,7 @@ import { useMouseTracking } from '../../common/hooks/useMouseTracking';
 import { useSize } from '../../common/hooks/useSize';
 import { TimeCaptions } from '../../common/layers/TimeCaptions';
 import TimeGraduations from '../../common/layers/TimeGraduations';
-import type { MouseContextType, PickingElement, Point } from '../../common/types';
+import type { MouseContextType, Point } from '../../common/types';
 import { DEFAULT_THEME } from '../../spaceTimeChart/lib/consts';
 import type { DataPoint } from '../../spaceTimeChart/lib/types';
 import { ChronogramContext } from '../lib/context';
@@ -53,22 +53,6 @@ export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
     [levelCrossingsOccupancies, width, height, timeOrigin, timeScale, xOffset, yOffset]
   );
 
-  const pickingState = useMemo(() => {
-    const pickingElements: PickingElement[] = [];
-    const resetPickingElements = () => {
-      pickingElements.length = 0;
-    };
-    const registerPickingElement = (element: PickingElement) => {
-      pickingElements.push(element);
-      return pickingElements.length - 1;
-    };
-    return {
-      pickingElements,
-      resetPickingElements,
-      registerPickingElement,
-    };
-  }, []);
-
   const contextState: ChronogramContextType = useMemo(() => {
     const getTimePixel = getTimeToPixel(timeOrigin, xOffset, timeScale);
     const getTime = getPixelToTime(timeOrigin, xOffset, timeScale);
@@ -82,7 +66,6 @@ export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
       }) as Point;
 
     return {
-      ...pickingState,
       fingerprint,
       width,
       height,
@@ -99,7 +82,7 @@ export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
       captionSize: DEFAULT_THEME.timeCaptionsSize,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fingerprint, pickingState]);
+  }, [fingerprint]);
 
   const mouseState = useMouseTracking(root);
   const { position, down, isHover } = mouseState;

--- a/front/ui/ui-charts/src/common/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/common/hooks/useCanvas.ts
@@ -16,6 +16,7 @@ import type {
   PickingDrawingFunction,
   PickingLayerType,
   Point,
+  PickingElement,
 } from '../types';
 import { useDevicePixelRatio } from './useDevicePixelRatio';
 import { useSize } from './useSize';
@@ -59,28 +60,51 @@ export function useCanvas<T extends BaseChartContextType>(
 
   const devicePixelRatio = useDevicePixelRatio();
 
+  const pickingState = useMemo(() => {
+    const pickingElements: PickingElement[] = [];
+    const resetPickingElements = () => {
+      pickingElements.length = 0;
+    };
+    const registerPickingElement = (element: PickingElement) => {
+      pickingElements.push(element);
+      return pickingElements.length - 1;
+    };
+    return {
+      pickingElements,
+      resetPickingElements,
+      registerPickingElement,
+    };
+  }, []);
+
   /**
    * This function renders all picking layers:
    */
-  const drawPicking = useCallback((context: T, layers?: Set<LayerType>) => {
-    context.resetPickingElements();
-    PICKING_LAYERS.forEach((layer) => {
-      if (layers && !layers.has(layer)) return;
+  const drawPicking = useCallback(
+    (context: T, layers?: Set<LayerType>) => {
+      pickingState.resetPickingElements();
+      PICKING_LAYERS.forEach((layer) => {
+        if (layers && !layers.has(layer)) return;
 
-      const ctx = contextsRef.current[`${PICKING}-${layer}`];
-      const set = pickingFunctions.current[layer];
+        const ctx = contextsRef.current[`${PICKING}-${layer}`];
+        const set = pickingFunctions.current[layer];
 
-      if (ctx && ctx.canvas.width && ctx.canvas.height) {
-        const { width, height } = sizeRef.current;
-        ctx.clearRect(0, 0, width, height);
+        if (ctx && ctx.canvas.width && ctx.canvas.height) {
+          const { width, height } = sizeRef.current;
+          ctx.clearRect(0, 0, width, height);
 
-        const imageData = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);
-        const pickingScalingRatio = getPickingScalingRatio();
-        set.forEach((fn) => fn(imageData, context, pickingScalingRatio));
-        ctx.putImageData(imageData, 0, 0);
-      }
-    });
-  }, []);
+          const imageData = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);
+          const pickingScalingRatio = getPickingScalingRatio();
+          const pickingContext = {
+            ...context,
+            registerPickingElement: pickingState.registerPickingElement,
+          };
+          set.forEach((fn) => fn(imageData, pickingContext, pickingScalingRatio));
+          ctx.putImageData(imageData, 0, 0);
+        }
+      });
+    },
+    [pickingState]
+  );
 
   /**
    * This function renders all visible / rendering layers:
@@ -269,7 +293,7 @@ export function useCanvas<T extends BaseChartContextType>(
         if (a === 255) {
           const color = rgbToHex(r, g, b);
           const index = colorToIndex(color);
-          const element = chartContextRef.current.pickingElements[index];
+          const element = pickingState.pickingElements[index];
           newHoveredItem = {
             layer,
             element,
@@ -284,7 +308,7 @@ export function useCanvas<T extends BaseChartContextType>(
     if (!isEqual(newHoveredItem, hoveredItem)) {
       setHoveredItem(newHoveredItem);
     }
-  }, [position, hoveredItem]);
+  }, [position, hoveredItem, pickingState]);
 
   // Keep the canvas context up to date:
   const canvasContext = useMemo<CanvasContextType<T>>(

--- a/front/ui/ui-charts/src/common/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/common/hooks/useCanvas.ts
@@ -44,6 +44,7 @@ export function useCanvas<T extends BaseChartContextType>(
   );
   const chartContextRef = useRef(chartContext);
   const scheduledRef = useRef<null | { frameId: number }>(null);
+  const dirtyLayers = useRef<Set<LayerType>>(new Set());
 
   const [hoveredItem, setHoveredItem] = useState<HoveredItem | null>(null);
 
@@ -139,9 +140,11 @@ export function useCanvas<T extends BaseChartContextType>(
   /**
    * This function draws everything that needs to be drawn, and clears the scheduleRef state:
    */
-  const draw = useCallback(() => {
-    drawRendering(chartContextRef.current);
-    drawPicking(chartContextRef.current);
+  const draw = useCallback((layersKind: 'dirty' | 'all') => {
+    const layers = layersKind === 'dirty' ? dirtyLayers.current : new Set(LAYERS);
+    drawRendering(chartContextRef.current, layers);
+    drawPicking(chartContextRef.current, layers);
+    dirtyLayers.current.clear();
 
     if (scheduledRef.current) {
       window.cancelAnimationFrame(scheduledRef.current.frameId);
@@ -151,13 +154,18 @@ export function useCanvas<T extends BaseChartContextType>(
   }, []);
 
   /**
-   * This function schedules a full render for next frame, if no scheduling has been done yet:
+   * This function schedules a render for next frame, if no scheduling has been done yet:
    */
-  const scheduleRendering = useCallback(() => {
+  const scheduleRendering = useCallback((layers?: Set<LayerType>) => {
+    for (const layer of layers ?? LAYERS) {
+      dirtyLayers.current.add(layer);
+    }
+
     if (!scheduledRef.current) {
-      scheduledRef.current = {
-        frameId: window.requestAnimationFrame(draw),
-      };
+      const frameId = window.requestAnimationFrame(() => {
+        draw('dirty');
+      });
+      scheduledRef.current = { frameId };
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -178,7 +186,7 @@ export function useCanvas<T extends BaseChartContextType>(
       set.add(fn);
     }
 
-    scheduleRendering();
+    scheduleRendering(new Set([layer]));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -198,7 +206,7 @@ export function useCanvas<T extends BaseChartContextType>(
       set.delete(fn);
     }
 
-    scheduleRendering();
+    scheduleRendering(new Set([layer]));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -280,7 +288,7 @@ export function useCanvas<T extends BaseChartContextType>(
       }
     }
 
-    draw();
+    draw('all');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [size, devicePixelRatio]);
 

--- a/front/ui/ui-charts/src/common/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/common/hooks/useCanvas.ts
@@ -61,13 +61,20 @@ export function useCanvas<T extends BaseChartContextType>(
   const devicePixelRatio = useDevicePixelRatio();
 
   const pickingState = useMemo(() => {
-    const pickingElements: PickingElement[] = [];
-    const resetPickingElements = () => {
-      pickingElements.length = 0;
+    const pickingElements: Record<PickingLayerType, PickingElement[]> = {
+      paths: [],
+      overlay: [],
     };
-    const registerPickingElement = (element: PickingElement) => {
-      pickingElements.push(element);
-      return pickingElements.length - 1;
+    const resetPickingElements = (layers?: Set<LayerType>) => {
+      for (const layer of PICKING_LAYERS) {
+        if (!layers || layers.has(layer)) {
+          pickingElements[layer].length = 0;
+        }
+      }
+    };
+    const registerPickingElement = (layer: PickingLayerType, element: PickingElement) => {
+      pickingElements[layer].push(element);
+      return pickingElements[layer].length - 1;
     };
     return {
       pickingElements,
@@ -81,7 +88,7 @@ export function useCanvas<T extends BaseChartContextType>(
    */
   const drawPicking = useCallback(
     (context: T, layers?: Set<LayerType>) => {
-      pickingState.resetPickingElements();
+      pickingState.resetPickingElements(layers);
       PICKING_LAYERS.forEach((layer) => {
         if (layers && !layers.has(layer)) return;
 
@@ -96,7 +103,8 @@ export function useCanvas<T extends BaseChartContextType>(
           const pickingScalingRatio = getPickingScalingRatio();
           const pickingContext = {
             ...context,
-            registerPickingElement: pickingState.registerPickingElement,
+            registerPickingElement: (elem: PickingElement) =>
+              pickingState.registerPickingElement(layer, elem),
           };
           set.forEach((fn) => fn(imageData, pickingContext, pickingScalingRatio));
           ctx.putImageData(imageData, 0, 0);
@@ -293,7 +301,7 @@ export function useCanvas<T extends BaseChartContextType>(
         if (a === 255) {
           const color = rgbToHex(r, g, b);
           const index = colorToIndex(color);
-          const element = pickingState.pickingElements[index];
+          const element = pickingState.pickingElements[layer][index];
           newHoveredItem = {
             layer,
             element,

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -6,9 +6,6 @@ import type { LAYERS, PICKING_LAYERS } from './consts';
 
 export type BaseChartContextType = {
   fingerprint: string;
-  pickingElements: PickingElement[];
-  resetPickingElements: () => void;
-  registerPickingElement: (element: PickingElement) => number;
   theme: { background: string };
 };
 
@@ -67,7 +64,9 @@ export type DrawingFunction<T> = (canvasContext: CanvasRenderingContext2D, stcCo
 
 export type PickingDrawingFunction<T> = (
   imageData: ImageData,
-  stcContext: T,
+  context: T & {
+    registerPickingElement: (element: PickingElement) => number;
+  },
   scalingRatio: number
 ) => void;
 

--- a/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import cx from 'classnames';
 
-import type { PickingElement } from '../../common';
 import { MouseContext, TimeChartCanvasContext } from '../../common/context';
 import { getTimeToPixel, getPixelToTime } from '../../common/helpers/time';
 import { useCanvas } from '../../common/hooks/useCanvas';
@@ -97,22 +96,6 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
     ]
   );
 
-  const pickingState = useMemo(() => {
-    const pickingElements: PickingElement[] = [];
-    const resetPickingElements = () => {
-      pickingElements.length = 0;
-    };
-    const registerPickingElement = (element: PickingElement) => {
-      pickingElements.push(element);
-      return pickingElements.length - 1;
-    };
-    return {
-      pickingElements,
-      resetPickingElements,
-      registerPickingElement,
-    };
-  }, []);
-
   const contextState: SpaceTimeChartContextType = useMemo(() => {
     const spaceScaleTree = spaceScalesToBinaryTree(spaceOrigin, spaceScales);
     const flatSteps = getFlatSteps(spaceScales);
@@ -139,7 +122,6 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
     const getData = getPointToData(getTime, getSpace, timeAxis, spaceAxis);
 
     return {
-      ...pickingState,
       fingerprint,
       width,
       height,
@@ -172,7 +154,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
         : fullTheme.dateCaptionsSize + fullTheme.timeCaptionsSize,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fingerprint, pickingState]);
+  }, [fingerprint]);
 
   const mouseState = useMouseTracking(root);
   const { position, down, isHover } = mouseState;


### PR DESCRIPTION
When the input of a chart changes, avoid redrawing all layers. Instead, only redraw layers which have changed.

A set of dirty layers is maintained. A layer is added to the set when registered/unregistered, and removed from the set when drawing it.

We still need to redraw all layers in a few situations: initial draw, resize, device pixel ratio change, and so on.