### PR TITLE
editoast: fix bump generated version

### DIFF
--- a/editoast/editoast_models/src/infra.rs
+++ b/editoast/editoast_models/src/infra.rs
@@ -107,6 +107,7 @@ impl Infra {
         &mut self,
         conn: &mut DbConnection,
     ) -> Result<(), database::DatabaseError> {
+        self.generated_version = Some(self.version);
         diesel::update(dsl::infra.filter(dsl::id.eq(self.id)))
             .set((dsl::generated_version.eq(self.generated_version),))
             .execute(conn.write().await.deref_mut())


### PR DESCRIPTION
Currently running `editoast infra generate` generate layers but do not bump the `generated_version`.
The application consider the infra as not generated (red dot visible in the interface).