### PR TITLE
editoast: add timetable_type field to timetable and train schedule set

### DIFF
--- a/editoast/database/src/tables.rs
+++ b/editoast/database/src/tables.rs
@@ -6,6 +6,10 @@ pub mod sql_types {
     pub struct Geometry;
 
     #[derive(diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "timetable_type"))]
+    pub struct TimetableType;
+
+    #[derive(diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "train_main_category"))]
     pub struct TrainMainCategory;
 }
@@ -788,9 +792,11 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use postgis_diesel::sql_types::*;
+    use super::sql_types::TimetableType;
 
     timetable (id) {
         id -> Int8,
+        timetable_type -> TimetableType,
     }
 }
 
@@ -891,6 +897,7 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use postgis_diesel::sql_types::*;
+    use super::sql_types::TimetableType;
 
     train_schedule_set (id) {
         id -> Int8,
@@ -899,6 +906,7 @@ diesel::table! {
         name -> Nullable<Varchar>,
         description -> Text,
         published -> Bool,
+        timetable_type -> TimetableType,
     }
 }
 

--- a/editoast/editoast_models/src/lib.rs
+++ b/editoast/editoast_models/src/lib.rs
@@ -24,6 +24,7 @@ pub mod tags;
 pub mod temporary_speed_limits;
 pub mod timetable;
 pub mod timetable_train_schedule_set;
+pub mod timetable_type;
 pub mod towed_rolling_stock;
 pub mod train_schedule;
 pub mod train_schedule_exception;

--- a/editoast/editoast_models/src/timetable.rs
+++ b/editoast/editoast_models/src/timetable.rs
@@ -1,6 +1,7 @@
 use common::units::millisecond;
 use common::units::quantities::Offset;
 use database::DatabaseError;
+use database::tables::sql_types;
 use diesel::prelude::*;
 use diesel::sql_query;
 use diesel::sql_types::Array;
@@ -14,6 +15,7 @@ use std::ops::DerefMut;
 use database::DbConnection;
 
 use crate::timetable_train_schedule_set::TimetableTrainScheduleSet;
+use crate::timetable_type::TimetableType;
 
 #[derive(Debug, Default, Clone, Model)]
 #[cfg_attr(test, derive(serde::Deserialize))]
