### PR TITLE
python: use `osrd_schemas_auto` in `railjson_generator`

### DIFF
--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "railjson_generator"
-version = "0.5.0"
+version = "0.6.0"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"
 
-dependencies = ["osrd-schemas"]
+dependencies = ["osrd-schemas", "osrd-schemas-auto"]
 
 [project.optional-dependencies]
 check = [
@@ -18,10 +18,11 @@ check = [
 [tool.pyright]
 include = ["railjson_generator"]
 exclude = ["**/__pycache__"]
-extraPaths = ["../osrd_schemas"]
+extraPaths = ["../../osrd_schemas_auto", "../osrd_schemas"]
 
 [tool.uv.sources]
 osrd-schemas = { path = "../osrd_schemas", editable = true }
+osrd-schemas-auto = { path = "../../osrd_schemas_auto", editable = true }
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"

--- a/python/railjson_generator/railjson_generator/schema/infra/electrification.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/electrification.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from railjson_generator.schema.infra.track_section import TrackSection
 
@@ -16,14 +16,14 @@ class Electrification:
         track_ranges = []
         for track in self.tracks:
             track_ranges.append(
-                infra.ApplicableDirectionsTrackRange(
+                models.ApplicableDirectionsTrackRange(
                     track=track.id,
                     begin=0,
                     end=track.length,
-                    applicable_directions=infra.ApplicableDirections.BOTH,
+                    applicable_directions=models.ApplicableDirections.BOTH,
                 )
             )
-        return infra.Electrification(
+        return models.Electrification(
             id=self.id,
             voltage=self.voltage,
             track_ranges=track_ranges,

--- a/python/railjson_generator/railjson_generator/schema/infra/endpoint.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/endpoint.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 if TYPE_CHECKING:
     from .switch import SwitchGroup
@@ -55,6 +55,6 @@ class TrackEndpoint:
             self.track_section.coordinates[-1] = (x, y)
 
     def to_rjs(self):
-        return infra.TrackEndpoint(
-            endpoint=infra.Endpoint[self.endpoint.name], track=self.track_section.id
+        return models.TrackEndpoint(
+            endpoint=models.Endpoint[self.endpoint.name], track=self.track_section.id
         )

--- a/python/railjson_generator/railjson_generator/schema/infra/infra.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/infra.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import List
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from railjson_generator.schema.infra.electrification import Electrification
 from railjson_generator.schema.infra.neutral_section import NeutralSection
@@ -32,8 +32,8 @@ class Infra:
         self.routes.append(Route(*args, **kwargs))
         return self.routes[-1]
 
-    def to_rjs(self) -> infra.RailJsonInfra:
-        return infra.RailJsonInfra(
+    def to_rjs(self) -> models.RailJson:
+        return models.RailJson(
             version=self.VERSION,
             track_sections=[track.to_rjs() for track in self.track_sections],
             switches=[switch.to_rjs() for switch in self.switches],
@@ -83,24 +83,24 @@ class Infra:
                 parts_per_op[op_part.operational_point.id].append(op_part.to_rjs(track))
         ops = []
         for op in self.operational_points:
-            new_op = infra.OperationalPoint(
+            new_op = models.OperationalPoint(
                 id=op.id,
                 parts=parts_per_op[op.id],
-                extensions={  # pyright: ignore[reportCallIssue] - 'extensions' exists but is registered through 'register_extension'
-                    "sncf": infra.OperationalPointSncfExtension(
+                extensions=models.OperationalPointExtensions(
+                    sncf=models.OperationalPointSncfExtension(
                         ci=int(str(op.uic)[2:]),  # remove two first digits of UIC code
                         ch_short_label=op.ch,
                         ch=op.ch,
                         ch_long_label="0",
                         trigram=op.trigram,
                     ),
-                    "identifier": infra.OperationalPointIdentifierExtension(
+                    identifier=models.OperationalPointIdentifierExtension(
                         uic=op.uic,
                         name=op.label,
                     ),
-                },
+                ),
                 weight=op.weight,
-                plc=op.plc,
+                plc=models.NonBlankString(op.plc) if op.plc is not None else None,
             )
             ops.append(new_op)
         return ops

--- a/python/railjson_generator/railjson_generator/schema/infra/level_crossing.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/level_crossing.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 
 @dataclass
@@ -12,7 +12,7 @@ class LevelCrossingPart:
     track: str
 
     def to_rjs(self):
-        return infra.LevelCrossingPart(
+        return models.LevelCrossingPart(
             track=self.track,
             position=self.position,
             pedal_upstream=self.pedal_upstream,
@@ -39,7 +39,7 @@ class LevelCrossing:
         self.parts.append(part)
 
     def to_rjs(self):
-        return infra.LevelCrossing(
+        return models.LevelCrossing(
             id=self.id,
             name=self.name,
             short_zone_length=self.short_zone_length,

--- a/python/railjson_generator/railjson_generator/schema/infra/make_geo_data.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/make_geo_data.py
@@ -1,12 +1,16 @@
 from typing import Mapping
 
-from geojson_pydantic import LineString
 from geojson_pydantic.types import LineStringCoords
+from osrd_schemas_auto import models
 
 
-def make_geo_line(points: LineStringCoords) -> LineString:
-    return LineString(coordinates=points, type="LineString")
+def make_geo_line(points: LineStringCoords) -> models.GeoJsonLineString:
+    return models.GeoJsonLineString(
+        models.LineStringGeometry(
+            coordinates=[list(point) for point in points], type="LineString"
+        )
+    )
 
 
-def make_geo_lines(points: LineStringCoords) -> Mapping[str, LineString]:
+def make_geo_lines(points: LineStringCoords) -> Mapping[str, models.GeoJsonLineString]:
     return {"geo": make_geo_line(points)}

--- a/python/railjson_generator/railjson_generator/schema/infra/neutral_section.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/neutral_section.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from railjson_generator.schema.infra.direction import Direction
 from railjson_generator.schema.infra.range_elements import DirectionalTrackRange
@@ -62,7 +62,7 @@ class NeutralSection:
         )
 
     def to_rjs(self):
-        return infra.NeutralSection(
+        return models.NeutralSection(
             id=self.label,
             announcement_track_ranges=[
                 track.to_rjs() for track in self.announcement_track_ranges

--- a/python/railjson_generator/railjson_generator/schema/infra/operational_point.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/operational_point.py
@@ -3,7 +3,7 @@ from typing import Annotated, List, Optional
 
 from pydantic import StringConstraints
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 NonBlankStr = Annotated[str, StringConstraints(min_length=1)]
 
@@ -51,7 +51,7 @@ class OperationalPointPart:
     local_track_name: str
 
     def to_rjs(self, track):
-        return infra.OperationalPointPart(
+        return models.OperationalPointPart(
             track=track.id,
             position=self.position,
             local_track_name=self.local_track_name,

--- a/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from .direction import ApplicableDirection, Direction
 
@@ -33,7 +34,7 @@ class Slope(RangeElement):
         self.gradient = gradient
 
     def to_rjs(self):
-        return infra.Slope(gradient=self.gradient, begin=self.begin, end=self.end)
+        return models.Slope(gradient=self.gradient, begin=self.begin, end=self.end)
 
 
 class Curve(RangeElement):
@@ -44,18 +45,18 @@ class Curve(RangeElement):
         self.radius = radius
 
     def to_rjs(self):
-        return infra.Curve(radius=self.radius, begin=self.begin, end=self.end)
+        return models.Curve(radius=self.radius, begin=self.begin, end=self.end)
 
 
 class LoadingGaugeLimit(RangeElement):
-    category: infra.LoadingGaugeType
+    category: models.LoadingGaugeType
 
     def __init__(self, begin, end, category):
         super().__init__(begin, end)
         self.category = category
 
     def to_rjs(self):
-        return infra.LoadingGaugeLimit(
+        return models.LoadingGaugeLimit(
             category=self.category, begin=self.begin, end=self.end
         )
 
@@ -72,10 +73,10 @@ class TrackRange(RangeElement):
 class DirectionalTrackRange(TrackRange):
     direction: Direction
 
-    def to_rjs(self):
-        return infra.DirectionalTrackRange(
+    def to_rjs(self):  # pyright: ignore[reportIncompatibleMethodOverride] - base TrackRange stays on osrd_schemas
+        return models.DirectionalTrackRange(
             track=self.track.id,
-            direction=infra.Direction[self.direction.name],
+            direction=models.Direction[self.direction.name],
             begin=self.begin,
             end=self.end,
         )
@@ -85,10 +86,10 @@ class DirectionalTrackRange(TrackRange):
 class ApplicableDirectionsTrackRange(TrackRange):
     applicable_directions: ApplicableDirection
 
-    def to_rjs(self):
-        return infra.ApplicableDirectionsTrackRange(
+    def to_rjs(self):  # pyright: ignore[reportIncompatibleMethodOverride] - base TrackRange stays on osrd_schemas
+        return models.ApplicableDirectionsTrackRange(
             track=self.track.id,
-            applicable_directions=infra.ApplicableDirections[
+            applicable_directions=models.ApplicableDirections[
                 self.applicable_directions.name
             ],
             begin=self.begin,

--- a/python/railjson_generator/railjson_generator/schema/infra/route.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/route.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
-from typing import List, Mapping, Optional
+from typing import List, Optional
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from .direction import Direction
 from .waypoint import Waypoint
@@ -12,7 +12,7 @@ class Route:
     waypoints: List[Waypoint]
     release_waypoints: List[Waypoint]
     entry_point_direction: Direction
-    switches_directions: Mapping[str, str] = field(default_factory=dict)
+    switches_directions: dict[str, str] = field(default_factory=dict)
     label: Optional[str] = field(default=None)
 
     def __hash__(self):
@@ -34,11 +34,13 @@ class Route:
             self.label = f"rt.{self.entry_point.label}->{self.exit_point.label}"
 
     def to_rjs(self):
-        return infra.Route(
+        return models.Route(
             id=self.label,  # pyright: ignore[reportArgumentType] - '__post_init__' ensures 'label' always has a value
             entry_point=self.entry_point.get_waypoint_ref(),
-            entry_point_direction=infra.Direction[self.entry_point_direction.name],
+            entry_point_direction=models.Direction[self.entry_point_direction.name],
             exit_point=self.exit_point.get_waypoint_ref(),
-            release_detectors=[w.id for w in self.release_waypoints],
+            release_detectors=[
+                models.ReleaseDetector(w.id) for w in self.release_waypoints
+            ],
             switches_directions=self.switches_directions,
         )

--- a/python/railjson_generator/railjson_generator/schema/infra/signal.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/signal.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from railjson_generator.schema.infra.direction import Direction
 
@@ -18,7 +18,7 @@ class SignalConditionalParameters:
     parameters: Dict[str, str]
 
     def to_rjs(self):
-        return infra.ConditionalParameter(
+        return models.ConditionalParameter(
             on_route=self.on_route,
             parameters=self.parameters,
         )
@@ -42,7 +42,7 @@ class LogicalSignal:
                 else self.default_parameters
             )
 
-        return infra.LogicalSignal(
+        return models.LogicalSignal(
             signaling_system=self.signaling_system,
             next_signaling_systems=self.next_signaling_systems,
             settings=self.settings,
@@ -65,7 +65,7 @@ class Signal:
 
     label: str = field(default_factory=_signal_id)
     installation_type: str = "CARRE"
-    side: infra.Side = infra.Side.LEFT
+    side: models.Side = models.Side.LEFT
 
     _index = 0
 
@@ -79,18 +79,18 @@ class Signal:
         return signal
 
     def to_rjs(self, track):
-        return infra.Signal(
+        return models.Signal(
             id=self.label,
             track=track.id,
             position=self.position,
-            direction=infra.Direction[self.direction.name],
+            direction=models.Direction[self.direction.name],
             sight_distance=self.sight_distance,
             logical_signals=[sig.to_rjs() for sig in self.logical_signals],
-            extensions={  # pyright: ignore[reportCallIssue] - 'extensions' exists but is registered through 'register_extension'
-                "sncf": {
-                    "label": self.label,
-                    "side": self.side,
-                    "kp": "",
-                }
-            },
+            extensions=models.SignalExtensions(
+                sncf=models.SignalSncfExtension(
+                    label=self.label,
+                    side=self.side,
+                    kp="",
+                )
+            ),
         )

--- a/python/railjson_generator/railjson_generator/schema/infra/speed_section.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/speed_section.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
-from typing import List, Mapping, Optional
+from typing import List, Optional
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from railjson_generator.schema.infra.range_elements import (
     ApplicableDirectionsTrackRange,
@@ -17,7 +17,7 @@ def _speed_section_id():
 @dataclass
 class SpeedSection:
     speed_limit: float
-    speed_limit_by_tag: Mapping[str, float] = field(default_factory=dict)
+    speed_limit_by_tag: dict[str, float] = field(default_factory=dict)
     track_ranges: List[ApplicableDirectionsTrackRange] = field(default_factory=list)
     label: str = field(default_factory=_speed_section_id)
     on_routes: Optional[List[str]] = None
@@ -44,10 +44,14 @@ class SpeedSection:
         self.track_ranges += track_ranges
 
     def to_rjs(self):
-        return infra.SpeedSection(
+        return models.SpeedSection(
             id=self.label,
             speed_limit=self.speed_limit,
             speed_limit_by_tag=self.speed_limit_by_tag,
             track_ranges=[track.to_rjs() for track in self.track_ranges],
-            on_routes=self.on_routes,
+            on_routes=(
+                [models.OnRoute(route) for route in self.on_routes]
+                if self.on_routes is not None
+                else None
+            ),
         )

--- a/python/railjson_generator/railjson_generator/schema/infra/switch.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/switch.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 from osrd_schemas.switch_type import (
     CROSSING,
     DOUBLE_SLIP_SWITCH,
@@ -79,7 +79,7 @@ class Switch:
         return track_section.add_detector(*args, position=position, **kwargs)
 
     def to_rjs(self):
-        return infra.Switch(
+        return models.Switch(
             id=self.label,
             switch_type=self.SWITCH_TYPE,
             group_change_delay=self.delay,
@@ -87,7 +87,9 @@ class Switch:
                 port_name: getattr(self, port_name).to_rjs()
                 for port_name in self.PORT_NAMES
             },
-            extensions={"sncf": {"label": self.label}},  # pyright: ignore[reportCallIssue] - 'extensions' exists but is registered through 'register_extension'
+            extensions=models.SwitchExtensions(
+                sncf=models.SwitchSncfExtension(label=self.label)
+            ),
         )
 
 

--- a/python/railjson_generator/railjson_generator/schema/infra/track_section.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/track_section.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from geojson_pydantic.types import LineStringCoords
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 from pydantic import ValidationError
 
 from railjson_generator.schema.infra.direction import ApplicableDirection, Direction
@@ -144,7 +144,7 @@ class TrackSection:
             print(f"Track section {self.label} has invalid coordinates:")
             print(self.coordinates)
             raise
-        return infra.TrackSection(
+        return models.TrackSectionModel(
             id=self.label,
             length=self.length,
             slopes=[slope.to_rjs() for slope in self.slopes],
@@ -154,14 +154,14 @@ class TrackSection:
                 for loading_gauge_limit in self.loading_gauge_limits
             ],
             **geo_data,
-            extensions={  # pyright: ignore[reportCallIssue] - 'extensions' exists but is registered through 'register_extension'
-                "sncf": {
-                    "line_code": self.line_code,
-                    "line_name": self.line_name,
-                    "track_number": self.track_number,
-                    "track_name": self.track_name,
-                }
-            },
+            extensions=models.TrackSectionExtensions(
+                sncf=models.TrackSectionSncfExtension(
+                    line_code=self.line_code,
+                    line_name=self.line_name,
+                    track_number=self.track_number,
+                    track_name=self.track_name,
+                )
+            ),
         )
 
     @property

--- a/python/railjson_generator/railjson_generator/schema/infra/waypoint.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/waypoint.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Union
 
-from osrd_schemas import infra
+from osrd_schemas_auto import models
 
 from railjson_generator.schema.infra.direction import Direction
 
@@ -30,10 +30,10 @@ class BufferStop:
         return self.label
 
     def get_waypoint_ref(self):
-        return infra.BufferStopReference(id=self.label, type="BufferStop")
+        return models.WaypointBufferStop(id=self.label, type="BufferStop")
 
     def to_rjs(self, track):
-        return infra.BufferStop(
+        return models.BufferStop(
             id=self.label,
             track=track.id,
             position=self.position,
@@ -67,10 +67,10 @@ class Detector:
         return self.label
 
     def get_waypoint_ref(self):
-        return infra.DetectorReference(id=self.label, type="Detector")
+        return models.WaypointDetector(id=self.label, type="Detector")
 
     def to_rjs(self, track):
-        return infra.Detector(
+        return models.Detector(
             id=self.label,
             track=track.id,
             position=self.position,

--- a/python/railjson_generator/uv.lock
+++ b/python/railjson_generator/uv.lock
@@ -12,6 +12,64 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -125,6 +183,36 @@ toml = [
 ]
 
 [[package]]
+name = "datamodel-code-generator"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "black" },
+    { name = "genson" },
+    { name = "inflect" },
+    { name = "isort" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/e1/dbf7c2edb1b1db1f4fd472ee92f985ec97d58902512013d9c4584108329c/datamodel_code_generator-0.35.0.tar.gz", hash = "sha256:46805fa2515d3871f6bfafce9aa63128e735a7a6a4cfcbf9c27b3794ee4ea846", size = 459915, upload-time = "2025-10-09T19:26:49.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/ef/0ed17459fe6076219fcd45f69a0bb4bd1cb041b39095ca2946808a9b5f04/datamodel_code_generator-0.35.0-py3-none-any.whl", hash = "sha256:c356d1e4a555f86667a4262db03d4598a30caeda8f51786555fd269c8abb806b", size = 121436, upload-time = "2025-10-09T19:26:48.437Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
+]
+
+[[package]]
 name = "geojson-pydantic"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -137,6 +225,19 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -146,12 +247,137 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/82/fa43935523efdfcce6abbae9da7f372b627b27142c3419fcf13bf5b0c397/isort-6.1.0.tar.gz", hash = "sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481", size = 824325, upload-time = "2025-10-01T16:26:45.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/cc/9b681a170efab4868a032631dea1e8446d8ec718a7f657b94d49d1a12643/isort-6.1.0-py3-none-any.whl", hash = "sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784", size = 94329, upload-time = "2025-10-01T16:26:43.291Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
 ]
 
 [[package]]
@@ -173,12 +399,53 @@ requires-dist = [
 provides-extras = ["check"]
 
 [[package]]
+name = "osrd-schemas-auto"
+version = "0.1.0"
+source = { editable = "../../osrd_schemas_auto" }
+dependencies = [
+    { name = "datamodel-code-generator" },
+    { name = "openapi-pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datamodel-code-generator", specifier = "==0.35.0" },
+    { name = "openapi-pydantic", specifier = "==0.5.1" },
+    { name = "pyyaml", specifier = "==6.0.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = "~=1.1.409" },
+    { name = "ruff", specifier = "~=0.15.10" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -359,11 +626,101 @@ wheels = [
 ]
 
 [[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "railjson-generator"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "osrd-schemas" },
+    { name = "osrd-schemas-auto" },
 ]
 
 [package.optional-dependencies]
@@ -377,6 +734,7 @@ check = [
 [package.metadata]
 requires-dist = [
     { name = "osrd-schemas", editable = "../osrd_schemas" },
+    { name = "osrd-schemas-auto", editable = "../../osrd_schemas_auto" },
     { name = "pyright", marker = "extra == 'check'", specifier = "~=1.1.393" },
     { name = "pytest", marker = "extra == 'check'", specifier = "~=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'check'", specifier = "~=4.1.0" },
@@ -461,6 +819,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
 ]
 
 [[package]]

--- a/tests/data/infras/etcs_infra/infra.json
+++ b/tests/data/infras/etcs_infra/infra.json
@@ -1,349 +1,1128 @@
 {
-    "version": "3.5.2",
-    "operational_points": [
+    "buffer_stops": [
         {
-            "id": "West_station",
-            "parts": [
-                {
-                    "track": "TA0",
-                    "position": 699.99959,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TA1",
-                    "position": 500.0,
-                    "local_track_name": "V2"
-                },
-                {
-                    "track": "TA2",
-                    "position": 500.0,
-                    "local_track_name": "V3"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 22,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "WS"
-                },
-                "identifier": {
-                    "name": "West_station",
-                    "uic": 8722
-                }
-            }
+            "id": "buffer_stop.0",
+            "position": 0.0,
+            "track": "TA0"
         },
         {
-            "id": "South_West_station",
-            "parts": [
-                {
-                    "track": "TB0",
-                    "position": 500.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 11,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SWS"
-                },
-                "identifier": {
-                    "name": "South_West_station",
-                    "uic": 8711
-                }
-            }
+            "id": "buffer_stop.1",
+            "position": 0.0,
+            "track": "TA1"
         },
         {
-            "id": "Mid_West_station",
-            "parts": [
-                {
-                    "track": "TC0",
-                    "position": 550.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TC1",
-                    "position": 550.0,
-                    "local_track_name": "V2"
-                },
-                {
-                    "track": "TC2",
-                    "position": 450.0,
-                    "local_track_name": "V3"
-                },
-                {
-                    "track": "TC3",
-                    "position": 450.0,
-                    "local_track_name": "V4"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 33,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "MWS"
-                },
-                "identifier": {
-                    "name": "Mid_West_station",
-                    "uic": 8733
-                }
-            }
+            "id": "buffer_stop.2",
+            "position": 0.0,
+            "track": "TA2"
         },
         {
-            "id": "Mid_East_station",
-            "parts": [
-                {
-                    "track": "TD0",
-                    "position": 14000.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TD1",
-                    "position": 14000.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 44,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "MES"
-                },
-                "identifier": {
-                    "name": "Mid_East_station",
-                    "uic": 8744
-                }
-            }
+            "id": "buffer_stop.3",
+            "position": 0.0,
+            "track": "TB0"
         },
         {
-            "id": "North_station",
-            "parts": [
-                {
-                    "track": "TE1",
-                    "position": 1000.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TE2",
-                    "position": 1025.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 55,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "NS"
-                },
-                "identifier": {
-                    "name": "North_station",
-                    "uic": 8755
-                }
-            }
+            "id": "buffer_stop.4",
+            "position": 6500.0,
+            "track": "TF1"
         },
         {
-            "id": "South_station",
-            "parts": [
-                {
-                    "track": "TF1",
-                    "position": 4300.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 66,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SS"
-                },
-                "identifier": {
-                    "name": "South_station",
-                    "uic": 8766
-                }
-            }
+            "id": "buffer_stop.5",
+            "position": 2000.0,
+            "track": "TG4"
         },
         {
-            "id": "North_East_station",
-            "parts": [
-                {
-                    "track": "TG4",
-                    "position": 1550.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TG5",
-                    "position": 1500.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 77,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "NES"
-                },
-                "identifier": {
-                    "name": "North_East_station",
-                    "uic": 8777
-                }
-            }
+            "id": "buffer_stop.6",
+            "position": 2000.0,
+            "track": "TG5"
         },
         {
-            "id": "South_East_station",
-            "parts": [
-                {
-                    "track": "TH1",
-                    "position": 4400.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 88,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SES"
-                },
-                "identifier": {
-                    "name": "South_East_station",
-                    "uic": 8788
-                }
-            }
+            "id": "buffer_stop.7",
+            "position": 5000.0,
+            "track": "TH1"
         }
     ],
+    "detectors": [
+        {
+            "id": "DA2",
+            "position": 1820.0,
+            "track": "TA0"
+        },
+        {
+            "id": "DA0",
+            "position": 1770.0,
+            "track": "TA1"
+        },
+        {
+            "id": "DA1",
+            "position": 1770.0,
+            "track": "TA2"
+        },
+        {
+            "id": "DA7",
+            "position": 25.0,
+            "track": "TA3"
+        },
+        {
+            "id": "DA8",
+            "position": 25.0,
+            "track": "TA4"
+        },
+        {
+            "id": "DA9",
+            "position": 25.0,
+            "track": "TA5"
+        },
+        {
+            "id": "DA3",
+            "position": 180.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_1",
+            "position": 1800.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_2",
+            "position": 3400.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_3",
+            "position": 5000.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_4",
+            "position": 6600.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_5",
+            "position": 8200.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA5",
+            "position": 9820.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA4",
+            "position": 180.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_1",
+            "position": 1800.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_2",
+            "position": 3400.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_3",
+            "position": 5000.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_4",
+            "position": 6600.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_5",
+            "position": 8200.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA6",
+            "position": 9820.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DB0",
+            "position": 2820.0,
+            "track": "TB0"
+        },
+        {
+            "id": "DC0",
+            "position": 180.0,
+            "track": "TC0"
+        },
+        {
+            "id": "DC4",
+            "position": 870.0,
+            "track": "TC0"
+        },
+        {
+            "id": "DC1",
+            "position": 180.0,
+            "track": "TC1"
+        },
+        {
+            "id": "DC5",
+            "position": 820.0,
+            "track": "TC1"
+        },
+        {
+            "id": "DC2",
+            "position": 180.0,
+            "track": "TC2"
+        },
+        {
+            "id": "DC6",
+            "position": 820.0,
+            "track": "TC2"
+        },
+        {
+            "id": "DC3",
+            "position": 180.0,
+            "track": "TC3"
+        },
+        {
+            "id": "DC7",
+            "position": 870.0,
+            "track": "TC3"
+        },
+        {
+            "id": "DD0",
+            "position": 180.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_1",
+            "position": 1737.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_2",
+            "position": 3275.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_3",
+            "position": 4812.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_4",
+            "position": 6350.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_5",
+            "position": 7887.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_6",
+            "position": 9425.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_7",
+            "position": 10962.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_8",
+            "position": 12500.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_9",
+            "position": 14037.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_10",
+            "position": 15575.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_11",
+            "position": 17112.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_12",
+            "position": 18650.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_13",
+            "position": 20187.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_14",
+            "position": 21725.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_15",
+            "position": 23262.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD2",
+            "position": 24820.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD1",
+            "position": 180.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_1",
+            "position": 1737.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_2",
+            "position": 3275.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_3",
+            "position": 4812.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_4",
+            "position": 6350.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_5",
+            "position": 7887.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_6",
+            "position": 9425.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_7",
+            "position": 10962.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_8",
+            "position": 12500.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_9",
+            "position": 14037.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_10",
+            "position": 15575.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_11",
+            "position": 17112.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_12",
+            "position": 18650.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_13",
+            "position": 20187.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_14",
+            "position": 21725.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_15",
+            "position": 23262.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD3",
+            "position": 24820.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD4",
+            "position": 180.0,
+            "track": "TD2"
+        },
+        {
+            "id": "DD6",
+            "position": 1820.0,
+            "track": "TD2"
+        },
+        {
+            "id": "DF0",
+            "position": 180.0,
+            "track": "TD3"
+        },
+        {
+            "id": "DH0",
+            "position": 2820.0,
+            "track": "TD3"
+        },
+        {
+            "id": "DE1",
+            "position": 180.0,
+            "track": "TE0"
+        },
+        {
+            "id": "DE0",
+            "position": 1320.0,
+            "track": "TE0"
+        },
+        {
+            "id": "DD5",
+            "position": 180.0,
+            "track": "TF1"
+        },
+        {
+            "id": "DF1_1",
+            "position": 2250.0,
+            "track": "TF1"
+        },
+        {
+            "id": "DE4",
+            "position": 180.0,
+            "track": "TE1"
+        },
+        {
+            "id": "DE2",
+            "position": 1820.0,
+            "track": "TE1"
+        },
+        {
+            "id": "DE5",
+            "position": 180.0,
+            "track": "TE2"
+        },
+        {
+            "id": "DE3",
+            "position": 1870.0,
+            "track": "TE2"
+        },
+        {
+            "id": "DE7",
+            "position": 180.0,
+            "track": "TE3"
+        },
+        {
+            "id": "DE6",
+            "position": 1820.0,
+            "track": "TE3"
+        },
+        {
+            "id": "DD7",
+            "position": 180.0,
+            "track": "TG0"
+        },
+        {
+            "id": "DG0",
+            "position": 820.0,
+            "track": "TG0"
+        },
+        {
+            "id": "DG1",
+            "position": 180.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG1_1",
+            "position": 2000.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG3",
+            "position": 3820.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG2",
+            "position": 180.0,
+            "track": "TG2"
+        },
+        {
+            "id": "DG4",
+            "position": 2820.0,
+            "track": "TG2"
+        },
+        {
+            "id": "DG7",
+            "position": 25.0,
+            "track": "TG3"
+        },
+        {
+            "id": "DG5",
+            "position": 180.0,
+            "track": "TG4"
+        },
+        {
+            "id": "DG6",
+            "position": 180.0,
+            "track": "TG5"
+        },
+        {
+            "id": "DH1",
+            "position": 180.0,
+            "track": "TH0"
+        },
+        {
+            "id": "DH2",
+            "position": 820.0,
+            "track": "TH0"
+        },
+        {
+            "id": "DH3",
+            "position": 180.0,
+            "track": "TH1"
+        },
+        {
+            "id": "DH1_1",
+            "position": 1800.0,
+            "track": "TH1"
+        },
+        {
+            "id": "DH1_2",
+            "position": 3400.0,
+            "track": "TH1"
+        }
+    ],
+    "electrifications": [
+        {
+            "id": "electrification_25k",
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA6"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA7"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TB0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TD3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1500.0,
+                    "track": "TE0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3.0,
+                    "track": "TF0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 6500.0,
+                    "track": "TF1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2050.0,
+                    "track": "TE2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TG0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TG1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TG2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TG3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 5000.0,
+                    "track": "TH1"
+                }
+            ],
+            "voltage": "25000V"
+        },
+        {
+            "id": "electrification_1.5k",
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TA0"
+                }
+            ],
+            "voltage": "1500V"
+        }
+    ],
+    "extended_switch_types": [],
     "level_crossings": [
         {
             "id": "lc1",
             "name": "LC1",
-            "short_zone_length": 2000,
             "parts": [
                 {
-                    "track": "TB0",
-                    "position": 750.0,
+                    "pedal_downstream": 4000,
                     "pedal_upstream": 4000,
-                    "pedal_downstream": 4000
+                    "position": 750.0,
+                    "track": "TB0"
                 }
-            ]
+            ],
+            "short_zone_length": 2000
         },
         {
             "id": "lc2",
             "name": "LC2",
-            "short_zone_length": 1500,
             "parts": [
                 {
-                    "track": "TC0",
-                    "position": 125.0,
+                    "pedal_downstream": 6000,
                     "pedal_upstream": 4000,
-                    "pedal_downstream": 6000
+                    "position": 125.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
+                    "pedal_downstream": 5000,
+                    "pedal_upstream": 5000,
                     "position": 120.0,
-                    "pedal_upstream": 5000,
-                    "pedal_downstream": 5000
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
+                    "pedal_downstream": 5000,
+                    "pedal_upstream": 5000,
                     "position": 110.0,
-                    "pedal_upstream": 5000,
-                    "pedal_downstream": 5000
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
-                    "position": 115.0,
+                    "pedal_downstream": 6000,
                     "pedal_upstream": 6000,
-                    "pedal_downstream": 6000
+                    "position": 115.0,
+                    "track": "TC3"
+                }
+            ],
+            "short_zone_length": 1500
+        }
+    ],
+    "neutral_sections": [
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 3500.0,
+                    "direction": "START_TO_STOP",
+                    "end": 4000.0,
+                    "track": "TG1"
+                }
+            ],
+            "id": "neutral_section.0",
+            "lower_pantograph": true,
+            "track_ranges": [
+                {
+                    "begin": 0.0,
+                    "direction": "START_TO_STOP",
+                    "end": 500.0,
+                    "track": "TG4"
+                },
+                {
+                    "begin": 0.0,
+                    "direction": "START_TO_STOP",
+                    "end": 10.0,
+                    "track": "TA6"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 1850.0,
+                    "direction": "START_TO_STOP",
+                    "end": 1960.0,
+                    "track": "TA0"
+                }
+            ],
+            "id": "neutral_section.1",
+            "lower_pantograph": true,
+            "track_ranges": [
+                {
+                    "begin": 1960.0,
+                    "direction": "START_TO_STOP",
+                    "end": 2000.0,
+                    "track": "TA0"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [],
+            "id": "neutral_section.2",
+            "lower_pantograph": false,
+            "track_ranges": [
+                {
+                    "begin": 8500.0,
+                    "direction": "START_TO_STOP",
+                    "end": 8600.0,
+                    "track": "TA6"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 1990.0,
+                    "direction": "STOP_TO_START",
+                    "end": 2000.0,
+                    "track": "TA0"
+                }
+            ],
+            "id": "neutral_section.3",
+            "lower_pantograph": false,
+            "track_ranges": [
+                {
+                    "begin": 1850.0,
+                    "direction": "STOP_TO_START",
+                    "end": 1990.0,
+                    "track": "TA0"
                 }
             ]
         }
     ],
+    "operational_points": [
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "West_station",
+                    "uic": 8722
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 22,
+                    "trigram": "WS"
+                }
+            },
+            "id": "West_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 699.99959,
+                    "track": "TA0"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 500.0,
+                    "track": "TA1"
+                },
+                {
+                    "local_track_name": "V3",
+                    "position": 500.0,
+                    "track": "TA2"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "South_West_station",
+                    "uic": 8711
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 11,
+                    "trigram": "SWS"
+                }
+            },
+            "id": "South_West_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 500.0,
+                    "track": "TB0"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "Mid_West_station",
+                    "uic": 8733
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 33,
+                    "trigram": "MWS"
+                }
+            },
+            "id": "Mid_West_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 550.0,
+                    "track": "TC0"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 550.0,
+                    "track": "TC1"
+                },
+                {
+                    "local_track_name": "V3",
+                    "position": 450.0,
+                    "track": "TC2"
+                },
+                {
+                    "local_track_name": "V4",
+                    "position": 450.0,
+                    "track": "TC3"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "Mid_East_station",
+                    "uic": 8744
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 44,
+                    "trigram": "MES"
+                }
+            },
+            "id": "Mid_East_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 14000.0,
+                    "track": "TD0"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 14000.0,
+                    "track": "TD1"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "North_station",
+                    "uic": 8755
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 55,
+                    "trigram": "NS"
+                }
+            },
+            "id": "North_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 1000.0,
+                    "track": "TE1"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 1025.0,
+                    "track": "TE2"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "South_station",
+                    "uic": 8766
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 66,
+                    "trigram": "SS"
+                }
+            },
+            "id": "South_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 4300.0,
+                    "track": "TF1"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "North_East_station",
+                    "uic": 8777
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 77,
+                    "trigram": "NES"
+                }
+            },
+            "id": "North_East_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 1550.0,
+                    "track": "TG4"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 1500.0,
+                    "track": "TG5"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "South_East_station",
+                    "uic": 8788
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 88,
+                    "trigram": "SES"
+                }
+            },
+            "id": "South_East_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 4400.0,
+                    "track": "TH1"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        }
+    ],
     "routes": [
         {
-            "id": "rt.buffer_stop.0->DA2",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA2"
+                "id": "DA2",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.0->DA2",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA2->DA5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA2"
+                "id": "DA2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
+            "id": "rt.DA2->DA5",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.1->DA0",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.1->DA0",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA0->DA5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
+            "id": "rt.DA0->DA5",
             "release_detectors": [],
             "switches_directions": {
                 "PA0": "A_B1",
@@ -351,16 +1130,16 @@
             }
         },
         {
-            "id": "rt.DA0->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DA0->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA0": "A_B2",
@@ -368,30 +1147,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop.2->DA1",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA1"
+                "id": "DA1",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.2->DA1",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA1->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA1"
+                "id": "DA1",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DA1->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA1": "A_B2",
@@ -399,16 +1178,16 @@
             }
         },
         {
-            "id": "rt.DA3->buffer_stop.1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
+            "id": "rt.DA3->buffer_stop.1",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B1",
@@ -416,64 +1195,64 @@
             }
         },
         {
-            "id": "rt.DA3->buffer_stop.0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
             },
+            "id": "rt.DA3->buffer_stop.0",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B2"
             }
         },
         {
-            "id": "rt.DA5->DC4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC4"
+                "id": "DC4",
+                "type": "Detector"
             },
+            "id": "rt.DA5->DC4",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B1"
             }
         },
         {
-            "id": "rt.DA5->DC5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC5"
+                "id": "DC5",
+                "type": "Detector"
             },
+            "id": "rt.DA5->DC5",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B2"
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.2",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B1",
@@ -481,16 +1260,16 @@
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.3",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B1",
@@ -498,16 +1277,16 @@
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.1",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B2",
@@ -515,62 +1294,62 @@
             }
         },
         {
-            "id": "rt.DA6->DC6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC6"
+                "id": "DC6",
+                "type": "Detector"
             },
+            "id": "rt.DA6->DC6",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B1"
             }
         },
         {
-            "id": "rt.DA6->DC7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC7"
+                "id": "DC7",
+                "type": "Detector"
             },
+            "id": "rt.DA6->DC7",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.3->DB0",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DB0"
+                "id": "DB0",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.3->DB0",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DB0->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DB0"
+                "id": "DB0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DB0->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA1": "A_B1",
@@ -578,368 +1357,368 @@
             }
         },
         {
-            "id": "rt.DC0->DA3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC0"
+                "id": "DC0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
+            "id": "rt.DC0->DA3",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B1"
             }
         },
         {
-            "id": "rt.DC4->DD2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC4"
+                "id": "DC4",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
+            "id": "rt.DC4->DD2",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B2"
             }
         },
         {
-            "id": "rt.DC1->DA3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC1"
+                "id": "DC1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
+            "id": "rt.DC1->DA3",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B2"
             }
         },
         {
-            "id": "rt.DC5->DD2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC5"
+                "id": "DC5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
+            "id": "rt.DC5->DD2",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B1"
             }
         },
         {
-            "id": "rt.DC2->DA4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC2"
+                "id": "DC2",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
+            "id": "rt.DC2->DA4",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B1"
             }
         },
         {
-            "id": "rt.DC6->DD3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC6"
+                "id": "DC6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
+            "id": "rt.DC6->DD3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B2"
             }
         },
         {
-            "id": "rt.DC3->DA4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC3"
+                "id": "DC3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
+            "id": "rt.DC3->DA4",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B2"
             }
         },
         {
-            "id": "rt.DC7->DD3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC7"
+                "id": "DC7",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
+            "id": "rt.DC7->DD3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B1"
             }
         },
         {
-            "id": "rt.DD0->DC1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC1"
+                "id": "DC1",
+                "type": "Detector"
             },
