### PR TITLE
editoast: use core_task for /train_schedules/:id/path

### DIFF
--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -428,11 +429,11 @@ fn build_pathfinding_request(
 /// Compute a path given a train schedule and an infrastructure.
 pub async fn pathfinding_from_train<T: TrainScheduleLike>(
     conn: DbConnection,
-    valkey: &mut cache::Connection,
+    valkey: cache::Connection,
     core: Arc<CoreClient>,
     infra: &Infra,
     train_schedule: T,
-    app_version: Option<&str>,
+    _app_version: Option<&str>,
 ) -> Result<PathfindingResult> {
     let Some(consist) =
         RollingStock::retrieve(conn.clone(), train_schedule.rolling_stock_name().to_owned())
@@ -449,22 +450,30 @@ pub async fn pathfinding_from_train<T: TrainScheduleLike>(
         ));
     };
 
-    Ok(Arc::unwrap_or_clone(
-        pathfinding_from_train_batch(
-            conn,
-            valkey,
-            core,
-            infra,
-            &[TrainScheduleWithConsist {
-                train_schedule,
-                consist,
-            }],
-            app_version,
-        )
-        .await?
-        .pop()
-        .unwrap(),
-    ))
+    use core_task::Task as _;
+    let path_items = train_schedule
+        .path()
+        .iter()
+        .map(|item| &item.location)
+        .collect_vec();
+    let op_cache =
+        OperationalPointCache::load_path_items(conn, infra.id, path_items.as_slice()).await?;
+
+    let pathfinding_input = PathfindingInput::from(&consist, &train_schedule);
+
+    let result = match build_pathfinding_request(&pathfinding_input, infra, &op_cache) {
+        Ok(request) => match request
+            .run(Arc::new(tokio::sync::Mutex::new(valkey)), core)
+            .await
+        {
+            Ok(path) => path.into(),
+            Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
+                core_error: core_error.into(),
+            }),
+        },
+        Err(err) => *err,
+    };
+    Ok(result)
 }
 
 #[derive(Debug, Clone)]

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -40,7 +39,6 @@ use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::timetable::PhysicsConsistParameters;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
-use editoast_models::rolling_stock::RollingStock;
 
 /// Path input is described by some rolling stock information
 /// and a list of path waypoints
@@ -424,56 +422,6 @@ fn build_pathfinding_request(
         speed_limit_tag: pathfinding_input.speed_limit_tag.clone(),
         stops_at_end_of_block: pathfinding_input.stops_at_end_of_block,
     })
-}
-
-/// Compute a path given a train schedule and an infrastructure.
-pub async fn pathfinding_from_train<T: TrainScheduleLike>(
-    conn: DbConnection,
-    valkey: cache::Connection,
-    core: Arc<CoreClient>,
-    infra: &Infra,
-    train_schedule: T,
-    _app_version: Option<&str>,
-) -> Result<PathfindingResult> {
-    let Some(consist) =
-        RollingStock::retrieve(conn.clone(), train_schedule.rolling_stock_name().to_owned())
-            .await?
-            .map(schemas::RollingStock::from)
-            .map(PhysicsConsistParameters::from_traction_engine)
-    else {
-        return Ok(PathfindingResult::Failure(
-            PathfindingFailure::PathfindingInputError(
-                PathfindingInputError::RollingStockNotFound {
-                    rolling_stock_name: train_schedule.rolling_stock_name().to_owned(),
-                },
-            ),
-        ));
-    };
-
-    use core_task::Task as _;
-    let path_items = train_schedule
-        .path()
-        .iter()
-        .map(|item| &item.location)
-        .collect_vec();
-    let op_cache =
-        OperationalPointCache::load_path_items(conn, infra.id, path_items.as_slice()).await?;
-
-    let pathfinding_input = PathfindingInput::from(&consist, &train_schedule);
-
-    let result = match build_pathfinding_request(&pathfinding_input, infra, &op_cache) {
-        Ok(request) => match request
-            .run(Arc::new(tokio::sync::Mutex::new(valkey)), core)
-            .await
-        {
-            Ok(path) => path.into(),
-            Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
-                core_error: core_error.into(),
-            }),
-        },
-        Err(err) => *err,
-    };
-    Ok(result)
 }
 
 #[derive(Debug, Clone)]

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -20,12 +20,14 @@ use core_client::pathfinding::PathfindingRequest;
 use core_client::pathfinding::PathfindingResultSuccess;
 use database::DbConnection;
 use educe::Educe;