@@ -21,6 +23,7 @@ use crate::timetable_train_schedule_set::TimetableTrainScheduleSet;
 #[model(gen(ops = crd, list))]
 pub struct Timetable {
     pub id: i64,
+    pub timetable_type: TimetableType,
 }
 
 impl From<Timetable> for Option<i64> {
@@ -162,6 +165,8 @@ impl Timetable {
 pub struct TimetableWithTrains {
     #[diesel(sql_type = BigInt)]
     pub id: i64,
+    #[diesel(sql_type = sql_types::TimetableType)]
+    pub timetable_type: TimetableType,
     #[diesel(sql_type = Array<BigInt>)]
     pub paced_train_ids: Vec<i64>,
 }
@@ -207,6 +212,7 @@ impl From<TimetableWithTrains> for Timetable {
     fn from(timetable_with_trains: TimetableWithTrains) -> Self {
         Self {
             id: timetable_with_trains.id,
+            timetable_type: timetable_with_trains.timetable_type,
         }
     }
 }

--- a/editoast/editoast_models/src/timetable_type.rs
+++ b/editoast/editoast_models/src/timetable_type.rs
@@ -1,0 +1,47 @@
+use database::tables::sql_types;
+use diesel::deserialize::FromSqlRow;
+use diesel::expression::AsExpression;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use std::io::Write;
+use std::ops::Deref;
+use std::str::FromStr;
+
+use diesel::deserialize::FromSql;
+use diesel::pg::Pg;
+use diesel::pg::PgValue;
+use diesel::serialize::Output;
+use diesel::serialize::ToSql;
+
+#[derive(
+    Debug, Clone, PartialEq, Default, Serialize, Deserialize, FromSqlRow, AsExpression, ToSchema,
+)]
+#[diesel(sql_type = sql_types::TimetableType)]
+pub struct TimetableType(pub schemas::timetable_type::TimetableType);
+
+impl FromSql<sql_types::TimetableType, Pg> for TimetableType {
+    fn from_sql(value: PgValue) -> diesel::deserialize::Result<Self> {
+        let s = std::str::from_utf8(value.as_bytes()).map_err(|_| "Invalid UTF-8 data")?;
+        schemas::timetable_type::TimetableType::from_str(s)
+            .map(TimetableType)
+            .map_err(|_| "Unrecognized enum variant for TimetableType".into())
+    }
+}
+
+impl ToSql<sql_types::TimetableType, Pg> for TimetableType {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> diesel::serialize::Result {
+        let variant: &str = &self.0.to_string();
+        out.write_all(variant.as_bytes())?;
+        Ok(diesel::serialize::IsNull::No)
+    }
+}
+
+impl Deref for TimetableType {
+    type Target = schemas::timetable_type::TimetableType;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/editoast/editoast_models/src/train_schedule_set.rs
+++ b/editoast/editoast_models/src/train_schedule_set.rs
@@ -9,6 +9,7 @@ use database::DbConnection;
 use editoast_derive::Model;
 
 use crate::prelude::*;
+use crate::timetable_type::TimetableType;
 
 #[derive(Deserialize, Serialize, ToSchema, Debug, Clone, PartialEq, Model)]
 #[model(table = database::tables::train_schedule_set)]
@@ -20,6 +21,7 @@ pub struct TrainScheduleSet {
     pub name: Option<String>,
     pub description: String,
     pub published: bool,
+    pub timetable_type: TimetableType,
 }
 
 impl TrainScheduleSet {

--- a/editoast/migrations/2026-06-16-121754-0000_timetable_type/down.sql
+++ b/editoast/migrations/2026-06-16-121754-0000_timetable_type/down.sql
@@ -1,0 +1,18 @@
+DROP TRIGGER IF EXISTS trigger_check_add_only_paced_in_hourly_train_schedule_set ON train_schedule;
+DROP FUNCTION IF EXISTS check_add_only_paced_in_hourly_train_schedule_set();
+
+DROP TRIGGER IF EXISTS trigger_check_timetable_and_train_schedule_set_same_type ON timetable_train_schedule_set;
+DROP FUNCTION IF EXISTS check_timetable_and_train_schedule_set_same_type();
+
+DROP TRIGGER IF EXISTS trigger_check_stdcm_search_environment_timetable_type_is_calendar ON stdcm_search_environment;
+DROP FUNCTION IF EXISTS check_stdcm_search_environment_timetable_type_is_calendar();
+
+DROP TRIGGER IF EXISTS trigger_check_timetable_type_is_immutable ON timetable;
+DROP FUNCTION IF EXISTS check_timetable_type_is_immutable();
+
+DROP TRIGGER IF EXISTS trigger_check_train_schedule_set_timetable_type_is_immutable ON train_schedule_set;
+DROP FUNCTION IF EXISTS check_train_schedule_set_timetable_type_is_immutable();
+
+ALTER TABLE "train_schedule_set" DROP COLUMN "timetable_type";
+ALTER TABLE "timetable" DROP COLUMN "timetable_type";
+DROP TYPE "timetable_type";

--- a/editoast/migrations/2026-06-16-121754-0000_timetable_type/up.sql
+++ b/editoast/migrations/2026-06-16-121754-0000_timetable_type/up.sql
@@ -1,0 +1,114 @@
+CREATE TYPE "timetable_type" AS ENUM (
+    'CALENDAR',
+    'HOURLY'
+);
+
+ALTER TABLE "timetable"
+ADD "timetable_type" timetable_type NOT NULL DEFAULT 'CALENDAR';
+
+ALTER TABLE "train_schedule_set"
+ADD "timetable_type" timetable_type NOT NULL DEFAULT 'CALENDAR';
+
+CREATE OR REPLACE FUNCTION check_add_only_paced_in_hourly_train_schedule_set()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM train_schedule_set
+        WHERE train_schedule_set.id = NEW.train_schedule_set_id
+        AND train_schedule_set.timetable_type = 'HOURLY'
+    ) THEN
+        -- Check if a unique train is inserted or updated in an HOURLY train_schedule_set
+        IF NEW.time_window IS NULL OR NEW.interval IS NULL THEN
+            RAISE EXCEPTION 'Cannot insert or update train_schedule with NULL time_window or interval for HOURLY timetable_type in train_schedule_set';
+        END IF;
+        IF NOT (0 <= NEW.start_time AND NEW.start_time * INTERVAL '1 millisecond' < NEW.interval AND NEW.interval <= NEW.time_window) THEN
+            RAISE EXCEPTION 'Invalid paced train_schedule: start_time=% must be >= 0 and < interval=%, interval must be <= time_window=%',
+                NEW.start_time,
+                NEW.interval,
+                NEW.time_window;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE OR REPLACE TRIGGER trigger_check_add_only_paced_in_hourly_train_schedule_set
+BEFORE INSERT OR UPDATE OF train_schedule_set_id, time_window, interval, start_time ON train_schedule
+FOR EACH ROW EXECUTE FUNCTION check_add_only_paced_in_hourly_train_schedule_set();
+
+
+CREATE OR REPLACE FUNCTION check_timetable_type_is_immutable()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.timetable_type IS DISTINCT FROM OLD.timetable_type THEN
+        RAISE EXCEPTION 'Cannot change timetable_type on timetable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE OR REPLACE TRIGGER trigger_check_timetable_type_is_immutable
+BEFORE UPDATE OF timetable_type ON timetable
+FOR EACH ROW EXECUTE FUNCTION check_timetable_type_is_immutable();
+
+CREATE OR REPLACE FUNCTION check_train_schedule_set_timetable_type_is_immutable()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.timetable_type IS DISTINCT FROM OLD.timetable_type THEN
+        RAISE EXCEPTION 'Cannot change timetable_type on train_schedule_set';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE OR REPLACE TRIGGER trigger_check_train_schedule_set_timetable_type_is_immutable
+BEFORE UPDATE OF timetable_type ON train_schedule_set
+FOR EACH ROW EXECUTE FUNCTION check_train_schedule_set_timetable_type_is_immutable();
+
+
+CREATE OR REPLACE FUNCTION check_timetable_and_train_schedule_set_same_type()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM timetable, train_schedule_set
+        WHERE timetable.id = NEW.timetable_id
+            AND train_schedule_set.id = NEW.train_schedule_set_id
+            AND timetable.timetable_type != train_schedule_set.timetable_type
+    )
+    THEN
+        RAISE EXCEPTION 'Cannot insert or update timetable_train_schedule_set with mismatched timetable and train_schedule_set types';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE OR REPLACE TRIGGER trigger_check_timetable_and_train_schedule_set_same_type
+BEFORE INSERT OR UPDATE OF timetable_id, train_schedule_set_id ON timetable_train_schedule_set
+FOR EACH ROW EXECUTE FUNCTION check_timetable_and_train_schedule_set_same_type();
+
+CREATE OR REPLACE FUNCTION check_stdcm_search_environment_timetable_type_is_calendar()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM timetable
+        WHERE timetable.id = NEW.timetable_id
+            AND timetable.timetable_type != 'CALENDAR'
+    )
+    THEN
+        RAISE EXCEPTION 'Cannot insert or update stdcm_search_environment with non calendar timetable_type in timetable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE OR REPLACE TRIGGER trigger_check_stdcm_search_environment_timetable_type_is_calendar
+BEFORE INSERT OR UPDATE OF timetable_id ON stdcm_search_environment
+FOR EACH ROW EXECUTE FUNCTION check_stdcm_search_environment_timetable_type_is_calendar();

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3721,6 +3721,7 @@ paths:
                   - id
                   - description
                   - published
