### PR TITLE
osrdyne: make the queue timeouts really long in single worker mode 

### DIFF
--- a/docker/docker-compose.single-worker.yml
+++ b/docker/docker-compose.single-worker.yml
@@ -5,6 +5,9 @@ services:
 
   osrdyne:
     volumes: !reset []
+    environment:
+      - OSRDYNE__QUEUE_UNBIND_DELAY=30y
+      - OSRDYNE__QUEUE_DELETE_DELAY=30y
 
   core:
     # Launch a single worker handling all infra

--- a/osrdyne/Cargo.lock
+++ b/osrdyne/Cargo.lock
@@ -1027,6 +1027,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1757,7 @@ dependencies = [
  "futures-lite",
  "hex",
  "http",
+ "humantime-serde",
  "im",
  "k8s-openapi",
  "kube",

--- a/osrdyne/Cargo.toml
+++ b/osrdyne/Cargo.toml
@@ -15,6 +15,7 @@ figment = { version = "0.10.19", features = ["env", "yaml"] }
 futures-lite = "2.6.1"
 hex = "0.4.3"
 http = "1.4.0"
+humantime-serde = "1.1.1"
 im = "15.1.0"
 k8s-openapi = { version = "0.27", features = ["v1_35"] }
 kube = { version = "3.1", default-features = false, features = [

--- a/osrdyne/src/config.rs
+++ b/osrdyne/src/config.rs
@@ -33,6 +33,10 @@ pub struct OsrdyneConfig {
     pub managed_by_value: String,
     pub extra_lifetime: Option<Duration>,
     pub opentelemetry: Option<OpentelemetryConfig>,
+    #[serde(with = "humantime_serde")]
+    pub queue_unbind_delay: Option<Duration>,
+    #[serde(with = "humantime_serde")]
+    pub queue_delete_delay: Option<Duration>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -64,6 +68,8 @@ impl Default for OsrdyneConfig {
             managed_by_value: "osrdyne".into(),
             extra_lifetime: None,
             opentelemetry: None,
+            queue_unbind_delay: Some(Duration::from_secs(10 * 60)),
+            queue_delete_delay: Some(Duration::from_secs(10 * 60)),
         }
     }
 }

--- a/osrdyne/src/main.rs
+++ b/osrdyne/src/main.rs
@@ -101,7 +101,16 @@ async fn main() -> Result<(), anyhow::Error> {
     // it is kept running across rabbitmq reconnects.
     let (sender, tracker_inbox) = mpsc::channel(100);
     let target_tracker_client = TargetTrackerClient::new(sender);
-    let target_tracker_config = TargetTrackerConfig::default();
+
+    let mut target_tracker_config = TargetTrackerConfig::default();
+    target_tracker_config.unbind_delay = config
+        .queue_unbind_delay
+        .unwrap_or(target_tracker_config.unbind_delay);
+    target_tracker_config.delete_delay = config
+        .queue_delete_delay
+        .unwrap_or(target_tracker_config.delete_delay);
+    let target_tracker_config = target_tracker_config;
+
     let mut target_tracker = spawn(target_tracker_actor(
         tracker_inbox,
         init_keys,

--- a/osrdyne/src/target_tracker/actor.rs
+++ b/osrdyne/src/target_tracker/actor.rs
@@ -6,6 +6,7 @@ use crate::Key;
 
 use super::{GenerationId, QueueStateMap, TargetTracker};
 
+#[derive(Debug)]
 pub struct TargetTrackerConfig {
     pub unbind_delay: Duration,
     pub delete_delay: Duration,


### PR DESCRIPTION
We only have a single worker group to "manage", and ideally the queue should never be deleted. Unfortunately, this would be a non trivial change, so we can just make it really long. 60 years is probably enough.