### PR TITLE
editoast: get rid of `enum Rejection` in authorizers

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -6,7 +6,18 @@ use strum::EnumIter;
 use strum::EnumString;
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, derive_more::From)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    derive_more::Display,
+    derive_more::From,
+)]
 pub enum Subject {
     User(User),
     Group(Group),
@@ -54,6 +65,7 @@ impl AsRef<User> for Subject {
         }
     }
 }
+
 #[cfg(test)]
 impl AsRef<Group> for Subject {
     fn as_ref(&self) -> &Group {
@@ -68,6 +80,7 @@ impl AsRef<Group> for Subject {
     fga::Type,
     fga::User,
     fga::Object,
+    derive_more::Display,
     derive_more::From,
     derive_more::FromStr,
     derive_more::Deref,
@@ -86,6 +99,7 @@ pub struct User(pub i64);
     fga::Type,
     fga::User,
     fga::Object,
+    derive_more::Display,
     derive_more::From,
     derive_more::FromStr,
     derive_more::Deref,
@@ -93,28 +107,12 @@ pub struct User(pub i64);
     Clone,
     Copy,
     PartialEq,
+    Eq,
     PartialOrd,
     Ord,
-    Eq,
     Hash,
 )]
 pub struct Group(pub i64);
-
-#[derive(
-    fga::Type,
-    fga::User,
-    fga::Object,
-    derive_more::From,
-    derive_more::FromStr,
-    derive_more::Deref,
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-)]
-pub struct Infra(pub i64);
 
 #[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -167,6 +165,23 @@ pub enum InfraGrant {
 )]
 #[fga(name = "rolling_stock")]
 pub struct RollingStock(pub i64);
+
+#[derive(
+    fga::Type,
+    fga::User,
+    fga::Object,
+    derive_more::Display,
+    derive_more::From,
+    derive_more::FromStr,
+    derive_more::Deref,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+)]
+pub struct Infra(pub i64);
 
 #[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -271,8 +271,8 @@ pub mod special_authorizers {
 
     /// Always authorizes without performing any check
     pub struct Authorize<'a>(pub &'a fga::Client);
-    /// Always rejects with the given rejection reason
-    pub struct Reject<Rejection>(Rejection);
+    /// Always rejects with the given check
+    pub struct Reject(pub super::Check);
 
     impl Authorizer for Authorize<'_> {
         type Rejection = Infallible;
@@ -286,17 +286,15 @@ pub mod special_authorizers {
         }
     }
 
-    impl<Rejection: Clone> Authorizer for Reject<Rejection> {
-        type Rejection = Rejection;
+    impl Authorizer for Reject {
+        type Rejection = super::Check;
         type Error = Infallible;
 
         async fn authorize<'a, T>(
             &'a self,
             _data: Protected<T>,
         ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
-            Ok(Access::Denied {
-                rejection: self.0.clone(),
-            })
+            Ok(Access::Denied { rejection: self.0 })
         }
     }
 

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -24,17 +24,20 @@ pub struct SystemAuthorizer<'a> {
 
 impl SystemAuthorizer<'_> {
     #[tracing::instrument(target = "SystemAuthorizer::check", skip_all, fields(?check), ret(level = "trace"), err)]