+            "id": "rt.DD0->DC1",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B1"
             }
         },
         {
-            "id": "rt.DD0->DC0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC0"
+                "id": "DC0",
+                "type": "Detector"
             },
+            "id": "rt.DD0->DC0",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B2"
             }
         },
         {
-            "id": "rt.DD2->DD6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
+            "id": "rt.DD2->DD6",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC"
             }
         },
         {
-            "id": "rt.DD1->DC3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC3"
+                "id": "DC3",
+                "type": "Detector"
             },
+            "id": "rt.DD1->DC3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B1"
             }
         },
         {
-            "id": "rt.DD1->DC2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC2"
+                "id": "DC2",
+                "type": "Detector"
             },
+            "id": "rt.DD1->DC2",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B2"
             }
         },
         {
-            "id": "rt.DD3->DH0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
+            "id": "rt.DD3->DH0",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC"
             }
         },
         {
-            "id": "rt.DD4->DD0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
+            "id": "rt.DD4->DD0",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC"
             }
         },
         {
-            "id": "rt.DD6->DE6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
+            "id": "rt.DD6->DE6",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B1"
             }
         },
         {
-            "id": "rt.DD6->DG0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
+            "id": "rt.DD6->DG0",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B2"
             }
         },
         {
-            "id": "rt.DF0->DD1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
+            "id": "rt.DF0->DD1",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC"
             }
         },
         {
-            "id": "rt.DH0->DG3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
+            "id": "rt.DH0->DG3",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B2"
             }
         },
         {
-            "id": "rt.DH0->DH2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
+            "id": "rt.DH0->DH2",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B2"
             }
         },
         {
-            "id": "rt.DE1->DE4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE4"
+                "id": "DE4",
+                "type": "Detector"
             },
+            "id": "rt.DE1->DE4",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B1"
             }
         },
         {
-            "id": "rt.DE1->DE5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE5"
+                "id": "DE5",
+                "type": "Detector"
             },
+            "id": "rt.DE1->DE5",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B2"
             }
         },
         {
-            "id": "rt.DE0->buffer_stop.4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.4"
+                "id": "buffer_stop.4",
+                "type": "BufferStop"
             },
+            "id": "rt.DE0->buffer_stop.4",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC",
@@ -947,30 +1726,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop.4->DD5",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.4"
+                "id": "buffer_stop.4",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD5"
+                "id": "DD5",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.4->DD5",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DD5->DE1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD5"
+                "id": "DD5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
+            "id": "rt.DD5->DE1",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC",
@@ -978,224 +1757,224 @@
             }
         },
         {
-            "id": "rt.DE4->DE7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE4"
+                "id": "DE4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
+            "id": "rt.DE4->DE7",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B2"
             }
         },
         {
-            "id": "rt.DE2->DE0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE2"
+                "id": "DE2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
+            "id": "rt.DE2->DE0",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B1"
             }
         },
         {
-            "id": "rt.DE5->DE7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE5"
+                "id": "DE5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
+            "id": "rt.DE5->DE7",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B1"
             }
         },
         {
-            "id": "rt.DE3->DE0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE3"
+                "id": "DE3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
+            "id": "rt.DE3->DE0",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B2"
             }
         },
         {
-            "id": "rt.DE7->DD4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
+            "id": "rt.DE7->DD4",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B1"
             }
         },
         {
-            "id": "rt.DE6->DE3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE3"
+                "id": "DE3",
+                "type": "Detector"
             },
+            "id": "rt.DE6->DE3",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B1"
             }
         },
         {
-            "id": "rt.DE6->DE2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE2"
+                "id": "DE2",
+                "type": "Detector"
             },
+            "id": "rt.DE6->DE2",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B2"
             }
         },
         {
-            "id": "rt.DD7->DD4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
+            "id": "rt.DD7->DD4",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B2"
             }
         },
         {
-            "id": "rt.DG0->DG3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
+            "id": "rt.DG0->DG3",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B1"
             }
         },
         {
-            "id": "rt.DG0->DH2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
+            "id": "rt.DG0->DH2",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B1"
             }
         },
         {
-            "id": "rt.DG1->DD7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
+            "id": "rt.DG1->DD7",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B1"
             }
         },
         {
-            "id": "rt.DG1->DF0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
+            "id": "rt.DG1->DF0",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B2"
             }
         },
         {
-            "id": "rt.DG3->buffer_stop.5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.5"
+                "id": "buffer_stop.5",
+                "type": "BufferStop"
             },
+            "id": "rt.DG3->buffer_stop.5",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B1"
             }
         },
         {
-            "id": "rt.DG3->buffer_stop.6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
+            "id": "rt.DG3->buffer_stop.6",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B2",
@@ -1203,108 +1982,108 @@
             }
         },
         {
-            "id": "rt.DG2->DH1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG2"
+                "id": "DG2",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
+            "id": "rt.DG2->DH1",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B1"
             }
         },
         {
-            "id": "rt.DG4->buffer_stop.6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG4"
+                "id": "DG4",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
+            "id": "rt.DG4->buffer_stop.6",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B1"
             }
         },
         {
-            "id": "rt.buffer_stop.5->DG5",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.5"
+                "id": "buffer_stop.5",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG5"
+                "id": "DG5",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.5->DG5",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DG5->DG1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG5"
+                "id": "DG5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
+            "id": "rt.DG5->DG1",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B1"
             }
         },
         {
-            "id": "rt.buffer_stop.6->DG6",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.6->DG6",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DG6->DG2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG2"
+                "id": "DG2",
+                "type": "Detector"
             },
+            "id": "rt.DG6->DG2",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B1"
             }
         },
         {
-            "id": "rt.DG6->DG1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
+            "id": "rt.DG6->DG1",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B2",
@@ -1312,106 +2091,2997 @@
             }
         },
         {
-            "id": "rt.DH1->DD7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
+            "id": "rt.DH1->DD7",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B1"
             }
         },
         {
-            "id": "rt.DH1->DF0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
+            "id": "rt.DH1->DF0",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B2"
             }
         },
         {
-            "id": "rt.DH2->DG4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG4"
+                "id": "DG4",
+                "type": "Detector"
             },
+            "id": "rt.DH2->DG4",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B1"
             }
         },
         {
-            "id": "rt.DH2->buffer_stop.7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.7"
+                "id": "buffer_stop.7",
+                "type": "BufferStop"
             },
+            "id": "rt.DH2->buffer_stop.7",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.7->DH3",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.7"
+                "id": "buffer_stop.7",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH3"
+                "id": "DH3",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.7->DH3",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DH3->DH1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH3"
+                "id": "DH3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
+            "id": "rt.DH3->DH1",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B2"
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TA0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1750.0,
+            "sight_distance": 400.0,
+            "track": "TA1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1750.0,
+            "sight_distance": 400.0,
+            "track": "TA2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1780.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 4980.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 6580.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 8180.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 8220.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 9800.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1820.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 5020.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 6620.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 8180.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 8220.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 9800.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SB0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SB0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TB0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 850.0,
+            "sight_distance": 400.0,
+            "track": "TC0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TC1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TC2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 850.0,
+            "sight_distance": 400.0,
+            "track": "TC3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1717.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3255.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3295.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 4792.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 6330.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 7867.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 7907.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 9405.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 10942.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_8",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_8",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 12480.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_8r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_8r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 12520.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_9",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_9",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 14017.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_10",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_10",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 15555.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_11",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_11",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 17092.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_11r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_11r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 17132.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_12",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_12",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 18630.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_13",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_13",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 20167.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_14",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_14",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 21705.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_14r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_14r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 21745.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_15",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_15",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 23242.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 24800.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1757.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3255.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3295.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 4832.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 6370.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 7867.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 7907.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 9445.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 10982.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_8r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_8r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 12480.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_8",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_8",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 12520.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_9",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_9",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 14057.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_10",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_10",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 15595.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_11r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_11r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 17092.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_11",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_11",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 17132.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_12",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_12",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 18670.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_13",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_13",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 20207.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_14r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_14r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 21705.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_14",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_14",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 21745.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_15",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_15",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 23282.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 24800.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TD2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TD3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1300.0,
+            "sight_distance": 400.0,
+            "track": "TE0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 2230.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 2270.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TE1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1850.0,
+            "sight_distance": 400.0,
+            "track": "TE2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TE3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TG0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1980.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 2020.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3800.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TG2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG4"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG5"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TH0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TH0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1780.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 1820.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {},
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "ETCS_LEVEL2"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        }
+    ],
+    "speed_sections": [
+        {
+            "id": "speed_section.0",
+            "on_routes": null,
+            "speed_limit": 83.33333333333333,
+            "speed_limit_by_tag": {
+                "HLP": 69.44444444444444
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TA0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA6"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA7"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TB0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TD3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1500.0,
+                    "track": "TE0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3.0,
+                    "track": "TF0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 6500.0,
+                    "track": "TF1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2050.0,
+                    "track": "TE2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TG0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TG1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TG2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TG3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 5000.0,
+                    "track": "TH1"
+                }
+            ]
+        },
+        {
+            "id": "speed_section.1",
+            "on_routes": null,
+            "speed_limit": 39.44444444444444,
+            "speed_limit_by_tag": {
+                "E32C": 27.77777777777778
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 500.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TH1"
+                }
+            ]
+        },
+        {
+            "id": "speed_section.2",
+            "on_routes": null,
+            "speed_limit": 31.11111111111111,
+            "speed_limit_by_tag": {
+                "MA100": 22.22222222222222
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 3500.0,
+                    "end": 4400.0,
+                    "track": "TH1"
+                }
+            ]
+        }
+    ],
     "switches": [
         {
-            "id": "PA0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1426,16 +5096,16 @@
                     "track": "TA4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA1",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1450,16 +5120,16 @@
                     "track": "TA2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA2",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1474,16 +5144,16 @@
                     "track": "TA0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA3",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA3",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1498,16 +5168,16 @@
                     "track": "TA4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA3"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1522,16 +5192,16 @@
                     "track": "TC1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1546,16 +5216,16 @@
                     "track": "TC3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC2",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1570,16 +5240,16 @@
                     "track": "TC0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC3",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC3",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1594,16 +5264,16 @@
                     "track": "TC2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC3"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PD0",
-            "switch_type": "crossing",
+            "extensions": {
+                "sncf": {
+                    "label": "PD0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PD0",
             "ports": {
                 "A1": {
                     "endpoint": "END",
@@ -1622,16 +5292,16 @@
                     "track": "TD2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PD0"
-                }
-            }
+            "switch_type": "crossing"
         },
         {
-            "id": "PD1",
-            "switch_type": "crossing",
+            "extensions": {
+                "sncf": {
+                    "label": "PD1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PD1",
             "ports": {
                 "A1": {
                     "endpoint": "END",
@@ -1650,16 +5320,16 @@
                     "track": "TD3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PD1"
-                }
-            }
+            "switch_type": "crossing"
         },
         {
-            "id": "PE0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE0",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1674,16 +5344,16 @@
                     "track": "TE2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PE1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1698,16 +5368,16 @@
                     "track": "TE1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PE2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE2",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1722,16 +5392,16 @@
                     "track": "TG0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PG0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PG0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PG0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1746,16 +5416,16 @@
                     "track": "TG3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PG0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PG1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PG1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PG1",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1770,16 +5440,16 @@
                     "track": "TG3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PG1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PH0",
-            "switch_type": "double_slip_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PH0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PH0",
             "ports": {
                 "A1": {
                     "endpoint": "BEGIN",
@@ -1798,16 +5468,16 @@
                     "track": "TD3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PH0"
-                }
-            }
+            "switch_type": "double_slip_switch"
         },
         {
-            "id": "PH1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PH1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PH1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1822,17 +5492,21 @@
                     "track": "TH1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PH1"
-                }
-            }
+            "switch_type": "point_switch"
         }
     ],
     "track_sections": [
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 424242,
+                    "line_name": "West_parking",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -1842,41 +5516,41 @@
                         -0.365,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA0",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [
                 {
-                    "category": "GB1",
                     "begin": 0.0,
+                    "category": "GB1",
                     "end": 200.0
                 },
                 {
-                    "category": "G1",
                     "begin": 200.0,
+                    "category": "G1",
                     "end": 1900.0
                 },
                 {
-                    "category": "FR3.3",
                     "begin": 100.0,
+                    "category": "FR3.3",
                     "end": 1500.0
                 }
             ],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -1886,25 +5560,25 @@
                         -0.37,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA1",
             "length": 1950.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "A",
+                    "track_number": 3
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -1914,25 +5588,25 @@
                         -0.37,
                         49.49979999999999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA2",
             "length": 1950.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 3,
-                    "track_name": "A"
+                    "track_name": "J1",
+                    "track_number": 4
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -1942,25 +5616,25 @@
                         -0.365,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA3",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 4,
-                    "track_name": "J1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -1970,25 +5644,25 @@
                         -0.365,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA4",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "J2",
+                    "track_number": 3
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -1998,25 +5672,25 @@
                         -0.365,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA5",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 424242,
-                    "line_name": "West_parking",
-                    "track_number": 3,
-                    "track_name": "J2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -2026,56 +5700,56 @@
                         -0.31,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA6",
             "length": 10000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": -3.0,
                     "begin": 4000.0,
-                    "end": 4300.0
+                    "end": 4300.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 4300.0,
-                    "end": 4700.0
+                    "end": 4700.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 4700.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7000.0,
-                    "end": 7300.0
+                    "end": 7300.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7300.0,
-                    "end": 7700.0
+                    "end": 7700.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7700.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -2085,56 +5759,56 @@
                         -0.31,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA7",
             "length": 10000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": -3.0,
                     "begin": 4000.0,
-                    "end": 4300.0
+                    "end": 4300.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 4300.0,
-                    "end": 4700.0
+                    "end": 4700.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 4700.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7000.0,
-                    "end": 7300.0
+                    "end": 7300.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7300.0,
-                    "end": 7700.0
+                    "end": 7700.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7700.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 3.0
                 }
-            ],
-            "curves": [],
-            "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            ]
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 414141,
+                    "line_name": "South_West_Parking",
+                    "track_name": "A",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -2152,25 +5826,25 @@
                         -0.37,
                         49.49979999999999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TB0",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 414141,
-                    "line_name": "South_West_Parking",
-                    "track_number": 1,
-                    "track_name": "A"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1bis",
+                    "track_number": 3
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2188,25 +5862,25 @@
                         -0.296,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC0",
             "length": 1050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 3,
-                    "track_name": "V1bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2216,25 +5890,25 @@
                         -0.296,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC1",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2244,25 +5918,25 @@
                         -0.296,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC2",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "V2bis",
+                    "track_number": 4
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2280,25 +5954,25 @@
                         -0.296,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC3",
             "length": 1050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 4,
-                    "track_name": "V2bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.296,
@@ -2308,56 +5982,56 @@
                         -0.172,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD0",
             "length": 25000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 3.0,
                     "begin": 6000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 8000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 14000.0,
-                    "end": 15000.0
+                    "end": 15000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 15000.0,
-                    "end": 16000.0
+                    "end": 16000.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 16000.0,
-                    "end": 17000.0
+                    "end": 17000.0,
+                    "gradient": -3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.296,
@@ -2367,56 +6041,56 @@
                         -0.172,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD1",
             "length": 25000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 3.0,
                     "begin": 6000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 8000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 14000.0,
-                    "end": 15000.0
+                    "end": 15000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 15000.0,
-                    "end": 16000.0
+                    "end": 16000.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 16000.0,
-                    "end": 17000.0
+                    "end": 17000.0,
+                    "gradient": -3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2426,25 +6100,25 @@
                         -0.15,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD2",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2458,25 +6132,36 @@
                         -0.135,
                         49.49995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD3",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [
+                {
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 6000.0
+                },
+                {
+                    "begin": 500.0,
+                    "end": 1000.0,
+                    "radius": 8000.0
+                }
+            ],
+            "extensions": {
+                "sncf": {
+                    "line_code": 444444,
+                    "line_name": "North_to_South_loop",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.165,
@@ -2490,36 +6175,25 @@
                         -0.172,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE0",
             "length": 1500.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 6000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 8000.0,
-                    "begin": 500.0,
-                    "end": 1000.0
-                }
-            ],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2529,25 +6203,31 @@
                         -0.172,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TF0",
             "length": 3.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [
+                {
+                    "begin": 3100.0,
+                    "end": 4400.0,
+                    "radius": 9500.0
+                }
+            ],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2565,31 +6245,36 @@
                         -0.135,
                         49.466
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TF1",
             "length": 6500.0,
-            "slopes": [],
+            "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
             "curves": [
                 {
-                    "radius": 9500.0,
-                    "begin": 3100.0,
-                    "end": 4400.0
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 5000.0
+                },
+                {
+                    "begin": 1700.0,
+                    "end": 2000.0,
+                    "radius": 6000.0
                 }
             ],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1bis",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2607,36 +6292,25 @@
                         -0.165,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE1",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 5000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 6000.0,
-                    "begin": 1700.0,
-                    "end": 2000.0
-                }
-            ],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 2,
-                    "track_name": "V1bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2646,25 +6320,46 @@
                         -0.165,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE2",
             "length": 2050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [
+                {
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 5000.0
+                },
+                {
+                    "begin": 650.0,
+                    "end": 850.0,
+                    "radius": 9000.0
+                },
+                {
+                    "begin": 1150.0,
+                    "end": 1350.0,
+                    "radius": 8000.0
+                },
+                {
+                    "begin": 1700.0,
+                    "end": 2000.0,
+                    "radius": 7000.0
+                }
+            ],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2682,46 +6377,25 @@
                         -0.15,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE3",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 5000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 9000.0,
-                    "begin": 650.0,
-                    "end": 850.0
-                },
-                {
-                    "radius": 8000.0,
-                    "begin": 1150.0,
-                    "end": 1350.0
-                },
-                {
-                    "radius": 7000.0,
-                    "begin": 1700.0,
-                    "end": 2000.0
-                }
-            ],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 444444,
-                    "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2735,25 +6409,25 @@
                         -0.135,
                         49.49995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG0",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 454545,
+                    "line_name": "North_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.135,
@@ -2783,25 +6457,25 @@
                         -0.1082,
                         49.513
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG1",
             "length": 4000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 454545,
                     "line_name": "North_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -2827,25 +6501,25 @@
                         -0.108,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG2",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 454545,
-                    "line_name": "North_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 464646,
+                    "line_name": "North_East_parking",
+                    "track_name": "J4",
+                    "track_number": 3
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1082,
@@ -2855,25 +6529,25 @@
                         -0.108,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG3",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
                     "line_name": "North_East_parking",
-                    "track_number": 3,
-                    "track_name": "J4"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1082,
@@ -2883,25 +6557,25 @@
                         -0.09,
                         49.513
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG4",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
                     "line_name": "North_East_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.108,
@@ -2911,25 +6585,25 @@
                         -0.09,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG5",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 464646,
-                    "line_name": "North_East_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V2",
+                    "track_number": 2
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.135,
@@ -2943,25 +6617,25 @@
                         -0.12,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TH0",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 474647,
+                    "line_name": "South_East_parking",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -2983,3688 +6657,14 @@
                         -0.09,
                         49.484
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TH1",
             "length": 5000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 474647,
-                    "line_name": "South_East_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         }
     ],
