### PR TITLE
core: make otel agent installed through gradle

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -8,14 +8,15 @@ COPY --chown=gradle:gradle . .
 # Remove broken symlink (to prevent kaniko from crashing)
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     --mount=type=cache,target=/home/gradle/src/build \
-    gradle shadowJar --no-daemon && \
+    gradle --no-daemon shadowJar copyOtelAgent && \
     cp build/libs/osrd-all.jar / && \
+    cp build/libs/agent/opentelemetry-javaagent.jar / && \
     rm  -rf /root/.kotlin/daemon/kotlin-daemon.* /tmp/hsperfdata_root/ /tmp/kotlin-daemon.*
 
 #### Running stage
 FROM eclipse-temurin:25 AS running_env
 
-ADD 'https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar' /app/opentelemetry-javaagent.jar
+COPY --from=build_env /opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
 COPY --from=build_env /osrd-all.jar /app/osrd_core.jar
 
 ARG OSRD_GIT_DESCRIBE

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,9 @@ plugins {
 }
 
 // region DEPENDENCIES
-
+configurations {
+    otelAgent
+}
 
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
@@ -75,6 +77,7 @@ dependencies {
     // OpenTelemetry
     implementation libs.opentelemetry.api
     implementation libs.opentelemetry.instrumentation.annotations
+    otelAgent libs.opentelemetry.javaagent
 
     // Use JUnit Jupiter API for testing.
     testImplementation libs.junit.jupiter.api
@@ -224,4 +227,10 @@ tasks.register("printSettings", DefaultTask) {
     doLast {
         println "java.home " + System.getProperty('java.home')
     }
+}
+
+tasks.register('copyOtelAgent', Copy) {
+    from configurations.otelAgent
+    into layout.buildDirectory.dir("libs/agent")
+    rename { "opentelemetry-javaagent.jar" }
 }

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ moshi = '1.15.2'
 junit = '6.0.+'
 mockito = '5.2.+'
 otel = '1.62.0'
+otel-agent = '2.28.1'
 
 [libraries]
 # kotlin stuff
@@ -62,6 +63,7 @@ jansi = { module = 'org.fusesource.jansi:jansi', version = '2.4.+' } # Apache 2.
 
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api', version.ref = 'otel' }
 opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations', version = '2.28.1' }
+opentelemetry-javaagent = { group = 'io.opentelemetry.javaagent', name = 'opentelemetry-javaagent', version.ref = 'otel-agent' }
 
 kaml = { module = 'com.charleskorn.kaml:kaml', version = '0.104.0' } # Apache 2.0
 


### PR DESCRIPTION
Follow-up on [this comment](https://github.com/OpenRailAssociation/osrd/pull/16394#discussion_r3274138818).

Note that it would be nice to have a phase that is both anterior to `gradle run` and `gradle shadowJar`, but in the end, `assemble` seems semantically reasonable. I’m all ears for suggestions.