+use futures::StreamExt;
 use ordered_float::OrderedFloat;
 use schemas::rolling_stock::LoadingGaugeType;
 use schemas::train_schedule::PathItemLocation;
 use schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::Mutex;
 use tracing::debug;
 use tracing::info;
 use utoipa::ToSchema;
@@ -115,6 +117,26 @@ impl PathfindingInput {
         self.hash(&mut hasher);
         let hash_path_input = hasher.finish();
         format!("pathfinding_{osrd_version}.{infra}.{infra_version}.{hash_path_input}")
+    }
+}
+
+impl From<&PathfindingInput> for core_task::PathfindingConsist {
+    fn from(val: &PathfindingInput) -> Self {
+        core_task::PathfindingConsist {
+            loading_gauge: val.rolling_stock_loading_gauge,
+            thermal: val.rolling_stock_is_thermal,
+            supported_electrifications: val.rolling_stock_supported_electrifications.clone(),
+            supported_signaling_systems: val.rolling_stock_supported_signaling_systems.clone(),
+            maximum_speed: val.rolling_stock_maximum_speed,
+            length: val.rolling_stock_length,
+            speed_limit_tag: val.speed_limit_tag.clone(),
+        }
+    }
+}
+
+impl From<PathfindingInput> for core_task::PathfindingConsist {
+    fn from(val: PathfindingInput) -> Self {
+        (&val).into()
     }
 }
 
@@ -240,25 +262,15 @@ pub(in crate::views) async fn post(
     })
     .await?;
 
-    use core_task::Task as _;
-    let valkey_conn = valkey_client.get_connection().await?;
     let op_cache =
         OperationalPointCache::load_path_items(conn, infra.id, &path_input.path_items).await?;
-    let request = match build_pathfinding_request(&path_input, &infra, &op_cache) {
-        Ok(request) => request,
+    let pathfinding_train = match build_pathfinding_train(&path_input, &op_cache) {
+        Ok(pathfinding_train) => pathfinding_train,
         Err(result) => return Ok(Json(*result)),
     };
-    Ok(Json(
-        match request
-            .run(Arc::new(tokio::sync::Mutex::new(valkey_conn)), core_client)
-            .await
-        {
-            Ok(path) => path.into(),
-            Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
-                core_error: core_error.into(),
-            }),
-        },
-    ))
+    let result =
+        single_pathfinding_request(pathfinding_train, &infra, valkey_client, core_client).await?;
+    Ok(Json(result))
 }
 
 /// Pathfinding batch computation given a list of path inputs
@@ -422,6 +434,64 @@ fn build_pathfinding_request(
         speed_limit_tag: pathfinding_input.speed_limit_tag.clone(),
         stops_at_end_of_block: pathfinding_input.stops_at_end_of_block,
     })
+}
+
+fn build_pathfinding_train(
+    pathfinding_input: &PathfindingInput,
+    op_cache: &OperationalPointCache,
+) -> std::result::Result<core_task::PathfindingTrain, Box<PathfindingResult>> {
+    if pathfinding_input.path_items.len() <= 1 {
+        return Err(Box::from(PathfindingResult::Failure(
+            PathfindingFailure::PathfindingInputError(PathfindingInputError::NotEnoughPathItems),
+        )));
+    }
+    let track_offsets: Vec<Vec<schemas::infra::TrackOffset>> = op_cache
+        .extract_location_from_path_items(&pathfinding_input.path_items)
+        .map_err(PathfindingResult::Failure)?;
+
+    let constraints = core_task::PathfindingConstraints {
+        path_items: track_offsets
+            .into_iter()
+            .map(core_task::PathItemAlternatives::from_iter)
+            .collect(),
+    };
+
+    Ok(core_task::PathfindingTrain {
+        consist: pathfinding_input.into(),
+        constraints,
+    })
+}
+
+pub(in crate::views) async fn single_pathfinding_request(
+    pathfinding_train: core_task::PathfindingTrain,
+    infra: &Infra,
+    valkey_client: Arc<cache::Client>,
+    core_client: Arc<CoreClient>,
+) -> Result<PathfindingResult> {
+    let mut pathfinding_env = core_task::PathfindingEnv::new(core_task::CoreEnv {
+        infra_id: infra.id as u64,
+        infra_version: infra.version,
+        client: core_client,
+    });
+    pathfinding_env.extend([((), pathfinding_train)]);
+
+    let valkey_conn = Arc::new(Mutex::new(valkey_client.get_connection().await?));
+    let result = match pathfinding_env
+        .into_stream(valkey_conn)
+        .collect::<Vec<_>>()
+        .await
+        .as_slice()
+    {
+        [path] => path.data.clone(),
+        _ => Err(core_client::Error::BrokenPipe),
+    };
+    let result = match result {
+        Ok(path) => path.into(),
+        Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
+            core_error: core_error.into(),
+        }),
+    };
+    Ok(result)
 }
 
 #[derive(Debug, Clone)]

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -610,7 +610,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
         .collect())
 }
 
