### PR TITLE
front: disable NPM scripts for all dependencies

### DIFF
--- a/front/.npmrc
+++ b/front/.npmrc
@@ -1,0 +1,3 @@
+# Post-install scripts are an attack vector for compromised NPM packages.
+# Disable these.
+ignore-scripts=true


### PR DESCRIPTION
Commit a8950ddb60af ("front: install dependencies with --ignore-scripts") ensures that none of our dependencies rely on post-install scripts. However, any post-install script is still run.

Users can configure their local machine to disable install scripts, but that requires manual action. Disable post-install scripts for the whole project in case users haven't done that.