### PR TITLE
front, editoast, core: add path geometry to STDCM debug conflict reports

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.S3Context
+import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.stdcm.graph.STDCMNode
@@ -51,13 +52,19 @@ class FailureExplainer(
             val remainingTime = parentNode.remainingTimeEstimation
             val travelTime = parentNode.timeData.totalRunningTime
             val geoPoint = parentNode.toGeoPoint(rawInfra, blockInfra)
+            val trainPath = parentNode.infraExplorer.buildFullPath(rawInfra, blockInfra)
             val lastOPName =
-                parentNode.infraExplorer
-                    .buildFullPath(rawInfra, blockInfra)
+                trainPath
                     .getOperationalPointParts()
                     .asSequence()
                     .mapNotNull { rawInfra.getOperationalPointPartProps(it.value)["identifier"] }
                     .lastOrNull()
+            val geoLineString = trainPath.getGeo()
+            val pathGeometry =
+                RJSLineString(
+                    "LineString",
+                    geoLineString.getPoints().map { listOf(it.lon, it.lat) },
+                )
             return ConflictReport(
                 originalStartTime.plus(
                     Duration.ofSeconds(parentNode.timeData.earliestReachableTime.toLong())
@@ -69,6 +76,7 @@ class FailureExplainer(
                 geoPoint.lat,
                 geoPoint.lon,
                 lastOPName,
+                pathGeometry,
             )
         }
 
@@ -111,6 +119,7 @@ class FailureExplainer(
         val lat: Double,
         val lon: Double,
         val lastOPName: String?,
+        @Json(name = "path_geometry") val pathGeometry: RJSLineString,
     )
 
     /** Register a new conflict. */

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -14301,6 +14301,8 @@ components:
         lon:
           type: number
           format: double
+        path_geometry:
+          $ref: '#/components/schemas/GeoJsonLineString'
         time_lost:
           type: number
           format: double

--- a/editoast/src/views/stdcm_debug.rs
+++ b/editoast/src/views/stdcm_debug.rs
@@ -4,7 +4,9 @@ use axum::extract::Path;
 use axum::extract::State;
 use chrono::DateTime;
 use chrono::Utc;
+use common::geometry::GeoJsonLineString;
 use editoast_derive::EditoastError;
+use geos::geojson::Geometry;
 use object_store::GetOptions;
 use object_store::ObjectStore as _;
 use object_store::aws::AmazonS3;
@@ -44,6 +46,9 @@ pub(in crate::views) struct SimDebugConflictReport {
     lon: f64,
     #[serde(rename = "lastOPName")]
     last_op_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = GeoJsonLineString)]
+    path_geometry: Option<Geometry>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]

--- a/front/src/applications/stdcm/StdcmDebugView.tsx
+++ b/front/src/applications/stdcm/StdcmDebugView.tsx
@@ -73,7 +73,12 @@ const StdcmDebugView = () => {
           <DebugSpeedDistanceDiagram simData={simulation_data} />
         </>
       )}
-      {failure && <DebugMap failureData={failure} />}
+      {(simulation_data || failure) && (
+        <DebugMap
+          simulationData={simulation_data ?? undefined}
+          failureData={failure ?? undefined}
+        />
+      )}
       {!simulation_data && !failure && <div className="stdcm-debug-view__status">{viewStatus}</div>}
     </div>
   );

--- a/front/src/applications/stdcm/StdcmDebugView.tsx
+++ b/front/src/applications/stdcm/StdcmDebugView.tsx
@@ -5,7 +5,7 @@ import { Search } from '@osrd-project/ui-icons';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import DebugFailureMap from 'applications/stdcm/components/DebugView/DebugFailureMap';
+import DebugMap from 'applications/stdcm/components/DebugView/DebugMap';
 import DebugSpaceTimeChart from 'applications/stdcm/components/DebugView/DebugSpaceTimeChart';
 import DebugSpeedDistanceDiagram from 'applications/stdcm/components/DebugView/DebugSpeedDistanceDiagram';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
@@ -73,7 +73,7 @@ const StdcmDebugView = () => {
           <DebugSpeedDistanceDiagram simData={simulation_data} />
         </>
       )}
-      {failure && <DebugFailureMap failureData={failure} />}
+      {failure && <DebugMap failureData={failure} />}
       {!simulation_data && !failure && <div className="stdcm-debug-view__status">{viewStatus}</div>}
     </div>
   );

