### PR TITLE
editoast: fix malformed train schedule path

### DIFF
--- a/editoast/migrations/2026-05-22-161500-0000_fix_local_track_name_format/down.sql
+++ b/editoast/migrations/2026-05-22-161500-0000_fix_local_track_name_format/down.sql
@@ -1,0 +1,2 @@
+-- Irreversible data correction migration.
+-- It normalizes malformed JSON values in-place.

--- a/editoast/migrations/2026-05-22-161500-0000_fix_local_track_name_format/up.sql
+++ b/editoast/migrations/2026-05-22-161500-0000_fix_local_track_name_format/up.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION normalize_local_track_name_in_path(path jsonb)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+SELECT
+    jsonb_agg(
+        CASE
+            WHEN elem @? '$.location.local_track_name.track_name'
+                THEN jsonb_set(
+                    elem,
+                    '{location,local_track_name}',
+                    elem->'location'->'local_track_name'->'track_name'
+                )
+            ELSE elem
+        END
+    )
+FROM jsonb_array_elements(path) AS elem;
+$$;
+
+UPDATE train_schedule
+SET path = normalize_local_track_name_in_path(path)
+WHERE path IS NOT NULL;
+
+UPDATE train_schedule_exception
+SET change_groups = jsonb_set(
+    change_groups,
+    '{path_and_schedule,path}',
+    normalize_local_track_name_in_path(change_groups#>'{path_and_schedule,path}')
+)
+WHERE change_groups ? 'path_and_schedule';
+
+DROP FUNCTION normalize_local_track_name_in_path(jsonb);


### PR DESCRIPTION
This adds a migration that fix malformed local_track_name. The original migration containing the issue is
`2026-01-20-144225_rename_track_reference_to_local_track_name`.

fixes #16435