### PR TITLE
front: fix waypoints not always visible in manchette

### DIFF
--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -136,6 +136,8 @@ const useManchetteWithSpaceTimeChart = ({
     totalDistance
   );
 
+  const spaceScale = zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, yZoom);
+
   const handleRectZoomEnd = useCallback(
     (prev: SyncManchetteState) => {
       if (!prev.rect || !spaceTimeChartRef?.current) {
@@ -333,11 +335,10 @@ const useManchetteWithSpaceTimeChart = ({
   const waypointsToDisplay = useMemo(
     () =>
       selectWaypointsToDisplay(waypoints, {
-        height,
         isProportional,
-        yZoom,
+        spaceScale,
       }),
-    [waypoints, height, isProportional, yZoom]
+    [waypoints, isProportional, spaceScale]
   );
 
   const { manchetteContents, manchetteHeight } = useMemo(() => {
@@ -536,7 +537,7 @@ const useManchetteWithSpaceTimeChart = ({
       zoomMode,
       rect,
       timeScale: zoomValueToTimeScale(xZoom),
-      spaceScale: zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, yZoom),
+      spaceScale,
       setTimeOrigin,
     }),
     [
@@ -564,8 +565,7 @@ const useManchetteWithSpaceTimeChart = ({
       toggleZoomMode,
       zoomMode,
       rect,
-      minZoomMillimeterPerPx,
-      maxZoomMillimeterPerPx,
+      spaceScale,
       setTimeOrigin,
       setSyncManchetteState,
       basicOnPan,

--- a/front/ui/ui-charts/src/manchette/utils/__tests__/helpers.spec.ts
+++ b/front/ui/ui-charts/src/manchette/utils/__tests__/helpers.spec.ts
@@ -9,8 +9,6 @@ import {
   zoomValueToSpaceScale,
 } from '../helpers';
 
-// Assuming these types from your code
-
 // Mock data for the tests
 const mockedWaypoints = [
   { position: 0, id: 'waypoint-1' },
@@ -21,56 +19,132 @@ const mockedWaypoints = [
 describe('selectWaypointsToDisplay', () => {
   it('should ensure that an empty array is returned when there is only 1 waypoint', () => {
     const result = selectWaypointsToDisplay([mockedWaypoints[0]], {
-      height: 500,
       isProportional: true,
-      yZoom: 1,
+      spaceScale: 1_000, // 1 meter per pixel
     });
     expect(result.length).toBe(0);
   });
 
   it('should display all points for non-proportional display', () => {
     const result = selectWaypointsToDisplay(mockedWaypoints, {
-      height: 100,
       isProportional: false,
-      yZoom: 1,
+      spaceScale: 1_000,
     });
     expect(result).toHaveLength(mockedWaypoints.length);
   });
 
   it('should correctly filter waypoints', () => {
+    // spaceScale 10 km/px, so consecutive waypoints are 10px apart (< 32px)
+    // -> waypoint-2 is hidden
     const result = selectWaypointsToDisplay(mockedWaypoints, {
-      height: 100,
       isProportional: true,
-      yZoom: 1,
+      spaceScale: 10_000_000,
     });
     expect(result).toHaveLength(2);
   });
 
   it('should return correct heights for proportional display, zoom 1', () => {
+    // spaceScale 1 km/px, so consecutive waypoints are 100px apart (> 32px)
+    // -> all waypoints shown
     const result = selectWaypointsToDisplay(mockedWaypoints, {
-      height: 500,
       isProportional: true,
-      yZoom: 1,
+      spaceScale: 1_000_000,
     });
     expect(result).toHaveLength(mockedWaypoints.length);
   });
 
   it('should return correct heights for proportional display, zoom 2', () => {
+    // spaceScale 0.5 km/px, so consecutive waypoints are 200px apart (> 32px)
+    // -> all waypoints shown
     const result = selectWaypointsToDisplay(mockedWaypoints, {
-      height: 500,
       isProportional: true,
-      yZoom: 2,
+      spaceScale: 500_000,
     });
     expect(result).toHaveLength(mockedWaypoints.length);
   });
 
   it('should ensure the last point is always displayed', () => {
     const result = selectWaypointsToDisplay(mockedWaypoints, {
-      height: 100,
       isProportional: true,
-      yZoom: 1,
+      spaceScale: 10_000_000,
     });
-    expect(result.some((waypoint) => waypoint.id === 'waypoint-3')).toBe(true);
+    expect(result.at(-1)?.id).toBe('waypoint-3');
+  });
+
+  it('should show a waypoint with sufficient pixel spacing at max zoom', () => {
+    // At max zoom (small mm/px), waypoint-2 sits ~467px from the origin (> 32px)
+    // -> all waypoints shown
+    const result = selectWaypointsToDisplay(
+      [
+        { position: 0, id: 'waypoint-1' },
+        { position: 467_290, id: 'waypoint-2' },
+        { position: 200_000_000, id: 'waypoint-3' },
+      ],
+      { isProportional: true, spaceScale: 1_000 }
+    );
+    expect(result).toHaveLength(3);
+  });
+
+  it('should filter a waypoint that would visually overlap at max zoom', () => {
+    // waypoint-2 is 500mm from the origin, so 0.5px on screen (< 32px)
+    // -> waypoint-2 is hidden
+    const result = selectWaypointsToDisplay(
+      [
+        { position: 0, id: 'waypoint-1' },
+        { position: 500, id: 'waypoint-2' },
+        { position: 200_000_000, id: 'waypoint-3' },
+      ],
+      { isProportional: true, spaceScale: 1_000 }
+    );
+    expect(result).toHaveLength(2);
+    expect(result.some((w) => w.id === 'waypoint-2')).toBe(false);
+  });
+
+  it('should filter the middle waypoint on a very short path even at max zoom', () => {
+    // On a 10m path, waypoint-2 sits 5px from the origin on screen (< 32px)
+    // -> waypoint-2 is hidden
+    const result = selectWaypointsToDisplay(
+      [
+        { position: 0, id: 'waypoint-1' },
+        { position: 5_000, id: 'waypoint-2' },
+        { position: 10_000, id: 'waypoint-3' },
+      ],
+      { isProportional: true, spaceScale: 1_000 }
+    );
+    expect(result).toHaveLength(2);
+    expect(result.some((w) => w.id === 'waypoint-2')).toBe(false);
+  });
+
+  it('should hide a lower-priority waypoint when close to a higher-priority one at low zoom, then show both at higher zoom', () => {
+    // waypoint-A (weight 1) and waypoint-B (weight 2) are 3km apart
+    const waypoints = [
+      { position: 0, id: 'first' },
+      { position: 50_000_000, id: 'waypoint-A', weight: 1 },
+      { position: 53_000_000, id: 'waypoint-B', weight: 2 },
+      { position: 200_000_000, id: 'last' },
+    ];
+
+    // Low zoom (large mm/px):
+    // A and B are only 3px apart on screen (< 32px) and B wins (higher weight)
+    // -> A is hidden
+    const lowZoomResult = selectWaypointsToDisplay(waypoints, {
+      isProportional: true,
+      spaceScale: 1_000_000,
+    });
+    expect(lowZoomResult).toHaveLength(3);
+    expect(lowZoomResult.some((w) => w.id === 'waypoint-A')).toBe(false);
+    expect(lowZoomResult.some((w) => w.id === 'waypoint-B')).toBe(true);
+
+    // High zoom (small mm/px):
+    // A and B are 3000px apart on screen (> 32px)
+    // -> all waypoints shown
+    const highZoomResult = selectWaypointsToDisplay(waypoints, {
+      isProportional: true,
+      spaceScale: 1_000,
+    });
+    expect(highZoomResult).toHaveLength(4);
+    expect(highZoomResult.some((w) => w.id === 'waypoint-A')).toBe(true);
+    expect(highZoomResult.some((w) => w.id === 'waypoint-B')).toBe(true);
   });
 });
 

--- a/front/ui/ui-charts/src/manchette/utils/helpers.ts
+++ b/front/ui/ui-charts/src/manchette/utils/helpers.ts
@@ -71,36 +71,6 @@ export const zoomX = (
   };
 };
 
-export const filterVisibleElements = (
-  elements: Waypoint[],
-  spaceScale: number,
-  minScreenGap: number
-): Waypoint[] => {
-  // On-screen pixel position of a waypoint (spaceScale is mm/px). A constant origin offset
-  // would cancel out in the comparison below, so we don't need it.
-  const getScreenPosition = (waypoint: Waypoint) => waypoint.position / spaceScale;
-
-  const firstElement = elements.at(0);
-  const lastElement = elements.at(-1);
-  if (!firstElement || !lastElement) return elements;
-
-  const sortedElements = [...elements].sort((a, b) => (b.weight ?? 0) - (a.weight ?? 0));
-  const displayedElements: Waypoint[] = [firstElement, lastElement];
-
-  for (const element of sortedElements) {
-    const hasSpace = !displayedElements.some(
-      (displayed) =>
-        Math.abs(getScreenPosition(element) - getScreenPosition(displayed)) < minScreenGap
-    );
-
-    if (hasSpace) {
-      displayedElements.push(element);
-    }
-  }
-
-  return displayedElements.sort((a, b) => a.position - b.position);
-};
-
 export const selectWaypointsToDisplay = (
   waypoints: Waypoint[],
   { isProportional, spaceScale }: { isProportional: boolean; spaceScale: number }
@@ -110,7 +80,30 @@ export const selectWaypointsToDisplay = (
   // display all waypoints in linear mode
   if (!isProportional) return waypoints;
 
-  return filterVisibleElements(waypoints, spaceScale, BASE_WAYPOINT_HEIGHT);
+  // In proportional mode, hide waypoints whose labels (BASE_WAYPOINT_HEIGHT px tall) would
+  // overlap at the current zoom. spaceScale is mm/px, so a waypoint's on-screen position is
+  // position / spaceScale (a because both scales start at zero).
+  const getScreenPosition = (waypoint: Waypoint) => waypoint.position / spaceScale;
+
+  // always keep the first and last waypoints, then greedily keep the highest-weight ones
+  // that still have room
+  const [firstWaypoint] = waypoints;
+  const lastWaypoint = waypoints.at(-1)!;
+  const displayedWaypoints: Waypoint[] = [firstWaypoint, lastWaypoint];
+
+  const waypointsByWeight = [...waypoints].sort((a, b) => (b.weight ?? 0) - (a.weight ?? 0));
+  for (const waypoint of waypointsByWeight) {
+    const hasSpace = !displayedWaypoints.some(
+      (displayed) =>
+        Math.abs(getScreenPosition(waypoint) - getScreenPosition(displayed)) < BASE_WAYPOINT_HEIGHT
+    );
+
+    if (hasSpace) {
+      displayedWaypoints.push(waypoint);
+    }
+  }
+
+  return displayedWaypoints.sort((a, b) => a.position - b.position);
 };
 
 /**

--- a/front/ui/ui-charts/src/manchette/utils/helpers.ts
+++ b/front/ui/ui-charts/src/manchette/utils/helpers.ts
@@ -2,7 +2,6 @@ import { type ReactNode } from 'react';
 
 import { clamp } from 'lodash';
 
-import { calcTotalDistance, getHeightWithoutLastWaypoint } from '.';
 import {
   BASE_WAYPOINT_HEIGHT,
   MAX_ZOOM_MS_PER_PX,
@@ -72,20 +71,14 @@ export const zoomX = (
   };
 };
 
-type WaypointsOptions = {
-  isProportional: boolean;
-  yZoom: number;
-  height: number;
-};
-
 export const filterVisibleElements = (
   elements: Waypoint[],
-  totalDistance: number,
-  heightWithoutFinalWaypoint: number,
-  minSpace: number
+  spaceScale: number,
+  minScreenGap: number
 ): Waypoint[] => {
-  const getPosition = (waypoint: Waypoint) =>
-    (waypoint.position / totalDistance) * heightWithoutFinalWaypoint;
+  // On-screen pixel position of a waypoint (spaceScale is mm/px). A constant origin offset
+  // would cancel out in the comparison below, so we don't need it.
+  const getScreenPosition = (waypoint: Waypoint) => waypoint.position / spaceScale;
 
   const firstElement = elements.at(0);
   const lastElement = elements.at(-1);
@@ -96,7 +89,8 @@ export const filterVisibleElements = (
 
   for (const element of sortedElements) {
     const hasSpace = !displayedElements.some(
-      (displayed) => Math.abs(getPosition(element) - getPosition(displayed)) < minSpace
+      (displayed) =>
+        Math.abs(getScreenPosition(element) - getScreenPosition(displayed)) < minScreenGap
     );
 
     if (hasSpace) {
@@ -109,20 +103,14 @@ export const filterVisibleElements = (
 
 export const selectWaypointsToDisplay = (
   waypoints: Waypoint[],
-  { height, isProportional, yZoom }: WaypointsOptions
+  { isProportional, spaceScale }: { isProportional: boolean; spaceScale: number }
 ): Waypoint[] => {
   if (waypoints.length < 2) return [];
 
   // display all waypoints in linear mode
   if (!isProportional) return waypoints;
 
-  const totalDistance = calcTotalDistance(waypoints);
-  const manchetteHeight = getHeightWithoutLastWaypoint(height);
-
-  // in proportional mode, hide some waypoints to avoid collisions
-  const minSpace = BASE_WAYPOINT_HEIGHT / yZoom;
-
-  return filterVisibleElements(waypoints, totalDistance, manchetteHeight, minSpace);
+  return filterVisibleElements(waypoints, spaceScale, BASE_WAYPOINT_HEIGHT);
 };
 
 /**
@@ -132,7 +120,7 @@ export const selectWaypointsToDisplay = (
  */
 export const getScales = (
   waypoints: Waypoint[],
-  { isProportional, yZoom, height }: WaypointsOptions,
+  { isProportional, yZoom, height }: { isProportional: boolean; yZoom: number; height: number },
   minZoomMillimeterPerPx: number,
   maxZoomMillimeterPerPx: number
 ) => {


### PR DESCRIPTION
The zoom was not taken well into account to calcul when a waypoint should be displayed or not.

fix #16731 

Fix proposed by copilot. Not the math knowledge to understand everything but the fix seems to work.
The doc can probably be better. I need your help to translate what's happening here into a comprehensive text :pray: 