### PR TITLE
core: build.gradle: update deprecated flag syntax

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -178,9 +178,11 @@ allprojects {
     }
 
     // Remove warning on each @Json annotation
-    kotlin {
-        compilerOptions {
-            freeCompilerArgs.add("-Xannotation-default-target=param-property")
+    plugins.withId('org.jetbrains.kotlin.jvm') {
+        kotlin {
+            compilerOptions {
+                freeCompilerArgs.add("-Xannotation-default-target=param-property")
+            }
         }
     }
 

--- a/core/envelope-sim/build.gradle
+++ b/core/envelope-sim/build.gradle
@@ -57,14 +57,14 @@ dependencies {
     testImplementation libs.kotlin.test
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
-        ]
+        ])
     }
 }
 

--- a/core/kt-fast-collections/build.gradle
+++ b/core/kt-fast-collections/build.gradle
@@ -29,11 +29,11 @@ kotlin {
     }
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
-       ]
+        ])
     }
 }

--- a/core/kt-osrd-path/build.gradle
+++ b/core/kt-osrd-path/build.gradle
@@ -30,13 +30,13 @@ dependencies {
     implementation libs.hppc
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
-        ]
+        ])
     }
 }

--- a/core/kt-osrd-rjs-parser/build.gradle
+++ b/core/kt-osrd-rjs-parser/build.gradle
@@ -47,13 +47,13 @@ sourceSets {
     main.resources.srcDirs += '../../assets/static_resources'
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
-        ]
+        ])
     }
 }

--- a/core/kt-osrd-signaling/build.gradle
+++ b/core/kt-osrd-signaling/build.gradle
@@ -26,13 +26,13 @@ dependencies {
     testImplementation libs.kotlin.test
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
-        ]
+        ])
     }
 }

--- a/core/kt-osrd-sim-infra/build.gradle
+++ b/core/kt-osrd-sim-infra/build.gradle
@@ -37,13 +37,13 @@ kotlin {
     }
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
-        ]
+        ])
     }
 }

--- a/core/kt-osrd-sim-interlocking/build.gradle
+++ b/core/kt-osrd-sim-interlocking/build.gradle
@@ -31,14 +31,14 @@ dependencies {
     testRuntimeOnly libs.logback.classic
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        ]
+        ])
     }
 }

--- a/core/kt-osrd-sncf-signaling/build.gradle
+++ b/core/kt-osrd-sncf-signaling/build.gradle
@@ -21,14 +21,14 @@ dependencies {
     testImplementation project(':osrd-mp')
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        ]
+        ])
     }
 }

--- a/core/kt-osrd-utils/build.gradle
+++ b/core/kt-osrd-utils/build.gradle
@@ -36,14 +36,14 @@ kotlin {
     }
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += [
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll([
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.contracts.ExperimentalContracts",
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        ]
+        ])
     }
 }


### PR DESCRIPTION
`kotlinOptions` is [deprecated](https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-from-kotlinoptions-to-compileroptions) and conflicts with the other `compileOptions` in root `build.gradle`

The change in the root `build.gradle` avoids an issue where the flag is added too early, it only worked in the root project.

Note: the [recommended way](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins_vs_cross_configuration) to factorize build options is quite different from what we do here, `allproject` is to be avoided. But it would be a larger refacto. I may do it in a follow-up PR. 