-    "speed_sections": [
-        {
-            "id": "speed_section.0",
-            "speed_limit": 83.33333333333333,
-            "speed_limit_by_tag": {
-                "HLP": 69.44444444444444
-            },
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA1",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA2",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA4",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA5",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA7",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TB0",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC0",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC1",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC2",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC3",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD0",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE0",
-                    "begin": 0.0,
-                    "end": 1500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF0",
-                    "begin": 0.0,
-                    "end": 3.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF1",
-                    "begin": 0.0,
-                    "end": 6500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE1",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE2",
-                    "begin": 0.0,
-                    "end": 2050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE3",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG2",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG5",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 5000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "speed_section.1",
-            "speed_limit": 39.44444444444444,
-            "speed_limit_by_tag": {
-                "E32C": 27.77777777777778
-            },
-            "track_ranges": [
-                {
-                    "track": "TH0",
-                    "begin": 500.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "speed_section.2",
-            "speed_limit": 31.11111111111111,
-            "speed_limit_by_tag": {
-                "MA100": 22.22222222222222
-            },
-            "track_ranges": [
-                {
-                    "track": "TH1",
-                    "begin": 3500.0,
-                    "end": 4400.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        }
-    ],
-    "electrifications": [
-        {
-            "id": "electrification_25k",
-            "voltage": "25000V",
-            "track_ranges": [
-                {
-                    "track": "TA1",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA2",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA4",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA5",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA7",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TB0",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC0",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC1",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC2",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC3",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD0",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE0",
-                    "begin": 0.0,
-                    "end": 1500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF0",
-                    "begin": 0.0,
-                    "end": 3.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF1",
-                    "begin": 0.0,
-                    "end": 6500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE1",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE2",
-                    "begin": 0.0,
-                    "end": 2050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE3",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG2",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG5",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 5000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ]
-        },
-        {
-            "id": "electrification_1.5k",
-            "voltage": "1500V",
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ]
-        }
-    ],
-    "signals": [
-        {
-            "track": "TA0",
-            "position": 1800.0,
-            "id": "SA2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA1",
-            "position": 1750.0,
-            "id": "SA0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA2",
-            "position": 1750.0,
-            "id": "SA1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 200.0,
-            "id": "SA3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 1780.0,
-            "id": "SA6_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 3380.0,
-            "id": "SA6_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 3420.0,
-            "id": "SA6_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 4980.0,
-            "id": "SA6_3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 6580.0,
-            "id": "SA6_4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 8180.0,
-            "id": "SA6_5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 8220.0,
-            "id": "SA6_5r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 9800.0,
-            "id": "SA5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 200.0,
-            "id": "SA4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 1820.0,
-            "id": "SA7_1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 3380.0,
-            "id": "SA7_2r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 3420.0,
-            "id": "SA7_2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 5020.0,
-            "id": "SA7_3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 6620.0,
-            "id": "SA7_4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 8180.0,
-            "id": "SA7_5r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 8220.0,
-            "id": "SA7_5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 9800.0,
-            "id": "SA6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TB0",
-            "position": 2800.0,
-            "id": "SB0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SB0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC0",
-            "position": 200.0,
-            "id": "SC0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC0",
-            "position": 850.0,
-            "id": "SC4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC1",
-            "position": 200.0,
-            "id": "SC1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC1",
-            "position": 800.0,
-            "id": "SC5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC2",
-            "position": 200.0,
-            "id": "SC2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC2",
-            "position": 800.0,
-            "id": "SC6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC3",
-            "position": 200.0,
-            "id": "SC3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC3",
-            "position": 850.0,
-            "id": "SC7",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 200.0,
-            "id": "SD0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 1717.5,
-            "id": "SD0_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 3255.0,
-            "id": "SD0_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 3295.0,
-            "id": "SD0_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 4792.5,
-            "id": "SD0_3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 6330.0,
-            "id": "SD0_4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 7867.5,
-            "id": "SD0_5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 7907.5,
-            "id": "SD0_5r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 9405.0,
-            "id": "SD0_6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 10942.5,
-            "id": "SD0_7",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 12480.0,
-            "id": "SD0_8",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_8",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 12520.0,
-            "id": "SD0_8r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_8r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 14017.5,
-            "id": "SD0_9",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_9",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 15555.0,
-            "id": "SD0_10",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_10",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 17092.5,
-            "id": "SD0_11",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_11",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 17132.5,
-            "id": "SD0_11r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_11r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 18630.0,
-            "id": "SD0_12",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_12",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 20167.5,
-            "id": "SD0_13",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_13",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 21705.0,
-            "id": "SD0_14",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_14",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 21745.0,
-            "id": "SD0_14r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_14r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 23242.5,
-            "id": "SD0_15",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_15",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 24800.0,
-            "id": "SD2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 200.0,
-            "id": "SD1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 1757.5,
-            "id": "SD1_1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 3255.0,
-            "id": "SD1_2r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 3295.0,
-            "id": "SD1_2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 4832.5,
-            "id": "SD1_3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 6370.0,
-            "id": "SD1_4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 7867.5,
-            "id": "SD1_5r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 7907.5,
-            "id": "SD1_5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 9445.0,
-            "id": "SD1_6",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 10982.5,
-            "id": "SD1_7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 12480.0,
-            "id": "SD1_8r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_8r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 12520.0,
-            "id": "SD1_8",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_8",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 14057.5,
-            "id": "SD1_9",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_9",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 15595.0,
-            "id": "SD1_10",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_10",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 17092.5,
-            "id": "SD1_11r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_11r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 17132.5,
-            "id": "SD1_11",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_11",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 18670.0,
-            "id": "SD1_12",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_12",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 20207.5,
-            "id": "SD1_13",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_13",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 21705.0,
-            "id": "SD1_14r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_14r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 21745.0,
-            "id": "SD1_14",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_14",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 23282.5,
-            "id": "SD1_15",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_15",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 24800.0,
-            "id": "SD3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD2",
-            "position": 200.0,
-            "id": "SD4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD2",
-            "position": 1800.0,
-            "id": "SD6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD3",
-            "position": 200.0,
-            "id": "SF0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD3",
-            "position": 2800.0,
-            "id": "SH0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE0",
-            "position": 200.0,
-            "id": "SE1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE0",
-            "position": 1300.0,
-            "id": "SE0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 200.0,
-            "id": "SD5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 2230.0,
-            "id": "SF1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 2270.0,
-            "id": "SF1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE1",
-            "position": 200.0,
-            "id": "SE4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE1",
-            "position": 1800.0,
-            "id": "SE2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE2",
-            "position": 200.0,
-            "id": "SE5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE2",
-            "position": 1850.0,
-            "id": "SE3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE3",
-            "position": 200.0,
-            "id": "SE7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE3",
-            "position": 1800.0,
-            "id": "SE6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG0",
-            "position": 200.0,
-            "id": "SD7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG0",
-            "position": 800.0,
-            "id": "SG0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 200.0,
-            "id": "SG1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 1980.0,
-            "id": "SG1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 2020.0,
-            "id": "SG1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 3800.0,
-            "id": "SG3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG2",
-            "position": 200.0,
-            "id": "SG2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG2",
-            "position": 2800.0,
-            "id": "SG4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG4",
-            "position": 200.0,
-            "id": "SG5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG5",
-            "position": 200.0,
-            "id": "SG6",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH0",
-            "position": 200.0,
-            "id": "SH1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH0",
-            "position": 800.0,
-            "id": "SH2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 200.0,
-            "id": "SH3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 1780.0,
-            "id": "SH1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 1820.0,
-            "id": "SH1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 3380.0,
-            "id": "SH1_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 3420.0,
-            "id": "SH1_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "ETCS_LEVEL2",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {},
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "TA0",
-            "position": 0.0,
-            "id": "buffer_stop.0"
-        },
-        {
-            "track": "TA1",
-            "position": 0.0,
-            "id": "buffer_stop.1"
-        },
-        {
-            "track": "TA2",
-            "position": 0.0,
-            "id": "buffer_stop.2"
-        },
-        {
-            "track": "TB0",
-            "position": 0.0,
-            "id": "buffer_stop.3"
-        },
-        {
-            "track": "TF1",
-            "position": 6500.0,
-            "id": "buffer_stop.4"
-        },
-        {
-            "track": "TG4",
-            "position": 2000.0,
-            "id": "buffer_stop.5"
-        },
-        {
-            "track": "TG5",
-            "position": 2000.0,
-            "id": "buffer_stop.6"
-        },
-        {
-            "track": "TH1",
-            "position": 5000.0,
-            "id": "buffer_stop.7"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "TA0",
-            "position": 1820.0,
-            "id": "DA2"
-        },
-        {
-            "track": "TA1",
-            "position": 1770.0,
-            "id": "DA0"
-        },
-        {
-            "track": "TA2",
-            "position": 1770.0,
-            "id": "DA1"
-        },
-        {
-            "track": "TA3",
-            "position": 25.0,
-            "id": "DA7"
-        },
-        {
-            "track": "TA4",
-            "position": 25.0,
-            "id": "DA8"
-        },
-        {
-            "track": "TA5",
-            "position": 25.0,
-            "id": "DA9"
-        },
-        {
-            "track": "TA6",
-            "position": 180.0,
-            "id": "DA3"
-        },
-        {
-            "track": "TA6",
-            "position": 1800.0,
-            "id": "DA6_1"
-        },
-        {
-            "track": "TA6",
-            "position": 3400.0,
-            "id": "DA6_2"
-        },
-        {
-            "track": "TA6",
-            "position": 5000.0,
-            "id": "DA6_3"
-        },
-        {
-            "track": "TA6",
-            "position": 6600.0,
-            "id": "DA6_4"
-        },
-        {
-            "track": "TA6",
-            "position": 8200.0,
-            "id": "DA6_5"
-        },
-        {
-            "track": "TA6",
-            "position": 9820.0,
-            "id": "DA5"
-        },
-        {
-            "track": "TA7",
-            "position": 180.0,
-            "id": "DA4"
-        },
-        {
-            "track": "TA7",
-            "position": 1800.0,
-            "id": "DA7_1"
-        },
-        {
-            "track": "TA7",
-            "position": 3400.0,
-            "id": "DA7_2"
-        },
-        {
-            "track": "TA7",
-            "position": 5000.0,
-            "id": "DA7_3"
-        },
-        {
-            "track": "TA7",
-            "position": 6600.0,
-            "id": "DA7_4"
-        },
-        {
-            "track": "TA7",
-            "position": 8200.0,
-            "id": "DA7_5"
-        },
-        {
-            "track": "TA7",
-            "position": 9820.0,
-            "id": "DA6"
-        },
-        {
-            "track": "TB0",
-            "position": 2820.0,
-            "id": "DB0"
-        },
-        {
-            "track": "TC0",
-            "position": 180.0,
-            "id": "DC0"
-        },
-        {
-            "track": "TC0",
-            "position": 870.0,
-            "id": "DC4"
-        },
-        {
-            "track": "TC1",
-            "position": 180.0,
-            "id": "DC1"
-        },
-        {
-            "track": "TC1",
-            "position": 820.0,
-            "id": "DC5"
-        },
-        {
-            "track": "TC2",
-            "position": 180.0,
-            "id": "DC2"
-        },
-        {
-            "track": "TC2",
-            "position": 820.0,
-            "id": "DC6"
-        },
-        {
-            "track": "TC3",
-            "position": 180.0,
-            "id": "DC3"
-        },
-        {
-            "track": "TC3",
-            "position": 870.0,
-            "id": "DC7"
-        },
-        {
-            "track": "TD0",
-            "position": 180.0,
-            "id": "DD0"
-        },
-        {
-            "track": "TD0",
-            "position": 1737.5,
-            "id": "DD0_1"
-        },
-        {
-            "track": "TD0",
-            "position": 3275.0,
-            "id": "DD0_2"
-        },
-        {
-            "track": "TD0",
-            "position": 4812.5,
-            "id": "DD0_3"
-        },
-        {
-            "track": "TD0",
-            "position": 6350.0,
-            "id": "DD0_4"
-        },
-        {
-            "track": "TD0",
-            "position": 7887.5,
-            "id": "DD0_5"
-        },
-        {
-            "track": "TD0",
-            "position": 9425.0,
-            "id": "DD0_6"
-        },
-        {
-            "track": "TD0",
-            "position": 10962.5,
-            "id": "DD0_7"
-        },
-        {
-            "track": "TD0",
-            "position": 12500.0,
-            "id": "DD0_8"
-        },
-        {
-            "track": "TD0",
-            "position": 14037.5,
-            "id": "DD0_9"
-        },
-        {
-            "track": "TD0",
-            "position": 15575.0,
-            "id": "DD0_10"
-        },
-        {
-            "track": "TD0",
-            "position": 17112.5,
-            "id": "DD0_11"
-        },
-        {
-            "track": "TD0",
-            "position": 18650.0,
-            "id": "DD0_12"
-        },
-        {
-            "track": "TD0",
-            "position": 20187.5,
-            "id": "DD0_13"
-        },
-        {
-            "track": "TD0",
-            "position": 21725.0,
-            "id": "DD0_14"
-        },
-        {
-            "track": "TD0",
-            "position": 23262.5,
-            "id": "DD0_15"
-        },
-        {
-            "track": "TD0",
-            "position": 24820.0,
-            "id": "DD2"
-        },
-        {
-            "track": "TD1",
-            "position": 180.0,
-            "id": "DD1"
-        },
-        {
-            "track": "TD1",
-            "position": 1737.5,
-            "id": "DD1_1"
-        },
-        {
-            "track": "TD1",
-            "position": 3275.0,
-            "id": "DD1_2"
-        },
-        {
-            "track": "TD1",
-            "position": 4812.5,
-            "id": "DD1_3"
-        },
-        {
-            "track": "TD1",
-            "position": 6350.0,
-            "id": "DD1_4"
-        },
-        {
-            "track": "TD1",
-            "position": 7887.5,
-            "id": "DD1_5"
-        },
-        {
-            "track": "TD1",
-            "position": 9425.0,
-            "id": "DD1_6"
-        },
-        {
-            "track": "TD1",
-            "position": 10962.5,
-            "id": "DD1_7"
-        },
-        {
-            "track": "TD1",
-            "position": 12500.0,
-            "id": "DD1_8"
-        },
-        {
-            "track": "TD1",
-            "position": 14037.5,
-            "id": "DD1_9"
-        },
-        {
-            "track": "TD1",
-            "position": 15575.0,
-            "id": "DD1_10"
-        },
-        {
-            "track": "TD1",
-            "position": 17112.5,
-            "id": "DD1_11"
-        },
-        {
-            "track": "TD1",
-            "position": 18650.0,
-            "id": "DD1_12"
-        },
-        {
-            "track": "TD1",
-            "position": 20187.5,
-            "id": "DD1_13"
-        },
-        {
-            "track": "TD1",
-            "position": 21725.0,
-            "id": "DD1_14"
-        },
-        {
-            "track": "TD1",
-            "position": 23262.5,
-            "id": "DD1_15"
-        },
-        {
-            "track": "TD1",
-            "position": 24820.0,
-            "id": "DD3"
-        },
-        {
-            "track": "TD2",
-            "position": 180.0,
-            "id": "DD4"
-        },
-        {
-            "track": "TD2",
-            "position": 1820.0,
-            "id": "DD6"
-        },
-        {
-            "track": "TD3",
-            "position": 180.0,
-            "id": "DF0"
-        },
-        {
-            "track": "TD3",
-            "position": 2820.0,
-            "id": "DH0"
-        },
-        {
-            "track": "TE0",
-            "position": 180.0,
-            "id": "DE1"
-        },
-        {
-            "track": "TE0",
-            "position": 1320.0,
-            "id": "DE0"
-        },
-        {
-            "track": "TF1",
-            "position": 180.0,
-            "id": "DD5"
-        },
-        {
-            "track": "TF1",
-            "position": 2250.0,
-            "id": "DF1_1"
-        },
-        {
-            "track": "TE1",
-            "position": 180.0,
-            "id": "DE4"
-        },
-        {
-            "track": "TE1",
-            "position": 1820.0,
-            "id": "DE2"
-        },
-        {
-            "track": "TE2",
-            "position": 180.0,
-            "id": "DE5"
-        },
-        {
-            "track": "TE2",
-            "position": 1870.0,
-            "id": "DE3"
-        },
-        {
-            "track": "TE3",
-            "position": 180.0,
-            "id": "DE7"
-        },
-        {
-            "track": "TE3",
-            "position": 1820.0,
-            "id": "DE6"
-        },
-        {
-            "track": "TG0",
-            "position": 180.0,
-            "id": "DD7"
-        },
-        {
-            "track": "TG0",
-            "position": 820.0,
-            "id": "DG0"
-        },
-        {
-            "track": "TG1",
-            "position": 180.0,
-            "id": "DG1"
-        },
-        {
-            "track": "TG1",
-            "position": 2000.0,
-            "id": "DG1_1"
-        },
-        {
-            "track": "TG1",
-            "position": 3820.0,
-            "id": "DG3"
-        },
-        {
-            "track": "TG2",
-            "position": 180.0,
-            "id": "DG2"
-        },
-        {
-            "track": "TG2",
-            "position": 2820.0,
-            "id": "DG4"
-        },
-        {
-            "track": "TG3",
-            "position": 25.0,
-            "id": "DG7"
-        },
-        {
-            "track": "TG4",
-            "position": 180.0,
-            "id": "DG5"
-        },
-        {
-            "track": "TG5",
-            "position": 180.0,
-            "id": "DG6"
-        },
-        {
-            "track": "TH0",
-            "position": 180.0,
-            "id": "DH1"
-        },
-        {
-            "track": "TH0",
-            "position": 820.0,
-            "id": "DH2"
-        },
-        {
-            "track": "TH1",
-            "position": 180.0,
-            "id": "DH3"
-        },
-        {
-            "track": "TH1",
-            "position": 1800.0,
-            "id": "DH1_1"
-        },
-        {
-            "track": "TH1",
-            "position": 3400.0,
-            "id": "DH1_2"
-        }
-    ],
-    "neutral_sections": [
-        {
-            "id": "neutral_section.0",
-            "announcement_track_ranges": [
-                {
-                    "track": "TG1",
-                    "begin": 3500.0,
-                    "end": 4000.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "direction": "START_TO_STOP"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": true
-        },
-        {
-            "id": "neutral_section.1",
-            "announcement_track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1850.0,
-                    "end": 1960.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1960.0,
-                    "end": 2000.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": true
-        },
-        {
-            "id": "neutral_section.2",
-            "announcement_track_ranges": [],
-            "track_ranges": [
-                {
-                    "track": "TA6",
-                    "begin": 8500.0,
-                    "end": 8600.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": false
-        },
-        {
-            "id": "neutral_section.3",
-            "announcement_track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1990.0,
-                    "end": 2000.0,
-                    "direction": "STOP_TO_START"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1850.0,
-                    "end": 1990.0,
-                    "direction": "STOP_TO_START"
-                }
-            ],
-            "lower_pantograph": false
-        }
-    ]
+    "version": "3.5.2"
 }

--- a/tests/data/infras/example_script/infra.json
+++ b/tests/data/infras/example_script/infra.json
@@ -1,434 +1,1002 @@
 {
-    "version": "3.5.2",
+    "buffer_stops": [
+        {
+            "id": "Custom Buffer Stop",
+            "position": 100.0,
+            "track": "track.0"
+        },
+        {
+            "id": "buffer_stop.0",
+            "position": 0.0,
+            "track": "track.1"
+        },
+        {
+            "id": "buffer_stop.1",
+            "position": 1000.0,
+            "track": "track.3"
+        },
+        {
+            "id": "buffer_stop.2",
+            "position": 1000.0,
+            "track": "track.5"
+        },
+        {
+            "id": "buffer_stop.3",
+            "position": 1000.0,
+            "track": "track.6"
+        }
+    ],
+    "detectors": [
+        {
+            "id": "detector.5",
+            "position": 800.0,
+            "track": "track.0"
+        },
+        {
+            "id": "detector.6",
+            "position": 800.0,
+            "track": "track.1"
+        },
+        {
+            "id": "detector.0",
+            "position": 200.0,
+            "track": "track.2"
+        },
+        {
+            "id": "detector.7",
+            "position": 800.0,
+            "track": "track.2"
+        },
+        {
+            "id": "detector.1",
+            "position": 200.0,
+            "track": "track.3"
+        },
+        {
+            "id": "detector.2",
+            "position": 200.0,
+            "track": "track.4"
+        },
+        {
+            "id": "detector.8",
+            "position": 800.0,
+            "track": "track.4"
+        },
+        {
+            "id": "detector.3",
+            "position": 200.0,
+            "track": "track.5"
+        },
+        {
+            "id": "detector.4",
+            "position": 200.0,
+            "track": "track.6"
+        }
+    ],
+    "electrifications": [],
+    "extended_switch_types": [],
+    "level_crossings": [],
+    "neutral_sections": [],
     "operational_points": [
         {
-            "id": "my-op",
-            "parts": [
-                {
-                    "track": "track.0",
-                    "position": 500.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "track.1",
-                    "position": 500.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "MY-"
-                },
                 "identifier": {
                     "name": "my-op",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "MY-"
                 }
-            }
+            },
+            "id": "my-op",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 500.0,
+                    "track": "track.0"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 500.0,
+                    "track": "track.1"
+                }
+            ],
+            "plc": null,
+            "weight": null
         }
     ],
-    "level_crossings": [],
     "routes": [
         {
+            "entry_point": {
+                "id": "Custom Buffer Stop",
+                "type": "BufferStop"
+            },
+            "entry_point_direction": "START_TO_STOP",
+            "exit_point": {
+                "id": "detector.5",
+                "type": "Detector"
+            },
             "id": "rt.Custom Buffer Stop->detector.5",
-            "entry_point": {
-                "type": "BufferStop",
-                "id": "Custom Buffer Stop"
-            },
-            "entry_point_direction": "START_TO_STOP",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.5"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "detector.5",
+                "type": "Detector"
+            },
+            "entry_point_direction": "STOP_TO_START",
+            "exit_point": {
+                "id": "Custom Buffer Stop",
+                "type": "BufferStop"
+            },
             "id": "rt.detector.5->Custom Buffer Stop",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.5"
-            },
-            "entry_point_direction": "STOP_TO_START",
-            "exit_point": {
-                "type": "BufferStop",
-                "id": "Custom Buffer Stop"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "detector.5",
+                "type": "Detector"
+            },
+            "entry_point_direction": "START_TO_STOP",
+            "exit_point": {
+                "id": "detector.0",
+                "type": "Detector"
+            },
             "id": "rt.detector.5->detector.0",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.5"
-            },
-            "entry_point_direction": "START_TO_STOP",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.0"
-            },
             "release_detectors": [],
             "switches_directions": {
                 "switch.0": "A_B2"
             }
         },
         {
+            "entry_point": {
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
+            },
+            "entry_point_direction": "START_TO_STOP",
+            "exit_point": {
+                "id": "detector.6",
+                "type": "Detector"
+            },
             "id": "rt.buffer_stop.0->detector.6",
-            "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
-            },
-            "entry_point_direction": "START_TO_STOP",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.6"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "detector.6",
+                "type": "Detector"
+            },
+            "entry_point_direction": "STOP_TO_START",
+            "exit_point": {
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
+            },
             "id": "rt.detector.6->buffer_stop.0",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.6"
-            },
-            "entry_point_direction": "STOP_TO_START",
-            "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "detector.6",
+                "type": "Detector"
+            },
+            "entry_point_direction": "START_TO_STOP",
+            "exit_point": {
+                "id": "detector.0",
+                "type": "Detector"
+            },
             "id": "rt.detector.6->detector.0",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.6"
-            },
-            "entry_point_direction": "START_TO_STOP",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.0"
-            },
             "release_detectors": [],
             "switches_directions": {
                 "switch.0": "A_B1"
             }
         },
         {
+            "entry_point": {
+                "id": "detector.0",
+                "type": "Detector"
+            },
+            "entry_point_direction": "START_TO_STOP",
+            "exit_point": {
+                "id": "detector.7",
+                "type": "Detector"
+            },
             "id": "rt.detector.0->detector.7",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.0"
-            },
-            "entry_point_direction": "START_TO_STOP",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.7"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "detector.7",
+                "type": "Detector"
+            },
+            "entry_point_direction": "STOP_TO_START",
+            "exit_point": {
+                "id": "detector.0",
+                "type": "Detector"
+            },
             "id": "rt.detector.7->detector.0",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.7"
-            },
-            "entry_point_direction": "STOP_TO_START",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.0"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.detector.0->detector.6",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.0"
+                "id": "detector.0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.6"
+                "id": "detector.6",
+                "type": "Detector"
             },
+            "id": "rt.detector.0->detector.6",
             "release_detectors": [],
             "switches_directions": {
                 "switch.0": "A_B1"
             }
         },
         {
-            "id": "rt.detector.0->detector.5",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.0"
+                "id": "detector.0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.5"
+                "id": "detector.5",
+                "type": "Detector"
             },
+            "id": "rt.detector.0->detector.5",
             "release_detectors": [],
             "switches_directions": {
                 "switch.0": "A_B2"
             }
         },
         {
+            "entry_point": {
+                "id": "detector.7",
+                "type": "Detector"
+            },
+            "entry_point_direction": "START_TO_STOP",
+            "exit_point": {
+                "id": "detector.1",
+                "type": "Detector"
+            },
             "id": "rt.detector.7->detector.1",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.7"
-            },
-            "entry_point_direction": "START_TO_STOP",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.1"
-            },
             "release_detectors": [],
             "switches_directions": {
                 "switch.1": "A_B1"
             }
         },
         {
+            "entry_point": {
+                "id": "detector.7",
+                "type": "Detector"
+            },
+            "entry_point_direction": "START_TO_STOP",
+            "exit_point": {
+                "id": "detector.2",
+                "type": "Detector"
+            },
             "id": "rt.detector.7->detector.2",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.7"
-            },
-            "entry_point_direction": "START_TO_STOP",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.2"
-            },
             "release_detectors": [],
             "switches_directions": {
                 "switch.1": "A_B2"
             }
         },
         {
-            "id": "rt.detector.1->buffer_stop.1",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.1"
+                "id": "detector.1",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
+            "id": "rt.detector.1->buffer_stop.1",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
+            },
+            "entry_point_direction": "STOP_TO_START",
+            "exit_point": {
+                "id": "detector.1",
+                "type": "Detector"
+            },
             "id": "rt.buffer_stop.1->detector.1",
-            "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
-            },
-            "entry_point_direction": "STOP_TO_START",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.1"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.detector.1->detector.7",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.1"
+                "id": "detector.1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.7"
+                "id": "detector.7",
+                "type": "Detector"
             },
+            "id": "rt.detector.1->detector.7",
             "release_detectors": [],
             "switches_directions": {
                 "switch.1": "A_B1"
             }
         },
         {
-            "id": "rt.detector.2->detector.8",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.2"
+                "id": "detector.2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.8"
+                "id": "detector.8",
+                "type": "Detector"
             },
+            "id": "rt.detector.2->detector.8",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "detector.8",
+                "type": "Detector"
+            },
+            "entry_point_direction": "STOP_TO_START",
+            "exit_point": {
+                "id": "detector.2",
+                "type": "Detector"
+            },
             "id": "rt.detector.8->detector.2",
-            "entry_point": {
-                "type": "Detector",
-                "id": "detector.8"
-            },
-            "entry_point_direction": "STOP_TO_START",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.2"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.detector.2->detector.7",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.2"
+                "id": "detector.2",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.7"
+                "id": "detector.7",
+                "type": "Detector"
             },
+            "id": "rt.detector.2->detector.7",
             "release_detectors": [],
             "switches_directions": {
                 "switch.1": "A_B2"
             }
         },
         {
-            "id": "rt.detector.8->detector.3",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.8"
+                "id": "detector.8",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.3"
+                "id": "detector.3",
+                "type": "Detector"
             },
+            "id": "rt.detector.8->detector.3",
             "release_detectors": [],
             "switches_directions": {
                 "switch.2": "A_B1"
             }
         },
         {
-            "id": "rt.detector.8->detector.4",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.8"
+                "id": "detector.8",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.4"
+                "id": "detector.4",
+                "type": "Detector"
             },
+            "id": "rt.detector.8->detector.4",
             "release_detectors": [],
             "switches_directions": {
                 "switch.2": "A_B2"
             }
         },
         {
-            "id": "rt.detector.3->buffer_stop.2",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.3"
+                "id": "detector.3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
             },
+            "id": "rt.detector.3->buffer_stop.2",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
+            },
+            "entry_point_direction": "STOP_TO_START",
+            "exit_point": {
+                "id": "detector.3",
+                "type": "Detector"
+            },
             "id": "rt.buffer_stop.2->detector.3",
-            "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
-            },
-            "entry_point_direction": "STOP_TO_START",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.3"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.detector.3->detector.8",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.3"
+                "id": "detector.3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.8"
+                "id": "detector.8",
+                "type": "Detector"
             },
+            "id": "rt.detector.3->detector.8",
             "release_detectors": [],
             "switches_directions": {
                 "switch.2": "A_B1"
             }
         },
         {
-            "id": "rt.detector.4->buffer_stop.3",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.4"
+                "id": "detector.4",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
+            "id": "rt.detector.4->buffer_stop.3",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
+            "entry_point": {
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
+            },
+            "entry_point_direction": "STOP_TO_START",
+            "exit_point": {
+                "id": "detector.4",
+                "type": "Detector"
+            },
             "id": "rt.buffer_stop.3->detector.4",
-            "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
-            },
-            "entry_point_direction": "STOP_TO_START",
-            "exit_point": {
-                "type": "Detector",
-                "id": "detector.4"
-            },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.detector.4->detector.8",
             "entry_point": {
-                "type": "Detector",
-                "id": "detector.4"
+                "id": "detector.4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "detector.8"
+                "id": "detector.8",
+                "type": "Detector"
             },
+            "id": "rt.detector.4->detector.8",
             "release_detectors": [],
             "switches_directions": {
                 "switch.2": "A_B2"
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.10",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.10",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 775.0,
+            "sight_distance": 400.0,
+            "track": "track.0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.11",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.11",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 825.0,
+            "sight_distance": 400.0,
+            "track": "track.0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.12",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.12",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 775.0,
+            "sight_distance": 400.0,
+            "track": "track.1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.13",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.13",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 825.0,
+            "sight_distance": 400.0,
+            "track": "track.1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 175.0,
+            "sight_distance": 400.0,
+            "track": "track.2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 225.0,
+            "sight_distance": 400.0,
+            "track": "track.2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.14",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.14",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 775.0,
+            "sight_distance": 400.0,
+            "track": "track.2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.15",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.15",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 825.0,
+            "sight_distance": 400.0,
+            "track": "track.2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 175.0,
+            "sight_distance": 400.0,
+            "track": "track.3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 225.0,
+            "sight_distance": 400.0,
+            "track": "track.3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 175.0,
+            "sight_distance": 400.0,
+            "track": "track.4"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 225.0,
+            "sight_distance": 400.0,
+            "track": "track.4"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.16",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.16",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 775.0,
+            "sight_distance": 400.0,
+            "track": "track.4"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.17",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.17",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 825.0,
+            "sight_distance": 400.0,
+            "track": "track.4"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 175.0,
+            "sight_distance": 400.0,
+            "track": "track.5"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 225.0,
+            "sight_distance": 400.0,
+            "track": "track.5"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.8",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.8",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 175.0,
+            "sight_distance": 400.0,
+            "track": "track.6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "signal.9",
+                    "side": "LEFT"
+                }
+            },
+            "id": "signal.9",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 225.0,
+            "sight_distance": 400.0,
+            "track": "track.6"
+        }
+    ],
+    "speed_sections": [],
     "switches": [
         {
-            "id": "switch.0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "switch.0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "switch.0",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -443,16 +1011,16 @@
                     "track": "track.0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "switch.0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "switch.1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "switch.1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "switch.1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -467,16 +1035,16 @@
                     "track": "track.4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "switch.1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "switch.2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "switch.2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "switch.2",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -491,17 +1059,21 @@
                     "track": "track.6"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "switch.2"
-                }
-            }
+            "switch_type": "point_switch"
         }
     ],
     "track_sections": [
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 0,
+                    "line_name": "placeholder_line",
+                    "track_name": "placeholder_track",
+                    "track_number": 0
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         0.0,
@@ -511,25 +1083,25 @@
                         1000.0,
                         0.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "track.0",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         0.0,
@@ -539,25 +1111,25 @@
                         1000.0,
                         0.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "track.1",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         1000.0,
@@ -567,25 +1139,25 @@
                         2030.0,
                         0.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "track.2",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         2030.0,
@@ -595,25 +1167,25 @@
                         3030.0,
                         250.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "track.3",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         2030.0,
@@ -623,25 +1195,25 @@
                         3030.0,
                         -250.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "track.4",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         3030.0,
@@ -651,25 +1223,25 @@
                         4030.0,
                         -500.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "track.5",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         3030.0,
@@ -679,586 +1251,14 @@
                         4030.0,
                         0.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "track.6",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 0,
-                    "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
-                }
-            }
+            "slopes": []
         }
     ],
-    "speed_sections": [],
-    "electrifications": [],
-    "signals": [
-        {
-            "track": "track.0",
-            "position": 775.0,
-            "id": "signal.10",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.10",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.0",
-            "position": 825.0,
-            "id": "signal.11",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.11",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.1",
-            "position": 775.0,
-            "id": "signal.12",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.12",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.1",
-            "position": 825.0,
-            "id": "signal.13",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.13",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.2",
-            "position": 175.0,
-            "id": "signal.0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.2",
-            "position": 225.0,
-            "id": "signal.1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.2",
-            "position": 775.0,
-            "id": "signal.14",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.14",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.2",
-            "position": 825.0,
-            "id": "signal.15",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.15",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.3",
-            "position": 175.0,
-            "id": "signal.2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.3",
-            "position": 225.0,
-            "id": "signal.3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.4",
-            "position": 175.0,
-            "id": "signal.4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.4",
-            "position": 225.0,
-            "id": "signal.5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.4",
-            "position": 775.0,
-            "id": "signal.16",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.16",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.4",
-            "position": 825.0,
-            "id": "signal.17",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.17",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.5",
-            "position": 175.0,
-            "id": "signal.6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.5",
-            "position": 225.0,
-            "id": "signal.7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.6",
-            "position": 175.0,
-            "id": "signal.8",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.8",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "track.6",
-            "position": 225.0,
-            "id": "signal.9",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "signal.9",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "track.0",
-            "position": 100.0,
-            "id": "Custom Buffer Stop"
-        },
-        {
-            "track": "track.1",
-            "position": 0.0,
-            "id": "buffer_stop.0"
-        },
-        {
-            "track": "track.3",
-            "position": 1000.0,
-            "id": "buffer_stop.1"
-        },
-        {
-            "track": "track.5",
-            "position": 1000.0,
-            "id": "buffer_stop.2"
-        },
-        {
-            "track": "track.6",
-            "position": 1000.0,
-            "id": "buffer_stop.3"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "track.0",
-            "position": 800.0,
-            "id": "detector.5"
-        },
-        {
-            "track": "track.1",
-            "position": 800.0,
-            "id": "detector.6"
-        },
-        {
-            "track": "track.2",
-            "position": 200.0,
-            "id": "detector.0"
-        },
-        {
-            "track": "track.2",
-            "position": 800.0,
-            "id": "detector.7"
-        },
-        {
-            "track": "track.3",
-            "position": 200.0,
-            "id": "detector.1"
-        },
-        {
-            "track": "track.4",
-            "position": 200.0,
-            "id": "detector.2"
-        },
-        {
-            "track": "track.4",
-            "position": 800.0,
-            "id": "detector.8"
-        },
-        {
-            "track": "track.5",
-            "position": 200.0,
-            "id": "detector.3"
-        },
-        {
-            "track": "track.6",
-            "position": 200.0,
-            "id": "detector.4"
-        }
-    ],
-    "neutral_sections": []
+    "version": "3.5.2"
 }

--- a/tests/data/infras/medium_infra/infra.json
+++ b/tests/data/infras/medium_infra/infra.json
@@ -1,370 +1,1203 @@
 {
-    "version": "3.5.2",
+    "buffer_stops": [
+        {
+            "id": "buffer_stop.0",
+            "position": 0.0,
+            "track": "TI0"
+        },
+        {
+            "id": "buffer_stop.1",
+            "position": 0.0,
+            "track": "TI1"
+        },
+        {
+            "id": "buffer_stop.2",
+            "position": 0.0,
+            "track": "TA0"
+        },
+        {
+            "id": "buffer_stop.3",
+            "position": 0.0,
+            "track": "TA1"
+        },
+        {
+            "id": "buffer_stop.4",
+            "position": 0.0,
+            "track": "TA2"
+        },
+        {
+            "id": "buffer_stop.5",
+            "position": 0.0,
+            "track": "TB0"
+        },
+        {
+            "id": "buffer_stop.6",
+            "position": 6500.0,
+            "track": "TF1"
+        },
+        {
+            "id": "buffer_stop.7",
+            "position": 2000.0,
+            "track": "TG4"
+        },
+        {
+            "id": "buffer_stop.8",
+            "position": 2000.0,
+            "track": "TG5"
+        },
+        {
+            "id": "buffer_stop.9",
+            "position": 5000.0,
+            "track": "TH1"
+        }
+    ],
+    "detectors": [
+        {
+            "id": "DI0",
+            "position": 570.0,
+            "track": "TI0"
+        },
+        {
+            "id": "DI1",
+            "position": 470.0,
+            "track": "TI1"
+        },
+        {
+            "id": "DI2",
+            "position": 2170.0,
+            "track": "TI2"
+        },
+        {
+            "id": "DI3",
+            "position": 125.0,
+            "track": "TI3"
+        },
+        {
+            "id": "DA2",
+            "position": 1570.0,
+            "track": "TA0"
+        },
+        {
+            "id": "DA0",
+            "position": 1770.0,
+            "track": "TA1"
+        },
+        {
+            "id": "DA1",
+            "position": 1770.0,
+            "track": "TA2"
+        },
+        {
+            "id": "DA7",
+            "position": 25.0,
+            "track": "TA3"
+        },
+        {
+            "id": "DA8",
+            "position": 25.0,
+            "track": "TA4"
+        },
+        {
+            "id": "DA9",
+            "position": 25.0,
+            "track": "TA5"
+        },
+        {
+            "id": "DA3",
+            "position": 180.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_1",
+            "position": 1800.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_2",
+            "position": 3400.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_3",
+            "position": 5000.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_4",
+            "position": 6600.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_5",
+            "position": 8200.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA5",
+            "position": 9820.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA4",
+            "position": 180.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_1",
+            "position": 1800.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_2",
+            "position": 3400.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_3",
+            "position": 5000.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_4",
+            "position": 6600.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_5",
+            "position": 8200.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA6",
+            "position": 9820.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DB0",
+            "position": 2820.0,
+            "track": "TB0"
+        },
+        {
+            "id": "DC0",
+            "position": 180.0,
+            "track": "TC0"
+        },
+        {
+            "id": "DC4",
+            "position": 870.0,
+            "track": "TC0"
+        },
+        {
+            "id": "DC1",
+            "position": 180.0,
+            "track": "TC1"
+        },
+        {
+            "id": "DC5",
+            "position": 820.0,
+            "track": "TC1"
+        },
+        {
+            "id": "DC2",
+            "position": 180.0,
+            "track": "TC2"
+        },
+        {
+            "id": "DC6",
+            "position": 820.0,
+            "track": "TC2"
+        },
+        {
+            "id": "DC3",
+            "position": 180.0,
+            "track": "TC3"
+        },
+        {
+            "id": "DC7",
+            "position": 870.0,
+            "track": "TC3"
+        },
+        {
+            "id": "DD0",
+            "position": 180.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_1",
+            "position": 1737.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_2",
+            "position": 3275.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_3",
+            "position": 4812.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_4",
+            "position": 6350.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_5",
+            "position": 7887.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_6",
+            "position": 9425.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_7",
+            "position": 10962.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_8",
+            "position": 12500.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_9",
+            "position": 14037.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_10",
+            "position": 15575.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_11",
+            "position": 17112.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_12",
+            "position": 18650.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_13",
+            "position": 20187.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_14",
+            "position": 21725.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_15",
+            "position": 23262.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD2",
+            "position": 24820.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD1",
+            "position": 180.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_1",
+            "position": 1737.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_2",
+            "position": 3275.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_3",
+            "position": 4812.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_4",
+            "position": 6350.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_5",
+            "position": 7887.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_6",
+            "position": 9425.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_7",
+            "position": 10962.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_8",
+            "position": 12500.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_9",
+            "position": 14037.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_10",
+            "position": 15575.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_11",
+            "position": 17112.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_12",
+            "position": 18650.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_13",
+            "position": 20187.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_14",
+            "position": 21725.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_15",
+            "position": 23262.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD3",
+            "position": 24820.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD4",
+            "position": 180.0,
+            "track": "TD2"
+        },
+        {
+            "id": "DD6",
+            "position": 1820.0,
+            "track": "TD2"
+        },
+        {
+            "id": "DF0",
+            "position": 180.0,
+            "track": "TD3"
+        },
+        {
+            "id": "DH0",
+            "position": 2820.0,
+            "track": "TD3"
+        },
+        {
+            "id": "DE1",
+            "position": 180.0,
+            "track": "TE0"
+        },
+        {
+            "id": "DE0",
+            "position": 1320.0,
+            "track": "TE0"
+        },
+        {
+            "id": "DD5",
+            "position": 180.0,
+            "track": "TF1"
+        },
+        {
+            "id": "DF1_1",
+            "position": 2250.0,
+            "track": "TF1"
+        },
+        {
+            "id": "DE4",
+            "position": 180.0,
+            "track": "TE1"
+        },
+        {
+            "id": "DE2",
+            "position": 1820.0,
+            "track": "TE1"
+        },
+        {
+            "id": "DE5",
+            "position": 180.0,
+            "track": "TE2"
+        },
+        {
+            "id": "DE3",
+            "position": 1870.0,
+            "track": "TE2"
+        },
+        {
+            "id": "DE7",
+            "position": 180.0,
+            "track": "TE3"
+        },
+        {
+            "id": "DE6",
+            "position": 1820.0,
+            "track": "TE3"
+        },
+        {
+            "id": "DD7",
+            "position": 180.0,
+            "track": "TG0"
+        },
+        {
+            "id": "DG0",
+            "position": 820.0,
+            "track": "TG0"
+        },
+        {
+            "id": "DG1",
+            "position": 180.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG1_1",
+            "position": 2000.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG3",
+            "position": 3820.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG2",
+            "position": 180.0,
+            "track": "TG2"
+        },
+        {
+            "id": "DG4",
+            "position": 2820.0,
+            "track": "TG2"
+        },
+        {
+            "id": "DG7",
+            "position": 25.0,
+            "track": "TG3"
+        },
+        {
+            "id": "DG5",
+            "position": 180.0,
+            "track": "TG4"
+        },
+        {
+            "id": "DG6",
+            "position": 180.0,
+            "track": "TG5"
+        },
+        {
+            "id": "DH1",
+            "position": 180.0,
+            "track": "TH0"
+        },
+        {
+            "id": "DH2",
+            "position": 820.0,
+            "track": "TH0"
+        },
+        {
+            "id": "DH3",
+            "position": 180.0,
+            "track": "TH1"
+        },
+        {
+            "id": "DH1_1",
+            "position": 1800.0,
+            "track": "TH1"
+        },
+        {
+            "id": "DH1_2",
+            "position": 3400.0,
+            "track": "TH1"
+        }
+    ],
+    "electrifications": [
+        {
+            "id": "electrification_25k",
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 750.0,
+                    "track": "TI0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 650.0,
+                    "track": "TI1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2350.0,
+                    "track": "TI2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA6"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA7"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TB0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TD3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1500.0,
+                    "track": "TE0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3.0,
+                    "track": "TF0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 6500.0,
+                    "track": "TF1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2050.0,
+                    "track": "TE2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TG0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TG1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TG2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TG3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 5000.0,
+                    "track": "TH1"
+                }
+            ],
+            "voltage": "25000V"
+        },
+        {
+            "id": "electrification_1.5k",
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1750.0,
+                    "track": "TA0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 250.0,
+                    "track": "TI3"
+                }
+            ],
+            "voltage": "1500V"
+        }
+    ],
+    "extended_switch_types": [],
+    "level_crossings": [],
+    "neutral_sections": [
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 3500.0,
+                    "direction": "START_TO_STOP",
+                    "end": 4000.0,
+                    "track": "TG1"
+                }
+            ],
+            "id": "neutral_section.0",
+            "lower_pantograph": true,
+            "track_ranges": [
+                {
+                    "begin": 0.0,
+                    "direction": "START_TO_STOP",
+                    "end": 500.0,
+                    "track": "TG4"
+                },
+                {
+                    "begin": 0.0,
+                    "direction": "START_TO_STOP",
+                    "end": 10.0,
+                    "track": "TA6"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 100.0,
+                    "direction": "START_TO_STOP",
+                    "end": 210.0,
+                    "track": "TI3"
+                }
+            ],
+            "id": "neutral_section.1",
+            "lower_pantograph": true,
+            "track_ranges": [
+                {
+                    "begin": 210.0,
+                    "direction": "START_TO_STOP",
+                    "end": 250.0,
+                    "track": "TI3"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [],
+            "id": "neutral_section.2",
+            "lower_pantograph": false,
+            "track_ranges": [
+                {
+                    "begin": 8500.0,
+                    "direction": "START_TO_STOP",
+                    "end": 8600.0,
+                    "track": "TA6"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 240.0,
+                    "direction": "STOP_TO_START",
+                    "end": 250.0,
+                    "track": "TI3"
+                }
+            ],
+            "id": "neutral_section.3",
+            "lower_pantograph": false,
+            "track_ranges": [
+                {
+                    "begin": 100.0,
+                    "direction": "STOP_TO_START",
+                    "end": 240.0,
+                    "track": "TI3"
+                }
+            ]
+        }
+    ],
     "operational_points": [
         {
+            "extensions": {
+                "identifier": {
+                    "name": "North_West_station",
+                    "uic": 8799
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 99,
+                    "trigram": "NWS"
+                }
+            },
             "id": "North_West_station",
             "parts": [
                 {
-                    "track": "TI0",
+                    "local_track_name": "A",
                     "position": 300.0,
-                    "local_track_name": "A"
+                    "track": "TI0"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 99,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "NWS"
-                },
                 "identifier": {
                     "name": "North_West_station",
                     "uic": 8799
+                },
+                "sncf": {
+                    "ch": "BC",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BC",
+                    "ci": 99,
+                    "trigram": "NWS"
                 }
-            }
-        },
-        {
+            },
             "id": "North_West_station_1",
             "parts": [
                 {
-                    "track": "TI1",
+                    "local_track_name": "B",
                     "position": 250.0,
-                    "local_track_name": "B"
+                    "track": "TI1"
                 }
             ],
-            "weight": null,
             "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 99,
-                    "ch": "BC",
-                    "ch_short_label": "BC",
-                    "ch_long_label": "0",
-                    "trigram": "NWS"
-                },
-                "identifier": {
-                    "name": "North_West_station",
-                    "uic": 8799
-                }
-            }
+            "weight": null
         },
         {
-            "id": "West_station",
-            "parts": [
-                {
-                    "track": "TA0",
-                    "position": 699.99959,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TA1",
-                    "position": 500.0,
-                    "local_track_name": "V2"
-                },
-                {
-                    "track": "TA2",
-                    "position": 500.0,
-                    "local_track_name": "A"
-                }
-            ],
-            "weight": null,
-            "plc": null,
             "extensions": {
-                "sncf": {
-                    "ci": 22,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "WS"
-                },
                 "identifier": {
                     "name": "West_station",
                     "uic": 8722
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 22,
+                    "trigram": "WS"
                 }
-            }
-        },
-        {
-            "id": "South_West_station",
+            },
+            "id": "West_station",
             "parts": [
                 {
-                    "track": "TB0",
+                    "local_track_name": "V1",
+                    "position": 699.99959,
+                    "track": "TA0"
+                },
+                {
+                    "local_track_name": "V2",
                     "position": 500.0,
-                    "local_track_name": "A"
+                    "track": "TA1"
+                },
+                {
+                    "local_track_name": "A",
+                    "position": 500.0,
+                    "track": "TA2"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 11,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SWS"
-                },
                 "identifier": {
                     "name": "South_West_station",
                     "uic": 8711
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 11,
+                    "trigram": "SWS"
                 }
-            }
-        },
-        {
-            "id": "Mid_West_station",
+            },
+            "id": "South_West_station",
             "parts": [
                 {
-                    "track": "TC0",
-                    "position": 550.0,
-                    "local_track_name": "V1bis"
-                },
-                {
-                    "track": "TC1",
-                    "position": 550.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TC2",
-                    "position": 450.0,
-                    "local_track_name": "V2"
-                },
-                {
-                    "track": "TC3",
-                    "position": 450.0,
-                    "local_track_name": "V2bis"
+                    "local_track_name": "A",
+                    "position": 500.0,
+                    "track": "TB0"
                 }
             ],