+                  - timetable_type
                   properties:
                     catalog_entry_id:
                       type:
@@ -3738,6 +3739,8 @@ paths:
                       - 'null'
                     published:
                       type: boolean
+                    timetable_type:
+                      $ref: '#/components/schemas/TimetableType'
     post:
       tags:
       - timetable
@@ -15504,10 +15507,18 @@ components:
       description: Creation result for a Timetable
       required:
       - timetable_id
+      - timetable_type
       properties:
         timetable_id:
           type: integer
           format: int64
+        timetable_type:
+          $ref: '#/components/schemas/TimetableType'
+    TimetableType:
+      type: string
+      enum:
+      - CALENDAR
+      - HOURLY
     TowedRollingStock:
       type: object
       required:
@@ -15967,6 +15978,7 @@ components:
       - id
       - description
       - published
+      - timetable_type
       properties:
         catalog_entry_id:
           type:
@@ -15984,6 +15996,8 @@ components:
           - 'null'
         published:
           type: boolean
+        timetable_type:
+          $ref: '#/components/schemas/TimetableType'
     TrainScheduleSetForm:
       type: object
       required:

--- a/editoast/schemas/src/lib.rs
+++ b/editoast/schemas/src/lib.rs
@@ -3,6 +3,7 @@ pub mod infra;
 pub mod paced_train;
 pub mod primitives;
 pub mod rolling_stock;
