### PR TITLE
editoast: s3: fallback to lib default behavior on missing variables

### DIFF
--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -141,10 +141,10 @@ pub async fn runserver(
 
 fn build_s3_config(s3: S3Args) -> Option<views::S3Config> {
     Some(views::S3Config {
-        endpoint: s3.endpoint?,
+        endpoint: s3.endpoint,
         bucket_name: s3.bucket_name?,
-        access_key_id: s3.access_key_id?,
-        secret_access_key: s3.secret_access_key?,
+        access_key_id: s3.access_key_id,
+        secret_access_key: s3.secret_access_key,
         region: s3.region,
     })
 }

--- a/editoast/src/views/server.rs
+++ b/editoast/src/views/server.rs
@@ -72,10 +72,10 @@ pub struct PostgresConfig {
 }
 
 pub struct S3Config {
-    pub endpoint: Url,
     pub bucket_name: String,
-    pub access_key_id: String,
-    pub secret_access_key: String,
+    pub endpoint: Option<Url>,
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
     pub region: Option<String>,
 }
 
@@ -241,15 +241,20 @@ impl AppState {
 fn build_s3_client(optional_config: &Option<S3Config>) -> Option<Arc<AmazonS3>> {
     let config = optional_config.as_ref()?;
     let bucket = config.bucket_name.clone();
-    let mut builder = AmazonS3Builder::new()
-        .with_bucket_name(bucket)
-        .with_virtual_hosted_style_request(false)
-        .with_allow_http(true)
-        .with_endpoint(config.endpoint.as_str())
-        .with_access_key_id(config.access_key_id.clone())
-        .with_secret_access_key(config.secret_access_key.clone());
+    let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket);
     if let Some(region) = &config.region {
-        builder = builder.with_region(region)
+        builder = builder.with_region(region);
+    }
+    if let Some(access_key) = &config.access_key_id {
+        builder = builder.with_access_key_id(access_key);
+    }
+    if let Some(secret_access_key) = &config.secret_access_key {
+        builder = builder.with_secret_access_key(secret_access_key);
+    }
+    if let Some(endpoint) = &config.endpoint {
+        builder = builder
+            .with_endpoint(endpoint.as_str())
+            .with_allow_http(true);
     }
     match builder.build() {
         Ok(client) => Some(Arc::new(client)),


### PR DESCRIPTION
The given env variables work fine in local environments, but prod may use different authentification systems.

Note: I only tested that it keeps working in local env, I don't know if it fixes issues on prod.

I'll also document editoast README, but only once this is stable (https://github.com/OpenRailAssociation/osrd/issues/16902).