-            "weight": 4,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 33,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "MWS"
-                },
                 "identifier": {
                     "name": "Mid_West_station",
                     "uic": 8733
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 33,
+                    "trigram": "MWS"
                 }
-            }
-        },
-        {
-            "id": "Mid_East_station",
+            },
+            "id": "Mid_West_station",
             "parts": [
                 {
-                    "track": "TD0",
-                    "position": 14000.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1bis",
+                    "position": 550.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TD1",
-                    "position": 14000.0,
-                    "local_track_name": "V2"
+                    "local_track_name": "V1",
+                    "position": 550.0,
+                    "track": "TC1"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 450.0,
+                    "track": "TC2"
+                },
+                {
+                    "local_track_name": "V2bis",
+                    "position": 450.0,
+                    "track": "TC3"
                 }
             ],
-            "weight": 10,
             "plc": null,
+            "weight": 4
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 44,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "MES"
-                },
                 "identifier": {
                     "name": "Mid_East_station",
                     "uic": 8744
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 44,
+                    "trigram": "MES"
                 }
-            }
-        },
-        {
-            "id": "North_station",
+            },
+            "id": "Mid_East_station",
             "parts": [
                 {
-                    "track": "TE1",
-                    "position": 1000.0,
-                    "local_track_name": "V1bis"
+                    "local_track_name": "V1",
+                    "position": 14000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TE2",
-                    "position": 1025.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V2",
+                    "position": 14000.0,
+                    "track": "TD1"
                 }
             ],
-            "weight": 3,
             "plc": null,
+            "weight": 10
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 55,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "NS"
-                },
                 "identifier": {
                     "name": "North_station",
                     "uic": 8755
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 55,
+                    "trigram": "NS"
                 }
-            }
-        },
-        {
-            "id": "South_station",
+            },
+            "id": "North_station",
             "parts": [
                 {
-                    "track": "TF1",
-                    "position": 4300.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1bis",
+                    "position": 1000.0,
+                    "track": "TE1"
+                },
+                {
+                    "local_track_name": "V1",
+                    "position": 1025.0,
+                    "track": "TE2"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": 3
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 66,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SS"
-                },
                 "identifier": {
                     "name": "South_station",
                     "uic": 8766
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 66,
+                    "trigram": "SS"
                 }
-            }
-        },
-        {
-            "id": "North_East_station",
+            },
+            "id": "South_station",
             "parts": [
                 {
-                    "track": "TG4",
-                    "position": 1550.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TG5",
-                    "position": 1500.0,
-                    "local_track_name": "V2"
+                    "local_track_name": "V1",
+                    "position": 4300.0,
+                    "track": "TF1"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 77,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "NES"
-                },
                 "identifier": {
                     "name": "North_East_station",
                     "uic": 8777
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 77,
+                    "trigram": "NES"
                 }
-            }
-        },
-        {
-            "id": "South_East_station",
+            },
+            "id": "North_East_station",
             "parts": [
                 {
-                    "track": "TH1",
-                    "position": 4400.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1",
+                    "position": 1550.0,
+                    "track": "TG4"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 1500.0,
+                    "track": "TG5"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 88,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SES"
-                },
                 "identifier": {
                     "name": "South_East_station",
                     "uic": 8788
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 88,
+                    "trigram": "SES"
                 }
-            }
+            },
+            "id": "South_East_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 4400.0,
+                    "track": "TH1"
+                }
+            ],
+            "plc": null,
+            "weight": null
         }
     ],
-    "level_crossings": [],
     "routes": [
         {
-            "id": "rt.buffer_stop.0->DI0",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DI0"
+                "id": "DI0",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.0->DI0",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DI0->DI2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DI0"
+                "id": "DI0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DI2"
+                "id": "DI2",
+                "type": "Detector"
             },
+            "id": "rt.DI0->DI2",
             "release_detectors": [],
             "switches_directions": {
                 "PI0": "A_B1"
             }
         },
         {
-            "id": "rt.buffer_stop.1->DI1",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DI1"
+                "id": "DI1",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.1->DI1",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DI1->DI2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DI1"
+                "id": "DI1",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DI2"
+                "id": "DI2",
+                "type": "Detector"
             },
+            "id": "rt.DI1->DI2",
             "release_detectors": [],
             "switches_directions": {
                 "PI0": "A_B2"
             }
         },
         {
-            "id": "rt.DI2->DA5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DI2"
+                "id": "DI2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
+            "id": "rt.DI2->DA5",
             "release_detectors": [],
             "switches_directions": {
                 "PI1": "A_B1",
@@ -372,46 +1205,46 @@
             }
         },
         {
-            "id": "rt.DI2->buffer_stop.2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DI2"
+                "id": "DI2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
             },
+            "id": "rt.DI2->buffer_stop.2",
             "release_detectors": [],
             "switches_directions": {
                 "PI1": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.2->DA2",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA2"
+                "id": "DA2",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.2->DA2",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA2->buffer_stop.1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA2"
+                "id": "DA2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
+            "id": "rt.DA2->buffer_stop.1",
             "release_detectors": [],
             "switches_directions": {
                 "PI1": "A_B2",
@@ -419,16 +1252,16 @@
             }
         },
         {
-            "id": "rt.DA2->buffer_stop.0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA2"
+                "id": "DA2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
             },
+            "id": "rt.DA2->buffer_stop.0",
             "release_detectors": [],
             "switches_directions": {
                 "PI1": "A_B2",
@@ -436,30 +1269,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop.3->DA0",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.3->DA0",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA0->DA5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
+            "id": "rt.DA0->DA5",
             "release_detectors": [],
             "switches_directions": {
                 "PA0": "A_B1",
@@ -467,16 +1300,16 @@
             }
         },
         {
-            "id": "rt.DA0->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DA0->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA0": "A_B2",
@@ -484,30 +1317,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop.4->DA1",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.4"
+                "id": "buffer_stop.4",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA1"
+                "id": "DA1",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.4->DA1",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA1->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA1"
+                "id": "DA1",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DA1->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA1": "A_B2",
@@ -515,16 +1348,16 @@
             }
         },
         {
-            "id": "rt.DA3->buffer_stop.3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
+            "id": "rt.DA3->buffer_stop.3",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B1",
@@ -532,16 +1365,16 @@
             }
         },
         {
-            "id": "rt.DA3->buffer_stop.1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
+            "id": "rt.DA3->buffer_stop.1",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B2",
@@ -550,16 +1383,16 @@
             }
         },
         {
-            "id": "rt.DA3->buffer_stop.0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
             },
+            "id": "rt.DA3->buffer_stop.0",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B2",
@@ -568,48 +1401,48 @@
             }
         },
         {
-            "id": "rt.DA5->DC4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC4"
+                "id": "DC4",
+                "type": "Detector"
             },
+            "id": "rt.DA5->DC4",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B1"
             }
         },
         {
-            "id": "rt.DA5->DC5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC5"
+                "id": "DC5",
+                "type": "Detector"
             },
+            "id": "rt.DA5->DC5",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B2"
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.4"
+                "id": "buffer_stop.4",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.4",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B1",
@@ -617,16 +1450,16 @@
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.5"
+                "id": "buffer_stop.5",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.5",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B1",
@@ -634,16 +1467,16 @@
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.3",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B2",
@@ -651,62 +1484,62 @@
             }
         },
         {
-            "id": "rt.DA6->DC6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC6"
+                "id": "DC6",
+                "type": "Detector"
             },
+            "id": "rt.DA6->DC6",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B1"
             }
         },
         {
-            "id": "rt.DA6->DC7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC7"
+                "id": "DC7",
+                "type": "Detector"
             },
+            "id": "rt.DA6->DC7",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.5->DB0",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.5"
+                "id": "buffer_stop.5",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DB0"
+                "id": "DB0",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.5->DB0",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DB0->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DB0"
+                "id": "DB0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DB0->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA1": "A_B1",
@@ -714,368 +1547,368 @@
             }
         },
         {
-            "id": "rt.DC0->DA3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC0"
+                "id": "DC0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
+            "id": "rt.DC0->DA3",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B1"
             }
         },
         {
-            "id": "rt.DC4->DD2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC4"
+                "id": "DC4",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
+            "id": "rt.DC4->DD2",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B2"
             }
         },
         {
-            "id": "rt.DC1->DA3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC1"
+                "id": "DC1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
+            "id": "rt.DC1->DA3",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B2"
             }
         },
         {
-            "id": "rt.DC5->DD2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC5"
+                "id": "DC5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
+            "id": "rt.DC5->DD2",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B1"
             }
         },
         {
-            "id": "rt.DC2->DA4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC2"
+                "id": "DC2",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
+            "id": "rt.DC2->DA4",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B1"
             }
         },
         {
-            "id": "rt.DC6->DD3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC6"
+                "id": "DC6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
+            "id": "rt.DC6->DD3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B2"
             }
         },
         {
-            "id": "rt.DC3->DA4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC3"
+                "id": "DC3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
+            "id": "rt.DC3->DA4",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B2"
             }
         },
         {
-            "id": "rt.DC7->DD3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC7"
+                "id": "DC7",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
+            "id": "rt.DC7->DD3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B1"
             }
         },
         {
-            "id": "rt.DD0->DC1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC1"
+                "id": "DC1",
+                "type": "Detector"
             },
+            "id": "rt.DD0->DC1",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B1"
             }
         },
         {
-            "id": "rt.DD0->DC0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC0"
+                "id": "DC0",
+                "type": "Detector"
             },
+            "id": "rt.DD0->DC0",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B2"
             }
         },
         {
-            "id": "rt.DD2->DD6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
+            "id": "rt.DD2->DD6",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC"
             }
         },
         {
-            "id": "rt.DD1->DC3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC3"
+                "id": "DC3",
+                "type": "Detector"
             },
+            "id": "rt.DD1->DC3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B1"
             }
         },
         {
-            "id": "rt.DD1->DC2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC2"
+                "id": "DC2",
+                "type": "Detector"
             },
+            "id": "rt.DD1->DC2",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B2"
             }
         },
         {
-            "id": "rt.DD3->DH0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
+            "id": "rt.DD3->DH0",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC"
             }
         },
         {
-            "id": "rt.DD4->DD0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
+            "id": "rt.DD4->DD0",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC"
             }
         },
         {
-            "id": "rt.DD6->DE6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
+            "id": "rt.DD6->DE6",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B1"
             }
         },
         {
-            "id": "rt.DD6->DG0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
+            "id": "rt.DD6->DG0",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B2"
             }
         },
         {
-            "id": "rt.DF0->DD1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
+            "id": "rt.DF0->DD1",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC"
             }
         },
         {
-            "id": "rt.DH0->DG3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
+            "id": "rt.DH0->DG3",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B2"
             }
         },
         {
-            "id": "rt.DH0->DH2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
+            "id": "rt.DH0->DH2",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B2"
             }
         },
         {
-            "id": "rt.DE1->DE4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE4"
+                "id": "DE4",
+                "type": "Detector"
             },
+            "id": "rt.DE1->DE4",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B1"
             }
         },
         {
-            "id": "rt.DE1->DE5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE5"
+                "id": "DE5",
+                "type": "Detector"
             },
+            "id": "rt.DE1->DE5",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B2"
             }
         },
         {
-            "id": "rt.DE0->buffer_stop.6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
+            "id": "rt.DE0->buffer_stop.6",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC",
@@ -1083,30 +1916,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop.6->DD5",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD5"
+                "id": "DD5",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.6->DD5",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DD5->DE1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD5"
+                "id": "DD5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
+            "id": "rt.DD5->DE1",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC",
@@ -1114,224 +1947,224 @@
             }
         },
         {
-            "id": "rt.DE4->DE7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE4"
+                "id": "DE4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
+            "id": "rt.DE4->DE7",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B2"
             }
         },
         {
-            "id": "rt.DE2->DE0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE2"
+                "id": "DE2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
+            "id": "rt.DE2->DE0",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B1"
             }
         },
         {
-            "id": "rt.DE5->DE7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE5"
+                "id": "DE5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
+            "id": "rt.DE5->DE7",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B1"
             }
         },
         {
-            "id": "rt.DE3->DE0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE3"
+                "id": "DE3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
+            "id": "rt.DE3->DE0",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B2"
             }
         },
         {
-            "id": "rt.DE7->DD4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
+            "id": "rt.DE7->DD4",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B1"
             }
         },
         {
-            "id": "rt.DE6->DE3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE3"
+                "id": "DE3",
+                "type": "Detector"
             },
+            "id": "rt.DE6->DE3",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B1"
             }
         },
         {
-            "id": "rt.DE6->DE2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE2"
+                "id": "DE2",
+                "type": "Detector"
             },
+            "id": "rt.DE6->DE2",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B2"
             }
         },
         {
-            "id": "rt.DD7->DD4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
+            "id": "rt.DD7->DD4",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B2"
             }
         },
         {
-            "id": "rt.DG0->DG3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
+            "id": "rt.DG0->DG3",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B1"
             }
         },
         {
-            "id": "rt.DG0->DH2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
+            "id": "rt.DG0->DH2",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B1"
             }
         },
         {
-            "id": "rt.DG1->DD7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
+            "id": "rt.DG1->DD7",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B1"
             }
         },
         {
-            "id": "rt.DG1->DF0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
+            "id": "rt.DG1->DF0",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B2"
             }
         },
         {
-            "id": "rt.DG3->buffer_stop.7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.7"
+                "id": "buffer_stop.7",
+                "type": "BufferStop"
             },
+            "id": "rt.DG3->buffer_stop.7",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B1"
             }
         },
         {
-            "id": "rt.DG3->buffer_stop.8",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.8"
+                "id": "buffer_stop.8",
+                "type": "BufferStop"
             },
+            "id": "rt.DG3->buffer_stop.8",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B2",
@@ -1339,108 +2172,108 @@
             }
         },
         {
-            "id": "rt.DG2->DH1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG2"
+                "id": "DG2",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
+            "id": "rt.DG2->DH1",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B1"
             }
         },
         {
-            "id": "rt.DG4->buffer_stop.8",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG4"
+                "id": "DG4",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.8"
+                "id": "buffer_stop.8",
+                "type": "BufferStop"
             },
+            "id": "rt.DG4->buffer_stop.8",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B1"
             }
         },
         {
-            "id": "rt.buffer_stop.7->DG5",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.7"
+                "id": "buffer_stop.7",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG5"
+                "id": "DG5",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.7->DG5",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DG5->DG1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG5"
+                "id": "DG5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
+            "id": "rt.DG5->DG1",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B1"
             }
         },
         {
-            "id": "rt.buffer_stop.8->DG6",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.8"
+                "id": "buffer_stop.8",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.8->DG6",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DG6->DG2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG2"
+                "id": "DG2",
+                "type": "Detector"
             },
+            "id": "rt.DG6->DG2",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B1"
             }
         },
         {
-            "id": "rt.DG6->DG1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
+            "id": "rt.DG6->DG1",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B2",
@@ -1448,106 +2281,3314 @@
             }
         },
         {
-            "id": "rt.DH1->DD7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
+            "id": "rt.DH1->DD7",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B1"
             }
         },
         {
-            "id": "rt.DH1->DF0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
+            "id": "rt.DH1->DF0",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B2"
             }
         },
         {
-            "id": "rt.DH2->DG4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG4"
+                "id": "DG4",
+                "type": "Detector"
             },
+            "id": "rt.DH2->DG4",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B1"
             }
         },
         {
-            "id": "rt.DH2->buffer_stop.9",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.9"
+                "id": "buffer_stop.9",
+                "type": "BufferStop"
             },
+            "id": "rt.DH2->buffer_stop.9",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.9->DH3",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.9"
+                "id": "buffer_stop.9",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH3"
+                "id": "DH3",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.9->DH3",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DH3->DH1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH3"
+                "id": "DH3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
+            "id": "rt.DH3->DH1",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B2"
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SI0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SI0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 550.0,
+            "sight_distance": 400.0,
+            "track": "TI0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SI1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SI1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 450.0,
+            "sight_distance": 400.0,
+            "track": "TI1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SI2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SI2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2150.0,
+            "sight_distance": 400.0,
+            "track": "TI2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1550.0,
+            "sight_distance": 400.0,
+            "track": "TA0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1750.0,
+            "sight_distance": 400.0,
+            "track": "TA1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1750.0,
+            "sight_distance": 400.0,
+            "track": "TA2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1780.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 4980.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6580.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8180.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8220.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9800.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1820.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 5020.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6620.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8180.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8220.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9800.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SB0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SB0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TB0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 850.0,
+            "sight_distance": 400.0,
+            "track": "TC0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TC1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TC2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 850.0,
+            "sight_distance": 400.0,
+            "track": "TC3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1717.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3255.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3295.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 4792.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6330.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7867.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7907.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9405.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 10942.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_8",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_8",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12480.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_8r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_8r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12520.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_9",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_9",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 14017.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_10",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_10",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 15555.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_11",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_11",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17092.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_11r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_11r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17132.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_12",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_12",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 18630.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_13",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_13",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 20167.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_14",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_14",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21705.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_14r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_14r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21745.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_15",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_15",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 23242.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 24800.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1757.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3255.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3295.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 4832.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6370.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7867.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7907.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9445.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 10982.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_8r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_8r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12480.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_8",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_8",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12520.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_9",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_9",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 14057.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_10",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_10",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 15595.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_11r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_11r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17092.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_11",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_11",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17132.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_12",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_12",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 18670.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_13",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_13",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 20207.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_14r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_14r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21705.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_14",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_14",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21745.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_15",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_15",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 23282.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 24800.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TD2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TD3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1300.0,
+            "sight_distance": 400.0,
+            "track": "TE0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2230.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2270.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TE1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1850.0,
+            "sight_distance": 400.0,
+            "track": "TE2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TE3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TG0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1980.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2020.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3800.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TG2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG4"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG5"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TH0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TH0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1780.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1820.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        }
+    ],
+    "speed_sections": [
+        {
+            "id": "speed_section.0",
+            "on_routes": null,
+            "speed_limit": 83.33333333333333,
+            "speed_limit_by_tag": {
+                "HLP": 69.44444444444444
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 750.0,
+                    "track": "TI0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 650.0,
+                    "track": "TI1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2350.0,
+                    "track": "TI2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 250.0,
+                    "track": "TI3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1750.0,
+                    "track": "TA0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA6"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA7"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TB0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TD3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1500.0,
+                    "track": "TE0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3.0,
+                    "track": "TF0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 6500.0,
+                    "track": "TF1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2050.0,
+                    "track": "TE2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TG0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TG1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TG2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TG3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 5000.0,
+                    "track": "TH1"
+                }
+            ]
+        },
+        {
+            "id": "speed_section.1",
+            "on_routes": null,
+            "speed_limit": 39.44444444444444,
+            "speed_limit_by_tag": {
+                "E32C": 27.77777777777778
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 500.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TH1"
+                }
+            ]
+        },
+        {
+            "id": "speed_section.2",
+            "on_routes": null,
+            "speed_limit": 31.11111111111111,
+            "speed_limit_by_tag": {
+                "MA100": 22.22222222222222
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 3500.0,
+                    "end": 4400.0,
+                    "track": "TH1"
+                }
+            ]
+        }
+    ],
     "switches": [
         {
-            "id": "PI0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PI0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PI0",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1562,16 +5603,16 @@
                     "track": "TI1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PI0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PI1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PI1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PI1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1586,16 +5627,16 @@
                     "track": "TA0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PI1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1610,16 +5651,16 @@
                     "track": "TA4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA1",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1634,16 +5675,16 @@
                     "track": "TA2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA2",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1658,16 +5699,16 @@
                     "track": "TI3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA3",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA3",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1682,16 +5723,16 @@
                     "track": "TA4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA3"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1706,16 +5747,16 @@
                     "track": "TC1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1730,16 +5771,16 @@
                     "track": "TC3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC2",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1754,16 +5795,16 @@
                     "track": "TC0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC3",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC3",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1778,16 +5819,16 @@
                     "track": "TC2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC3"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PD0",
-            "switch_type": "crossing",
+            "extensions": {
+                "sncf": {
+                    "label": "PD0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PD0",
             "ports": {
                 "A1": {
                     "endpoint": "END",
@@ -1806,16 +5847,16 @@
                     "track": "TD2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PD0"
-                }
-            }
+            "switch_type": "crossing"
         },
         {
-            "id": "PD1",
-            "switch_type": "crossing",
+            "extensions": {
+                "sncf": {
+                    "label": "PD1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PD1",
             "ports": {
                 "A1": {
                     "endpoint": "END",
@@ -1834,16 +5875,16 @@
                     "track": "TD3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PD1"
-                }
-            }
+            "switch_type": "crossing"
         },
         {
-            "id": "PE0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE0",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1858,16 +5899,16 @@
                     "track": "TE2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PE1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1882,16 +5923,16 @@
                     "track": "TE1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PE2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE2",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1906,16 +5947,16 @@
                     "track": "TG0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PG0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PG0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PG0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1930,16 +5971,16 @@
                     "track": "TG3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PG0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PG1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PG1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PG1",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1954,16 +5995,16 @@
                     "track": "TG3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PG1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PH0",
-            "switch_type": "double_slip_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PH0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PH0",
             "ports": {
                 "A1": {
                     "endpoint": "BEGIN",
@@ -1982,16 +6023,16 @@
                     "track": "TD3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PH0"
-                }
-            }
+            "switch_type": "double_slip_switch"
         },
         {
-            "id": "PH1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PH1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PH1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -2006,17 +6047,21 @@
                     "track": "TH1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PH1"
-                }
-            }
+            "switch_type": "point_switch"
         }
     ],
     "track_sections": [
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 404040,
+                    "line_name": "North_West_Parking",
+                    "track_name": "A",
+                    "track_number": 2
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.399905989,
@@ -2030,25 +6075,25 @@
                         -0.390308459,
                         49.510052494
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TI0",
             "length": 750.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 404040,
                     "line_name": "North_West_Parking",
-                    "track_number": 2,
-                    "track_name": "A"
+                    "track_name": "B",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.399908223,
@@ -2058,25 +6103,25 @@
                         -0.390308459,
                         49.510052494
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TI1",
             "length": 650.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 404040,
                     "line_name": "North_West_Parking",
-                    "track_number": 1,
-                    "track_name": "B"
+                    "track_name": "A-B",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.390308459,
@@ -2094,25 +6139,25 @@
                         -0.37,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TI2",
             "length": 2350.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 404040,
-                    "line_name": "North_West_Parking",
-                    "track_number": 1,
-                    "track_name": "A-B"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 424242,
+                    "line_name": "West_parking",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -2122,31 +6167,31 @@
                         -0.365,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TI3",
             "length": 250.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [
                 {
-                    "category": "GA",
                     "begin": 0.0,
+                    "category": "GA",
                     "end": 150.0
                 }
             ],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -2156,41 +6201,41 @@
                         -0.37,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA0",
             "length": 1750.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [
                 {
-                    "category": "GB",
                     "begin": 0.0,
+                    "category": "GB",
                     "end": 200.0
                 },
                 {
-                    "category": "GA",
                     "begin": 200.0,
+                    "category": "GA",
                     "end": 1750.0
                 },
                 {
-                    "category": "GB",
                     "begin": 100.0,
+                    "category": "GB",
                     "end": 1500.0
                 }
             ],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -2200,25 +6245,25 @@
                         -0.37,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA1",
             "length": 1950.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "A",
+                    "track_number": 3
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -2228,25 +6273,25 @@
                         -0.37,
                         49.49979999999999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA2",
             "length": 1950.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 3,
-                    "track_name": "A"
+                    "track_name": "J1",
+                    "track_number": 4
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -2256,25 +6301,25 @@
                         -0.365,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA3",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 4,
-                    "track_name": "J1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -2284,25 +6329,25 @@
                         -0.365,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA4",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "J2",
+                    "track_number": 3
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -2312,25 +6357,25 @@
                         -0.365,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA5",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 424242,
-                    "line_name": "West_parking",
-                    "track_number": 3,
-                    "track_name": "J2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -2340,56 +6385,56 @@
                         -0.31,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA6",
             "length": 10000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": -3.0,
                     "begin": 4000.0,
-                    "end": 4300.0
+                    "end": 4300.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 4300.0,
-                    "end": 4700.0
+                    "end": 4700.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 4700.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7000.0,
-                    "end": 7300.0
+                    "end": 7300.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7300.0,
-                    "end": 7700.0
+                    "end": 7700.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7700.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -2399,56 +6444,56 @@
                         -0.31,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA7",
             "length": 10000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": -3.0,
                     "begin": 4000.0,
-                    "end": 4300.0
+                    "end": 4300.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 4300.0,
-                    "end": 4700.0
+                    "end": 4700.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 4700.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7000.0,
-                    "end": 7300.0
+                    "end": 7300.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7300.0,
-                    "end": 7700.0
+                    "end": 7700.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7700.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 3.0
                 }
-            ],
-            "curves": [],
-            "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            ]
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 414141,
+                    "line_name": "South_West_Parking",
+                    "track_name": "A",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -2466,25 +6511,25 @@
                         -0.37,
                         49.49979999999999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TB0",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 414141,
-                    "line_name": "South_West_Parking",
-                    "track_number": 1,
-                    "track_name": "A"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1bis",
+                    "track_number": 3
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2502,25 +6547,25 @@
                         -0.296,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC0",
             "length": 1050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 3,
-                    "track_name": "V1bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2530,25 +6575,25 @@
                         -0.296,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC1",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2558,25 +6603,25 @@
                         -0.296,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC2",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "V2bis",
+                    "track_number": 4
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2594,25 +6639,25 @@
                         -0.296,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC3",
             "length": 1050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 4,
-                    "track_name": "V2bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.296,
@@ -2622,56 +6667,56 @@
                         -0.172,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD0",
             "length": 25000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 3.0,
                     "begin": 6000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 8000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 14000.0,
-                    "end": 15000.0
+                    "end": 15000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 15000.0,
-                    "end": 16000.0
+                    "end": 16000.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 16000.0,
-                    "end": 17000.0
+                    "end": 17000.0,
+                    "gradient": -3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.296,
@@ -2681,56 +6726,56 @@
                         -0.172,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD1",
             "length": 25000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 3.0,
                     "begin": 6000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 8000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 14000.0,
-                    "end": 15000.0
+                    "end": 15000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 15000.0,
-                    "end": 16000.0
+                    "end": 16000.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 16000.0,
-                    "end": 17000.0
+                    "end": 17000.0,
+                    "gradient": -3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2740,25 +6785,25 @@
                         -0.15,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD2",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2772,25 +6817,36 @@
                         -0.135,
                         49.49995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD3",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [
+                {
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 6000.0
+                },
+                {
+                    "begin": 500.0,
+                    "end": 1000.0,
+                    "radius": 8000.0
+                }
+            ],
+            "extensions": {
+                "sncf": {
+                    "line_code": 444444,
+                    "line_name": "North_to_South_loop",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.165,
@@ -2804,36 +6860,25 @@
                         -0.172,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE0",
             "length": 1500.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 6000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 8000.0,
-                    "begin": 500.0,
-                    "end": 1000.0
-                }
-            ],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2843,25 +6888,31 @@
                         -0.172,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TF0",
             "length": 3.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [
+                {
+                    "begin": 3100.0,
+                    "end": 4400.0,
+                    "radius": 9500.0
+                }
+            ],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2879,31 +6930,36 @@
                         -0.135,
                         49.466
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TF1",
             "length": 6500.0,
-            "slopes": [],
+            "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
             "curves": [
                 {
-                    "radius": 9500.0,
-                    "begin": 3100.0,
-                    "end": 4400.0
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 5000.0
+                },
+                {
+                    "begin": 1700.0,
+                    "end": 2000.0,
+                    "radius": 6000.0
                 }
             ],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1bis",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2921,36 +6977,25 @@
                         -0.165,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE1",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 5000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 6000.0,
-                    "begin": 1700.0,
-                    "end": 2000.0
-                }
-            ],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 2,
-                    "track_name": "V1bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2960,25 +7005,46 @@
                         -0.165,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE2",
             "length": 2050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [
+                {
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 5000.0
+                },
+                {
+                    "begin": 650.0,
+                    "end": 850.0,
+                    "radius": 9000.0
+                },
+                {
+                    "begin": 1150.0,
+                    "end": 1350.0,
+                    "radius": 8000.0
+                },
+                {
+                    "begin": 1700.0,
+                    "end": 2000.0,
+                    "radius": 7000.0
+                }
+            ],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2996,46 +7062,25 @@
                         -0.15,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE3",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 5000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 9000.0,
-                    "begin": 650.0,
-                    "end": 850.0
-                },
-                {
-                    "radius": 8000.0,
-                    "begin": 1150.0,
-                    "end": 1350.0
-                },
-                {
-                    "radius": 7000.0,
-                    "begin": 1700.0,
-                    "end": 2000.0
-                }
-            ],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 444444,
-                    "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -3049,25 +7094,25 @@
                         -0.135,
                         49.49995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG0",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 454545,