+pub mod timetable_type;
 pub mod train_schedule;
 pub mod train_schedule_exception;
 

--- a/editoast/schemas/src/timetable_type.rs
+++ b/editoast/schemas/src/timetable_type.rs
@@ -1,0 +1,30 @@
+use serde::Deserialize;
+use serde::Serialize;
+use strum::Display;
+use strum::EnumString;
+use strum::IntoStaticStr;
+use utoipa::ToSchema;
+
+// This enum maps to a Postgres enum type, specifically `timetable_type`.
+// Any changes made to this enum must be reflected in the corresponding Postgres enum,
+// and vice versa, to ensure consistency between the application and the database.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    ToSchema,
+    EnumString,
+    IntoStaticStr,
+    Display,
+    Default,
+)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TimetableType {
+    #[default]
+    Calendar,
+    Hourly,
+}

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -302,11 +302,13 @@ pub mod tests {
     use chrono::DurationRound;
     use chrono::TimeZone;
     use chrono::Utc;
+    use editoast_models::Timetable;
     use pretty_assertions::assert_eq;
 
     use editoast_models::stdcm_search_environment::fixtures::stdcm_search_env_fixtures;
 
     use super::*;
+    use crate::error::InternalError;
     use crate::views::test_app;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -403,6 +405,61 @@ pub mod tests {
             .json(&form)
             .await
             .assert_status_unprocessable_entity();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn create_stdcm_search_env_with_timetable_type_is_different_than_calendar() {
+        // GIVEN
+        let app = test_app!().skip_authz().build();
+        let pool = app.db_pool();
+
+        let (
+            infra,
+            _timetable,
+            work_schedule_group,
+            temporary_speed_limit_group,
+            electrical_profile_set,
+        ) = stdcm_search_env_fixtures(&mut pool.get_ok()).await;
+
+        let hourly_timetable = Timetable::changeset()
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ))
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create timetable");
+
+        let form = StdcmSearchEnvironmentCreateForm {
+            infra_id: infra.id,
+            electrical_profile_set_id: Some(electrical_profile_set.id),
+            work_schedule_group_id: Some(work_schedule_group.id),
+            temporary_speed_limit_group_id: Some(temporary_speed_limit_group.id),
+            timetable_id: hourly_timetable.id,
+            search_window_begin: Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap(),
+            search_window_end: Utc.with_ymd_and_hms(2024, 1, 15, 0, 0, 0).unwrap(),
+            enabled_from: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+            enabled_until: Utc.with_ymd_and_hms(2024, 1, 1, 23, 59, 59).unwrap(),
+            operational_points: Some(Vec::from([1, 2, 3])),
+            operational_points_id_filtered: Vec::from(["uuid-1".to_string(), "uuid-2".to_string()])
+                .into(),
+            speed_limits: Some(SpeedLimits {
+                speed_limit_tags: vec![("MA80".to_string(), 80), ("MA90".to_string(), 90)]
+                    .into_iter()
+                    .collect::<HashMap<String, i64>>(),
+                default_speed_limit_tag: Some("MA80".to_string()),
+            }),
+            allowed_tracks: None,
+        };
+
+        // WHEN
+        let response: InternalError = app
+            .post("/stdcm/search_environment")
+            .json(&form)
+            .await
+            .assert_status_internal_server_error()
+            .json();
+
+        assert_eq!(&response.error_type, "editoast:ModelError")
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -49,6 +49,7 @@ use schemas::rolling_stock::LoadingGaugeType;
 use schemas::rolling_stock::RollingResistance;
 use schemas::rolling_stock::RollingStock;
 use schemas::rolling_stock::TowedRollingStock;
+use schemas::timetable_type::TimetableType;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
 use schemas::train_schedule::TrainScheduleLike;
@@ -106,12 +107,14 @@ enum TimetableError {
 #[cfg_attr(test, derive(PartialEq))]
 pub(in crate::views) struct TimetableResult {
     pub timetable_id: i64,
+    pub timetable_type: TimetableType,
 }
 
 impl From<Timetable> for TimetableResult {
     fn from(timetable: Timetable) -> Self {
         Self {
             timetable_id: timetable.id,
+            timetable_type: timetable.timetable_type.0,
         }
     }
 }
@@ -1130,6 +1133,7 @@ mod tests {
     use schemas::fixtures::simple_rolling_stock;
     use schemas::fixtures::towed_rolling_stock;
 
+    use editoast_models::train_schedule::TrainScheduleChangeset;
     use schemas::rolling_stock::RollingResistance;
     use schemas::train_schedule::OperationalPointPartReference;
     use schemas::train_schedule::PathItem;
@@ -1145,7 +1149,6 @@ mod tests {
     use crate::fixtures::create_train_schedule_set;
     use crate::fixtures::simple_paced_train_base;
     use crate::views::test_app;
-    use editoast_models::train_schedule::TrainScheduleChangeset;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_timetable() {
@@ -1760,5 +1763,86 @@ mod tests {
             response.get("Mid_East_station"),
             Some(&HashSet::from(["East_1".to_string()]))
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_set_links_train_schedule_sets_to_timetable_with_hourly_type() {
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let mut conn = db_pool.get().await.unwrap();
+
+        let timetable = Timetable::changeset()
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ))
+            .create(&mut conn)
+            .await
+            .expect("Failed to create timetable");
+
+        let train_schedule_set = TrainScheduleSet::changeset()
+            .name(None)
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ))
+            .create(&mut conn)
+            .await
+            .expect("Failed to create train schedule set");
+
+        let train_schedule_set_id = train_schedule_set.id;
+        let train_schedule_set_form = TrainScheduleSetForm {
+            train_schedule_set_ids: HashSet::from([train_schedule_set_id]),
+        };
+
+        app.post(format!("/timetable/{}/train_schedule_sets", timetable.id).as_str())
+            .json(&train_schedule_set_form)
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
+
+        let train_schedule_sets: Vec<TrainScheduleSet> = app
+            .get(format!("/timetable/{}/train_schedule_sets", timetable.id).as_str())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(train_schedule_sets, vec![train_schedule_set]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_set_links_train_schedule_sets_to_timetable_with_type_mismatch() {
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let mut conn = db_pool.get().await.unwrap();
+
+        let hourly_timetable = Timetable::changeset()
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ))
+            .create(&mut conn)
+            .await
+            .expect("Failed to create timetable");
+
+        let train_schedule_set = TrainScheduleSet::changeset()
+            .name(None)
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Calendar,
+            ))
+            .create(&mut conn)
+            .await
+            .expect("Failed to create train schedule set");
+
+        let train_schedule_set_id = train_schedule_set.id;
+        let train_schedule_set_form = TrainScheduleSetForm {
+            train_schedule_set_ids: HashSet::from([train_schedule_set_id]),
+        };
+
+        let response: InternalError = app
+            .post(format!("/timetable/{}/train_schedule_sets", hourly_timetable.id).as_str())
+            .json(&train_schedule_set_form)
+            .await
+            .assert_status_internal_server_error()
+            .json();
+
+        assert_eq!(&response.error_type, "editoast:ModelError")
     }
 }

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -324,6 +324,7 @@ pub(in crate::views) async fn get_train_schedules(
 #[cfg(test)]
 mod tests {
 
+    use crate::error::InternalError;
     use crate::fixtures::create_catalog_entry;
     use crate::fixtures::create_train_schedule_set;
     use crate::fixtures::simple_paced_train_base;
@@ -332,6 +333,7 @@ mod tests {
     use crate::views::train_schedule_set::TrainScheduleSetForm;
     use crate::views::train_schedule_set::TrainScheduleSetResponse;
     use chrono::Duration;
+    use common::units::second;
     use database::DbConnection;
     use editoast_models::CatalogEntry;
     use editoast_models::TrainScheduleSet;
@@ -393,6 +395,129 @@ mod tests {
             .expect("Failed to fetch train schedules");
 
         assert!(list_result.len() == 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn create_train_schedule_in_hourly_train_schedule_set() {
+        let app = test_app!().skip_authz().build();
+        let pool = app.db_pool();
+
+        let train_schedule_set = TrainScheduleSet::changeset()
+            .name(Some("hourly_train_schedule_set".into()))
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ))
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create train schedule set");
+        let mut train_schedule_1 = simple_paced_train_base();
+        let mut train_schedule_2 = simple_paced_train_base();
+        train_schedule_1.train_occurrence.start_time = second::i64::new(5 * 60);
+        train_schedule_2.train_occurrence.start_time = second::i64::new(5 * 60);
+        train_schedule_1.paced.as_mut().unwrap().time_window =
+            Duration::minutes(120).try_into().unwrap();
+        train_schedule_1.paced.as_mut().unwrap().interval =
+            Duration::minutes(30).try_into().unwrap();
+        train_schedule_2.paced.as_mut().unwrap().time_window =
+            Duration::minutes(120).try_into().unwrap();
+        train_schedule_2.paced.as_mut().unwrap().interval =
+            Duration::minutes(15).try_into().unwrap();
+
+        let train_schedules = vec![train_schedule_1, train_schedule_2.clone()];
+
+        let response: Vec<TrainScheduleResponse> = app
+            .post(
+                format!(
+                    "/train_schedule_sets/{}/train_schedules",
+                    train_schedule_set.id
+                )
+                .as_str(),
+            )
+            .json(&train_schedules)
+            .await
+            .assert_status(StatusCode::CREATED)
+            .json();
+
+        assert!(response.len() == 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn create_unique_train_schedule_in_hourly_train_schedule_set() {
+        let app = test_app!().skip_authz().build();
+        let pool = app.db_pool();
+
+        let train_schedule_set = TrainScheduleSet::changeset()
+            .name(Some("hourly_train_schedule_set".into()))
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ))
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create train schedule set");
+        let mut train_schedule_1 = simple_paced_train_base();
+        let mut train_schedule_2 = simple_paced_train_base();
+        train_schedule_1.train_occurrence.start_time = second::i64::new(5 * 60);
+        train_schedule_2.train_occurrence.start_time = second::i64::new(5 * 60);
+        train_schedule_1.paced = None;
+        train_schedule_2.paced.as_mut().unwrap().time_window =
+            Duration::minutes(120).try_into().unwrap();
+        train_schedule_2.paced.as_mut().unwrap().interval =
+            Duration::minutes(30).try_into().unwrap();
+
+        let train_schedules = vec![train_schedule_1, train_schedule_2.clone()];
+
+        let response: InternalError = app
+            .post(
+                format!(
+                    "/train_schedule_sets/{}/train_schedules",
+                    train_schedule_set.id
+                )
+                .as_str(),
+            )
+            .json(&train_schedules)
+            .await
+            .assert_status_internal_server_error()
+            .json();
+
+        assert_eq!(&response.error_type, "editoast:ModelError")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn create_invalid_start_time_train_schedule_in_hourly_train_schedule_set() {
+        let app = test_app!().skip_authz().build();
+        let pool = app.db_pool();
+
+        let train_schedule_set = TrainScheduleSet::changeset()
+            .name(Some("hourly_train_schedule_set".into()))
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ))
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create train schedule set");
+        let mut train_schedule_1 = simple_paced_train_base();
+        train_schedule_1.train_occurrence.start_time = second::i64::new(121 * 60);
+        train_schedule_1.paced.as_mut().unwrap().time_window =
+            Duration::minutes(120).try_into().unwrap();
+        train_schedule_1.paced.as_mut().unwrap().interval =
+            Duration::minutes(30).try_into().unwrap();
+
+        let train_schedules = vec![train_schedule_1.clone()];
+
+        let response: InternalError = app
+            .post(
+                format!(
+                    "/train_schedule_sets/{}/train_schedules",
+                    train_schedule_set.id
+                )
+                .as_str(),
+            )
+            .json(&train_schedules)
+            .await
+            .assert_status_internal_server_error()
+            .json();
+
+        assert_eq!(&response.error_type, "editoast:ModelError")
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -458,6 +583,7 @@ mod tests {
             name: Some("test".to_string()),
             description: String::default(),
             published: false,
+            timetable_type: Default::default(),
         };
 
         assert_eq!(
@@ -494,6 +620,7 @@ mod tests {
             name: Some("test".to_string()),
             description: String::default(),
             published: false,
+            timetable_type: Default::default(),
         };
 
         assert_eq!(
@@ -527,6 +654,7 @@ mod tests {
                     name: None,
                     description: String::default(),
                     published: false,
+                    timetable_type: Default::default(),
                 },
                 train_schedule_count: 0
             }
@@ -557,6 +685,7 @@ mod tests {
                     name: Some("test_with_catalog_entry".into()),
                     description: String::default(),
                     published: false,
+                    timetable_type: Default::default(),
                 },
                 train_schedule_count: 0
             }
@@ -673,6 +802,7 @@ mod tests {
                     name: Some("test_updated".to_string()),
                     description: "test description".to_string(),
                     published: false,
+                    timetable_type: Default::default(),
                 },
                 train_schedule_count: 0
             }
@@ -709,6 +839,7 @@ mod tests {
                     name: Some("test_updated".to_string()),
                     description: "test description".to_string(),
                     published: true,
+                    timetable_type: Default::default(),
                 },
                 train_schedule_count: 0
             }

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetForm.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainScheduleSet/TrainScheduleSetForm.tsx
@@ -209,6 +209,7 @@ const TrainScheduleSetForm = ({
             description,
             catalog: catalogEntry!,
             published: false,
+            timetable_type: 'CALENDAR',
           });
         } else {
           onValidation(true);

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2540,6 +2540,7 @@ export type GetTimetableByIdTrainScheduleSetsApiResponse =
     id: number;
     name?: string | null;
     published: boolean;
+    timetable_type: TimetableType;
   }[];
 export type GetTimetableByIdTrainScheduleSetsApiArg = {
   /** A timetable ID */
@@ -4671,8 +4672,10 @@ export type SubCategory = {
 export type SubCategoryPage = PaginationStats & {
   results: SubCategory[];
 };
+export type TimetableType = 'CALENDAR' | 'HOURLY';
 export type TimetableResult = {
   timetable_id: number;
+  timetable_type: TimetableType;
 };
 export type CoreConflictType = 'Spacing' | 'Routing';
 export type CoreConflictRequirement = {
@@ -4996,6 +4999,7 @@ export type TrainScheduleSet = {
   id: number;
   name?: string | null;
   published: boolean;
+  timetable_type: TimetableType;
 };
 export type TrainScheduleSetResponse = TrainScheduleSet & {
   train_schedule_count: number;

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -3705,12 +3705,9 @@ class TestOperation(BaseModel):
     """
 
 
-class TimetableResult(BaseModel):
-    """
-    Creation result for a Timetable
-    """
-
-    timetable_id: int
+class TimetableType(Enum):
+    CALENDAR = "CALENDAR"
+    HOURLY = "HOURLY"
 
 
 class TowedRollingStock(BaseModel):
@@ -3874,6 +3871,7 @@ class TrainScheduleSet(BaseModel):
     id: int
     name: str | None = None
     published: bool
+    timetable_type: TimetableType
 
 
 class TrainScheduleSetForm(BaseModel):
@@ -5353,6 +5351,15 @@ class SwitchExtensions(BaseModel):
         extra="forbid",
     )
     sncf: SwitchSncfExtension | None = None
+
+
+class TimetableResult(BaseModel):
+    """
+    Creation result for a Timetable
+    """
+
+    timetable_id: int
+    timetable_type: TimetableType
 
 
 class TrackSectionExtensions(BaseModel):


### PR DESCRIPTION
part of https://github.com/OpenRailAssociation/osrd/issues/16500

This PR add timetable_type field (HOURLY|CALENDAR) with default to CALENDAR
- [x] Databases migrations
- [x] TimetableType models
- [x] Database level constraints implemented with trigger
- [x] Testes