--- a/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
@@ -25,9 +25,9 @@ const toFeatures = (
 
 const fmtSeconds = (seconds: number) => `${Math.round(seconds)}s`;
 
-type DebugFailureMapProps = { failureData: SimDebugFailureReport };
+type DebugMapProps = { failureData: SimDebugFailureReport };
 
-const DebugFailureMap = ({ failureData }: DebugFailureMapProps) => {
+const DebugMap = ({ failureData }: DebugMapProps) => {
   const mapRef = useRef<MapRef | null>(null);
   const mapBlankStyle = useMapBlankStyle();
   const [hovered, setHovered] = useState<{
@@ -76,8 +76,8 @@ const DebugFailureMap = ({ failureData }: DebugFailureMapProps) => {
   }, []);
 
   return (
-    <div className="debug-failure-map">
-      <div className="debug-failure-map__map">
+    <div className="debug-map">
+      <div className="debug-map__map">
         <ReactMapGL
           ref={mapRef}
           initialViewState={initialViewState}
@@ -127,20 +127,20 @@ const DebugFailureMap = ({ failureData }: DebugFailureMapProps) => {
         </ReactMapGL>
       </div>
 
-      <div className="debug-failure-map__legend">
+      <div className="debug-map__legend">
         <span>
-          <span className="debug-failure-map__legend-dot debug-failure-map__legend-dot--largest" />
+          <span className="debug-map__legend-dot debug-map__legend-dot--largest" />
           Largest conflicts
         </span>
         <span>
-          <span className="debug-failure-map__legend-dot debug-failure-map__legend-dot--closest" />
+          <span className="debug-map__legend-dot debug-map__legend-dot--closest" />
           Closest conflicts
         </span>
       </div>
 
       {hovered && (
         <div
-          className="debug-failure-map__tooltip"
+          className="debug-map__tooltip"
           style={{ left: hovered.clientX + 12, top: hovered.clientY + 12 }}
         >
           <div>
@@ -157,4 +157,4 @@ const DebugFailureMap = ({ failureData }: DebugFailureMapProps) => {
   );
 };
 
-export default DebugFailureMap;
+export default DebugMap;

--- a/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
+import bbox from '@turf/bbox';
 import type { Feature, FeatureCollection, Point } from 'geojson';
-import type { MapLayerMouseEvent } from 'maplibre-gl';
+import type { LngLatBoundsLike, MapLayerMouseEvent } from 'maplibre-gl';
 import type { MapRef } from 'react-map-gl/maplibre';
 import ReactMapGL, { Source } from 'react-map-gl/maplibre';
 
-import type { SimDebugConflictReport, SimDebugFailureReport } from 'common/api/osrdEditoastApi';
+import type {
+  SimDebugConflictReport,
+  SimDebugData,
+  SimDebugFailureReport,
+} from 'common/api/osrdEditoastApi';
 import { OrderedLayer, VirtualLayers, genOSMLayerProps, useMapBlankStyle } from 'common/Map/Layers';
 import OpenStreetMapSource from 'common/Map/Sources/OpenStreetMap';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
@@ -16,7 +21,7 @@ const toFeatures = (
   points: SimDebugConflictReport[],
   category: 'largest' | 'closest'
 ): Feature<Point>[] =>
-  points.map((point, i) => ({
+  points.map(({ path_geometry: _, ...point }, i) => ({
     type: 'Feature',
     id: i,
     properties: { ...point, category },
@@ -25,9 +30,12 @@ const toFeatures = (
 
 const fmtSeconds = (seconds: number) => `${Math.round(seconds)}s`;
 
-type DebugMapProps = { failureData: SimDebugFailureReport };
+type DebugMapProps = {
+  failureData?: SimDebugFailureReport;
+  simulationData?: SimDebugData;
+};
 
-const DebugMap = ({ failureData }: DebugMapProps) => {
+const DebugMap = ({ failureData, simulationData }: DebugMapProps) => {
   const mapRef = useRef<MapRef | null>(null);
   const mapBlankStyle = useMapBlankStyle();
   const [hovered, setHovered] = useState<{
@@ -40,40 +48,57 @@ const DebugMap = ({ failureData }: DebugMapProps) => {
     () => ({
       type: 'FeatureCollection',
       features: [
-        ...toFeatures(failureData.largest_conflicts ?? [], 'largest'),
-        ...toFeatures(failureData.closest_conflicts ?? [], 'closest'),
+        ...toFeatures(failureData?.largest_conflicts ?? [], 'largest'),
+        ...toFeatures(failureData?.closest_conflicts ?? [], 'closest'),
       ],
     }),
     [failureData]
   );
 
   const initialViewState = useMemo(() => {
+    const fitBoundsOptions = { padding: 50, maxZoom: 12 };
+    if (simulationData?.path_properties.geometry) {
+      const [minLon, minLat, maxLon, maxLat] = bbox(simulationData.path_properties.geometry);
+      const bounds: LngLatBoundsLike = [
+        [minLon, minLat],
+        [maxLon, maxLat],
+      ];
+      return { bounds, fitBoundsOptions };
+    }
     const allPoints = [
-      ...(failureData.largest_conflicts ?? []),
-      ...(failureData.closest_conflicts ?? []),
+      ...(failureData?.largest_conflicts ?? []),
+      ...(failureData?.closest_conflicts ?? []),
     ];
     if (allPoints.length === 0) return { latitude: 46.2, longitude: 2.5, zoom: 5 };
     const lats = allPoints.map((point) => point.lat);
     const lons = allPoints.map((point) => point.lon);
-    return {
-      latitude: (Math.min(...lats) + Math.max(...lats)) / 2,
-      longitude: (Math.min(...lons) + Math.max(...lons)) / 2,
-      zoom: 8,
-    };
-  }, [failureData]);
+    const bounds: LngLatBoundsLike = [
+      [Math.min(...lons), Math.min(...lats)],
+      [Math.max(...lons), Math.max(...lats)],
+    ];
+    return { bounds, fitBoundsOptions };
+  }, [failureData, simulationData]);
 
-  const handleMouseMove = useCallback((event: MapLayerMouseEvent) => {
-    const feature = event.features?.[0];
-    if (!feature) {
-      setHovered(null);
-      return;
-    }
-    setHovered({
-      point: feature.properties as HoveredPoint,
-      clientX: event.point.x,
-      clientY: event.point.y,
-    });
-  }, []);
+  const handleMouseMove = useCallback(
+    (event: MapLayerMouseEvent) => {
+      const feature = event.features?.[0];
+      if (!feature) {
+        setHovered(null);
+        return;
+      }
+      const category = feature.properties?.category as 'largest' | 'closest';
+      const id = feature.id as number;
+      const conflicts =
+        category === 'largest' ? failureData?.largest_conflicts : failureData?.closest_conflicts;
+      const point = conflicts?.[id];
+      if (!point) {
+        setHovered(null);
+        return;
+      }
+      setHovered({ point: { ...point, category }, clientX: event.point.x, clientY: event.point.y });
+    },
+    [failureData]
+  );
 
   return (
     <div className="debug-map">
@@ -98,6 +123,38 @@ const DebugMap = ({ failureData }: DebugMapProps) => {
             .map(({ id, ...props }) => (
               <OrderedLayer key={id} id={id} {...props} />
             ))}
+          {simulationData?.path_properties.geometry && !hovered && (
+            <Source
+              id="success-path"
+              type="geojson"
+              data={{
+                type: 'Feature',
+                geometry: simulationData.path_properties.geometry,
+                properties: {},
+              }}
+            >
+              <OrderedLayer
+                id="success-path-line"
+                type="line"
+                layerOrder={LAYER_GROUPS_ORDER[LAYERS.PATH.GROUP]}
+                paint={{ 'line-color': 'rgba(0, 100, 220, 0.8)', 'line-width': 3 }}
+              />
+            </Source>
+          )}
+          {hovered?.point.path_geometry && (
+            <Source
+              id="conflict-path"
+              type="geojson"
+              data={{ type: 'Feature', geometry: hovered.point.path_geometry, properties: {} }}
+            >
+              <OrderedLayer
+                id="conflict-path-line"
+                type="line"
+                layerOrder={LAYER_GROUPS_ORDER[LAYERS.PATH.GROUP]}
+                paint={{ 'line-color': 'rgba(220, 80, 0, 0.8)', 'line-width': 2.5 }}
+              />
+            </Source>
+          )}
           <Source id="conflicts" type="geojson" data={geojson}>
             <OrderedLayer
               id="conflicts-largest"

--- a/front/src/applications/stdcm/styles/_debugView.scss
+++ b/front/src/applications/stdcm/styles/_debugView.scss
@@ -56,7 +56,7 @@
   }
 }
 
-.debug-failure-map {
+.debug-map {
   position: relative;
   width: 100%;
   height: 500px;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4362,6 +4362,7 @@ export type SimDebugConflictReport = {
   lastOPName?: string | null;
   lat: number;
   lon: number;
+  path_geometry?: GeoJsonLineString;
   time_lost: number;
 };
 export type SimDebugFailureReport = {

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -3346,26 +3346,10 @@ class SignalSncfExtension(BaseModel):
     side: Side | None = None
 
 
-class SimDebugConflictReport(BaseModel):
-    at: AwareDatetime
-    best_remaining_time: float
-    caused_by: str
-    current_travel_time: float
-    lastOPName: str | None = None
-    lat: float
-    lon: float
-    time_lost: float
-
-
 class SimDebugEngineeringAllowanceRange(BaseModel):
     added_duration: float
     from_: Annotated[float, Field(alias="from")]
     to: float
-
-
-class SimDebugFailureReport(BaseModel):
-    closest_conflicts: list[SimDebugConflictReport]
-    largest_conflicts: list[SimDebugConflictReport]
 
 
 class SimDebugTrainZoneRequirement(BaseModel):
@@ -6151,6 +6135,18 @@ class Signal(BaseModel):
     track: Annotated[str, Field(max_length=255, min_length=1)]
 
 
+class SimDebugConflictReport(BaseModel):
+    at: AwareDatetime
+    best_remaining_time: float
+    caused_by: str
+    current_travel_time: float
+    lastOPName: str | None = None
+    lat: float
+    lon: float
+    path_geometry: GeoJsonLineString | None = None
+    time_lost: float
+
+
 class SimDebugData(BaseModel):
     departure_time: AwareDatetime
     engineering_allowances_ranges: list[SimDebugEngineeringAllowanceRange]
@@ -6160,6 +6156,11 @@ class SimDebugData(BaseModel):
     train_positions: list[float]
     train_times: list[float]
     zone_locations: list[SimDebugZoneLocation]
+
+
+class SimDebugFailureReport(BaseModel):
+    closest_conflicts: list[SimDebugConflictReport]
+    largest_conflicts: list[SimDebugConflictReport]
 
 
 class ResponseSuccess(SimulationResponseSuccess):


### PR DESCRIPTION
Note to reviewers: this is a "nice to have" thing, reviewing it should have a fairly low priority.

Fix https://github.com/OpenRailAssociation/osrd/issues/16840

The core and editoast parts are tiny, it's just to forward some extra data. This is mostly a front PR. 

Disclaimer: I still used an LLM for a draft of the front-end part, and I did carefully review it. It's a more limited change compared to the previous PR so it's easier to keep under control. 

Change list: 

* Rename `DebugFailureMap` to `DebugMap`, as it's not just rendered to render conflict data
* Core logs a full `LineString` per conflicting point.
    * as a bonus, this will help with https://github.com/osrd-project/osrd-confidential/issues/804 (part of the implementation plan)
* On the debug page:
    * The map is rendered when we have *at least one of* conflict data and simulation data
    * The initial zoom level is less arbitrary and covers the final path (if successful)
    * On successful searches, the train path is rendered on the map
    * When hovering a conflict point, the train path is hidden and replaced with the path that lead to the conflict location

Note: the path extends a bit further than the conflict location, as it includes the "lookahead" section. Basically the path is "locked in" for a few km past the end of the simulation, and it's useful data. 


How to test:

* Happy path: run the stack (don't forget the `telemetry` flag on `osrd-compose`), run an stdcm search, toggle debug mode, click the "link to debug page". Hover on conflict points.
* Unsuccessful search: the easiest way to trigger that is to set the maximum rolling stock speed very low, and the timetable must not be empty. The full path won't be visible, but hovering points still show partial paths.

---

Example here, I cheated a bit to have more points than usual. On `dev`, we only display the points, there's no line.

https://github.com/user-attachments/assets/79cc7122-04a0-43a1-a329-de9b76c8fc84

