### PR TITLE
editoast: core_client: compare mocked JSON, not strings 

### DIFF
--- a/editoast/authz/src/v2/roles.rs
+++ b/editoast/authz/src/v2/roles.rs
@@ -86,8 +86,9 @@ pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::v2::TestClientExt as _;
+    use crate::v2::add_members;
     use crate::v2::special_authorizers::Authorize;
-    use crate::v2::{TestClientExt as _, add_members};
 
     use super::*;
 

--- a/editoast/core_client/src/mocking.rs
+++ b/editoast/core_client/src/mocking.rs
@@ -86,10 +86,13 @@ impl MockingClient {
         req_path: &str,
         req_body: Option<&B>,
     ) -> Result<Option<R::Response>, MockingError> {
-        match (
-            req_body.map(|b| serde_json::to_string(b).expect("could not serialize request body")),
-            stub.body.as_ref().map(|b| b.as_str().to_string()),
-        ) {
+        let actual =
+            req_body.map(|b| serde_json::to_value(b).expect("could not serialize request body"));
+        let expected = stub.body.as_ref().map(|b| {
+            serde_json::from_str::<serde_json::Value>(b)
+                .expect("expected request body should be valid JSON")
+        });
+        match (actual, expected) {
             (Some(actual), Some(expected)) => assert_eq!(actual, expected, "request body mismatch"),
             (None, Some(expected)) => panic!("missing request body: '{expected}'"),
             _ => (),


### PR DESCRIPTION
When comparing the actual vs. the expected mocked request body,
we used to `assert_eq!` on strings, thus making key order relevant.
Changed to to `serde_json::Value` comparison.

The only "regression" here is that the `Debug` representation of
`serde_json::Value` is show on failure now. But at the same time we now
use `pretty_assertions` so the diff should still be useful, even if less
friendly.