+                    "line_name": "North_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.135,
@@ -3097,25 +7142,25 @@
                         -0.1082,
                         49.513
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG1",
             "length": 4000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 454545,
                     "line_name": "North_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -3141,25 +7186,25 @@
                         -0.108,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG2",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 454545,
-                    "line_name": "North_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 464646,
+                    "line_name": "North_East_parking",
+                    "track_name": "J4",
+                    "track_number": 3
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1082,
@@ -3169,25 +7214,25 @@
                         -0.108,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG3",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
                     "line_name": "North_East_parking",
-                    "track_number": 3,
-                    "track_name": "J4"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1082,
@@ -3197,25 +7242,25 @@
                         -0.09,
                         49.513
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG4",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
                     "line_name": "North_East_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.108,
@@ -3225,25 +7270,25 @@
                         -0.09,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG5",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 464646,
-                    "line_name": "North_East_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V2",
+                    "track_number": 2
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.135,
@@ -3257,25 +7302,25 @@
                         -0.12,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TH0",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 474647,
+                    "line_name": "South_East_parking",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -3297,4059 +7342,14 @@
                         -0.09,
                         49.484
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TH1",
             "length": 5000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 474647,
-                    "line_name": "South_East_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         }
     ],
-    "speed_sections": [
-        {
-            "id": "speed_section.0",
-            "speed_limit": 83.33333333333333,
-            "speed_limit_by_tag": {
-                "HLP": 69.44444444444444
-            },
-            "track_ranges": [
-                {
-                    "track": "TI0",
-                    "begin": 0.0,
-                    "end": 750.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TI1",
-                    "begin": 0.0,
-                    "end": 650.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TI2",
-                    "begin": 0.0,
-                    "end": 2350.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TI3",
-                    "begin": 0.0,
-                    "end": 250.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA0",
-                    "begin": 0.0,
-                    "end": 1750.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA1",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA2",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA4",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA5",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA7",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TB0",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC0",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC1",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC2",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC3",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD0",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE0",
-                    "begin": 0.0,
-                    "end": 1500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF0",
-                    "begin": 0.0,
-                    "end": 3.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF1",
-                    "begin": 0.0,
-                    "end": 6500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE1",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE2",
-                    "begin": 0.0,
-                    "end": 2050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE3",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG2",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG5",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 5000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "speed_section.1",
-            "speed_limit": 39.44444444444444,
-            "speed_limit_by_tag": {
-                "E32C": 27.77777777777778
-            },
-            "track_ranges": [
-                {
-                    "track": "TH0",
-                    "begin": 500.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "speed_section.2",
-            "speed_limit": 31.11111111111111,
-            "speed_limit_by_tag": {
-                "MA100": 22.22222222222222
-            },
-            "track_ranges": [
-                {
-                    "track": "TH1",
-                    "begin": 3500.0,
-                    "end": 4400.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        }
-    ],
-    "electrifications": [
-        {
-            "id": "electrification_25k",
-            "voltage": "25000V",
-            "track_ranges": [
-                {
-                    "track": "TI0",
-                    "begin": 0.0,
-                    "end": 750.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TI1",
-                    "begin": 0.0,
-                    "end": 650.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TI2",
-                    "begin": 0.0,
-                    "end": 2350.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA1",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA2",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA4",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA5",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA7",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TB0",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC0",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC1",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC2",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC3",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD0",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE0",
-                    "begin": 0.0,
-                    "end": 1500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF0",
-                    "begin": 0.0,
-                    "end": 3.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF1",
-                    "begin": 0.0,
-                    "end": 6500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE1",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE2",
-                    "begin": 0.0,
-                    "end": 2050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE3",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG2",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG5",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 5000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ]
-        },
-        {
-            "id": "electrification_1.5k",
-            "voltage": "1500V",
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 0.0,
-                    "end": 1750.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TI3",
-                    "begin": 0.0,
-                    "end": 250.0,
-                    "applicable_directions": "BOTH"
-                }
-            ]
-        }
-    ],
-    "signals": [
-        {
-            "track": "TI0",
-            "position": 550.0,
-            "id": "SI0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SI0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TI1",
-            "position": 450.0,
-            "id": "SI1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SI1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TI2",
-            "position": 2150.0,
-            "id": "SI2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SI2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA0",
-            "position": 1550.0,
-            "id": "SA2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA1",
-            "position": 1750.0,
-            "id": "SA0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA2",
-            "position": 1750.0,
-            "id": "SA1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 200.0,
-            "id": "SA3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 1780.0,
-            "id": "SA6_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 3380.0,
-            "id": "SA6_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 3420.0,
-            "id": "SA6_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 4980.0,
-            "id": "SA6_3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 6580.0,
-            "id": "SA6_4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 8180.0,
-            "id": "SA6_5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 8220.0,
-            "id": "SA6_5r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 9800.0,
-            "id": "SA5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 200.0,
-            "id": "SA4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 1820.0,
-            "id": "SA7_1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 3380.0,
-            "id": "SA7_2r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 3420.0,
-            "id": "SA7_2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 5020.0,
-            "id": "SA7_3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 6620.0,
-            "id": "SA7_4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 8180.0,
-            "id": "SA7_5r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 8220.0,
-            "id": "SA7_5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 9800.0,
-            "id": "SA6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TB0",
-            "position": 2800.0,
-            "id": "SB0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SB0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC0",
-            "position": 200.0,
-            "id": "SC0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC0",
-            "position": 850.0,
-            "id": "SC4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC1",
-            "position": 200.0,
-            "id": "SC1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC1",
-            "position": 800.0,
-            "id": "SC5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC2",
-            "position": 200.0,
-            "id": "SC2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC2",
-            "position": 800.0,
-            "id": "SC6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC3",
-            "position": 200.0,
-            "id": "SC3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC3",
-            "position": 850.0,
-            "id": "SC7",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 200.0,
-            "id": "SD0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 1717.5,
-            "id": "SD0_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 3255.0,
-            "id": "SD0_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 3295.0,
-            "id": "SD0_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 4792.5,
-            "id": "SD0_3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 6330.0,
-            "id": "SD0_4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 7867.5,
-            "id": "SD0_5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 7907.5,
-            "id": "SD0_5r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 9405.0,
-            "id": "SD0_6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 10942.5,
-            "id": "SD0_7",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 12480.0,
-            "id": "SD0_8",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_8",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 12520.0,
-            "id": "SD0_8r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_8r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 14017.5,
-            "id": "SD0_9",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_9",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 15555.0,
-            "id": "SD0_10",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_10",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 17092.5,
-            "id": "SD0_11",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_11",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 17132.5,
-            "id": "SD0_11r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_11r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 18630.0,
-            "id": "SD0_12",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_12",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 20167.5,
-            "id": "SD0_13",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_13",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 21705.0,
-            "id": "SD0_14",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_14",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 21745.0,
-            "id": "SD0_14r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_14r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 23242.5,
-            "id": "SD0_15",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_15",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 24800.0,
-            "id": "SD2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 200.0,
-            "id": "SD1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 1757.5,
-            "id": "SD1_1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 3255.0,
-            "id": "SD1_2r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 3295.0,
-            "id": "SD1_2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 4832.5,
-            "id": "SD1_3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 6370.0,
-            "id": "SD1_4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 7867.5,
-            "id": "SD1_5r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 7907.5,
-            "id": "SD1_5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 9445.0,
-            "id": "SD1_6",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 10982.5,
-            "id": "SD1_7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 12480.0,
-            "id": "SD1_8r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_8r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 12520.0,
-            "id": "SD1_8",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_8",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 14057.5,
-            "id": "SD1_9",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_9",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 15595.0,
-            "id": "SD1_10",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_10",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 17092.5,
-            "id": "SD1_11r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_11r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 17132.5,
-            "id": "SD1_11",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_11",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 18670.0,
-            "id": "SD1_12",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_12",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 20207.5,
-            "id": "SD1_13",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_13",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 21705.0,
-            "id": "SD1_14r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_14r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 21745.0,
-            "id": "SD1_14",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_14",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 23282.5,
-            "id": "SD1_15",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_15",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 24800.0,
-            "id": "SD3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD2",
-            "position": 200.0,
-            "id": "SD4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD2",
-            "position": 1800.0,
-            "id": "SD6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD3",
-            "position": 200.0,
-            "id": "SF0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD3",
-            "position": 2800.0,
-            "id": "SH0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE0",
-            "position": 200.0,
-            "id": "SE1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE0",
-            "position": 1300.0,
-            "id": "SE0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 200.0,
-            "id": "SD5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 2230.0,
-            "id": "SF1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 2270.0,
-            "id": "SF1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE1",
-            "position": 200.0,
-            "id": "SE4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE1",
-            "position": 1800.0,
-            "id": "SE2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE2",
-            "position": 200.0,
-            "id": "SE5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE2",
-            "position": 1850.0,
-            "id": "SE3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE3",
-            "position": 200.0,
-            "id": "SE7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE3",
-            "position": 1800.0,
-            "id": "SE6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG0",
-            "position": 200.0,
-            "id": "SD7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG0",
-            "position": 800.0,
-            "id": "SG0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 200.0,
-            "id": "SG1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 1980.0,
-            "id": "SG1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 2020.0,
-            "id": "SG1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 3800.0,
-            "id": "SG3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG2",
-            "position": 200.0,
-            "id": "SG2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG2",
-            "position": 2800.0,
-            "id": "SG4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG4",
-            "position": 200.0,
-            "id": "SG5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG5",
-            "position": 200.0,
-            "id": "SG6",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH0",
-            "position": 200.0,
-            "id": "SH1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH0",
-            "position": 800.0,
-            "id": "SH2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 200.0,
-            "id": "SH3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 1780.0,
-            "id": "SH1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 1820.0,
-            "id": "SH1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 3380.0,
-            "id": "SH1_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 3420.0,
-            "id": "SH1_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "TI0",
-            "position": 0.0,
-            "id": "buffer_stop.0"
-        },
-        {
-            "track": "TI1",
-            "position": 0.0,
-            "id": "buffer_stop.1"
-        },
-        {
-            "track": "TA0",
-            "position": 0.0,
-            "id": "buffer_stop.2"
-        },
-        {
-            "track": "TA1",
-            "position": 0.0,
-            "id": "buffer_stop.3"
-        },
-        {
-            "track": "TA2",
-            "position": 0.0,
-            "id": "buffer_stop.4"
-        },
-        {
-            "track": "TB0",
-            "position": 0.0,
-            "id": "buffer_stop.5"
-        },
-        {
-            "track": "TF1",
-            "position": 6500.0,
-            "id": "buffer_stop.6"
-        },
-        {
-            "track": "TG4",
-            "position": 2000.0,
-            "id": "buffer_stop.7"
-        },
-        {
-            "track": "TG5",
-            "position": 2000.0,
-            "id": "buffer_stop.8"
-        },
-        {
-            "track": "TH1",
-            "position": 5000.0,
-            "id": "buffer_stop.9"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "TI0",
-            "position": 570.0,
-            "id": "DI0"
-        },
-        {
-            "track": "TI1",
-            "position": 470.0,
-            "id": "DI1"
-        },
-        {
-            "track": "TI2",
-            "position": 2170.0,
-            "id": "DI2"
-        },
-        {
-            "track": "TI3",
-            "position": 125.0,
-            "id": "DI3"
-        },
-        {
-            "track": "TA0",
-            "position": 1570.0,
-            "id": "DA2"
-        },
-        {
-            "track": "TA1",
-            "position": 1770.0,
-            "id": "DA0"
-        },
-        {
-            "track": "TA2",
-            "position": 1770.0,
-            "id": "DA1"
-        },
-        {
-            "track": "TA3",
-            "position": 25.0,
-            "id": "DA7"
-        },
-        {
-            "track": "TA4",
-            "position": 25.0,
-            "id": "DA8"
-        },
-        {
-            "track": "TA5",
-            "position": 25.0,
-            "id": "DA9"
-        },
-        {
-            "track": "TA6",
-            "position": 180.0,
-            "id": "DA3"
-        },
-        {
-            "track": "TA6",
-            "position": 1800.0,
-            "id": "DA6_1"
-        },
-        {
-            "track": "TA6",
-            "position": 3400.0,
-            "id": "DA6_2"
-        },
-        {
-            "track": "TA6",
-            "position": 5000.0,
-            "id": "DA6_3"
-        },
-        {
-            "track": "TA6",
-            "position": 6600.0,
-            "id": "DA6_4"
-        },
-        {
-            "track": "TA6",
-            "position": 8200.0,
-            "id": "DA6_5"
-        },
-        {
-            "track": "TA6",
-            "position": 9820.0,
-            "id": "DA5"
-        },
-        {
-            "track": "TA7",
-            "position": 180.0,
-            "id": "DA4"
-        },
-        {
-            "track": "TA7",
-            "position": 1800.0,
-            "id": "DA7_1"
-        },
-        {
-            "track": "TA7",
-            "position": 3400.0,
-            "id": "DA7_2"
-        },
-        {
-            "track": "TA7",
-            "position": 5000.0,
-            "id": "DA7_3"
-        },
-        {
-            "track": "TA7",
-            "position": 6600.0,
-            "id": "DA7_4"
-        },
-        {
-            "track": "TA7",
-            "position": 8200.0,
-            "id": "DA7_5"
-        },
-        {
-            "track": "TA7",
-            "position": 9820.0,
-            "id": "DA6"
-        },
-        {
-            "track": "TB0",
-            "position": 2820.0,
-            "id": "DB0"
-        },
-        {
-            "track": "TC0",
-            "position": 180.0,
-            "id": "DC0"
-        },
-        {
-            "track": "TC0",
-            "position": 870.0,
-            "id": "DC4"
-        },
-        {
-            "track": "TC1",
-            "position": 180.0,
-            "id": "DC1"
-        },
-        {
-            "track": "TC1",
-            "position": 820.0,
-            "id": "DC5"
-        },
-        {
-            "track": "TC2",
-            "position": 180.0,
-            "id": "DC2"
-        },
-        {
-            "track": "TC2",
-            "position": 820.0,
-            "id": "DC6"
-        },
-        {
-            "track": "TC3",
-            "position": 180.0,
-            "id": "DC3"
-        },
-        {
-            "track": "TC3",
-            "position": 870.0,
-            "id": "DC7"
-        },
-        {
-            "track": "TD0",
-            "position": 180.0,
-            "id": "DD0"
-        },
-        {
-            "track": "TD0",
-            "position": 1737.5,
-            "id": "DD0_1"
-        },
-        {
-            "track": "TD0",
-            "position": 3275.0,
-            "id": "DD0_2"
-        },
-        {
-            "track": "TD0",
-            "position": 4812.5,
-            "id": "DD0_3"
-        },
-        {
-            "track": "TD0",
-            "position": 6350.0,
-            "id": "DD0_4"
-        },
-        {
-            "track": "TD0",
-            "position": 7887.5,
-            "id": "DD0_5"
-        },
-        {
-            "track": "TD0",
-            "position": 9425.0,
-            "id": "DD0_6"
-        },
-        {
-            "track": "TD0",
-            "position": 10962.5,
-            "id": "DD0_7"
-        },
-        {
-            "track": "TD0",
-            "position": 12500.0,
-            "id": "DD0_8"
-        },
-        {
-            "track": "TD0",
-            "position": 14037.5,
-            "id": "DD0_9"
-        },
-        {
-            "track": "TD0",
-            "position": 15575.0,
-            "id": "DD0_10"
-        },
-        {
-            "track": "TD0",
-            "position": 17112.5,
-            "id": "DD0_11"
-        },
-        {
-            "track": "TD0",
-            "position": 18650.0,
-            "id": "DD0_12"
-        },
-        {
-            "track": "TD0",
-            "position": 20187.5,
-            "id": "DD0_13"
-        },
-        {
-            "track": "TD0",
-            "position": 21725.0,
-            "id": "DD0_14"
-        },
-        {
-            "track": "TD0",
-            "position": 23262.5,
-            "id": "DD0_15"
-        },
-        {
-            "track": "TD0",
-            "position": 24820.0,
-            "id": "DD2"
-        },
-        {
-            "track": "TD1",
-            "position": 180.0,
-            "id": "DD1"
-        },
-        {
-            "track": "TD1",
-            "position": 1737.5,
-            "id": "DD1_1"
-        },
-        {
-            "track": "TD1",
-            "position": 3275.0,
-            "id": "DD1_2"
-        },
-        {
-            "track": "TD1",
-            "position": 4812.5,
-            "id": "DD1_3"
-        },
-        {
-            "track": "TD1",
-            "position": 6350.0,
-            "id": "DD1_4"
-        },
-        {
-            "track": "TD1",
-            "position": 7887.5,
-            "id": "DD1_5"
-        },
-        {
-            "track": "TD1",
-            "position": 9425.0,
-            "id": "DD1_6"
-        },
-        {
-            "track": "TD1",
-            "position": 10962.5,
-            "id": "DD1_7"
-        },
-        {
-            "track": "TD1",
-            "position": 12500.0,
-            "id": "DD1_8"
-        },
-        {
-            "track": "TD1",
-            "position": 14037.5,
-            "id": "DD1_9"
-        },
-        {
-            "track": "TD1",
-            "position": 15575.0,
-            "id": "DD1_10"
-        },
-        {
-            "track": "TD1",
-            "position": 17112.5,
-            "id": "DD1_11"
-        },
-        {
-            "track": "TD1",
-            "position": 18650.0,
-            "id": "DD1_12"
-        },
-        {
-            "track": "TD1",
-            "position": 20187.5,
-            "id": "DD1_13"
-        },
-        {
-            "track": "TD1",
-            "position": 21725.0,
-            "id": "DD1_14"
-        },
-        {
-            "track": "TD1",
-            "position": 23262.5,
-            "id": "DD1_15"
-        },
-        {
-            "track": "TD1",
-            "position": 24820.0,
-            "id": "DD3"
-        },
-        {
-            "track": "TD2",
-            "position": 180.0,
-            "id": "DD4"
-        },
-        {
-            "track": "TD2",
-            "position": 1820.0,
-            "id": "DD6"
-        },
-        {
-            "track": "TD3",
-            "position": 180.0,
-            "id": "DF0"
-        },
-        {
-            "track": "TD3",
-            "position": 2820.0,
-            "id": "DH0"
-        },
-        {
-            "track": "TE0",
-            "position": 180.0,
-            "id": "DE1"
-        },
-        {
-            "track": "TE0",
-            "position": 1320.0,
-            "id": "DE0"
-        },
-        {
-            "track": "TF1",
-            "position": 180.0,
-            "id": "DD5"
-        },
-        {
-            "track": "TF1",
-            "position": 2250.0,
-            "id": "DF1_1"
-        },
-        {
-            "track": "TE1",
-            "position": 180.0,
-            "id": "DE4"
-        },
-        {
-            "track": "TE1",
-            "position": 1820.0,
-            "id": "DE2"
-        },
-        {
-            "track": "TE2",
-            "position": 180.0,
-            "id": "DE5"
-        },
-        {
-            "track": "TE2",
-            "position": 1870.0,
-            "id": "DE3"
-        },
-        {
-            "track": "TE3",
-            "position": 180.0,
-            "id": "DE7"
-        },
-        {
-            "track": "TE3",
-            "position": 1820.0,
-            "id": "DE6"
-        },
-        {
-            "track": "TG0",
-            "position": 180.0,
-            "id": "DD7"
-        },
-        {
-            "track": "TG0",
-            "position": 820.0,
-            "id": "DG0"
-        },
-        {
-            "track": "TG1",
-            "position": 180.0,
-            "id": "DG1"
-        },
-        {
-            "track": "TG1",
-            "position": 2000.0,
-            "id": "DG1_1"
-        },
-        {
-            "track": "TG1",
-            "position": 3820.0,
-            "id": "DG3"
-        },
-        {
-            "track": "TG2",
-            "position": 180.0,
-            "id": "DG2"
-        },
-        {
-            "track": "TG2",
-            "position": 2820.0,
-            "id": "DG4"
-        },
-        {
-            "track": "TG3",
-            "position": 25.0,
-            "id": "DG7"
-        },
-        {
-            "track": "TG4",
-            "position": 180.0,
-            "id": "DG5"
-        },
-        {
-            "track": "TG5",
-            "position": 180.0,
-            "id": "DG6"
-        },
-        {
-            "track": "TH0",
-            "position": 180.0,
-            "id": "DH1"
-        },
-        {
-            "track": "TH0",
-            "position": 820.0,
-            "id": "DH2"
-        },
-        {
-            "track": "TH1",
-            "position": 180.0,
-            "id": "DH3"
-        },
-        {
-            "track": "TH1",
-            "position": 1800.0,
-            "id": "DH1_1"
-        },
-        {
-            "track": "TH1",
-            "position": 3400.0,
-            "id": "DH1_2"
-        }
-    ],
-    "neutral_sections": [
-        {
-            "id": "neutral_section.0",
-            "announcement_track_ranges": [
-                {
-                    "track": "TG1",
-                    "begin": 3500.0,
-                    "end": 4000.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "direction": "START_TO_STOP"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": true
-        },
-        {
-            "id": "neutral_section.1",
-            "announcement_track_ranges": [
-                {
-                    "track": "TI3",
-                    "begin": 100.0,
-                    "end": 210.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TI3",
-                    "begin": 210.0,
-                    "end": 250.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": true
-        },
-        {
-            "id": "neutral_section.2",
-            "announcement_track_ranges": [],
-            "track_ranges": [
-                {
-                    "track": "TA6",
-                    "begin": 8500.0,
-                    "end": 8600.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": false
-        },
-        {
-            "id": "neutral_section.3",
-            "announcement_track_ranges": [
-                {
-                    "track": "TI3",
-                    "begin": 240.0,
-                    "end": 250.0,
-                    "direction": "STOP_TO_START"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TI3",
-                    "begin": 100.0,
-                    "end": 240.0,
-                    "direction": "STOP_TO_START"
-                }
-            ],
-            "lower_pantograph": false
-        }
-    ]
+    "version": "3.5.2"
 }

--- a/tests/data/infras/nested_switches/infra.json
+++ b/tests/data/infras/nested_switches/infra.json
@@ -1,49 +1,85 @@
 {
-    "version": "3.5.2",
-    "operational_points": [],
+    "buffer_stops": [
+        {
+            "id": "BS1",
+            "position": 0.0,
+            "track": "T1"
+        },
+        {
+            "id": "BST1bis",
+            "position": 10000.0,
+            "track": "T1bis"
+        },
+        {
+            "id": "BST2",
+            "position": 9000.0,
+            "track": "T2"
+        },
+        {
+            "id": "BST3ter",
+            "position": 4000.0,
+            "track": "T3ter"
+        },
+        {
+            "id": "BST4bis",
+            "position": 3000.0,
+            "track": "T4bis"
+        }
+    ],
+    "detectors": [
+        {
+            "id": "DETECTOR",
+            "position": 15.0,
+            "track": "T1"
+        }
+    ],
+    "electrifications": [],
+    "extended_switch_types": [],
     "level_crossings": [],
+    "neutral_sections": [],
+    "operational_points": [],
     "routes": [
         {
-            "id": "BS1 -> DETECTOR",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "BS1"
+                "id": "BS1",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DETECTOR"
+                "id": "DETECTOR",
+                "type": "Detector"
             },
+            "id": "BS1 -> DETECTOR",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "1 -> 1'",
             "entry_point": {
-                "type": "Detector",
-                "id": "DETECTOR"
+                "id": "DETECTOR",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "BST1bis"
+                "id": "BST1bis",
+                "type": "BufferStop"
             },
+            "id": "1 -> 1'",
             "release_detectors": [],
             "switches_directions": {
                 "S1": "A_B2"
             }
         },
         {
-            "id": "1 -> 2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DETECTOR"
+                "id": "DETECTOR",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "BST2"
+                "id": "BST2",
+                "type": "BufferStop"
             },
+            "id": "1 -> 2",
             "release_detectors": [],
             "switches_directions": {
                 "S1": "A_B1",
@@ -51,16 +87,16 @@
             }
         },
         {
-            "id": "1 -> 3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DETECTOR"
+                "id": "DETECTOR",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "BST3ter"
+                "id": "BST3ter",
+                "type": "BufferStop"
             },
+            "id": "1 -> 3",
             "release_detectors": [],
             "switches_directions": {
                 "S1": "A_B1",
@@ -71,16 +107,16 @@
             }
         },
         {
-            "id": "1 -> 4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DETECTOR"
+                "id": "DETECTOR",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "BST4bis"
+                "id": "BST4bis",
+                "type": "BufferStop"
             },
+            "id": "1 -> 4",
             "release_detectors": [],
             "switches_directions": {
                 "S1": "A_B1",
@@ -92,16 +128,16 @@
             }
         },
         {
-            "id": "1 -> 4'",
             "entry_point": {
-                "type": "Detector",
-                "id": "DETECTOR"
+                "id": "DETECTOR",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "BST4bis"
+                "id": "BST4bis",
+                "type": "BufferStop"
             },
+            "id": "1 -> 4'",
             "release_detectors": [],
             "switches_directions": {
                 "S1": "A_B1",
@@ -113,12 +149,298 @@
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SIGNAL",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SIGNAL",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 10.0,
+            "sight_distance": 400.0,
+            "track": "T1"
+        }
+    ],
+    "speed_sections": [
+        {
+            "id": "sp/50/t1...t1bis",
+            "on_routes": null,
+            "speed_limit": 50.0,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 2015.0,
+                    "track": "T1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "T1bis"
+                }
+            ]
+        },
+        {
+            "id": "sp/40/td1..td3_t4",
+            "on_routes": null,
+            "speed_limit": 40.0,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "T3"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD3"
+                }
+            ]
+        },
+        {
+            "id": "sp/42/1 -> 1'",
+            "on_routes": [
+                "1 -> 1'"
+            ],
+            "speed_limit": 42.0,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 2015.0,
+                    "track": "T1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "T1bis"
+                }
+            ]
+        },
+        {
+            "id": "sp/60/1 -> 2",
+            "on_routes": [
+                "1 -> 2"
+            ],
+            "speed_limit": 60.0,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 2015.0,
+                    "track": "T1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 9000.0,
+                    "track": "T2"
+                }
+            ]
+        },
+        {
+            "id": "sp/30/1 -> 3",
+            "on_routes": [
+                "1 -> 3"
+            ],
+            "speed_limit": 30.0,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 2015.0,
+                    "track": "T1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "T3"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "T3bis"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "T3ter"
+                }
+            ]
+        },
+        {
+            "id": "sp/80/1 -> 4",
+            "on_routes": [
+                "1 -> 4"
+            ],
+            "speed_limit": 80.0,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 2015.0,
+                    "track": "T1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "T3"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD3"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "T4"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "T4bis"
+                }
+            ]
+        },
+        {
+            "id": "sp/30/1 -> 4'",
+            "on_routes": [
+                "1 -> 4'"
+            ],
+            "speed_limit": 30.0,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 2015.0,
+                    "track": "T1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "T3"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "T3bis"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 500.0,
+                    "track": "TD3bis"
+                },
+                {
+                    "applicable_directions": "START_TO_STOP",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "T4bis"
+                }
+            ]
+        }
+    ],
     "switches": [
         {
-            "id": "S1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "S1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "S1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -133,16 +455,16 @@
                     "track": "T1bis"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "S1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "S2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "S2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "S2",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -157,16 +479,16 @@
                     "track": "T2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "S2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "S3",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "S3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "S3",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -181,16 +503,16 @@
                     "track": "T3bis"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "S3"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "S3bis",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "S3bis"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "S3bis",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -205,16 +527,16 @@
                     "track": "T3ter"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "S3bis"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "S4",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "S4"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "S4",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -229,16 +551,16 @@
                     "track": "T4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "S4"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "TD2_T3",
-            "switch_type": "link",
+            "extensions": {
+                "sncf": {
+                    "label": "TD2_T3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "TD2_T3",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -249,16 +571,16 @@
                     "track": "T3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "TD2_T3"
-                }
-            }
+            "switch_type": "link"
         },
         {
-            "id": "TD3_T4",
-            "switch_type": "link",
+            "extensions": {
+                "sncf": {
+                    "label": "TD3_T4"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "TD3_T4",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -269,17 +591,21 @@
                     "track": "T4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "TD3_T4"
-                }
-            }
+            "switch_type": "link"
         }
     ],
     "track_sections": [
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 0,
+                    "line_name": "placeholder_line",
+                    "track_name": "placeholder_track",
+                    "track_number": 0
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.375,
@@ -289,25 +615,25 @@
                         -0.365,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T1",
             "length": 2015.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -317,25 +643,25 @@
                         -0.265,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T1bis",
             "length": 10000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -345,25 +671,25 @@
                         -0.355,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD1",
             "length": 500.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.355,
@@ -373,25 +699,25 @@
                         -0.265,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T2",
             "length": 9000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.355,
@@ -401,25 +727,25 @@
                         -0.345,
                         49.52
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD2",
             "length": 500.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.345,
@@ -429,25 +755,25 @@
                         -0.33499999999999996,
                         49.52
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T3",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.33499999999999996,
@@ -457,25 +783,25 @@
                         -0.325,
                         49.52
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T3bis",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.325,
@@ -485,25 +811,25 @@
                         -0.265,
                         49.52
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T3ter",
             "length": 4000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.33499999999999996,
@@ -513,25 +839,25 @@
                         -0.325,
                         49.53
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD3",
             "length": 500.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.325,
@@ -541,25 +867,25 @@
                         -0.315,
                         49.53
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T4",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.325,
@@ -569,25 +895,25 @@
                         -0.315,
                         49.53
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD3bis",
             "length": 500.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.315,
@@ -597,340 +923,14 @@
                         -0.265,
                         49.53
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "T4bis",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 0,
-                    "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
-                }
-            }
+            "slopes": []
         }
     ],
-    "speed_sections": [
-        {
-            "id": "sp/50/t1...t1bis",
-            "speed_limit": 50.0,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "T1",
-                    "begin": 0.0,
-                    "end": 2015.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T1bis",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "START_TO_STOP"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "sp/40/td1..td3_t4",
-            "speed_limit": 40.0,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T3",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "sp/42/1 -> 1'",
-            "speed_limit": 42.0,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "T1",
-                    "begin": 0.0,
-                    "end": 2015.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T1bis",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "START_TO_STOP"
-                }
-            ],
-            "on_routes": [
-                "1 -> 1'"
-            ]
-        },
-        {
-            "id": "sp/60/1 -> 2",
-            "speed_limit": 60.0,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "T1",
-                    "begin": 0.0,
-                    "end": 2015.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T2",
-                    "begin": 0.0,
-                    "end": 9000.0,
-                    "applicable_directions": "START_TO_STOP"
-                }
-            ],
-            "on_routes": [
-                "1 -> 2"
-            ]
-        },
-        {
-            "id": "sp/30/1 -> 3",
-            "speed_limit": 30.0,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "T1",
-                    "begin": 0.0,
-                    "end": 2015.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T3",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T3bis",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T3ter",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "START_TO_STOP"
-                }
-            ],
-            "on_routes": [
-                "1 -> 3"
-            ]
-        },
-        {
-            "id": "sp/80/1 -> 4",
-            "speed_limit": 80.0,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "T1",
-                    "begin": 0.0,
-                    "end": 2015.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T3",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T4",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T4bis",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "START_TO_STOP"
-                }
-            ],
-            "on_routes": [
-                "1 -> 4"
-            ]
-        },
-        {
-            "id": "sp/30/1 -> 4'",
-            "speed_limit": 30.0,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "T1",
-                    "begin": 0.0,
-                    "end": 2015.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T3",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T3bis",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "TD3bis",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "applicable_directions": "START_TO_STOP"
-                },
-                {
-                    "track": "T4bis",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "START_TO_STOP"
-                }
-            ],
-            "on_routes": [
-                "1 -> 4'"
-            ]
-        }
-    ],
-    "electrifications": [],
-    "signals": [
-        {
-            "track": "T1",
-            "position": 10.0,
-            "id": "SIGNAL",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SIGNAL",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "T1",
-            "position": 0.0,
-            "id": "BS1"
-        },
-        {
-            "track": "T1bis",
-            "position": 10000.0,
-            "id": "BST1bis"
-        },
-        {
-            "track": "T2",
-            "position": 9000.0,
-            "id": "BST2"
-        },
-        {
-            "track": "T3ter",
-            "position": 4000.0,
-            "id": "BST3ter"
-        },
-        {
-            "track": "T4bis",
-            "position": 3000.0,
-            "id": "BST4bis"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "T1",
-            "position": 15.0,
-            "id": "DETECTOR"
-        }
-    ],
-    "neutral_sections": []
+    "version": "3.5.2"
 }