-    async fn check(&self, check: &Check) -> Result<Option<Check>, editoast_models::Error> {
+    async fn check<'ch>(
+        &self,
+        check: &'ch Check,
+    ) -> Result<Option<&'ch Check>, editoast_models::Error> {
         let conn = &mut self.conn.clone();
         Ok(match check {
             Check::SubjectExists(authz::Subject::User(user)) => {
-                (!editoast_models::User::exists(conn, **user).await?).then_some(*check)
+                (!editoast_models::User::exists(conn, **user).await?).then_some(check)
             }
             Check::SubjectExists(authz::Subject::Group(group)) => {
-                (!editoast_models::Group::exists(conn, **group).await?).then_some(*check)
+                (!editoast_models::Group::exists(conn, **group).await?).then_some(check)
             }
             Check::InfraExists(infra) => {
-                (!editoast_models::Infra::exists(conn, **infra).await?).then_some(*check)
+                (!editoast_models::Infra::exists(conn, **infra).await?).then_some(check)
             }
             // checked by UserAuthorizer
             Check::IssuerHasRole(_) | Check::IssuerHasInfraPrivilege(_, _) => None,
@@ -61,7 +64,7 @@ impl Authorizer for SystemAuthorizer<'_> {
                 .collect::<FuturesUnordered<_>>();
             while let Some(result) = checks.next().await {
                 if let Some(check) = result? {
-                    return Ok(Access::Denied { rejection: check });
+                    return Ok(Access::Denied { rejection: *check });
                 }
             }
         }
@@ -92,9 +95,12 @@ impl<'c> UserAuthorizer<'c> {
     }
 
     #[tracing::instrument(target = "UserAutorizer::check", skip_all, fields(?check, issuer = ?self.user, roles = ?self.roles), ret(level = "trace"), err)]
-    async fn check(&self, check: &Check) -> Result<Option<Check>, authz::v2::OpenFgaError> {
+    async fn check<'ch>(
+        &self,
+        check: &'ch Check,
+    ) -> Result<Option<&'ch Check>, authz::v2::OpenFgaError> {
         Ok(match check {
-            Check::IssuerHasRole(role) if !self.roles.contains(role) => Some(*check),
+            Check::IssuerHasRole(role) if !self.roles.contains(role) => Some(check),
             Check::IssuerHasRole(_) => None,
 
             Check::IssuerHasInfraPrivilege(privilege, infra) => {
@@ -102,7 +108,7 @@ impl<'c> UserAuthorizer<'c> {
                     .access_authorized::<Infallible>(self.openfga)
                     .access()
                     .await?;
-                (!privileges.contains(privilege)).then_some(*check)
+                (!privileges.contains(privilege)).then_some(check)
             }
             // checked by SystemAuthorizer
             Check::SubjectExists(_) | Check::InfraExists(_) => None,
@@ -149,7 +155,7 @@ impl Authorizer for UserAuthorizer<'_> {
             }
             while let Some(result) = checks.next().await {
                 if let Some(check) = result? {
-                    return Ok(Access::Denied { rejection: check });
+                    return Ok(Access::Denied { rejection: *check });
                 }
             }
         }

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,6 +1,5 @@
 use std::convert::Infallible;
 
-use authz::InfraPrivilege;
 use authz::v2::Access;
 use authz::v2::Authorizer;
 use authz::v2::Check;
@@ -25,20 +24,17 @@ pub struct SystemAuthorizer<'a> {
 
 impl SystemAuthorizer<'_> {
     #[tracing::instrument(target = "SystemAuthorizer::check", skip_all, fields(?check), ret(level = "trace"), err)]
-    async fn check(&self, check: &Check) -> Result<Option<Rejection>, editoast_models::Error> {
+    async fn check(&self, check: &Check) -> Result<Option<Check>, editoast_models::Error> {
         let conn = &mut self.conn.clone();
         Ok(match check {
-            Check::SubjectExists(authz::Subject::User(authz::User(user_id))) => {
-                (!editoast_models::User::exists(conn, *user_id).await?)
-                    .then_some(Rejection::NoSuchUser(*user_id))
+            Check::SubjectExists(authz::Subject::User(user)) => {
+                (!editoast_models::User::exists(conn, **user).await?).then_some(*check)
             }
-            Check::SubjectExists(authz::Subject::Group(authz::Group(group_id))) => {
-                (!editoast_models::Group::exists(conn, *group_id).await?)
-                    .then_some(Rejection::NoSuchGroup(*group_id))
+            Check::SubjectExists(authz::Subject::Group(group)) => {
+                (!editoast_models::Group::exists(conn, **group).await?).then_some(*check)
             }
-            Check::InfraExists(authz::Infra(infra_id)) => {
-                (!editoast_models::Infra::exists(conn, *infra_id).await?)
-                    .then_some(Rejection::NoSuchInfra(*infra_id))
+            Check::InfraExists(infra) => {
+                (!editoast_models::Infra::exists(conn, **infra).await?).then_some(*check)
             }
             // checked by UserAuthorizer
             Check::IssuerHasRole(_) | Check::IssuerHasInfraPrivilege(_, _) => None,
@@ -47,8 +43,8 @@ impl SystemAuthorizer<'_> {
 }
 
 impl Authorizer for SystemAuthorizer<'_> {
+    type Rejection = Check;
     type Error = editoast_models::Error;
-    type Rejection = Rejection;
 
     #[tracing::instrument(skip_all)]
     async fn authorize<'a, T>(
@@ -64,8 +60,8 @@ impl Authorizer for SystemAuthorizer<'_> {
                 .map(|check| self.check(check).in_current_span())
                 .collect::<FuturesUnordered<_>>();
             while let Some(result) = checks.next().await {
-                if let Some(rejection) = result? {
-                    return Ok(Access::Denied { rejection });
+                if let Some(check) = result? {
+                    return Ok(Access::Denied { rejection: check });
                 }
             }
         }
@@ -96,11 +92,9 @@ impl<'c> UserAuthorizer<'c> {
     }
 
     #[tracing::instrument(target = "UserAutorizer::check", skip_all, fields(?check, issuer = ?self.user, roles = ?self.roles), ret(level = "trace"), err)]
-    async fn check(&self, check: &Check) -> Result<Option<Rejection>, authz::v2::OpenFgaError> {
+    async fn check(&self, check: &Check) -> Result<Option<Check>, authz::v2::OpenFgaError> {
         Ok(match check {
-            Check::IssuerHasRole(role) if !self.roles.contains(role) => Some(
-                Rejection::LackingRole(authz::Subject::user(self.user), *role),
-            ),
+            Check::IssuerHasRole(role) if !self.roles.contains(role) => Some(*check),
             Check::IssuerHasRole(_) => None,
 
             Check::IssuerHasInfraPrivilege(privilege, infra) => {
@@ -108,11 +102,7 @@ impl<'c> UserAuthorizer<'c> {
                     .access_authorized::<Infallible>(self.openfga)
                     .access()
                     .await?;
-                (!privileges.contains(privilege)).then_some(Rejection::LackingInfraPrivilege(
-                    *privilege,
-                    authz::Subject::user(self.user),
-                    *infra,
-                ))
+                (!privileges.contains(privilege)).then_some(*check)
             }
             // checked by SystemAuthorizer
             Check::SubjectExists(_) | Check::InfraExists(_) => None,
@@ -121,8 +111,8 @@ impl<'c> UserAuthorizer<'c> {
 }
 
 impl Authorizer for UserAuthorizer<'_> {
+    type Rejection = Check;
     type Error = Error;
-    type Rejection = Rejection;
 
     #[tracing::instrument(skip_all)]
     async fn authorize<'a, T>(
@@ -158,8 +148,8 @@ impl Authorizer for UserAuthorizer<'_> {
                 }
             }
             while let Some(result) = checks.next().await {
-                if let Some(rejection) = result? {
-                    return Ok(Access::Denied { rejection });
+                if let Some(check) = result? {
+                    return Ok(Access::Denied { rejection: check });
                 }
             }
         }
@@ -175,33 +165,11 @@ pub enum Error {
     OpenFga(#[from] authz::v2::OpenFgaError),
 }
 
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum Rejection {
-    // Data consistency rejections
-    // ---------------------------
-    NoSuchUser(i64),
-    NoSuchGroup(#[expect(dead_code)] i64),
-    NoSuchInfra(i64),
-
-    // Permission rejections
-    // ---------------------
-    LackingRole(
-        #[expect(dead_code)] authz::Subject,
-        #[expect(dead_code)] authz::Role,
-    ),
-    LackingInfraPrivilege(
-        InfraPrivilege,
-        #[expect(dead_code)] authz::Subject,
-        authz::Infra,
-    ),
-}
-
-/// Wraps [`unreachable!`] with a message specific to impossible rejections
+/// Wraps [`unreachable!`] with a message specific to impossible checks
 macro_rules! impossible {
-    ($rejection:expr) => {
+    ($check:expr) => {
         unreachable!(
-            "impossible rejection {:?} — if this occurs, some authz::Protected check rejection has been overlooked", $rejection
+            "impossible check {:?} — if this occurs, some authz::Protected check handling has been overlooked", $check
         )
     };
 }

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -176,8 +176,8 @@ pub async fn exclude_group(
     match system.authorize(remove_member).await?.access().await? {
         Ok(()) => Ok(()),
         Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
-        Err(Check::SubjectExists(subject)) => {
-            bail!("No such user {subject}")
+        Err(Check::SubjectExists(authz::Subject::User(user))) => {
+            bail!("No such user {user}")
         }
         Err(check) => impossible!(check),
     }
@@ -221,8 +221,8 @@ pub async fn include_group(
     match system.authorize(add_member).await?.access().await? {
         Ok(()) => Ok(()),
         Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
-        Err(Check::SubjectExists(subject)) => {
-            bail!("No such user {subject}")
+        Err(Check::SubjectExists(authz::Subject::User(user))) => {
+            bail!("No such user {user}")
         }
         Err(check) => impossible!(check),
     }

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -3,6 +3,7 @@ use anyhow::bail;
 use authz;
 use authz::Group;
 use authz::v2::Authorizer;
+use authz::v2::Check;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnectionPoolV2;
@@ -11,7 +12,6 @@ use editoast_models::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::authorizers::Rejection;
 use crate::authorizers::SystemAuthorizer;
 use crate::authorizers::impossible;
 
@@ -120,8 +120,8 @@ pub async fn group_info(
         .await?
     {
         Ok(user_ids) => user_ids,
-        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
-        Err(rejection) => impossible!(rejection),
+        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
+        Err(check) => impossible!(check),
     };
 
     println!("id     : {group_id}");
@@ -175,9 +175,11 @@ pub async fn exclude_group(
     let remove_member = authz::v2::remove_members(authz::Group(group_id), authz_users);
     match system.authorize(remove_member).await?.access().await? {
         Ok(()) => Ok(()),
-        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
-        Err(Rejection::NoSuchUser(user_id)) => bail!("No such user {user_id}"),
-        Err(rejection) => impossible!(rejection),
+        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
+        Err(Check::SubjectExists(subject)) => {
+            bail!("No such user {subject}")
+        }
+        Err(check) => impossible!(check),
     }
 }
 
@@ -218,9 +220,11 @@ pub async fn include_group(
     let add_member = authz::v2::add_members(authz::Group(group_id), authz_users);
     match system.authorize(add_member).await?.access().await? {
         Ok(()) => Ok(()),
-        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
-        Err(Rejection::NoSuchUser(user_id)) => bail!("No such user {user_id}"),
-        Err(rejection) => impossible!(rejection),
+        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
+        Err(Check::SubjectExists(subject)) => {
+            bail!("No such user {subject}")
+        }
+        Err(check) => impossible!(check),
     }
 }
 
@@ -249,15 +253,15 @@ pub async fn delete_group(
         .await?
     {
         Ok(user_ids) => HashSet::from_iter(user_ids),
-        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
-        Err(rejection) => impossible!(rejection),
+        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
+        Err(check) => impossible!(check),
     };
     let remove_member = authz::v2::remove_members(group, users_in_group);
     match system.authorize(remove_member).await?.access().await? {
         Ok(()) => {}
-        Err(Rejection::NoSuchGroup(_)) => unreachable!("tested above"),
-        Err(Rejection::NoSuchUser(_)) => unreachable!("tested above"),
-        Err(rejection) => impossible!(rejection),
+        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
+        Err(Check::SubjectExists(authz::Subject::User(_))) => unreachable!("tested above"),
+        Err(check) => impossible!(check),
     }
 
     let deleted = editoast_models::Group::delete_static(&mut conn, group_id).await?;

--- a/editoast/src/client/roles.rs
+++ b/editoast/src/client/roles.rs
@@ -9,6 +9,7 @@ use authz::Role;
 use authz::identity::GroupInfo;
 use authz::identity::UserInfo;
 use authz::v2::Authorizer;
+use authz::v2::Check;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnection;
@@ -19,7 +20,6 @@ use itertools::Itertools as _;
 use strum::IntoEnumIterator;
 use tracing::info;
 
-use crate::authorizers::Rejection;
 use crate::authorizers::SystemAuthorizer;
 use crate::authorizers::impossible;
 
@@ -202,10 +202,10 @@ pub async fn add_roles(
     let add_roles = authz::v2::add_roles(subject.into_authz(), roles);
     match system.authorize(add_roles).await?.access().await? {
         Ok(()) => Ok(()),
-        Err(Rejection::NoSuchUser(_)) | Err(Rejection::NoSuchGroup(_)) => {
+        Err(Check::SubjectExists(_)) => {
             unreachable!("checked by parse_and_fetch_subject")
         }
-        Err(rejection) => impossible!(rejection),
+        Err(check) => impossible!(check),
     }
 }
 
@@ -237,9 +237,9 @@ pub async fn remove_roles(
     let remove_roles = authz::v2::remove_roles(subject.into_authz(), roles);
     match system.authorize(remove_roles).await?.access().await? {
         Ok(()) => Ok(()),
-        Err(Rejection::NoSuchUser(_)) | Err(Rejection::NoSuchGroup(_)) => {
+        Err(Check::SubjectExists(_)) => {
             unreachable!("checked by parse_and_fetch_subject")
         }
-        Err(rejection) => impossible!(rejection),
+        Err(check) => impossible!(check),
     }
 }

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use anyhow::bail;
 use authz;
+use authz::v2::Check;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnectionPoolV2;
@@ -13,7 +14,6 @@ use futures::TryStreamExt as _;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::authorizers::Rejection;
 use crate::authorizers::SystemAuthorizer;
 use crate::authorizers::impossible;
 
@@ -113,7 +113,7 @@ pub async fn list_user(
         .await?;
         let group_members = match group_member_access.access().await? {
             Ok(users) => users.into_iter().flatten().collect::<HashSet<_>>(),
-            Err(Rejection::NoSuchGroup(_)) => {
+            Err(Check::SubjectExists(authz::Subject::Group(_))) => {
                 unreachable!("groups were listed from the database")
             }
             Err(rejection) => impossible!(rejection),

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -91,7 +91,7 @@ fn service_router() -> server::router::DocumentedRouter {
                 path.route("/grants", post!(authz::update_grants))
                     .route(
                         "/{resource_type}/{resource_id}",
-                        get!(authz::my_grants_on_ressource),
+                        get!(authz::my_grants_on_resource),
                     )
                     .nests("/me", |path| {
                         path.route("/", get!(authz::whoami))

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::authorizers::Rejection;
 use crate::authorizers::UserAuthorizer;
 use crate::authorizers::impossible;
 use crate::error::Result;
@@ -14,6 +13,7 @@ use ::authz::Role;
 use authz::Authorization;
 use authz::v2;
 use authz::v2::Authorizer;
+use authz::v2::Check;
 use axum::Extension;
 use axum::extract::Path;
 use axum::extract::State;
@@ -342,21 +342,21 @@ pub(in crate::views) async fn user_privileges(
                         privileges,
                     });
                 }
-                Err(Rejection::NoSuchInfra(_)) => {
+                Err(Check::InfraExists(_)) => {
                     // not an error under the target API
                     // (though maybe we should revisit it?)
                 }
-                Err(Rejection::LackingInfraPrivilege(InfraPrivilege::CanRead, _, infra)) => {
+                Err(Check::IssuerHasInfraPrivilege(InfraPrivilege::CanRead, infra)) => {
                     result_infras.push(ResourcePrivileges {
                         resource_id: *infra,
                         privileges: HashSet::new(),
                     });
                 }
-                Err(Rejection::NoSuchUser(_)) => {
+                Err(Check::SubjectExists(authz::Subject::User(_))) => {
                     panic!("race condition: user deleted");
                 }
-                Err(rejection @ Rejection::LackingInfraPrivilege(_, _, _)) | Err(rejection) => {
-                    impossible!(rejection)
+                Err(check @ Check::IssuerHasInfraPrivilege(_, _)) | Err(check) => {
+                    impossible!(check)
                 }
             }
         }
@@ -430,19 +430,19 @@ pub(in crate::views) async fn user_grants(
             let grant = match grant_access.access().await? {
                 Ok(Some(grant)) => grant,
                 Ok(None) => continue,
-                Err(Rejection::NoSuchInfra(infra_id)) => {
-                    tracing::warn!(infra_id, "non-existent infra — skipping");
+                Err(Check::InfraExists(infra)) => {
+                    tracing::warn!(%infra, "non-existent infra — skipping");
                     continue;
                 }
-                Err(Rejection::LackingInfraPrivilege(privilege, ..)) => {
+                Err(Check::IssuerHasInfraPrivilege(privilege, infra)) => {
                     debug_assert_eq!(privilege, InfraPrivilege::CanRead);
-                    tracing::warn!(infra_id, "user cannot read infra — skipping");
+                    tracing::warn!(%infra, "user cannot read infra — skipping");
                     continue;
                 }
-                Err(Rejection::NoSuchUser(user_id)) => {
-                    unreachable!("user {user_id} exists or race condition")
+                Err(Check::SubjectExists(subject)) => {
+                    unreachable!("{subject} exists or race condition")
                 }
-                Err(rejection) => impossible!(rejection),
+                Err(check) => impossible!(check),
             };
             response
                 .entry(ResourceType::Infra)
@@ -520,10 +520,10 @@ pub(in crate::views) async fn my_grants_on_ressource(
                 .access()
                 .await?
                 .map_err(|err| match err {
-                    Rejection::LackingInfraPrivilege(InfraPrivilege::CanRead, ..) => {
+                    Check::IssuerHasInfraPrivilege(InfraPrivilege::CanRead, ..) => {
                         AuthzError::Authz(AuthorizationError::Forbidden)
                     }
-                    Rejection::NoSuchInfra(_) => AuthzError::UnknownResource {
+                    Check::InfraExists(_) => AuthzError::UnknownResource {
                         resource_id: infra.0,
                     },
                     rejection => impossible!(rejection),

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -486,7 +486,7 @@ pub(in crate::views) struct SubjectGrant {
         (status = 200, description = "Get list of user that have a grant on the resource", body = inline(Vec<SubjectGrant>)),
     ),
 )]
-pub(in crate::views) async fn my_grants_on_ressource(
+pub(in crate::views) async fn my_grants_on_resource(
     Extension(user): Extension<Option<authz::User>>,
     Extension(roles): Extension<Vec<authz::Role>>,
     State(AppState {


### PR DESCRIPTION
> [!IMPORTANT]
> - [x] To merge after https://github.com/OpenRailAssociation/osrd/pull/16790.
>
> Ready to review, only kept as a draft to avoid spamming since not mergeable atm.

refs https://github.com/osrd-project/osrd-confidential/issues/1168