-fn build_pathfinding_consist(
+pub fn build_pathfinding_consist(
     physics_consist_parameters: &PhysicsConsistParameters,
     speed_limit_tag: Option<String>,
 ) -> PathfindingConsist {

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -40,6 +40,7 @@ use schemas::primitives::TimeWindow;
 use schemas::train_schedule::OperationalPointPartReference;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
+use schemas::train_schedule::TrainScheduleLike as _;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -53,8 +54,8 @@ use crate::error::EditoastError as _;
 use crate::error::Result;
 use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::operational_point_cache::OperationalPointCache;
+use crate::views::path::pathfinding::PathfindingFailure;
 use crate::views::path::pathfinding::PathfindingResult;
-use crate::views::path::pathfinding::pathfinding_from_train;
 use crate::views::projection::OperationalPointProjection;
 use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathOperationalPointForm;
@@ -614,7 +615,6 @@ pub(in crate::views) async fn get_path(
         db_pool,
         valkey_client,
         core_client,
-        config,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -657,18 +657,70 @@ pub(in crate::views) async fn get_path(
         None => train_schedule.into_train_occurrence(),
     };
 
+    let rolling_stock_name = train_occurence.rolling_stock_name().to_owned();
+    let Some(consist) = RollingStock::retrieve(conn.clone(), rolling_stock_name.clone())
+        .await?
+        .map(schemas::RollingStock::from)
+        .map(PhysicsConsistParameters::from_traction_engine)
+    else {
+        let failure = PathfindingFailure::PathfindingInputError(
+            PathfindingInputError::RollingStockNotFound { rolling_stock_name },
+        );
+        return Ok(Json(PathfindingResult::Failure(failure)));
+    };
+
+    let path_items = train_occurence
+        .path()
+        .iter()
+        .map(|item| &item.location)
+        .collect_vec();
+
+    let pathfinding_input = PathfindingInput::from(&consist, &train_schedule);
     let valkey_conn = valkey_client.get_connection().await?;
-    Ok(Json(
-        pathfinding_from_train(
-            conn,
-            valkey_conn,
-            core_client,
-            &infra,
-            train_schedule,
-            config.app_version.as_deref(),
-        )
-        .await?,
-    ))
+    let result = match build_pathfinding_request(&pathfinding_input, &infra, &op_cache) {
+        Ok(request) => match request
+            .run(Arc::new(tokio::sync::Mutex::new(valkey_conn)), core_client)
+            .await
+        {
+            Ok(track_offsets) => track_offsets,
+            Err(err) => return Ok(Json(PathfindingResult::Failure(err))),
+        };
+
+    let constraints = core_task::PathfindingConstraints {
+        path_items: track_offsets
+            .into_iter()
+            .map(core_task::PathItemAlternatives::from_iter)
+            .collect(),
+    };
+
+    let mut pathfinding_env = core_task::PathfindingEnv::new(core_task::CoreEnv {
+        infra_id: infra.id as u64,
+        infra_version: infra.version,
+        client: core_client,
+    });
+    let pathfinding_train = core_task::PathfindingTrain {
+        consist: build_pathfinding_consist(&consist, train_occurence.speed_limit_tag().cloned()),
+        constraints,
+    };
+    pathfinding_env.extend([((), pathfinding_train)]);
+
+    let valkey_conn = Arc::new(Mutex::new(valkey_client.get_connection().await?));
+    let result = match pathfinding_env
+        .into_stream(valkey_conn)
+        .collect::<Vec<_>>()
+        .await
+        .as_slice()
+    {
+        [path] => path.data.clone(),
+        _ => Err(core_client::Error::BrokenPipe),
+    };
+    let result = match result {
+        Ok(path) => path.into(),
+        Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
+            core_error: core_error.into(),
+        }),
+    };
+    Ok(Json(result))
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -72,6 +72,7 @@ use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::SummaryResponse;
 use crate::views::timetable::simulation::build_path_items_to_position;
+use crate::views::timetable::simulation::build_pathfinding_consist;
 use crate::views::timetable::simulation::build_sim_power_restriction_items;
 use crate::views::timetable::simulation::build_sim_schedule_items;
 use crate::views::timetable::simulation::train_simulation_ordered_batch;
@@ -645,7 +646,7 @@ pub(in crate::views) async fn get_path(
         })
         .await?;
 
-    let train_schedule = match exception_id {
+    let train_occurence = match exception_id {
         Some(exception_id) => {
             let exception =
                 TrainScheduleException::retrieve_or_fail(conn.clone(), exception_id, || {
@@ -675,12 +676,10 @@ pub(in crate::views) async fn get_path(
         .map(|item| &item.location)
         .collect_vec();
 
-    let pathfinding_input = PathfindingInput::from(&consist, &train_schedule);
-    let valkey_conn = valkey_client.get_connection().await?;
-    let result = match build_pathfinding_request(&pathfinding_input, &infra, &op_cache) {
-        Ok(request) => match request
-            .run(Arc::new(tokio::sync::Mutex::new(valkey_conn)), core_client)
-            .await
+    let track_offsets =
+        match OperationalPointCache::load_path_items(conn, infra.id, path_items.as_slice())
+            .await?
+            .extract_location_from_path_items(&path_items)
         {
             Ok(track_offsets) => track_offsets,
             Err(err) => return Ok(Json(PathfindingResult::Failure(err))),

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -625,7 +625,6 @@ pub(in crate::views) async fn get_path(
     Query(ExceptionQueryParam { exception_id }): Query<ExceptionQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
     let conn = db_pool.get().await?;
-    let mut valkey_conn = valkey_client.get_connection().await?;
 
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
@@ -658,10 +657,11 @@ pub(in crate::views) async fn get_path(
         None => train_schedule.into_train_occurrence(),
     };
 
+    let valkey_conn = valkey_client.get_connection().await?;
     Ok(Json(
         pathfinding_from_train(
             conn,
-            &mut valkey_conn,
+            valkey_conn,
             core_client,
             &infra,
             train_schedule,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -56,6 +56,7 @@ use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::path::pathfinding::PathfindingFailure;
 use crate::views::path::pathfinding::PathfindingResult;
+use crate::views::path::pathfinding::single_pathfinding_request;
 use crate::views::projection::OperationalPointProjection;
 use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathOperationalPointForm;
@@ -692,33 +693,12 @@ pub(in crate::views) async fn get_path(
             .collect(),
     };
 
-    let mut pathfinding_env = core_task::PathfindingEnv::new(core_task::CoreEnv {
-        infra_id: infra.id as u64,
-        infra_version: infra.version,
-        client: core_client,
-    });
     let pathfinding_train = core_task::PathfindingTrain {
         consist: build_pathfinding_consist(&consist, train_occurence.speed_limit_tag().cloned()),
         constraints,
     };
-    pathfinding_env.extend([((), pathfinding_train)]);
-
-    let valkey_conn = Arc::new(Mutex::new(valkey_client.get_connection().await?));
-    let result = match pathfinding_env
-        .into_stream(valkey_conn)
-        .collect::<Vec<_>>()
-        .await
-        .as_slice()
-    {
-        [path] => path.data.clone(),
-        _ => Err(core_client::Error::BrokenPipe),
-    };
-    let result = match result {
-        Ok(path) => path.into(),
-        Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
-            core_error: core_error.into(),
-        }),
-    };
+    let result =
+        single_pathfinding_request(pathfinding_train, &infra, valkey_client, core_client).await?;
     Ok(Json(result))
 }
 


### PR DESCRIPTION
As we don’t need the PathfindingEnv, we directly run the task