--- a/tests/data/infras/overlapping_routes/infra.json
+++ b/tests/data/infras/overlapping_routes/infra.json
@@ -1,134 +1,195 @@
 {
-    "version": "3.5.2",
+    "buffer_stops": [
+        {
+            "id": "bf.a1",
+            "position": 0.0,
+            "track": "t_a1"
+        },
+        {
+            "id": "bf.b1",
+            "position": 1000.0,
+            "track": "t_b1"
+        },
+        {
+            "id": "bf.a2",
+            "position": 0.0,
+            "track": "t_a2"
+        },
+        {
+            "id": "bf.b2",
+            "position": 1000.0,
+            "track": "t_b2"
+        }
+    ],
+    "detectors": [
+        {
+            "id": "det.a1.nf",
+            "position": 900.0,
+            "track": "t_a1"
+        },
+        {
+            "id": "det.b1.nf",
+            "position": 100.0,
+            "track": "t_b1"
+        },
+        {
+            "id": "det.a2.nf",
+            "position": 900.0,
+            "track": "t_a2"
+        },
+        {
+            "id": "det.b2.nf",
+            "position": 100.0,
+            "track": "t_b2"
+        },
+        {
+            "id": "det.center.1",
+            "position": 4000.0,
+            "track": "t_center"
+        },
+        {
+            "id": "det.center.2",
+            "position": 6000.0,
+            "track": "t_center"
+        },
+        {
+            "id": "det.center.3",
+            "position": 8000.0,
+            "track": "t_center"
+        }
+    ],
+    "electrifications": [],
+    "extended_switch_types": [],
+    "level_crossings": [],
+    "neutral_sections": [],
     "operational_points": [
         {
-            "id": "op.a1",
-            "parts": [
-                {
-                    "track": "t_a1",
-                    "position": 0.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.a1",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
-        },
-        {
-            "id": "op.a2",
+            },
+            "id": "op.a1",
             "parts": [
                 {
-                    "track": "t_a2",
-                    "position": 1000.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1",
+                    "position": 0.0,
+                    "track": "t_a1"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.a2",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
-        },
-        {
-            "id": "op.b1",
+            },
+            "id": "op.a2",
             "parts": [
                 {
-                    "track": "t_b1",
-                    "position": 0.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1",
+                    "position": 1000.0,
+                    "track": "t_a2"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.b1",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
-        },
-        {
-            "id": "op.b2",
+            },
+            "id": "op.b1",
             "parts": [
                 {
-                    "track": "t_b2",
-                    "position": 1000.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1",
+                    "position": 0.0,
+                    "track": "t_b1"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.b2",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
+            },
+            "id": "op.b2",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 1000.0,
+                    "track": "t_b2"
+                }
+            ],
+            "plc": null,
+            "weight": null
         }
     ],
-    "level_crossings": [],
     "routes": [
         {
-            "id": "rt.bf.a1->det.a1.nf",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.a1"
+                "id": "bf.a1",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.a1.nf"
+                "id": "det.a1.nf",
+                "type": "Detector"
             },
+            "id": "rt.bf.a1->det.a1.nf",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.det.a1.nf->det.b2.nf",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.a1.nf"
+                "id": "det.a1.nf",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.b2.nf"
+                "id": "det.b2.nf",
+                "type": "Detector"
             },
+            "id": "rt.det.a1.nf->det.b2.nf",
             "release_detectors": [
                 "det.center.1",
                 "det.center.2",
@@ -140,16 +201,16 @@
             }
         },
         {
-            "id": "rt.det.a1.nf->det.b1.nf",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.a1.nf"
+                "id": "det.a1.nf",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.b1.nf"
+                "id": "det.b1.nf",
+                "type": "Detector"
             },
+            "id": "rt.det.a1.nf->det.b1.nf",
             "release_detectors": [
                 "det.center.1",
                 "det.center.2",
@@ -161,30 +222,30 @@
             }
         },
         {
-            "id": "rt.det.b1.nf->bf.b1",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.b1.nf"
+                "id": "det.b1.nf",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.b1"
+                "id": "bf.b1",
+                "type": "BufferStop"
             },
+            "id": "rt.det.b1.nf->bf.b1",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.bf.b1->bf.a2",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.b1"
+                "id": "bf.b1",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.a2"
+                "id": "bf.a2",
+                "type": "BufferStop"
             },
+            "id": "rt.bf.b1->bf.a2",
             "release_detectors": [
                 "det.b1.nf",
                 "det.center.3",
@@ -198,16 +259,16 @@
             }
         },
         {
-            "id": "rt.bf.b1->bf.a1",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.b1"
+                "id": "bf.b1",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.a1"
+                "id": "bf.a1",
+                "type": "BufferStop"
             },
+            "id": "rt.bf.b1->bf.a1",
             "release_detectors": [
                 "det.b1.nf",
                 "det.center.3",
@@ -221,30 +282,30 @@
             }
         },
         {
-            "id": "rt.bf.a2->det.a2.nf",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.a2"
+                "id": "bf.a2",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.a2.nf"
+                "id": "det.a2.nf",
+                "type": "Detector"
             },
+            "id": "rt.bf.a2->det.a2.nf",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.det.a2.nf->det.b2.nf",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.a2.nf"
+                "id": "det.a2.nf",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.b2.nf"
+                "id": "det.b2.nf",
+                "type": "Detector"
             },
+            "id": "rt.det.a2.nf->det.b2.nf",
             "release_detectors": [
                 "det.center.1",
                 "det.center.2",
@@ -256,16 +317,16 @@
             }
         },
         {
-            "id": "rt.det.a2.nf->det.b1.nf",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.a2.nf"
+                "id": "det.a2.nf",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.b1.nf"
+                "id": "det.b1.nf",
+                "type": "Detector"
             },
+            "id": "rt.det.a2.nf->det.b1.nf",
             "release_detectors": [
                 "det.center.1",
                 "det.center.2",
@@ -277,30 +338,30 @@
             }
         },
         {
-            "id": "rt.det.b2.nf->bf.b2",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.b2.nf"
+                "id": "det.b2.nf",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.b2"
+                "id": "bf.b2",
+                "type": "BufferStop"
             },
+            "id": "rt.det.b2.nf->bf.b2",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.bf.b2->bf.a2",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.b2"
+                "id": "bf.b2",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.a2"
+                "id": "bf.a2",
+                "type": "BufferStop"
             },
+            "id": "rt.bf.b2->bf.a2",
             "release_detectors": [
                 "det.b2.nf",
                 "det.center.3",
@@ -314,16 +375,16 @@
             }
         },
         {
-            "id": "rt.bf.b2->bf.a1",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.b2"
+                "id": "bf.b2",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.a1"
+                "id": "bf.a1",
+                "type": "BufferStop"
             },
+            "id": "rt.bf.b2->bf.a1",
             "release_detectors": [
                 "det.b2.nf",
                 "det.center.3",
@@ -337,12 +398,207 @@
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.a1.nf",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.a1.nf",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 900.0,
+            "sight_distance": 400.0,
+            "track": "t_a1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.b1.nf",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.b1.nf",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 100.0,
+            "sight_distance": 400.0,
+            "track": "t_b1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.a2.nf",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.a2.nf",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 900.0,
+            "sight_distance": 400.0,
+            "track": "t_a2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.b2.nf",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.b2.nf",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 100.0,
+            "sight_distance": 400.0,
+            "track": "t_b2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.center.1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.center.1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 4000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.center.2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.center.2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.center.3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.center.3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        }
+    ],
+    "speed_sections": [],
     "switches": [
         {
-            "id": "s.a",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "s.a"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "s.a",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -357,16 +613,16 @@
                     "track": "t_a2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "s.a"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "s.b",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "s.b"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "s.b",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -381,17 +637,21 @@
                     "track": "t_b2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "s.b"
-                }
-            }
+            "switch_type": "point_switch"
         }
     ],
     "track_sections": [
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 0,
+                    "line_name": "placeholder_line",
+                    "track_name": "placeholder_track",
+                    "track_number": 0
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -401,25 +661,25 @@
                         -0.1,
                         49.98
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_a1",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         0.1,
@@ -429,25 +689,25 @@
                         0.12,
                         50.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_b1",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -457,25 +717,25 @@
                         -0.1,
                         49.98
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_a2",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         0.1,
@@ -485,25 +745,25 @@
                         0.12,
                         49.98
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_b2",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1,
@@ -513,274 +773,14 @@
                         0.1,
                         49.98
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_center",
             "length": 10000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 0,
-                    "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
-                }
-            }
+            "slopes": []
         }
     ],
-    "speed_sections": [],
-    "electrifications": [],
-    "signals": [
-        {
-            "track": "t_a1",
-            "position": 900.0,
-            "id": "s.a1.nf",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.a1.nf",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_b1",
-            "position": 100.0,
-            "id": "s.b1.nf",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.b1.nf",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_a2",
-            "position": 900.0,
-            "id": "s.a2.nf",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.a2.nf",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_b2",
-            "position": 100.0,
-            "id": "s.b2.nf",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.b2.nf",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 4000.0,
-            "id": "s.center.1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.center.1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 6000.0,
-            "id": "s.center.2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.center.2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 8000.0,
-            "id": "s.center.3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.center.3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "t_a1",
-            "position": 0.0,
-            "id": "bf.a1"
-        },
-        {
-            "track": "t_b1",
-            "position": 1000.0,
-            "id": "bf.b1"
-        },
-        {
-            "track": "t_a2",
-            "position": 0.0,
-            "id": "bf.a2"
-        },
-        {
-            "track": "t_b2",
-            "position": 1000.0,
-            "id": "bf.b2"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "t_a1",
-            "position": 900.0,
-            "id": "det.a1.nf"
-        },
-        {
-            "track": "t_b1",
-            "position": 100.0,
-            "id": "det.b1.nf"
-        },
-        {
-            "track": "t_a2",
-            "position": 900.0,
-            "id": "det.a2.nf"
-        },
-        {
-            "track": "t_b2",
-            "position": 100.0,
-            "id": "det.b2.nf"
-        },
-        {
-            "track": "t_center",
-            "position": 4000.0,
-            "id": "det.center.1"
-        },
-        {
-            "track": "t_center",
-            "position": 6000.0,
-            "id": "det.center.2"
-        },
-        {
-            "track": "t_center",
-            "position": 8000.0,
-            "id": "det.center.3"
-        }
-    ],
-    "neutral_sections": []
+    "version": "3.5.2"
 }

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -1,349 +1,1128 @@
 {
-    "version": "3.5.2",
-    "operational_points": [
+    "buffer_stops": [
         {
-            "id": "West_station",
-            "parts": [
-                {
-                    "track": "TA0",
-                    "position": 699.99959,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TA1",
-                    "position": 500.0,
-                    "local_track_name": "V2"
-                },
-                {
-                    "track": "TA2",
-                    "position": 500.0,
-                    "local_track_name": "V3"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 22,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "WS"
-                },
-                "identifier": {
-                    "name": "West_station",
-                    "uic": 8722
-                }
-            }
+            "id": "buffer_stop.0",
+            "position": 0.0,
+            "track": "TA0"
         },
         {
-            "id": "South_West_station",
-            "parts": [
-                {
-                    "track": "TB0",
-                    "position": 500.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 11,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SWS"
-                },
-                "identifier": {
-                    "name": "South_West_station",
-                    "uic": 8711
-                }
-            }
+            "id": "buffer_stop.1",
+            "position": 0.0,
+            "track": "TA1"
         },
         {
-            "id": "Mid_West_station",
-            "parts": [
-                {
-                    "track": "TC0",
-                    "position": 550.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TC1",
-                    "position": 550.0,
-                    "local_track_name": "V2"
-                },
-                {
-                    "track": "TC2",
-                    "position": 450.0,
-                    "local_track_name": "V3"
-                },
-                {
-                    "track": "TC3",
-                    "position": 450.0,
-                    "local_track_name": "V4"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 33,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "MWS"
-                },
-                "identifier": {
-                    "name": "Mid_West_station",
-                    "uic": 8733
-                }
-            }
+            "id": "buffer_stop.2",
+            "position": 0.0,
+            "track": "TA2"
         },
         {
-            "id": "Mid_East_station",
-            "parts": [
-                {
-                    "track": "TD0",
-                    "position": 14000.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TD1",
-                    "position": 14000.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 44,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "MES"
-                },
-                "identifier": {
-                    "name": "Mid_East_station",
-                    "uic": 8744
-                }
-            }
+            "id": "buffer_stop.3",
+            "position": 0.0,
+            "track": "TB0"
         },
         {
-            "id": "North_station",
-            "parts": [
-                {
-                    "track": "TE1",
-                    "position": 1000.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TE2",
-                    "position": 1025.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 55,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "NS"
-                },
-                "identifier": {
-                    "name": "North_station",
-                    "uic": 8755
-                }
-            }
+            "id": "buffer_stop.4",
+            "position": 6500.0,
+            "track": "TF1"
         },
         {
-            "id": "South_station",
-            "parts": [
-                {
-                    "track": "TF1",
-                    "position": 4300.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 66,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SS"
-                },
-                "identifier": {
-                    "name": "South_station",
-                    "uic": 8766
-                }
-            }
+            "id": "buffer_stop.5",
+            "position": 2000.0,
+            "track": "TG4"
         },
         {
-            "id": "North_East_station",
-            "parts": [
-                {
-                    "track": "TG4",
-                    "position": 1550.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "TG5",
-                    "position": 1500.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 77,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "NES"
-                },
-                "identifier": {
-                    "name": "North_East_station",
-                    "uic": 8777
-                }
-            }
+            "id": "buffer_stop.6",
+            "position": 2000.0,
+            "track": "TG5"
         },
         {
-            "id": "South_East_station",
-            "parts": [
-                {
-                    "track": "TH1",
-                    "position": 4400.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
-            "extensions": {
-                "sncf": {
-                    "ci": 88,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "SES"
-                },
-                "identifier": {
-                    "name": "South_East_station",
-                    "uic": 8788
-                }
-            }
+            "id": "buffer_stop.7",
+            "position": 5000.0,
+            "track": "TH1"
         }
     ],
+    "detectors": [
+        {
+            "id": "DA2",
+            "position": 1820.0,
+            "track": "TA0"
+        },
+        {
+            "id": "DA0",
+            "position": 1770.0,
+            "track": "TA1"
+        },
+        {
+            "id": "DA1",
+            "position": 1770.0,
+            "track": "TA2"
+        },
+        {
+            "id": "DA7",
+            "position": 25.0,
+            "track": "TA3"
+        },
+        {
+            "id": "DA8",
+            "position": 25.0,
+            "track": "TA4"
+        },
+        {
+            "id": "DA9",
+            "position": 25.0,
+            "track": "TA5"
+        },
+        {
+            "id": "DA3",
+            "position": 180.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_1",
+            "position": 1800.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_2",
+            "position": 3400.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_3",
+            "position": 5000.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_4",
+            "position": 6600.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA6_5",
+            "position": 8200.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA5",
+            "position": 9820.0,
+            "track": "TA6"
+        },
+        {
+            "id": "DA4",
+            "position": 180.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_1",
+            "position": 1800.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_2",
+            "position": 3400.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_3",
+            "position": 5000.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_4",
+            "position": 6600.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA7_5",
+            "position": 8200.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DA6",
+            "position": 9820.0,
+            "track": "TA7"
+        },
+        {
+            "id": "DB0",
+            "position": 2820.0,
+            "track": "TB0"
+        },
+        {
+            "id": "DC0",
+            "position": 180.0,
+            "track": "TC0"
+        },
+        {
+            "id": "DC4",
+            "position": 870.0,
+            "track": "TC0"
+        },
+        {
+            "id": "DC1",
+            "position": 180.0,
+            "track": "TC1"
+        },
+        {
+            "id": "DC5",
+            "position": 820.0,
+            "track": "TC1"
+        },
+        {
+            "id": "DC2",
+            "position": 180.0,
+            "track": "TC2"
+        },
+        {
+            "id": "DC6",
+            "position": 820.0,
+            "track": "TC2"
+        },
+        {
+            "id": "DC3",
+            "position": 180.0,
+            "track": "TC3"
+        },
+        {
+            "id": "DC7",
+            "position": 870.0,
+            "track": "TC3"
+        },
+        {
+            "id": "DD0",
+            "position": 180.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_1",
+            "position": 1737.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_2",
+            "position": 3275.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_3",
+            "position": 4812.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_4",
+            "position": 6350.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_5",
+            "position": 7887.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_6",
+            "position": 9425.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_7",
+            "position": 10962.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_8",
+            "position": 12500.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_9",
+            "position": 14037.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_10",
+            "position": 15575.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_11",
+            "position": 17112.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_12",
+            "position": 18650.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_13",
+            "position": 20187.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_14",
+            "position": 21725.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD0_15",
+            "position": 23262.5,
+            "track": "TD0"
+        },
+        {
+            "id": "DD2",
+            "position": 24820.0,
+            "track": "TD0"
+        },
+        {
+            "id": "DD1",
+            "position": 180.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_1",
+            "position": 1737.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_2",
+            "position": 3275.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_3",
+            "position": 4812.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_4",
+            "position": 6350.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_5",
+            "position": 7887.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_6",
+            "position": 9425.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_7",
+            "position": 10962.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_8",
+            "position": 12500.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_9",
+            "position": 14037.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_10",
+            "position": 15575.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_11",
+            "position": 17112.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_12",
+            "position": 18650.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_13",
+            "position": 20187.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_14",
+            "position": 21725.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD1_15",
+            "position": 23262.5,
+            "track": "TD1"
+        },
+        {
+            "id": "DD3",
+            "position": 24820.0,
+            "track": "TD1"
+        },
+        {
+            "id": "DD4",
+            "position": 180.0,
+            "track": "TD2"
+        },
+        {
+            "id": "DD6",
+            "position": 1820.0,
+            "track": "TD2"
+        },
+        {
+            "id": "DF0",
+            "position": 180.0,
+            "track": "TD3"
+        },
+        {
+            "id": "DH0",
+            "position": 2820.0,
+            "track": "TD3"
+        },
+        {
+            "id": "DE1",
+            "position": 180.0,
+            "track": "TE0"
+        },
+        {
+            "id": "DE0",
+            "position": 1320.0,
+            "track": "TE0"
+        },
+        {
+            "id": "DD5",
+            "position": 180.0,
+            "track": "TF1"
+        },
+        {
+            "id": "DF1_1",
+            "position": 2250.0,
+            "track": "TF1"
+        },
+        {
+            "id": "DE4",
+            "position": 180.0,
+            "track": "TE1"
+        },
+        {
+            "id": "DE2",
+            "position": 1820.0,
+            "track": "TE1"
+        },
+        {
+            "id": "DE5",
+            "position": 180.0,
+            "track": "TE2"
+        },
+        {
+            "id": "DE3",
+            "position": 1870.0,
+            "track": "TE2"
+        },
+        {
+            "id": "DE7",
+            "position": 180.0,
+            "track": "TE3"
+        },
+        {
+            "id": "DE6",
+            "position": 1820.0,
+            "track": "TE3"
+        },
+        {
+            "id": "DD7",
+            "position": 180.0,
+            "track": "TG0"
+        },
+        {
+            "id": "DG0",
+            "position": 820.0,
+            "track": "TG0"
+        },
+        {
+            "id": "DG1",
+            "position": 180.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG1_1",
+            "position": 2000.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG3",
+            "position": 3820.0,
+            "track": "TG1"
+        },
+        {
+            "id": "DG2",
+            "position": 180.0,
+            "track": "TG2"
+        },
+        {
+            "id": "DG4",
+            "position": 2820.0,
+            "track": "TG2"
+        },
+        {
+            "id": "DG7",
+            "position": 25.0,
+            "track": "TG3"
+        },
+        {
+            "id": "DG5",
+            "position": 180.0,
+            "track": "TG4"
+        },
+        {
+            "id": "DG6",
+            "position": 180.0,
+            "track": "TG5"
+        },
+        {
+            "id": "DH1",
+            "position": 180.0,
+            "track": "TH0"
+        },
+        {
+            "id": "DH2",
+            "position": 820.0,
+            "track": "TH0"
+        },
+        {
+            "id": "DH3",
+            "position": 180.0,
+            "track": "TH1"
+        },
+        {
+            "id": "DH1_1",
+            "position": 1800.0,
+            "track": "TH1"
+        },
+        {
+            "id": "DH1_2",
+            "position": 3400.0,
+            "track": "TH1"
+        }
+    ],
+    "electrifications": [
+        {
+            "id": "electrification_25k",
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA6"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA7"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TB0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TD3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1500.0,
+                    "track": "TE0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3.0,
+                    "track": "TF0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 6500.0,
+                    "track": "TF1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2050.0,
+                    "track": "TE2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TG0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TG1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TG2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TG3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 5000.0,
+                    "track": "TH1"
+                }
+            ],
+            "voltage": "25000V"
+        },
+        {
+            "id": "electrification_1.5k",
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TA0"
+                }
+            ],
+            "voltage": "1500V"
+        }
+    ],
+    "extended_switch_types": [],
     "level_crossings": [
         {
             "id": "lc1",
             "name": "LC1",
-            "short_zone_length": 2000,
             "parts": [
                 {
-                    "track": "TB0",
-                    "position": 750.0,
+                    "pedal_downstream": 4000,
                     "pedal_upstream": 4000,
-                    "pedal_downstream": 4000
+                    "position": 750.0,
+                    "track": "TB0"
                 }
-            ]
+            ],
+            "short_zone_length": 2000
         },
         {
             "id": "lc2",
             "name": "LC2",
-            "short_zone_length": 1500,
             "parts": [
                 {
-                    "track": "TC0",
-                    "position": 125.0,
+                    "pedal_downstream": 6000,
                     "pedal_upstream": 4000,
-                    "pedal_downstream": 6000
+                    "position": 125.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
+                    "pedal_downstream": 5000,
+                    "pedal_upstream": 5000,
                     "position": 120.0,
-                    "pedal_upstream": 5000,
-                    "pedal_downstream": 5000
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
+                    "pedal_downstream": 5000,
+                    "pedal_upstream": 5000,
                     "position": 110.0,
-                    "pedal_upstream": 5000,
-                    "pedal_downstream": 5000
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
-                    "position": 115.0,
+                    "pedal_downstream": 6000,
                     "pedal_upstream": 6000,
-                    "pedal_downstream": 6000
+                    "position": 115.0,
+                    "track": "TC3"
+                }
+            ],
+            "short_zone_length": 1500
+        }
+    ],
+    "neutral_sections": [
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 3500.0,
+                    "direction": "START_TO_STOP",
+                    "end": 4000.0,
+                    "track": "TG1"
+                }
+            ],
+            "id": "neutral_section.0",
+            "lower_pantograph": true,
+            "track_ranges": [
+                {
+                    "begin": 0.0,
+                    "direction": "START_TO_STOP",
+                    "end": 500.0,
+                    "track": "TG4"
+                },
+                {
+                    "begin": 0.0,
+                    "direction": "START_TO_STOP",
+                    "end": 10.0,
+                    "track": "TA6"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 1850.0,
+                    "direction": "START_TO_STOP",
+                    "end": 1960.0,
+                    "track": "TA0"
+                }
+            ],
+            "id": "neutral_section.1",
+            "lower_pantograph": true,
+            "track_ranges": [
+                {
+                    "begin": 1960.0,
+                    "direction": "START_TO_STOP",
+                    "end": 2000.0,
+                    "track": "TA0"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [],
+            "id": "neutral_section.2",
+            "lower_pantograph": false,
+            "track_ranges": [
+                {
+                    "begin": 8500.0,
+                    "direction": "START_TO_STOP",
+                    "end": 8600.0,
+                    "track": "TA6"
+                }
+            ]
+        },
+        {
+            "announcement_track_ranges": [
+                {
+                    "begin": 1990.0,
+                    "direction": "STOP_TO_START",
+                    "end": 2000.0,
+                    "track": "TA0"
+                }
+            ],
+            "id": "neutral_section.3",
+            "lower_pantograph": false,
+            "track_ranges": [
+                {
+                    "begin": 1850.0,
+                    "direction": "STOP_TO_START",
+                    "end": 1990.0,
+                    "track": "TA0"
                 }
             ]
         }
     ],
+    "operational_points": [
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "West_station",
+                    "uic": 8722
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 22,
+                    "trigram": "WS"
+                }
+            },
+            "id": "West_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 699.99959,
+                    "track": "TA0"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 500.0,
+                    "track": "TA1"
+                },
+                {
+                    "local_track_name": "V3",
+                    "position": 500.0,
+                    "track": "TA2"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "South_West_station",
+                    "uic": 8711
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 11,
+                    "trigram": "SWS"
+                }
+            },
+            "id": "South_West_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 500.0,
+                    "track": "TB0"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "Mid_West_station",
+                    "uic": 8733
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 33,
+                    "trigram": "MWS"
+                }
+            },
+            "id": "Mid_West_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 550.0,
+                    "track": "TC0"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 550.0,
+                    "track": "TC1"
+                },
+                {
+                    "local_track_name": "V3",
+                    "position": 450.0,
+                    "track": "TC2"
+                },
+                {
+                    "local_track_name": "V4",
+                    "position": 450.0,
+                    "track": "TC3"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "Mid_East_station",
+                    "uic": 8744
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 44,
+                    "trigram": "MES"
+                }
+            },
+            "id": "Mid_East_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 14000.0,
+                    "track": "TD0"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 14000.0,
+                    "track": "TD1"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "North_station",
+                    "uic": 8755
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 55,
+                    "trigram": "NS"
+                }
+            },
+            "id": "North_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 1000.0,
+                    "track": "TE1"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 1025.0,
+                    "track": "TE2"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "South_station",
+                    "uic": 8766
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 66,
+                    "trigram": "SS"
+                }
+            },
+            "id": "South_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 4300.0,
+                    "track": "TF1"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "North_East_station",
+                    "uic": 8777
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 77,
+                    "trigram": "NES"
+                }
+            },
+            "id": "North_East_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 1550.0,
+                    "track": "TG4"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 1500.0,
+                    "track": "TG5"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        },
+        {
+            "extensions": {
+                "identifier": {
+                    "name": "South_East_station",
+                    "uic": 8788
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 88,
+                    "trigram": "SES"
+                }
+            },
+            "id": "South_East_station",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 4400.0,
+                    "track": "TH1"
+                }
+            ],
+            "plc": null,
+            "weight": null
+        }
+    ],
     "routes": [
         {
-            "id": "rt.buffer_stop.0->DA2",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA2"
+                "id": "DA2",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.0->DA2",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA2->DA5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA2"
+                "id": "DA2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
+            "id": "rt.DA2->DA5",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.1->DA0",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.1->DA0",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA0->DA5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
+            "id": "rt.DA0->DA5",
             "release_detectors": [],
             "switches_directions": {
                 "PA0": "A_B1",
@@ -351,16 +1130,16 @@
             }
         },
         {
-            "id": "rt.DA0->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA0"
+                "id": "DA0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DA0->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA0": "A_B2",
@@ -368,30 +1147,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop.2->DA1",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA1"
+                "id": "DA1",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.2->DA1",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DA1->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA1"
+                "id": "DA1",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DA1->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA1": "A_B2",
@@ -399,16 +1178,16 @@
             }
         },
         {
-            "id": "rt.DA3->buffer_stop.1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
+            "id": "rt.DA3->buffer_stop.1",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B1",
@@ -416,64 +1195,64 @@
             }
         },
         {
-            "id": "rt.DA3->buffer_stop.0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.0"
+                "id": "buffer_stop.0",
+                "type": "BufferStop"
             },
+            "id": "rt.DA3->buffer_stop.0",
             "release_detectors": [],
             "switches_directions": {
                 "PA2": "A_B2"
             }
         },
         {
-            "id": "rt.DA5->DC4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC4"
+                "id": "DC4",
+                "type": "Detector"
             },
+            "id": "rt.DA5->DC4",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B1"
             }
         },
         {
-            "id": "rt.DA5->DC5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA5"
+                "id": "DA5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC5"
+                "id": "DC5",
+                "type": "Detector"
             },
+            "id": "rt.DA5->DC5",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B2"
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.2"
+                "id": "buffer_stop.2",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.2",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B1",
@@ -481,16 +1260,16 @@
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.3",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B1",
@@ -498,16 +1277,16 @@
             }
         },
         {
-            "id": "rt.DA4->buffer_stop.1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.1"
+                "id": "buffer_stop.1",
+                "type": "BufferStop"
             },
+            "id": "rt.DA4->buffer_stop.1",
             "release_detectors": [],
             "switches_directions": {
                 "PA3": "A_B2",
@@ -515,62 +1294,62 @@
             }
         },
         {
-            "id": "rt.DA6->DC6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC6"
+                "id": "DC6",
+                "type": "Detector"
             },
+            "id": "rt.DA6->DC6",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B1"
             }
         },
         {
-            "id": "rt.DA6->DC7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC7"
+                "id": "DC7",
+                "type": "Detector"
             },
+            "id": "rt.DA6->DC7",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.3->DB0",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.3"
+                "id": "buffer_stop.3",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DB0"
+                "id": "DB0",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.3->DB0",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DB0->DA6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DB0"
+                "id": "DB0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA6"
+                "id": "DA6",
+                "type": "Detector"
             },
+            "id": "rt.DB0->DA6",
             "release_detectors": [],
             "switches_directions": {
                 "PA1": "A_B1",
@@ -578,368 +1357,368 @@
             }
         },
         {
-            "id": "rt.DC0->DA3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC0"
+                "id": "DC0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
+            "id": "rt.DC0->DA3",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B1"
             }
         },
         {
-            "id": "rt.DC4->DD2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC4"
+                "id": "DC4",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
+            "id": "rt.DC4->DD2",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B2"
             }
         },
         {
-            "id": "rt.DC1->DA3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC1"
+                "id": "DC1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA3"
+                "id": "DA3",
+                "type": "Detector"
             },
+            "id": "rt.DC1->DA3",
             "release_detectors": [],
             "switches_directions": {
                 "PC0": "A_B2"
             }
         },
         {
-            "id": "rt.DC5->DD2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC5"
+                "id": "DC5",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
+            "id": "rt.DC5->DD2",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B1"
             }
         },
         {
-            "id": "rt.DC2->DA4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC2"
+                "id": "DC2",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
+            "id": "rt.DC2->DA4",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B1"
             }
         },
         {
-            "id": "rt.DC6->DD3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC6"
+                "id": "DC6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
+            "id": "rt.DC6->DD3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B2"
             }
         },
         {
-            "id": "rt.DC3->DA4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC3"
+                "id": "DC3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DA4"
+                "id": "DA4",
+                "type": "Detector"
             },
+            "id": "rt.DC3->DA4",
             "release_detectors": [],
             "switches_directions": {
                 "PC1": "A_B2"
             }
         },
         {
-            "id": "rt.DC7->DD3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DC7"
+                "id": "DC7",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
+            "id": "rt.DC7->DD3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B1"
             }
         },
         {
-            "id": "rt.DD0->DC1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC1"
+                "id": "DC1",
+                "type": "Detector"
             },
+            "id": "rt.DD0->DC1",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B1"
             }
         },
         {
-            "id": "rt.DD0->DC0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC0"
+                "id": "DC0",
+                "type": "Detector"
             },
+            "id": "rt.DD0->DC0",
             "release_detectors": [],
             "switches_directions": {
                 "PC2": "A_B2"
             }
         },
         {
-            "id": "rt.DD2->DD6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD2"
+                "id": "DD2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
+            "id": "rt.DD2->DD6",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC"
             }
         },
         {
-            "id": "rt.DD1->DC3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC3"
+                "id": "DC3",
+                "type": "Detector"
             },
+            "id": "rt.DD1->DC3",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B1"
             }
         },
         {
-            "id": "rt.DD1->DC2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DC2"
+                "id": "DC2",
+                "type": "Detector"
             },
+            "id": "rt.DD1->DC2",
             "release_detectors": [],
             "switches_directions": {
                 "PC3": "A_B2"
             }
         },
         {
-            "id": "rt.DD3->DH0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD3"
+                "id": "DD3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
+            "id": "rt.DD3->DH0",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC"
             }
         },
         {
-            "id": "rt.DD4->DD0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD0"
+                "id": "DD0",
+                "type": "Detector"
             },
+            "id": "rt.DD4->DD0",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC"
             }
         },
         {
-            "id": "rt.DD6->DE6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
+            "id": "rt.DD6->DE6",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B1"
             }
         },
         {
-            "id": "rt.DD6->DG0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD6"
+                "id": "DD6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
+            "id": "rt.DD6->DG0",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B2"
             }
         },
         {
-            "id": "rt.DF0->DD1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD1"
+                "id": "DD1",
+                "type": "Detector"
             },
+            "id": "rt.DF0->DD1",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC"
             }
         },
         {
-            "id": "rt.DH0->DG3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
+            "id": "rt.DH0->DG3",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B2"
             }
         },
         {
-            "id": "rt.DH0->DH2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH0"
+                "id": "DH0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
+            "id": "rt.DH0->DH2",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B2"
             }
         },
         {
-            "id": "rt.DE1->DE4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE4"
+                "id": "DE4",
+                "type": "Detector"
             },
+            "id": "rt.DE1->DE4",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B1"
             }
         },
         {
-            "id": "rt.DE1->DE5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE5"
+                "id": "DE5",
+                "type": "Detector"
             },
+            "id": "rt.DE1->DE5",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B2"
             }
         },
         {
-            "id": "rt.DE0->buffer_stop.4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.4"
+                "id": "buffer_stop.4",
+                "type": "BufferStop"
             },
+            "id": "rt.DE0->buffer_stop.4",
             "release_detectors": [],
             "switches_directions": {
                 "PD1": "STATIC",
@@ -947,30 +1726,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop.4->DD5",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.4"
+                "id": "buffer_stop.4",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD5"
+                "id": "DD5",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.4->DD5",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DD5->DE1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD5"
+                "id": "DD5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE1"
+                "id": "DE1",
+                "type": "Detector"
             },
+            "id": "rt.DD5->DE1",
             "release_detectors": [],
             "switches_directions": {
                 "PD0": "STATIC",
@@ -978,224 +1757,224 @@
             }
         },
         {
-            "id": "rt.DE4->DE7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE4"
+                "id": "DE4",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
+            "id": "rt.DE4->DE7",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B2"
             }
         },
         {
-            "id": "rt.DE2->DE0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE2"
+                "id": "DE2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
+            "id": "rt.DE2->DE0",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B1"
             }
         },
         {
-            "id": "rt.DE5->DE7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE5"
+                "id": "DE5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
+            "id": "rt.DE5->DE7",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B1"
             }
         },
         {
-            "id": "rt.DE3->DE0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE3"
+                "id": "DE3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE0"
+                "id": "DE0",
+                "type": "Detector"
             },
+            "id": "rt.DE3->DE0",
             "release_detectors": [],
             "switches_directions": {
                 "PE0": "A_B2"
             }
         },
         {
-            "id": "rt.DE7->DD4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE7"
+                "id": "DE7",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
+            "id": "rt.DE7->DD4",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B1"
             }
         },
         {
-            "id": "rt.DE6->DE3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE3"
+                "id": "DE3",
+                "type": "Detector"
             },
+            "id": "rt.DE6->DE3",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B1"
             }
         },
         {
-            "id": "rt.DE6->DE2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DE6"
+                "id": "DE6",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DE2"
+                "id": "DE2",
+                "type": "Detector"
             },
