### PR TITLE
front: fix overtake filters

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
@@ -67,7 +67,7 @@ const StdcmOperationalPoint = ({
             (normalized(op.name).includes(normalized(searchTerm)) ||
               op.trigram.includes(searchTerm.toUpperCase())) &&
             // TODO: Replace this temporary implementation with a permanent solution
-            !normalized(op.name).startsWith(normalized('OVERTAKE'))
+            !normalized(op.name).includes(normalized('OVERTAKE'))
         )
         .reduce<StdcmOp[]>((acc, p) => {
           const newObject = stdcmOpFromSearchResult(p);

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -268,7 +268,7 @@ export function consolidateOvertakesToSingleSteps(
   const consolidatedSteps: StdcmResultsOperationalPoint[] = [];
   for (let i = 0; i < steps.length - 1; i += 1) {
     const [step, nextStep] = [steps[i], steps[i + 1]];
-    const overtakenStepMatch = step.name?.match(/^OVERTAKE.*;(.*)$/);
+    const overtakenStepMatch = step.name?.match(/OVERTAKE[^;]*;(.*)$/);
     if (overtakenStepMatch) {
       const stopDuration =
         convertHHMMTimeToSeconds(nextStep.time!) - convertHHMMTimeToSeconds(step.time!);


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16847

"temporary solution"

Context: the overtake format has recently changed from `OVERTAKE;real_name` to `TRIGRAM FAKE_OVERTAKE_something_something;real_name`

The main change is that we're looking for the `OVERTAKE` string at any point, not just at the start. Both when filtering the OP list and when generating the overtake stops. It's backward compatible. 

Testing requires getting a recent France infra (338 on dev). Then:

* To test the OP filter, search for any OP that has an overtake (e.g. DPY) and make sure you can't select the overtake version
* To test the overtake itself, import a full timetable and keep trying different paths. It happens more often when lowering the RS max speed. On `dev`, there's no indication that there's been an overtake at all.


#### If someone's more familiar than me with this feature, please double check that I haven't forgotten a place where we look for overtake OPs