### PR TITLE
osrd_schemas_auto: make `models.py` hidden in review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 # https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
 editoast/openapi.yaml linguist-generated=true
 front/src/reducers/osrdconf/infra_schema.json linguist-generated=true
+osrd_schemas_auto/osrd_schemas_auto/models.py linguist-generated=true


### PR DESCRIPTION
This file is auto-generated. So less important to review. It does make the file invisible during review, only folded automatically (like `*.lock` files).