+            "id": "rt.DE6->DE2",
             "release_detectors": [],
             "switches_directions": {
                 "PE1": "A_B2"
             }
         },
         {
-            "id": "rt.DD7->DD4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD4"
+                "id": "DD4",
+                "type": "Detector"
             },
+            "id": "rt.DD7->DD4",
             "release_detectors": [],
             "switches_directions": {
                 "PE2": "A_B2"
             }
         },
         {
-            "id": "rt.DG0->DG3",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
+            "id": "rt.DG0->DG3",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B1"
             }
         },
         {
-            "id": "rt.DG0->DH2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG0"
+                "id": "DG0",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
+            "id": "rt.DG0->DH2",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B1"
             }
         },
         {
-            "id": "rt.DG1->DD7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
+            "id": "rt.DG1->DD7",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B1"
             }
         },
         {
-            "id": "rt.DG1->DF0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
+            "id": "rt.DG1->DF0",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A1_B2"
             }
         },
         {
-            "id": "rt.DG3->buffer_stop.5",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.5"
+                "id": "buffer_stop.5",
+                "type": "BufferStop"
             },
+            "id": "rt.DG3->buffer_stop.5",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B1"
             }
         },
         {
-            "id": "rt.DG3->buffer_stop.6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG3"
+                "id": "DG3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
+            "id": "rt.DG3->buffer_stop.6",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B2",
@@ -1203,108 +1982,108 @@
             }
         },
         {
-            "id": "rt.DG2->DH1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG2"
+                "id": "DG2",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
+            "id": "rt.DG2->DH1",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B1"
             }
         },
         {
-            "id": "rt.DG4->buffer_stop.6",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG4"
+                "id": "DG4",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
+            "id": "rt.DG4->buffer_stop.6",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B1"
             }
         },
         {
-            "id": "rt.buffer_stop.5->DG5",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.5"
+                "id": "buffer_stop.5",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG5"
+                "id": "DG5",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.5->DG5",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DG5->DG1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG5"
+                "id": "DG5",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
+            "id": "rt.DG5->DG1",
             "release_detectors": [],
             "switches_directions": {
                 "PG0": "A_B1"
             }
         },
         {
-            "id": "rt.buffer_stop.6->DG6",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.6"
+                "id": "buffer_stop.6",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.6->DG6",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DG6->DG2",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG2"
+                "id": "DG2",
+                "type": "Detector"
             },
+            "id": "rt.DG6->DG2",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B1"
             }
         },
         {
-            "id": "rt.DG6->DG1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DG6"
+                "id": "DG6",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG1"
+                "id": "DG1",
+                "type": "Detector"
             },
+            "id": "rt.DG6->DG1",
             "release_detectors": [],
             "switches_directions": {
                 "PG1": "A_B2",
@@ -1312,106 +2091,3209 @@
             }
         },
         {
-            "id": "rt.DH1->DD7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DD7"
+                "id": "DD7",
+                "type": "Detector"
             },
+            "id": "rt.DH1->DD7",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B1"
             }
         },
         {
-            "id": "rt.DH1->DF0",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DF0"
+                "id": "DF0",
+                "type": "Detector"
             },
+            "id": "rt.DH1->DF0",
             "release_detectors": [],
             "switches_directions": {
                 "PH0": "A2_B2"
             }
         },
         {
-            "id": "rt.DH2->DG4",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "DG4"
+                "id": "DG4",
+                "type": "Detector"
             },
+            "id": "rt.DH2->DG4",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B1"
             }
         },
         {
-            "id": "rt.DH2->buffer_stop.7",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH2"
+                "id": "DH2",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.7"
+                "id": "buffer_stop.7",
+                "type": "BufferStop"
             },
+            "id": "rt.DH2->buffer_stop.7",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B2"
             }
         },
         {
-            "id": "rt.buffer_stop.7->DH3",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop.7"
+                "id": "buffer_stop.7",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH3"
+                "id": "DH3",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop.7->DH3",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DH3->DH1",
             "entry_point": {
-                "type": "Detector",
-                "id": "DH3"
+                "id": "DH3",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "DH1"
+                "id": "DH1",
+                "type": "Detector"
             },
+            "id": "rt.DH3->DH1",
             "release_detectors": [],
             "switches_directions": {
                 "PH1": "A_B2"
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TA0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1750.0,
+            "sight_distance": 400.0,
+            "track": "TA1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1750.0,
+            "sight_distance": 400.0,
+            "track": "TA2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1780.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 4980.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6580.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8180.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8220.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9800.0,
+            "sight_distance": 400.0,
+            "track": "TA6"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1820.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 5020.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6620.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8180.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA7_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA7_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 8220.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SA6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SA6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9800.0,
+            "sight_distance": 400.0,
+            "track": "TA7"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SB0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SB0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TB0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 850.0,
+            "sight_distance": 400.0,
+            "track": "TC0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TC1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TC2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TC3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SC7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SC7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 850.0,
+            "sight_distance": 400.0,
+            "track": "TC3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1717.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3255.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3295.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 4792.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6330.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7867.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7907.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9405.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 10942.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_8",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_8",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12480.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_8r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_8r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12520.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_9",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_9",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 14017.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_10",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_10",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 15555.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_11",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_11",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17092.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_11r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_11r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17132.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_12",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_12",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 18630.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_13",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_13",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 20167.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_14",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_14",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21705.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_14r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_14r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21745.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD0_15",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD0_15",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 23242.5,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 24800.0,
+            "sight_distance": 400.0,
+            "track": "TD0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1757.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3255.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3295.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 4832.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6370.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_5r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_5r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7867.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7907.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9445.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 10982.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_8r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_8r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12480.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_8",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_8",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 12520.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_9",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_9",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 14057.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_10",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_10",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 15595.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_11r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_11r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17092.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_11",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_11",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 17132.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_12",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_12",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 18670.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_13",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_13",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 20207.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_14r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_14r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21705.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_14",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_14",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 21745.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD1_15",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD1_15",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 23282.5,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 24800.0,
+            "sight_distance": 400.0,
+            "track": "TD1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TD2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TD3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TD3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1300.0,
+            "sight_distance": 400.0,
+            "track": "TE0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2230.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SF1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SF1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2270.0,
+            "sight_distance": 400.0,
+            "track": "TF1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TE1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1850.0,
+            "sight_distance": 400.0,
+            "track": "TE2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TE3"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SE6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SE6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1800.0,
+            "sight_distance": 400.0,
+            "track": "TE3"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SD7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SD7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG0",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG0",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TG0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1980.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2020.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3800.0,
+            "sight_distance": 400.0,
+            "track": "TG1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG2"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 2800.0,
+            "sight_distance": 400.0,
+            "track": "TG2"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG4"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SG6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SG6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TG5"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TH0"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 800.0,
+            "sight_distance": 400.0,
+            "track": "TH0"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 200.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1780.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_1r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_1r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1820.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3380.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "SH1_2r",
+                    "side": "LEFT"
+                }
+            },
+            "id": "SH1_2r",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3420.0,
+            "sight_distance": 400.0,
+            "track": "TH1"
+        }
+    ],
+    "speed_sections": [
+        {
+            "id": "speed_section.0",
+            "on_routes": null,
+            "speed_limit": 83.33333333333333,
+            "speed_limit_by_tag": {
+                "HLP": 69.44444444444444
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TA0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "track": "TA2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TA5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA6"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "track": "TA7"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TB0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TC2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "track": "TC3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "track": "TD1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TD2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TD3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1500.0,
+                    "track": "TE0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3.0,
+                    "track": "TF0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 6500.0,
+                    "track": "TF1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2050.0,
+                    "track": "TE2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TE3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TG0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TG1"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 3000.0,
+                    "track": "TG2"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "track": "TG3"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG4"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "track": "TG5"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 5000.0,
+                    "track": "TH1"
+                }
+            ]
+        },
+        {
+            "id": "speed_section.1",
+            "on_routes": null,
+            "speed_limit": 39.44444444444444,
+            "speed_limit_by_tag": {
+                "E32C": 27.77777777777778
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 500.0,
+                    "end": 1000.0,
+                    "track": "TH0"
+                },
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "track": "TH1"
+                }
+            ]
+        },
+        {
+            "id": "speed_section.2",
+            "on_routes": null,
+            "speed_limit": 31.11111111111111,
+            "speed_limit_by_tag": {
+                "MA100": 22.22222222222222
+            },
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 3500.0,
+                    "end": 4400.0,
+                    "track": "TH1"
+                }
+            ]
+        }
+    ],
     "switches": [
         {
-            "id": "PA0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1426,16 +5308,16 @@
                     "track": "TA4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA1",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1450,16 +5332,16 @@
                     "track": "TA2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA2",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1474,16 +5356,16 @@
                     "track": "TA0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PA3",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PA3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PA3",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1498,16 +5380,16 @@
                     "track": "TA4"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PA3"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1522,16 +5404,16 @@
                     "track": "TC1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1546,16 +5428,16 @@
                     "track": "TC3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC2",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1570,16 +5452,16 @@
                     "track": "TC0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PC3",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PC3"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PC3",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1594,16 +5476,16 @@
                     "track": "TC2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PC3"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PD0",
-            "switch_type": "crossing",
+            "extensions": {
+                "sncf": {
+                    "label": "PD0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PD0",
             "ports": {
                 "A1": {
                     "endpoint": "END",
@@ -1622,16 +5504,16 @@
                     "track": "TD2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PD0"
-                }
-            }
+            "switch_type": "crossing"
         },
         {
-            "id": "PD1",
-            "switch_type": "crossing",
+            "extensions": {
+                "sncf": {
+                    "label": "PD1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PD1",
             "ports": {
                 "A1": {
                     "endpoint": "END",
@@ -1650,16 +5532,16 @@
                     "track": "TD3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PD1"
-                }
-            }
+            "switch_type": "crossing"
         },
         {
-            "id": "PE0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE0",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1674,16 +5556,16 @@
                     "track": "TE2"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PE1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1698,16 +5580,16 @@
                     "track": "TE1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PE2",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PE2"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PE2",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1722,16 +5604,16 @@
                     "track": "TG0"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PE2"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PG0",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PG0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PG0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1746,16 +5628,16 @@
                     "track": "TG3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PG0"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PG1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PG1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PG1",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -1770,16 +5652,16 @@
                     "track": "TG3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PG1"
-                }
-            }
+            "switch_type": "point_switch"
         },
         {
-            "id": "PH0",
-            "switch_type": "double_slip_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PH0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PH0",
             "ports": {
                 "A1": {
                     "endpoint": "BEGIN",
@@ -1798,16 +5680,16 @@
                     "track": "TD3"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PH0"
-                }
-            }
+            "switch_type": "double_slip_switch"
         },
         {
-            "id": "PH1",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "PH1"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "PH1",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -1822,17 +5704,21 @@
                     "track": "TH1"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "PH1"
-                }
-            }
+            "switch_type": "point_switch"
         }
     ],
     "track_sections": [
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 424242,
+                    "line_name": "West_parking",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -1842,41 +5728,41 @@
                         -0.365,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA0",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [
                 {
-                    "category": "GB1",
                     "begin": 0.0,
+                    "category": "GB1",
                     "end": 200.0
                 },
                 {
-                    "category": "G1",
                     "begin": 200.0,
+                    "category": "G1",
                     "end": 1900.0
                 },
                 {
-                    "category": "FR3.3",
                     "begin": 100.0,
+                    "category": "FR3.3",
                     "end": 1500.0
                 }
             ],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -1886,25 +5772,25 @@
                         -0.37,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA1",
             "length": 1950.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "A",
+                    "track_number": 3
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -1914,25 +5800,25 @@
                         -0.37,
                         49.49979999999999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA2",
             "length": 1950.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 3,
-                    "track_name": "A"
+                    "track_name": "J1",
+                    "track_number": 4
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -1942,25 +5828,25 @@
                         -0.365,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA3",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 4,
-                    "track_name": "J1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -1970,25 +5856,25 @@
                         -0.365,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA4",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
                     "line_name": "West_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "J2",
+                    "track_number": 3
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.37,
@@ -1998,25 +5884,25 @@
                         -0.365,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA5",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 424242,
-                    "line_name": "West_parking",
-                    "track_number": 3,
-                    "track_name": "J2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -2026,56 +5912,56 @@
                         -0.31,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA6",
             "length": 10000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": -3.0,
                     "begin": 4000.0,
-                    "end": 4300.0
+                    "end": 4300.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 4300.0,
-                    "end": 4700.0
+                    "end": 4700.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 4700.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7000.0,
-                    "end": 7300.0
+                    "end": 7300.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7300.0,
-                    "end": 7700.0
+                    "end": 7700.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7700.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.365,
@@ -2085,56 +5971,56 @@
                         -0.31,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TA7",
             "length": 10000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": -3.0,
                     "begin": 4000.0,
-                    "end": 4300.0
+                    "end": 4300.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 4300.0,
-                    "end": 4700.0
+                    "end": 4700.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 4700.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7000.0,
-                    "end": 7300.0
+                    "end": 7300.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7300.0,
-                    "end": 7700.0
+                    "end": 7700.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 7700.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 3.0
                 }
-            ],
-            "curves": [],
-            "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            ]
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 414141,
+                    "line_name": "South_West_Parking",
+                    "track_name": "A",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.4,
@@ -2152,25 +6038,25 @@
                         -0.37,
                         49.49979999999999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TB0",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 414141,
-                    "line_name": "South_West_Parking",
-                    "track_number": 1,
-                    "track_name": "A"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1bis",
+                    "track_number": 3
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2188,25 +6074,25 @@
                         -0.296,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC0",
             "length": 1050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 3,
-                    "track_name": "V1bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2216,25 +6102,25 @@
                         -0.296,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC1",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2244,25 +6130,25 @@
                         -0.296,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC2",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "V2bis",
+                    "track_number": 4
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.31,
@@ -2280,25 +6166,25 @@
                         -0.296,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TC3",
             "length": 1050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 4,
-                    "track_name": "V2bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.296,
@@ -2308,56 +6194,56 @@
                         -0.172,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD0",
             "length": 25000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 3.0,
                     "begin": 6000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 8000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 14000.0,
-                    "end": 15000.0
+                    "end": 15000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 15000.0,
-                    "end": 16000.0
+                    "end": 16000.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 16000.0,
-                    "end": 17000.0
+                    "end": 17000.0,
+                    "gradient": -3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.296,
@@ -2367,56 +6253,56 @@
                         -0.172,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD1",
             "length": 25000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 3.0,
                     "begin": 6000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": 6.0,
                     "begin": 7000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "gradient": 6.0
                 },
                 {
-                    "gradient": 3.0,
                     "begin": 8000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "gradient": 3.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 14000.0,
-                    "end": 15000.0
+                    "end": 15000.0,
+                    "gradient": -3.0
                 },
                 {
-                    "gradient": -6.0,
                     "begin": 15000.0,
-                    "end": 16000.0
+                    "end": 16000.0,
+                    "gradient": -6.0
                 },
                 {
-                    "gradient": -3.0,
                     "begin": 16000.0,
-                    "end": 17000.0
+                    "end": 17000.0,
+                    "gradient": -3.0
                 }
-            ],
+            ]
+        },
+        {
             "curves": [],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2426,25 +6312,25 @@
                         -0.15,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD2",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
                     "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2458,25 +6344,36 @@
                         -0.135,
                         49.49995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TD3",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [
+                {
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 6000.0
+                },
+                {
+                    "begin": 500.0,
+                    "end": 1000.0,
+                    "radius": 8000.0
+                }
+            ],
+            "extensions": {
+                "sncf": {
+                    "line_code": 444444,
+                    "line_name": "North_to_South_loop",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.165,
@@ -2490,36 +6387,25 @@
                         -0.172,
                         49.5
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE0",
             "length": 1500.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 6000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 8000.0,
-                    "begin": 500.0,
-                    "end": 1000.0
-                }
-            ],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2529,25 +6415,31 @@
                         -0.172,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TF0",
             "length": 3.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [
+                {
+                    "begin": 3100.0,
+                    "end": 4400.0,
+                    "radius": 9500.0
+                }
+            ],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.172,
@@ -2565,31 +6457,36 @@
                         -0.135,
                         49.466
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TF1",
             "length": 6500.0,
-            "slopes": [],
+            "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
             "curves": [
                 {
-                    "radius": 9500.0,
-                    "begin": 3100.0,
-                    "end": 4400.0
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 5000.0
+                },
+                {
+                    "begin": 1700.0,
+                    "end": 2000.0,
+                    "radius": 6000.0
                 }
             ],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1bis",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2607,36 +6504,25 @@
                         -0.165,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE1",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 5000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 6000.0,
-                    "begin": 1700.0,
-                    "end": 2000.0
-                }
-            ],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 2,
-                    "track_name": "V1bis"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2646,25 +6532,46 @@
                         -0.165,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE2",
             "length": 2050.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [
+                {
+                    "begin": 0.0,
+                    "end": 300.0,
+                    "radius": 5000.0
+                },
+                {
+                    "begin": 650.0,
+                    "end": 850.0,
+                    "radius": 9000.0
+                },
+                {
+                    "begin": 1150.0,
+                    "end": 1350.0,
+                    "radius": 8000.0
+                },
+                {
+                    "begin": 1700.0,
+                    "end": 2000.0,
+                    "radius": 7000.0
+                }
+            ],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
                     "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2682,46 +6589,25 @@
                         -0.15,
                         49.51
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TE3",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [
-                {
-                    "radius": 5000.0,
-                    "begin": 0.0,
-                    "end": 300.0
-                },
-                {
-                    "radius": 9000.0,
-                    "begin": 650.0,
-                    "end": 850.0
-                },
-                {
-                    "radius": 8000.0,
-                    "begin": 1150.0,
-                    "end": 1350.0
-                },
-                {
-                    "radius": 7000.0,
-                    "begin": 1700.0,
-                    "end": 2000.0
-                }
-            ],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 444444,
-                    "line_name": "North_to_South_loop",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.15,
@@ -2735,25 +6621,25 @@
                         -0.135,
                         49.49995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG0",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 454545,
+                    "line_name": "North_East_road",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.135,
@@ -2783,25 +6669,25 @@
                         -0.1082,
                         49.513
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG1",
             "length": 4000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 454545,
                     "line_name": "North_East_road",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -2827,25 +6713,25 @@
                         -0.108,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG2",
             "length": 3000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 454545,
-                    "line_name": "North_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 464646,
+                    "line_name": "North_East_parking",
+                    "track_name": "J4",
+                    "track_number": 3
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1082,
@@ -2855,25 +6741,25 @@
                         -0.108,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG3",
             "length": 50.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
                     "line_name": "North_East_parking",
-                    "track_number": 3,
-                    "track_name": "J4"
+                    "track_name": "V1",
+                    "track_number": 1
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1082,
@@ -2883,25 +6769,25 @@
                         -0.09,
                         49.513
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG4",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
                     "line_name": "North_East_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
+                    "track_name": "V2",
+                    "track_number": 2
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.108,
@@ -2911,25 +6797,25 @@
                         -0.09,
                         49.512899999999995
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TG5",
             "length": 2000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 464646,
-                    "line_name": "North_East_parking",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 434343,
+                    "line_name": "West_to_East_road",
+                    "track_name": "V2",
+                    "track_number": 2
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.135,
@@ -2943,25 +6829,25 @@
                         -0.12,
                         49.4999
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TH0",
             "length": 1000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 434343,
-                    "line_name": "West_to_East_road",
-                    "track_number": 2,
-                    "track_name": "V2"
-                }
-            }
+            "slopes": []
         },
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 474647,
+                    "line_name": "South_East_parking",
+                    "track_name": "V1",
+                    "track_number": 1
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.12,
@@ -2983,3900 +6869,14 @@
                         -0.09,
                         49.484
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "TH1",
             "length": 5000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 474647,
-                    "line_name": "South_East_parking",
-                    "track_number": 1,
-                    "track_name": "V1"
-                }
-            }
+            "slopes": []
         }
     ],
-    "speed_sections": [
-        {
-            "id": "speed_section.0",
-            "speed_limit": 83.33333333333333,
-            "speed_limit_by_tag": {
-                "HLP": 69.44444444444444
-            },
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA1",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA2",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA4",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA5",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA7",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TB0",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC0",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC1",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC2",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC3",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD0",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD1",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE0",
-                    "begin": 0.0,
-                    "end": 1500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF0",
-                    "begin": 0.0,
-                    "end": 3.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF1",
-                    "begin": 0.0,
-                    "end": 6500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE1",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE2",
-                    "begin": 0.0,
-                    "end": 2050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE3",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG2",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG5",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 5000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "speed_section.1",
-            "speed_limit": 39.44444444444444,
-            "speed_limit_by_tag": {
-                "E32C": 27.77777777777778
-            },
-            "track_ranges": [
-                {
-                    "track": "TH0",
-                    "begin": 500.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        },
-        {
-            "id": "speed_section.2",
-            "speed_limit": 31.11111111111111,
-            "speed_limit_by_tag": {
-                "MA100": 22.22222222222222
-            },
-            "track_ranges": [
-                {
-                    "track": "TH1",
-                    "begin": 3500.0,
-                    "end": 4400.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        }
-    ],
-    "electrifications": [
-        {
-            "id": "electrification_25k",
-            "voltage": "25000V",
-            "track_ranges": [
-                {
-                    "track": "TA1",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA2",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA4",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA5",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA7",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TB0",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC0",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC1",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC2",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC3",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD0",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD3",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE0",
-                    "begin": 0.0,
-                    "end": 1500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF0",
-                    "begin": 0.0,
-                    "end": 3.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF1",
-                    "begin": 0.0,
-                    "end": 6500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE1",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE2",
-                    "begin": 0.0,
-                    "end": 2050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE3",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG2",
-                    "begin": 0.0,
-                    "end": 3000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG3",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG5",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TH1",
-                    "begin": 0.0,
-                    "end": 5000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ]
-        },
-        {
-            "id": "electrification_1.5k",
-            "voltage": "1500V",
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ]
-        }
-    ],
-    "signals": [
-        {
-            "track": "TA0",
-            "position": 1800.0,
-            "id": "SA2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA1",
-            "position": 1750.0,
-            "id": "SA0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA2",
-            "position": 1750.0,
-            "id": "SA1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 200.0,
-            "id": "SA3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 1780.0,
-            "id": "SA6_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 3380.0,
-            "id": "SA6_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 3420.0,
-            "id": "SA6_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 4980.0,
-            "id": "SA6_3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 6580.0,
-            "id": "SA6_4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 8180.0,
-            "id": "SA6_5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 8220.0,
-            "id": "SA6_5r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA6",
-            "position": 9800.0,
-            "id": "SA5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 200.0,
-            "id": "SA4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 1820.0,
-            "id": "SA7_1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 3380.0,
-            "id": "SA7_2r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 3420.0,
-            "id": "SA7_2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 5020.0,
-            "id": "SA7_3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 6620.0,
-            "id": "SA7_4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 8180.0,
-            "id": "SA7_5r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 8220.0,
-            "id": "SA7_5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA7_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TA7",
-            "position": 9800.0,
-            "id": "SA6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SA6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TB0",
-            "position": 2800.0,
-            "id": "SB0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SB0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC0",
-            "position": 200.0,
-            "id": "SC0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC0",
-            "position": 850.0,
-            "id": "SC4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC1",
-            "position": 200.0,
-            "id": "SC1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC1",
-            "position": 800.0,
-            "id": "SC5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC2",
-            "position": 200.0,
-            "id": "SC2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC2",
-            "position": 800.0,
-            "id": "SC6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC3",
-            "position": 200.0,
-            "id": "SC3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TC3",
-            "position": 850.0,
-            "id": "SC7",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SC7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 200.0,
-            "id": "SD0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 1717.5,
-            "id": "SD0_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 3255.0,
-            "id": "SD0_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 3295.0,
-            "id": "SD0_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 4792.5,
-            "id": "SD0_3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 6330.0,
-            "id": "SD0_4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 7867.5,
-            "id": "SD0_5",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 7907.5,
-            "id": "SD0_5r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 9405.0,
-            "id": "SD0_6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 10942.5,
-            "id": "SD0_7",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 12480.0,
-            "id": "SD0_8",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_8",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 12520.0,
-            "id": "SD0_8r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_8r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 14017.5,
-            "id": "SD0_9",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_9",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 15555.0,
-            "id": "SD0_10",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_10",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 17092.5,
-            "id": "SD0_11",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_11",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 17132.5,
-            "id": "SD0_11r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_11r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 18630.0,
-            "id": "SD0_12",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_12",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 20167.5,
-            "id": "SD0_13",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_13",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 21705.0,
-            "id": "SD0_14",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_14",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 21745.0,
-            "id": "SD0_14r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_14r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 23242.5,
-            "id": "SD0_15",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD0_15",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD0",
-            "position": 24800.0,
-            "id": "SD2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 200.0,
-            "id": "SD1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 1757.5,
-            "id": "SD1_1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 3255.0,
-            "id": "SD1_2r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 3295.0,
-            "id": "SD1_2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 4832.5,
-            "id": "SD1_3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 6370.0,
-            "id": "SD1_4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 7867.5,
-            "id": "SD1_5r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_5r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 7907.5,
-            "id": "SD1_5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 9445.0,
-            "id": "SD1_6",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 10982.5,
-            "id": "SD1_7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 12480.0,
-            "id": "SD1_8r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_8r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 12520.0,
-            "id": "SD1_8",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_8",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 14057.5,
-            "id": "SD1_9",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_9",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 15595.0,
-            "id": "SD1_10",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_10",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 17092.5,
-            "id": "SD1_11r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_11r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 17132.5,
-            "id": "SD1_11",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_11",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 18670.0,
-            "id": "SD1_12",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_12",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 20207.5,
-            "id": "SD1_13",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_13",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 21705.0,
-            "id": "SD1_14r",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_14r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 21745.0,
-            "id": "SD1_14",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_14",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 23282.5,
-            "id": "SD1_15",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD1_15",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD1",
-            "position": 24800.0,
-            "id": "SD3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD2",
-            "position": 200.0,
-            "id": "SD4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD2",
-            "position": 1800.0,
-            "id": "SD6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD3",
-            "position": 200.0,
-            "id": "SF0",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TD3",
-            "position": 2800.0,
-            "id": "SH0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE0",
-            "position": 200.0,
-            "id": "SE1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE0",
-            "position": 1300.0,
-            "id": "SE0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 200.0,
-            "id": "SD5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 2230.0,
-            "id": "SF1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TF1",
-            "position": 2270.0,
-            "id": "SF1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SF1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE1",
-            "position": 200.0,
-            "id": "SE4",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE1",
-            "position": 1800.0,
-            "id": "SE2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE2",
-            "position": 200.0,
-            "id": "SE5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE2",
-            "position": 1850.0,
-            "id": "SE3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE3",
-            "position": 200.0,
-            "id": "SE7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TE3",
-            "position": 1800.0,
-            "id": "SE6",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SE6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG0",
-            "position": 200.0,
-            "id": "SD7",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SD7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG0",
-            "position": 800.0,
-            "id": "SG0",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG0",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 200.0,
-            "id": "SG1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 1980.0,
-            "id": "SG1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 2020.0,
-            "id": "SG1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG1",
-            "position": 3800.0,
-            "id": "SG3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG2",
-            "position": 200.0,
-            "id": "SG2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG2",
-            "position": 2800.0,
-            "id": "SG4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG4",
-            "position": 200.0,
-            "id": "SG5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TG5",
-            "position": 200.0,
-            "id": "SG6",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SG6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH0",
-            "position": 200.0,
-            "id": "SH1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH0",
-            "position": 800.0,
-            "id": "SH2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 200.0,
-            "id": "SH3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 1780.0,
-            "id": "SH1_1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 1820.0,
-            "id": "SH1_1r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_1r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 3380.0,
-            "id": "SH1_2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "TH1",
-            "position": 3420.0,
-            "id": "SH1_2r",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "SH1_2r",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "TA0",
-            "position": 0.0,
-            "id": "buffer_stop.0"
-        },
-        {
-            "track": "TA1",
-            "position": 0.0,
-            "id": "buffer_stop.1"
-        },
-        {
-            "track": "TA2",
-            "position": 0.0,
-            "id": "buffer_stop.2"
-        },
-        {
-            "track": "TB0",
-            "position": 0.0,
-            "id": "buffer_stop.3"
-        },
-        {
-            "track": "TF1",
-            "position": 6500.0,
-            "id": "buffer_stop.4"
-        },
-        {
-            "track": "TG4",
-            "position": 2000.0,
-            "id": "buffer_stop.5"
-        },
-        {
-            "track": "TG5",
-            "position": 2000.0,
-            "id": "buffer_stop.6"
-        },
-        {
-            "track": "TH1",
-            "position": 5000.0,
-            "id": "buffer_stop.7"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "TA0",
-            "position": 1820.0,
-            "id": "DA2"
-        },
-        {
-            "track": "TA1",
-            "position": 1770.0,
-            "id": "DA0"
-        },
-        {
-            "track": "TA2",
-            "position": 1770.0,
-            "id": "DA1"
-        },
-        {
-            "track": "TA3",
-            "position": 25.0,
-            "id": "DA7"
-        },
-        {
-            "track": "TA4",
-            "position": 25.0,
-            "id": "DA8"
-        },
-        {
-            "track": "TA5",
-            "position": 25.0,
-            "id": "DA9"
-        },
-        {
-            "track": "TA6",
-            "position": 180.0,
-            "id": "DA3"
-        },
-        {
-            "track": "TA6",
-            "position": 1800.0,
-            "id": "DA6_1"
-        },
-        {
-            "track": "TA6",
-            "position": 3400.0,
-            "id": "DA6_2"
-        },
-        {
-            "track": "TA6",
-            "position": 5000.0,
-            "id": "DA6_3"
-        },
-        {
-            "track": "TA6",
-            "position": 6600.0,
-            "id": "DA6_4"
-        },
-        {
-            "track": "TA6",
-            "position": 8200.0,
-            "id": "DA6_5"
-        },
-        {
-            "track": "TA6",
-            "position": 9820.0,
-            "id": "DA5"
-        },
-        {
-            "track": "TA7",
-            "position": 180.0,
-            "id": "DA4"
-        },
-        {
-            "track": "TA7",
-            "position": 1800.0,
-            "id": "DA7_1"
-        },
-        {
-            "track": "TA7",
-            "position": 3400.0,
-            "id": "DA7_2"
-        },
-        {
-            "track": "TA7",
-            "position": 5000.0,
-            "id": "DA7_3"
-        },
-        {
-            "track": "TA7",
-            "position": 6600.0,
-            "id": "DA7_4"
-        },
-        {
-            "track": "TA7",
-            "position": 8200.0,
-            "id": "DA7_5"
-        },
-        {
-            "track": "TA7",
-            "position": 9820.0,
-            "id": "DA6"
-        },
-        {
-            "track": "TB0",
-            "position": 2820.0,
-            "id": "DB0"
-        },
-        {
-            "track": "TC0",
-            "position": 180.0,
-            "id": "DC0"
-        },
-        {
-            "track": "TC0",
-            "position": 870.0,
-            "id": "DC4"
-        },
-        {
-            "track": "TC1",
-            "position": 180.0,
-            "id": "DC1"
-        },
-        {
-            "track": "TC1",
-            "position": 820.0,
-            "id": "DC5"
-        },
-        {
-            "track": "TC2",
-            "position": 180.0,
-            "id": "DC2"
-        },
-        {
-            "track": "TC2",
-            "position": 820.0,
-            "id": "DC6"
-        },
-        {
-            "track": "TC3",
-            "position": 180.0,
-            "id": "DC3"
-        },
-        {
-            "track": "TC3",
-            "position": 870.0,
-            "id": "DC7"
-        },
-        {
-            "track": "TD0",
-            "position": 180.0,
-            "id": "DD0"
-        },
-        {
-            "track": "TD0",
-            "position": 1737.5,
-            "id": "DD0_1"
-        },
-        {
-            "track": "TD0",
-            "position": 3275.0,
-            "id": "DD0_2"
-        },
-        {
-            "track": "TD0",
-            "position": 4812.5,
-            "id": "DD0_3"
-        },
-        {
-            "track": "TD0",
-            "position": 6350.0,
-            "id": "DD0_4"
-        },
-        {
-            "track": "TD0",
-            "position": 7887.5,
-            "id": "DD0_5"
-        },
-        {
-            "track": "TD0",
-            "position": 9425.0,
-            "id": "DD0_6"
-        },
-        {
-            "track": "TD0",
-            "position": 10962.5,
-            "id": "DD0_7"
-        },
-        {
-            "track": "TD0",
-            "position": 12500.0,
-            "id": "DD0_8"
-        },
-        {
-            "track": "TD0",
-            "position": 14037.5,
-            "id": "DD0_9"
-        },
-        {
-            "track": "TD0",
-            "position": 15575.0,
-            "id": "DD0_10"
-        },
-        {
-            "track": "TD0",
-            "position": 17112.5,
-            "id": "DD0_11"
-        },
-        {
-            "track": "TD0",
-            "position": 18650.0,
-            "id": "DD0_12"
-        },
-        {
-            "track": "TD0",
-            "position": 20187.5,
-            "id": "DD0_13"
-        },
-        {
-            "track": "TD0",
-            "position": 21725.0,
-            "id": "DD0_14"
-        },
-        {
-            "track": "TD0",
-            "position": 23262.5,
-            "id": "DD0_15"
-        },
-        {
-            "track": "TD0",
-            "position": 24820.0,
-            "id": "DD2"
-        },
-        {
-            "track": "TD1",
-            "position": 180.0,
-            "id": "DD1"
-        },
-        {
-            "track": "TD1",
-            "position": 1737.5,
-            "id": "DD1_1"
-        },
-        {
-            "track": "TD1",
-            "position": 3275.0,
-            "id": "DD1_2"
-        },
-        {
-            "track": "TD1",
-            "position": 4812.5,
-            "id": "DD1_3"
-        },
-        {
-            "track": "TD1",
-            "position": 6350.0,
-            "id": "DD1_4"
-        },
-        {
-            "track": "TD1",
-            "position": 7887.5,
-            "id": "DD1_5"
-        },
-        {
-            "track": "TD1",
-            "position": 9425.0,
-            "id": "DD1_6"
-        },
-        {
-            "track": "TD1",
-            "position": 10962.5,
-            "id": "DD1_7"
-        },
-        {
-            "track": "TD1",
-            "position": 12500.0,
-            "id": "DD1_8"
-        },
-        {
-            "track": "TD1",
-            "position": 14037.5,
-            "id": "DD1_9"
-        },
-        {
-            "track": "TD1",
-            "position": 15575.0,
-            "id": "DD1_10"
-        },
-        {
-            "track": "TD1",
-            "position": 17112.5,
-            "id": "DD1_11"
-        },
-        {
-            "track": "TD1",
-            "position": 18650.0,
-            "id": "DD1_12"
-        },
-        {
-            "track": "TD1",
-            "position": 20187.5,
-            "id": "DD1_13"
-        },
-        {
-            "track": "TD1",
-            "position": 21725.0,
-            "id": "DD1_14"
-        },
-        {
-            "track": "TD1",
-            "position": 23262.5,
-            "id": "DD1_15"
-        },
-        {
-            "track": "TD1",
-            "position": 24820.0,
-            "id": "DD3"
-        },
-        {
-            "track": "TD2",
-            "position": 180.0,
-            "id": "DD4"
-        },
-        {
-            "track": "TD2",
-            "position": 1820.0,
-            "id": "DD6"
-        },
-        {
-            "track": "TD3",
-            "position": 180.0,
-            "id": "DF0"
-        },
-        {
-            "track": "TD3",
-            "position": 2820.0,
-            "id": "DH0"
-        },
-        {
-            "track": "TE0",
-            "position": 180.0,
-            "id": "DE1"
-        },
-        {
-            "track": "TE0",
-            "position": 1320.0,
-            "id": "DE0"
-        },
-        {
-            "track": "TF1",
-            "position": 180.0,
-            "id": "DD5"
-        },
-        {
-            "track": "TF1",
-            "position": 2250.0,
-            "id": "DF1_1"
-        },
-        {
-            "track": "TE1",
-            "position": 180.0,
-            "id": "DE4"
-        },
-        {
-            "track": "TE1",
-            "position": 1820.0,
-            "id": "DE2"
-        },
-        {
-            "track": "TE2",
-            "position": 180.0,
-            "id": "DE5"
-        },
-        {
-            "track": "TE2",
-            "position": 1870.0,
-            "id": "DE3"
-        },
-        {
-            "track": "TE3",
-            "position": 180.0,
-            "id": "DE7"
-        },
-        {
-            "track": "TE3",
-            "position": 1820.0,
-            "id": "DE6"
-        },
-        {
-            "track": "TG0",
-            "position": 180.0,
-            "id": "DD7"
-        },
-        {
-            "track": "TG0",
-            "position": 820.0,
-            "id": "DG0"
-        },
-        {
-            "track": "TG1",
-            "position": 180.0,
-            "id": "DG1"
-        },
-        {
-            "track": "TG1",
-            "position": 2000.0,
-            "id": "DG1_1"
-        },
-        {
-            "track": "TG1",
-            "position": 3820.0,
-            "id": "DG3"
-        },
-        {
-            "track": "TG2",
-            "position": 180.0,
-            "id": "DG2"
-        },
-        {
-            "track": "TG2",
-            "position": 2820.0,
-            "id": "DG4"
-        },
-        {
-            "track": "TG3",
-            "position": 25.0,
-            "id": "DG7"
-        },
-        {
-            "track": "TG4",
-            "position": 180.0,
-            "id": "DG5"
-        },
-        {
-            "track": "TG5",
-            "position": 180.0,
-            "id": "DG6"
-        },
-        {
-            "track": "TH0",
-            "position": 180.0,
-            "id": "DH1"
-        },
-        {
-            "track": "TH0",
-            "position": 820.0,
-            "id": "DH2"
-        },
-        {
-            "track": "TH1",
-            "position": 180.0,
-            "id": "DH3"
-        },
-        {
-            "track": "TH1",
-            "position": 1800.0,
-            "id": "DH1_1"
-        },
-        {
-            "track": "TH1",
-            "position": 3400.0,
-            "id": "DH1_2"
-        }
-    ],
-    "neutral_sections": [
-        {
-            "id": "neutral_section.0",
-            "announcement_track_ranges": [
-                {
-                    "track": "TG1",
-                    "begin": 3500.0,
-                    "end": 4000.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TG4",
-                    "begin": 0.0,
-                    "end": 500.0,
-                    "direction": "START_TO_STOP"
-                },
-                {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": true
-        },
-        {
-            "id": "neutral_section.1",
-            "announcement_track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1850.0,
-                    "end": 1960.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1960.0,
-                    "end": 2000.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": true
-        },
-        {
-            "id": "neutral_section.2",
-            "announcement_track_ranges": [],
-            "track_ranges": [
-                {
-                    "track": "TA6",
-                    "begin": 8500.0,
-                    "end": 8600.0,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-            "lower_pantograph": false
-        },
-        {
-            "id": "neutral_section.3",
-            "announcement_track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1990.0,
-                    "end": 2000.0,
-                    "direction": "STOP_TO_START"
-                }
-            ],
-            "track_ranges": [
-                {
-                    "track": "TA0",
-                    "begin": 1850.0,
-                    "end": 1990.0,
-                    "direction": "STOP_TO_START"
-                }
-            ],
-            "lower_pantograph": false
-        }
-    ]
+    "version": "3.5.2"
 }

--- a/tests/data/infras/tiny_infra/infra.json
+++ b/tests/data/infras/tiny_infra/infra.json
@@ -1,89 +1,130 @@
 {
-    "version": "3.5.2",
+    "buffer_stops": [
+        {
+            "id": "buffer_stop_a",
+            "position": 0.0,
+            "track": "ne.micro.foo_a"
+        },
+        {
+            "id": "buffer_stop_b",
+            "position": 0.0,
+            "track": "ne.micro.foo_b"
+        },
+        {
+            "id": "buffer_stop_c",
+            "position": 200.0,
+            "track": "ne.micro.bar_a"
+        }
+    ],
+    "detectors": [
+        {
+            "id": "tde.foo_a-switch_foo",
+            "position": 175.0,
+            "track": "ne.micro.foo_a"
+        },
+        {
+            "id": "tde.foo_b-switch_foo",
+            "position": 175.0,
+            "track": "ne.micro.foo_b"
+        },
+        {
+            "id": "tde.track-bar",
+            "position": 25.0,
+            "track": "ne.micro.bar_a"
+        },
+        {
+            "id": "tde.switch_foo-track",
+            "position": 25.0,
+            "track": "ne.micro.foo_to_bar"
+        }
+    ],
+    "electrifications": [],
+    "extended_switch_types": [],
+    "level_crossings": [],
+    "neutral_sections": [],
     "operational_points": [
         {
-            "id": "op.station_foo",
-            "parts": [
-                {
-                    "track": "ne.micro.foo_a",
-                    "position": 100.0,
-                    "local_track_name": "V1"
-                },
-                {
-                    "track": "ne.micro.foo_b",
-                    "position": 100.0,
-                    "local_track_name": "V2"
-                }
-            ],
-            "weight": null,
-            "plc": null,
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.station_foo",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
-        },
-        {
-            "id": "op.station_bar",
+            },
+            "id": "op.station_foo",
             "parts": [
                 {
-                    "track": "ne.micro.bar_a",
+                    "local_track_name": "V1",
                     "position": 100.0,
-                    "local_track_name": "V1"
+                    "track": "ne.micro.foo_a"
+                },
+                {
+                    "local_track_name": "V2",
+                    "position": 100.0,
+                    "track": "ne.micro.foo_b"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.station_bar",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
+            },
+            "id": "op.station_bar",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 100.0,
+                    "track": "ne.micro.bar_a"
+                }
+            ],
+            "plc": null,
+            "weight": null
         }
     ],
-    "level_crossings": [],
     "routes": [
         {
-            "id": "rt.buffer_stop_a->tde.foo_a-switch_foo",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop_a"
+                "id": "buffer_stop_a",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "tde.foo_a-switch_foo"
+                "id": "tde.foo_a-switch_foo",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop_a->tde.foo_a-switch_foo",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.tde.foo_a-switch_foo->buffer_stop_c",
             "entry_point": {
-                "type": "Detector",
-                "id": "tde.foo_a-switch_foo"
+                "id": "tde.foo_a-switch_foo",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop_c"
+                "id": "buffer_stop_c",
+                "type": "BufferStop"
             },
+            "id": "rt.tde.foo_a-switch_foo->buffer_stop_c",
             "release_detectors": [
                 "tde.switch_foo-track",
                 "tde.track-bar"
@@ -94,30 +135,30 @@
             }
         },
         {
-            "id": "rt.buffer_stop_b->tde.foo_b-switch_foo",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop_b"
+                "id": "buffer_stop_b",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "tde.foo_b-switch_foo"
+                "id": "tde.foo_b-switch_foo",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop_b->tde.foo_b-switch_foo",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.tde.foo_b-switch_foo->buffer_stop_c",
             "entry_point": {
-                "type": "Detector",
-                "id": "tde.foo_b-switch_foo"
+                "id": "tde.foo_b-switch_foo",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop_c"
+                "id": "buffer_stop_c",
+                "type": "BufferStop"
             },
+            "id": "rt.tde.foo_b-switch_foo->buffer_stop_c",
             "release_detectors": [
                 "tde.switch_foo-track",
                 "tde.track-bar"
@@ -128,46 +169,46 @@
             }
         },
         {
-            "id": "rt.buffer_stop_c->tde.track-bar",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop_c"
+                "id": "buffer_stop_c",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "tde.track-bar"
+                "id": "tde.track-bar",
+                "type": "Detector"
             },
+            "id": "rt.buffer_stop_c->tde.track-bar",
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.tde.track-bar->tde.switch_foo-track",
             "entry_point": {
-                "type": "Detector",
-                "id": "tde.track-bar"
+                "id": "tde.track-bar",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "tde.switch_foo-track"
+                "id": "tde.switch_foo-track",
+                "type": "Detector"
             },
+            "id": "rt.tde.track-bar->tde.switch_foo-track",
             "release_detectors": [],
             "switches_directions": {
                 "switch.0": "STATIC"
             }
         },
         {
-            "id": "rt.tde.switch_foo-track->buffer_stop_b",
             "entry_point": {
-                "type": "Detector",
-                "id": "tde.switch_foo-track"
+                "id": "tde.switch_foo-track",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop_b"
+                "id": "buffer_stop_b",
+                "type": "BufferStop"
             },
+            "id": "rt.tde.switch_foo-track->buffer_stop_b",
             "release_detectors": [
                 "tde.foo_b-switch_foo"
             ],
@@ -176,16 +217,16 @@
             }
         },
         {
-            "id": "rt.tde.switch_foo-track->buffer_stop_a",
             "entry_point": {
-                "type": "Detector",
-                "id": "tde.switch_foo-track"
+                "id": "tde.switch_foo-track",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "buffer_stop_a"
+                "id": "buffer_stop_a",
+                "type": "BufferStop"
             },
+            "id": "rt.tde.switch_foo-track->buffer_stop_a",
             "release_detectors": [
                 "tde.foo_a-switch_foo"
             ],
@@ -194,12 +235,168 @@
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "il.sig.C1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "il.sig.C1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 150.0,
+            "sight_distance": 400.0,
+            "track": "ne.micro.foo_a"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "il.sig.C3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "il.sig.C3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 150.0,
+            "sight_distance": 400.0,
+            "track": "ne.micro.foo_b"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "il.sig.S7",
+                    "side": "LEFT"
+                }
+            },
+            "id": "il.sig.S7",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 0.0,
+            "sight_distance": 400.0,
+            "track": "ne.micro.bar_a"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "il.sig.C2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "il.sig.C2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 50.0,
+            "sight_distance": 400.0,
+            "track": "ne.micro.bar_a"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "il.sig.C6",
+                    "side": "LEFT"
+                }
+            },
+            "id": "il.sig.C6",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 50.0,
+            "sight_distance": 400.0,
+            "track": "ne.micro.foo_to_bar"
+        }
+    ],
+    "speed_sections": [
+        {
+            "id": "speed_section.0",
+            "on_routes": null,
+            "speed_limit": 16.666666666666668,
+            "speed_limit_by_tag": {},
+            "track_ranges": [
+                {
+                    "applicable_directions": "BOTH",
+                    "begin": 2000.0,
+                    "end": 6000.0,
+                    "track": "ne.micro.foo_to_bar"
+                }
+            ]
+        }
+    ],
     "switches": [
         {
-            "id": "switch.0",
-            "switch_type": "link",
+            "extensions": {
+                "sncf": {
+                    "label": "switch.0"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "switch.0",
             "ports": {
                 "A": {
                     "endpoint": "END",
@@ -210,16 +407,16 @@
                     "track": "ne.micro.bar_a"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "switch.0"
-                }
-            }
+            "switch_type": "link"
         },
         {
-            "id": "il.switch_foo",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "il.switch_foo"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "il.switch_foo",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -234,17 +431,27 @@
                     "track": "ne.micro.foo_a"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "il.switch_foo"
-                }
-            }
+            "switch_type": "point_switch"
         }
     ],
     "track_sections": [
         {
+            "curves": [
+                {
+                    "begin": 0.0,
+                    "end": 200.0,
+                    "radius": 2000.0
+                }
+            ],
+            "extensions": {
+                "sncf": {
+                    "line_code": 0,
+                    "line_name": "placeholder_line",
+                    "track_name": "placeholder_track",
+                    "track_number": 0
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -42.0,
@@ -254,31 +461,31 @@
                         -42.0,
                         71.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "ne.micro.foo_a",
             "length": 200.0,
-            "slopes": [],
+            "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
             "curves": [
                 {
-                    "radius": 2000.0,
                     "begin": 0.0,
-                    "end": 200.0
+                    "end": 200.0,
+                    "radius": 2000.0
                 }
             ],
-            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -41.0,
@@ -288,37 +495,31 @@
                         -42.0,
                         71.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "ne.micro.foo_b",
             "length": 200.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 10.0,
                     "begin": 0.0,
-                    "end": 200.0
+                    "end": 200.0,
+                    "gradient": 10.0
                 }
-            ],
-            "curves": [
-                {
-                    "radius": 2000.0,
-                    "begin": 0.0,
-                    "end": 200.0
-                }
-            ],
-            "loading_gauge_limits": [],
+            ]
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -42.0,
@@ -328,25 +529,25 @@
                         -42.0,
                         73.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "ne.micro.bar_a",
             "length": 200.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -42.0,
@@ -356,226 +557,25 @@
                         -42.0,
                         72.0
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "ne.micro.foo_to_bar",
             "length": 10000.0,
+            "loading_gauge_limits": [],
             "slopes": [
                 {
-                    "gradient": 10.0,
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "gradient": 10.0
                 },
                 {
-                    "gradient": -10.0,
                     "begin": 5000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "gradient": -10.0
                 }
-            ],
-            "curves": [],
-            "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 0,
-                    "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
-                }
-            }
+            ]
         }
     ],
-    "speed_sections": [
-        {
-            "id": "speed_section.0",
-            "speed_limit": 16.666666666666668,
-            "speed_limit_by_tag": {},
-            "track_ranges": [
-                {
-                    "track": "ne.micro.foo_to_bar",
-                    "begin": 2000.0,
-                    "end": 6000.0,
-                    "applicable_directions": "BOTH"
-                }
-            ],
-            "on_routes": null
-        }
-    ],
-    "electrifications": [],
-    "signals": [
-        {
-            "track": "ne.micro.foo_a",
-            "position": 150.0,
-            "id": "il.sig.C1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "il.sig.C1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "ne.micro.foo_b",
-            "position": 150.0,
-            "id": "il.sig.C3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "il.sig.C3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "ne.micro.bar_a",
-            "position": 0.0,
-            "id": "il.sig.S7",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "il.sig.S7",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "ne.micro.bar_a",
-            "position": 50.0,
-            "id": "il.sig.C2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "il.sig.C2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "ne.micro.foo_to_bar",
-            "position": 50.0,
-            "id": "il.sig.C6",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "il.sig.C6",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "ne.micro.foo_a",
-            "position": 0.0,
-            "id": "buffer_stop_a"
-        },
-        {
-            "track": "ne.micro.foo_b",
-            "position": 0.0,
-            "id": "buffer_stop_b"
-        },
-        {
-            "track": "ne.micro.bar_a",
-            "position": 200.0,
-            "id": "buffer_stop_c"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "ne.micro.foo_a",
-            "position": 175.0,
-            "id": "tde.foo_a-switch_foo"
-        },
-        {
-            "track": "ne.micro.foo_b",
-            "position": 175.0,
-            "id": "tde.foo_b-switch_foo"
-        },
-        {
-            "track": "ne.micro.bar_a",
-            "position": 25.0,
-            "id": "tde.track-bar"
-        },
-        {
-            "track": "ne.micro.foo_to_bar",
-            "position": 25.0,
-            "id": "tde.switch_foo-track"
-        }
-    ],
-    "neutral_sections": []
+    "version": "3.5.2"
 }

--- a/tests/data/infras/y_infra/infra.json
+++ b/tests/data/infras/y_infra/infra.json
@@ -1,95 +1,171 @@
 {
-    "version": "3.5.2",
+    "buffer_stops": [
+        {
+            "id": "bf.a",
+            "position": 0.0,
+            "track": "t_a"
+        },
+        {
+            "id": "bf.b",
+            "position": 0.0,
+            "track": "t_b"
+        },
+        {
+            "id": "bf.c",
+            "position": 10000.0,
+            "track": "t_center"
+        }
+    ],
+    "detectors": [
+        {
+            "id": "det.a1",
+            "position": 3000.0,
+            "track": "t_a"
+        },
+        {
+            "id": "det.a2",
+            "position": 6000.0,
+            "track": "t_a"
+        },
+        {
+            "id": "det.a3",
+            "position": 9000.0,
+            "track": "t_a"
+        },
+        {
+            "id": "det.b1",
+            "position": 3000.0,
+            "track": "t_b"
+        },
+        {
+            "id": "det.b2",
+            "position": 6000.0,
+            "track": "t_b"
+        },
+        {
+            "id": "det.b3",
+            "position": 9000.0,
+            "track": "t_b"
+        },
+        {
+            "id": "det.c1",
+            "position": 1000.0,
+            "track": "t_center"
+        },
+        {
+            "id": "det.c2",
+            "position": 3000.0,
+            "track": "t_center"
+        },
+        {
+            "id": "det.c3",
+            "position": 5000.0,
+            "track": "t_center"
+        },
+        {
+            "id": "det.c4",
+            "position": 7000.0,
+            "track": "t_center"
+        },
+        {
+            "id": "det.c5",
+            "position": 9000.0,
+            "track": "t_center"
+        }
+    ],
+    "electrifications": [],
+    "extended_switch_types": [],
+    "level_crossings": [],
+    "neutral_sections": [],
     "operational_points": [
         {
-            "id": "op.a",
-            "parts": [
-                {
-                    "track": "t_a",
-                    "position": 0.0,
-                    "local_track_name": "V1"
-                }
-            ],
-            "weight": null,
-            "plc": null,
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.a",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
-        },
-        {
-            "id": "op.b",
+            },
+            "id": "op.a",
             "parts": [
                 {
-                    "track": "t_b",
+                    "local_track_name": "V1",
                     "position": 0.0,
-                    "local_track_name": "V1"
+                    "track": "t_a"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.b",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
-        },
-        {
-            "id": "op.c",
+            },
+            "id": "op.b",
             "parts": [
                 {
-                    "track": "t_center",
-                    "position": 10000.0,
-                    "local_track_name": "V1"
+                    "local_track_name": "V1",
+                    "position": 0.0,
+                    "track": "t_b"
                 }
             ],
-            "weight": null,
             "plc": null,
+            "weight": null
+        },
+        {
             "extensions": {
-                "sncf": {
-                    "ci": 0,
-                    "ch": "BV",
-                    "ch_short_label": "BV",
-                    "ch_long_label": "0",
-                    "trigram": "OP."
-                },
                 "identifier": {
                     "name": "op.c",
                     "uic": 8700
+                },
+                "sncf": {
+                    "ch": "BV",
+                    "ch_long_label": "0",
+                    "ch_short_label": "BV",
+                    "ci": 0,
+                    "trigram": "OP."
                 }
-            }
+            },
+            "id": "op.c",
+            "parts": [
+                {
+                    "local_track_name": "V1",
+                    "position": 10000.0,
+                    "track": "t_center"
+                }
+            ],
+            "plc": null,
+            "weight": null
         }
     ],
-    "level_crossings": [],
     "routes": [
         {
-            "id": "rt.bf.a->det.a3",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.a"
+                "id": "bf.a",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.a3"
+                "id": "det.a3",
+                "type": "Detector"
             },
+            "id": "rt.bf.a->det.a3",
             "release_detectors": [
                 "det.a1",
                 "det.a2"
@@ -97,16 +173,16 @@
             "switches_directions": {}
         },
         {
-            "id": "rt.det.a3->bf.c",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.a3"
+                "id": "det.a3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.c"
+                "id": "bf.c",
+                "type": "BufferStop"
             },
+            "id": "rt.det.a3->bf.c",
             "release_detectors": [
                 "det.c1",
                 "det.c2",
@@ -119,16 +195,16 @@
             }
         },
         {
-            "id": "rt.bf.b->det.b3",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.b"
+                "id": "bf.b",
+                "type": "BufferStop"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.b3"
+                "id": "det.b3",
+                "type": "Detector"
             },
+            "id": "rt.bf.b->det.b3",
             "release_detectors": [
                 "det.b1",
                 "det.b2"
@@ -136,16 +212,16 @@
             "switches_directions": {}
         },
         {
-            "id": "rt.det.b3->bf.c",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.b3"
+                "id": "det.b3",
+                "type": "Detector"
             },
             "entry_point_direction": "START_TO_STOP",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.c"
+                "id": "bf.c",
+                "type": "BufferStop"
             },
+            "id": "rt.det.b3->bf.c",
             "release_detectors": [
                 "det.c1",
                 "det.c2",
@@ -158,16 +234,16 @@
             }
         },
         {
-            "id": "rt.bf.c->det.c1",
             "entry_point": {
-                "type": "BufferStop",
-                "id": "bf.c"
+                "id": "bf.c",
+                "type": "BufferStop"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "Detector",
-                "id": "det.c1"
+                "id": "det.c1",
+                "type": "Detector"
             },
+            "id": "rt.bf.c->det.c1",
             "release_detectors": [
                 "det.c5",
                 "det.c4",
@@ -177,16 +253,16 @@
             "switches_directions": {}
         },
         {
-            "id": "rt.det.c1->bf.a",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.c1"
+                "id": "det.c1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.a"
+                "id": "bf.a",
+                "type": "BufferStop"
             },
+            "id": "rt.det.c1->bf.a",
             "release_detectors": [
                 "det.a3",
                 "det.a2",
@@ -197,16 +273,16 @@
             }
         },
         {
-            "id": "rt.det.c1->bf.b",
             "entry_point": {
-                "type": "Detector",
-                "id": "det.c1"
+                "id": "det.c1",
+                "type": "Detector"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
-                "type": "BufferStop",
-                "id": "bf.b"
+                "id": "bf.b",
+                "type": "BufferStop"
             },
+            "id": "rt.det.c1->bf.b",
             "release_detectors": [
                 "det.b3",
                 "det.b2",
@@ -217,12 +293,423 @@
             }
         }
     ],
-    "extended_switch_types": [],
+    "signals": [
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.left.a1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.left.a1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3000.0,
+            "sight_distance": 400.0,
+            "track": "t_a"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.a1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.a1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3000.0,
+            "sight_distance": 400.0,
+            "track": "t_a"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.left.a2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.left.a2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6000.0,
+            "sight_distance": 400.0,
+            "track": "t_a"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.a2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.a2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6000.0,
+            "sight_distance": 400.0,
+            "track": "t_a"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.a3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.a3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9000.0,
+            "sight_distance": 400.0,
+            "track": "t_a"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.left.b1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.left.b1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3000.0,
+            "sight_distance": 400.0,
+            "track": "t_b"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.b1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.b1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3000.0,
+            "sight_distance": 400.0,
+            "track": "t_b"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.left.b2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.left.b2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6000.0,
+            "sight_distance": 400.0,
+            "track": "t_b"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.b2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.b2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 6000.0,
+            "sight_distance": 400.0,
+            "track": "t_b"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.b3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.b3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9000.0,
+            "sight_distance": 400.0,
+            "track": "t_b"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.left.c1",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.left.c1",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "true"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 1000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.c2",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.c2",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 3000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.left.c3",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.left.c3",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 5000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        },
+        {
+            "direction": "START_TO_STOP",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.right.c4",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.right.c4",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 7000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        },
+        {
+            "direction": "STOP_TO_START",
+            "extensions": {
+                "sncf": {
+                    "kp": "",
+                    "label": "s.left.c5",
+                    "side": "LEFT"
+                }
+            },
+            "id": "s.left.c5",
+            "logical_signals": [
+                {
+                    "conditional_parameters": [],
+                    "default_parameters": {
+                        "jaune_cli": "false"
+                    },
+                    "next_signaling_systems": [],
+                    "settings": {
+                        "Nf": "false"
+                    },
+                    "signaling_system": "BAL"
+                }
+            ],
+            "position": 9000.0,
+            "sight_distance": 400.0,
+            "track": "t_center"
+        }
+    ],
+    "speed_sections": [],
     "switches": [
         {
-            "id": "switch",
-            "switch_type": "point_switch",
+            "extensions": {
+                "sncf": {
+                    "label": "switch"
+                }
+            },
             "group_change_delay": 0.0,
+            "id": "switch",
             "ports": {
                 "A": {
                     "endpoint": "BEGIN",
@@ -237,17 +724,21 @@
                     "track": "t_b"
                 }
             },
-            "extensions": {
-                "sncf": {
-                    "label": "switch"
-                }
-            }
+            "switch_type": "point_switch"
         }
     ],
     "track_sections": [
         {
+            "curves": [],
+            "extensions": {
+                "sncf": {
+                    "line_code": 0,
+                    "line_name": "placeholder_line",
+                    "track_name": "placeholder_track",
+                    "track_number": 0
+                }
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.3,
@@ -257,25 +748,25 @@
                         -0.1,
                         49.98
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_a",
             "length": 10000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.3,
@@ -285,25 +776,25 @@
                         -0.1,
                         49.98
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_b",
             "length": 10000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
+            "slopes": []
+        },
+        {
+            "curves": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
                     "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
+                    "track_name": "placeholder_track",
+                    "track_number": 0
                 }
-            }
-        },
-        {
+            },
             "geo": {
-                "type": "LineString",
                 "coordinates": [
                     [
                         -0.1,
@@ -313,505 +804,14 @@
                         0.1,
                         49.98
                     ]
-                ]
+                ],
+                "type": "LineString"
             },
             "id": "t_center",
             "length": 10000.0,
-            "slopes": [],
-            "curves": [],
             "loading_gauge_limits": [],
-            "extensions": {
-                "sncf": {
-                    "line_code": 0,
-                    "line_name": "placeholder_line",
-                    "track_number": 0,
-                    "track_name": "placeholder_track"
-                }
-            }
+            "slopes": []
         }
     ],
-    "speed_sections": [],
-    "electrifications": [],
-    "signals": [
-        {
-            "track": "t_a",
-            "position": 3000.0,
-            "id": "s.left.a1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.left.a1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_a",
-            "position": 3000.0,
-            "id": "s.right.a1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.a1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_a",
-            "position": 6000.0,
-            "id": "s.left.a2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.left.a2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_a",
-            "position": 6000.0,
-            "id": "s.right.a2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.a2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_a",
-            "position": 9000.0,
-            "id": "s.right.a3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.a3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_b",
-            "position": 3000.0,
-            "id": "s.left.b1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.left.b1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_b",
-            "position": 3000.0,
-            "id": "s.right.b1",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.b1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_b",
-            "position": 6000.0,
-            "id": "s.left.b2",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.left.b2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_b",
-            "position": 6000.0,
-            "id": "s.right.b2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.b2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_b",
-            "position": 9000.0,
-            "id": "s.right.b3",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.b3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 1000.0,
-            "id": "s.left.c1",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "true"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.left.c1",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 3000.0,
-            "id": "s.right.c2",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.c2",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 5000.0,
-            "id": "s.left.c3",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.left.c3",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 7000.0,
-            "id": "s.right.c4",
-            "direction": "START_TO_STOP",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.right.c4",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        },
-        {
-            "track": "t_center",
-            "position": 9000.0,
-            "id": "s.left.c5",
-            "direction": "STOP_TO_START",
-            "sight_distance": 400.0,
-            "logical_signals": [
-                {
-                    "signaling_system": "BAL",
-                    "next_signaling_systems": [],
-                    "settings": {
-                        "Nf": "false"
-                    },
-                    "default_parameters": {
-                        "jaune_cli": "false"
-                    },
-                    "conditional_parameters": []
-                }
-            ],
-            "extensions": {
-                "sncf": {
-                    "label": "s.left.c5",
-                    "side": "LEFT",
-                    "kp": ""
-                }
-            }
-        }
-    ],
-    "buffer_stops": [
-        {
-            "track": "t_a",
-            "position": 0.0,
-            "id": "bf.a"
-        },
-        {
-            "track": "t_b",
-            "position": 0.0,
-            "id": "bf.b"
-        },
-        {
-            "track": "t_center",
-            "position": 10000.0,
-            "id": "bf.c"
-        }
-    ],
-    "detectors": [
-        {
-            "track": "t_a",
-            "position": 3000.0,
-            "id": "det.a1"
-        },
-        {
-            "track": "t_a",
-            "position": 6000.0,
-            "id": "det.a2"
-        },
-        {
-            "track": "t_a",
-            "position": 9000.0,
-            "id": "det.a3"
-        },
-        {
-            "track": "t_b",
-            "position": 3000.0,
-            "id": "det.b1"
-        },
-        {
-            "track": "t_b",
-            "position": 6000.0,
-            "id": "det.b2"
-        },
-        {
-            "track": "t_b",
-            "position": 9000.0,
-            "id": "det.b3"
-        },
-        {
-            "track": "t_center",
-            "position": 1000.0,
-            "id": "det.c1"
-        },
-        {
-            "track": "t_center",
-            "position": 3000.0,
-            "id": "det.c2"
-        },
-        {
-            "track": "t_center",
-            "position": 5000.0,
-            "id": "det.c3"
-        },
-        {
-            "track": "t_center",
-            "position": 7000.0,
-            "id": "det.c4"
-        },
-        {
-            "track": "t_center",
-            "position": 9000.0,
-            "id": "det.c5"
-        }
-    ],
-    "neutral_sections": []
+    "version": "3.5.2"
 }

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -12,6 +12,52 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -107,6 +153,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
     { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -223,6 +281,36 @@ toml = [
 ]
 
 [[package]]
+name = "datamodel-code-generator"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "black" },
+    { name = "genson" },
+    { name = "inflect" },
+    { name = "isort" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/e1/dbf7c2edb1b1db1f4fd472ee92f985ec97d58902512013d9c4584108329c/datamodel_code_generator-0.35.0.tar.gz", hash = "sha256:46805fa2515d3871f6bfafce9aa63128e735a7a6a4cfcbf9c27b3794ee4ea846", size = 459915, upload-time = "2025-10-09T19:26:49.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/ef/0ed17459fe6076219fcd45f69a0bb4bd1cb041b39095ca2946808a9b5f04/datamodel_code_generator-0.35.0-py3-none-any.whl", hash = "sha256:c356d1e4a555f86667a4262db03d4598a30caeda8f51786555fd269c8abb806b", size = 121436, upload-time = "2025-10-09T19:26:48.437Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
+]
+
+[[package]]
 name = "geojson-pydantic"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -244,6 +332,19 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -253,12 +354,137 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/82/fa43935523efdfcce6abbae9da7f372b627b27142c3419fcf13bf5b0c397/isort-6.1.0.tar.gz", hash = "sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481", size = 824325, upload-time = "2025-10-01T16:26:45.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/cc/9b681a170efab4868a032631dea1e8446d8ec718a7f657b94d49d1a12643/isort-6.1.0-py3-none-any.whl", hash = "sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784", size = 94329, upload-time = "2025-10-01T16:26:43.291Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
 ]
 
 [[package]]
@@ -280,12 +506,53 @@ requires-dist = [
 provides-extras = ["check"]
 
 [[package]]
+name = "osrd-schemas-auto"
+version = "0.1.0"
+source = { editable = "../osrd_schemas_auto" }
+dependencies = [
+    { name = "datamodel-code-generator" },
+    { name = "openapi-pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datamodel-code-generator", specifier = "==0.35.0" },
+    { name = "openapi-pydantic", specifier = "==0.5.1" },
+    { name = "pyyaml", specifier = "==6.0.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = "~=1.1.409" },
+    { name = "ruff", specifier = "~=0.15.10" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -467,16 +734,107 @@ wheels = [
 ]
 
 [[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "railjson-generator"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "../python/railjson_generator" }
 dependencies = [
     { name = "osrd-schemas" },
+    { name = "osrd-schemas-auto" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "osrd-schemas", editable = "../python/osrd_schemas" },
+    { name = "osrd-schemas-auto", editable = "../osrd_schemas_auto" },
     { name = "pyright", marker = "extra == 'check'", specifier = "~=1.1.393" },
     { name = "pytest", marker = "extra == 'check'", specifier = "~=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'check'", specifier = "~=4.1.0" },
@@ -606,6 +964,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15162

Import schema classes from the auto-generated `osrd_schemas_auto` package when a matching class exists there. Classes with no match, or with a different shape, still come from `osrd_schemas`.