### PR TITLE
stdcm: track and report work schedule IDs

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableCacheManager.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableRangeSet
 import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
+import fr.sncf.osrd.conflicts.RequirementId
 import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.utils.compress
 import fr.sncf.osrd.utils.decompress
@@ -43,7 +44,7 @@ data class STDCMTimetableData(
     val detailedRequirements: Map<ZoneId, List<DetailedRequirement>>,
 ) {
     @Serializable
-    data class DetailedRequirement(val from: Double, val to: Double, val trainName: String?)
+    data class DetailedRequirement(val from: Double, val to: Double, val source: RequirementId?)
 
     fun toSerializable(): SerializableMap {
         return SerializableMap(detailedRequirements.mapKeys { it.key.index })

--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -8,6 +8,8 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.conflicts.TrainRequirementsById
+import fr.sncf.osrd.conflicts.RequirementId
+import fr.sncf.osrd.conflicts.RequirementType
 import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.ZoneId
@@ -181,7 +183,9 @@ class TimetableDownloader(
                             STDCMTimetableData.DetailedRequirement(
                                 requirement.beginTime,
                                 requirement.endTime,
-                                trainRequirementById.trainName,
+                                trainRequirementById.trainName?.let {
+                                    RequirementId(it, RequirementType.TRAIN)
+                                },
                             )
                         )
                 }

--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -18,6 +18,8 @@ import fr.sncf.osrd.api.standalone_sim.SimulationRequest
 import fr.sncf.osrd.api.stdcm.STDCMEndpoint
 import fr.sncf.osrd.api.stdcm.stdcmRequestAdapter
 import fr.sncf.osrd.cli.ValidateInfra.parseRailJSONFromFile
+import fr.sncf.osrd.conflicts.RequirementId
+import fr.sncf.osrd.conflicts.RequirementType
 import fr.sncf.osrd.conflicts.SpacingRequirement
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.ZoneId
@@ -211,7 +213,7 @@ class JSONTimetableReader(val jsonTimetablePath: String) : TimetableProvider {
                         STDCMTimetableData.DetailedRequirement(
                             spacingReq.beginTime,
                             spacingReq.endTime,
-                            train.trainName,
+                            train.trainName?.let { RequirementId(it, RequirementType.TRAIN) },
                         )
                     )
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/CommonSchemas.kt
@@ -112,6 +112,8 @@ class RJSSpacingRequirement(
 )
 
 data class WorkSchedule(
+    /** Work schedule unique identifier, may contain some metadata */
+    @Json(name = "obj_id") val objId: String,
     /** List of affected track ranges */
     @Json(name = "track_ranges") val trackRanges: Collection<TrackRange> = listOf(),
     @Json(name = "start_time") val startTime: TimeDelta,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/RequirementsParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/RequirementsParser.kt
@@ -128,28 +128,29 @@ fun convertWorkScheduleMap(
     return res
 }
 
-/**
- * Convert work schedules into timetable spacing requirements, without taking work schedule id into
- * account.
- */
+/** Convert work schedules into timetable spacing requirements. */
 @WithSpan(value = "Parsing work schedules", kind = SpanKind.SERVER)
 fun convertWorkScheduleCollection(
     rawInfra: RawSignalingInfra,
     workSchedules: Collection<WorkSchedule>,
     timeToAdd: TimeDelta = 0.seconds,
-): Requirements {
+): List<Requirements> {
     val logAggregator = LogAggregator({ requirementsParserLogger.warn(it) })
-    val workSchedulesRequirements = mutableListOf<RJSSpacingRequirement>()
+    val res = mutableListOf<Requirements>()
     for (workSchedule in workSchedules) {
-        workSchedulesRequirements.addAll(
-            convertWorkSchedule(rawInfra, workSchedule, timeToAdd, logAggregator)
+        val workSchedulesRequirements =
+            convertWorkSchedule(rawInfra, workSchedule, timeToAdd, logAggregator).map {
+                SpacingRequirement.fromRJS(it, rawInfra)
+            }
+        res.add(
+            Requirements(
+                RequirementId(workSchedule.objId, RequirementType.WORK_SCHEDULE),
+                workSchedulesRequirements,
+                listOf(),
+            )
         )
     }
-    return Requirements(
-        RequirementId(DEFAULT_WORK_SCHEDULE_ID, RequirementType.WORK_SCHEDULE),
-        workSchedulesRequirements.map { SpacingRequirement.fromRJS(it, rawInfra) },
-        listOf(),
-    )
+    return res
 }
 
 private fun convertWorkSchedule(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
@@ -13,6 +13,7 @@ import fr.sncf.osrd.api.standalone_sim.SimulationSuccess
 import fr.sncf.osrd.api.standalone_sim.polymorphicElectricalProfileAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSimulationResponseAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSpeedLimitSourceAdapter
+import fr.sncf.osrd.conflicts.RequirementId
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.BlockInfra
@@ -70,7 +71,7 @@ data class TrainZoneRequirement(
     @Json(name = "zone_name") val zoneName: String,
     @Json(name = "begin_time") val beginTime: TimeDelta,
     @Json(name = "end_time") val endTime: TimeDelta,
-    @Json(name = "train_name") val trainName: String?,
+    val source: RequirementId?,
 )
 
 data class ZoneLocation(
@@ -173,7 +174,7 @@ fun makeOtherRequirements(
                     zoneName = rawInfra.getZoneName(zoneRange.value),
                     beginTime = beginTime.seconds,
                     endTime = endTime.seconds,
-                    trainName = metadata.trainName,
+                    source = metadata.source,
                 )
             )
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -522,9 +522,9 @@ fun getRequirements(
 ): RequirementsWithMetadata {
     val requirements = mutableMapOf<ZoneId, TreeRangeSet<Double>>()
     val metadata = mutableMapOf<ZoneId, MutableList<STDCMTimetableData.DetailedRequirement>>()
-    convertWorkScheduleCollection(infra.rawInfra, request.workSchedules)
-        .spacingRequirements
-        .forEach { spacingReq ->
+    for (convertedWorkSchedule in
+        convertWorkScheduleCollection(infra.rawInfra, request.workSchedules)) {
+        for (spacingReq in convertedWorkSchedule.spacingRequirements) {
             val set = requirements.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
             set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
             metadata
@@ -533,10 +533,11 @@ fun getRequirements(
                     STDCMTimetableData.DetailedRequirement(
                         spacingReq.beginTime,
                         spacingReq.endTime,
-                        "work schedule",
+                        convertedWorkSchedule.id.id,
                     )
                 )
         }
+    }
 
     val trainRequirements = runBlocking { timetableCacheManager.get(infra, request.timetableId) }
     // Cached requirements are relative to EPOCH. Add time diff with request start time

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -533,7 +533,7 @@ fun getRequirements(
                     STDCMTimetableData.DetailedRequirement(
                         spacingReq.beginTime,
                         spacingReq.endTime,
-                        convertedWorkSchedule.id.id,
+                        convertedWorkSchedule.id,
                     )
                 )
         }
@@ -577,7 +577,7 @@ fun getRequirements(
                     STDCMTimetableData.DetailedRequirement(
                         metadata.from - searchWindowBeginEpoch,
                         metadata.to - searchWindowBeginEpoch,
-                        metadata.trainName,
+                        metadata.source,
                     )
                 )
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/Conflicts.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/Conflicts.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.Json
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
 import fr.sncf.osrd.sim_infra.api.RouteId
 import fr.sncf.osrd.sim_infra.api.ZoneId
+import kotlinx.serialization.Serializable
 
 class Conflict(
     val startTime: Double,
@@ -33,6 +34,7 @@ class Requirements(
     val routingRequirements: Collection<RoutingRequirement>,
 )
 
+@Serializable
 data class RequirementId(
     // Either a train db id or a work schedule db id
     val id: String,

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalConflictDetector.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalConflictDetector.kt
@@ -8,8 +8,6 @@ import java.util.TreeMap
 import kotlin.math.max
 import kotlin.math.min
 
-const val DEFAULT_WORK_SCHEDULE_ID: String = "default work schedule ID"
-
 sealed interface IncrementalConflictResponse
 
 data class ConflictResponse(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -270,7 +270,7 @@ class BlockAvailability(
                     requirementsWithMetadata
                         ?.metadata[conflictProperties.conflictingZone]
                         ?.firstOrNull { it.from <= endTime && it.to >= startTime }
-                        ?.trainName
+                        ?.source
                         ?.let {
                             listOf(
                                 BlockAvailabilityInterface.ConflictCause(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm.preprocessing.interfaces
 
+import fr.sncf.osrd.conflicts.RequirementId
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Offset
@@ -81,11 +82,8 @@ interface BlockAvailabilityInterface {
     ) : Availability()
 
     data class ConflictCause(
-        /**
-         * Describes the actual conflicting object: the work schedule obj_id, or train names for
-         * other trains. TODO: use a RequirementId instead.
-         */
-        val cause: String,
+        /** Describes the actual conflicting object. */
+        val cause: RequirementId,
         /** How much delay we needed to add to avoid this specific conflict. */
         val duration: Double,
     )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -82,8 +82,8 @@ interface BlockAvailabilityInterface {
 
     data class ConflictCause(
         /**
-         * Describes the actual conflicting object: either "work schedule" for work schedules, or
-         * train names for other trains. TODO: import work schedule IDs as well.
+         * Describes the actual conflicting object: the work schedule obj_id, or train names for
+         * other trains. TODO: use a RequirementId instead.
          */
         val cause: String,
         /** How much delay we needed to add to avoid this specific conflict. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.S3Context
+import fr.sncf.osrd.conflicts.RequirementId
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
@@ -39,7 +40,7 @@ class FailureExplainer(
     data class PendingConflict(
         val parentNode: STDCMNode,
         val timeLost: Double,
-        val cause: String,
+        val cause: RequirementId,
         val bestRemainingTime: Double,
     ) {
         private val nodeStr = parentNode.toString()
@@ -115,7 +116,7 @@ class FailureExplainer(
         @Json(name = "time_lost") val timeLost: Double,
         @Json(name = "best_remaining_time") val bestRemainingTime: Double,
         @Json(name = "current_travel_time") val currentTravelTime: Double,
-        @Json(name = "caused_by") val causedBy: String,
+        val source: RequirementId,
         val lat: Double,
         val lon: Double,
         val lastOPName: String?,
@@ -123,7 +124,7 @@ class FailureExplainer(
     )
 
     /** Register a new conflict. */
-    fun conflictCallback(parentNode: STDCMNode, timeLost: Double, cause: String) {
+    fun conflictCallback(parentNode: STDCMNode, timeLost: Double, cause: RequirementId) {
         val pendingConflict =
             PendingConflict(parentNode, timeLost, cause, parentNode.remainingTimeEstimation)
         largestConflicts.register(pendingConflict)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -176,13 +176,14 @@ class FullSTDCMTests {
                         smallInfra.rawInfra,
                         listOf(
                             WorkSchedule(
+                                "test_work_schedule",
                                 listOf(TrackRange("TB0", Offset(0.meters), Offset(2000.meters))),
                                 0.seconds,
                                 3600.seconds,
                             )
                         ),
                     )
-                    .spacingRequirements
+                    .flatMap { it.spacingRequirements }
             )
         val start = convertRouteLocation(smallInfra, "rt.buffer_stop.3->DB0", Offset(0.meters))
         val end = convertRouteLocation(smallInfra, "rt.DH2->buffer_stop.7", Offset(0.meters))

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -89,6 +89,8 @@ pub struct StepTimingData {
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
 #[schema(as = CoreWorkSchedule)]
 pub struct WorkSchedule {
+    /// Unique identifier for the work schedule
+    pub obj_id: String,
     /// Start time as a time delta from the stdcm start time in ms
     pub start_time: u64,
     /// End time as a time delta from the stdcm start time in ms

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12663,6 +12663,21 @@ components:
             within the target document where the operation is performed.
         value:
           description: Value to replace with.
+    RequirementId:
+      type: object
+      required:
+      - id
+      - type
+      properties:
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/RequirementType'
+    RequirementType:
+      type: string
+      enum:
+      - TRAIN
+      - WORK_SCHEDULE
     ResourceType:
       type: string
       enum:
@@ -13927,7 +13942,6 @@ components:
       - time_lost
       - best_remaining_time
       - current_travel_time
-      - caused_by
       - lat
       - lon
       properties:
@@ -13937,8 +13951,6 @@ components:
         best_remaining_time:
           type: number
           format: double
-        caused_by:
-          type: string
         current_travel_time:
           type: number
           format: double
@@ -13954,6 +13966,10 @@ components:
           format: double
         path_geometry:
           $ref: '#/components/schemas/GeoJsonLineString'
+        source:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/RequirementId'
         time_lost:
           type: number
           format: double
@@ -14042,10 +14058,10 @@ components:
         end_time:
           type: number
           format: double
-        train_name:
-          type:
-          - string
-          - 'null'
+        source:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/RequirementId'
         zone_name:
           type: string
     SimDebugZoneLocation:

--- a/editoast/src/views/stdcm_debug.rs
+++ b/editoast/src/views/stdcm_debug.rs
@@ -36,12 +36,26 @@ enum StdcmDebugError {
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(in crate::views) enum RequirementType {
+    Train,
+    WorkSchedule,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct RequirementId {
+    id: String,
+    #[serde(rename = "type")]
+    requirement_type: RequirementType,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
 pub(in crate::views) struct SimDebugConflictReport {
     at: DateTime<Utc>,
     time_lost: f64,
     best_remaining_time: f64,
     current_travel_time: f64,
-    caused_by: String,
+    source: Option<RequirementId>,
     lat: f64,
     lon: f64,
     #[serde(rename = "lastOPName")]
@@ -62,7 +76,7 @@ pub(in crate::views) struct SimDebugTrainZoneRequirement {
     zone_name: String,
     begin_time: f64,
     end_time: f64,
-    train_name: Option<String>,
+    source: Option<RequirementId>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -551,6 +551,7 @@ pub fn as_core_work_schedule(
     }
 
     Some(core_client::stdcm::WorkSchedule {
+        obj_id: work_schedule.obj_id.clone(),
         start_time,
         end_time,
         track_ranges: work_schedule

--- a/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
@@ -24,7 +24,11 @@ const toFeatures = (
   points.map(({ path_geometry: _, ...point }, i) => ({
     type: 'Feature',
     id: i,
-    properties: { ...point, category },
+    properties: {
+      ...point,
+      category,
+      source: point.source ? `${point.source.type} ${point.source.id}` : `(unknown)`,
+    },
     geometry: { type: 'Point', coordinates: [point.lon, point.lat] },
   }));
 
@@ -95,7 +99,11 @@ const DebugMap = ({ failureData, simulationData }: DebugMapProps) => {
         setHovered(null);
         return;
       }
-      setHovered({ point: { ...point, category }, clientX: event.point.x, clientY: event.point.y });
+      setHovered({
+        point: { ...point, category, source: feature.properties?.source },
+        clientX: event.point.x,
+        clientY: event.point.y,
+      });
     },
     [failureData]
   );
@@ -204,7 +212,7 @@ const DebugMap = ({ failureData, simulationData }: DebugMapProps) => {
             <strong>{hovered.point.lastOPName}</strong>
           </div>
           <div>at: {hovered.point.at}</div>
-          <div>caused by: {hovered.point.caused_by}</div>
+          <div>caused by: {hovered.point.source?.toString()}</div>
           <div>time lost: {fmtSeconds(hovered.point.time_lost)}</div>
           <div>best remaining: {fmtSeconds(hovered.point.best_remaining_time)}</div>
           <div>travel time: {fmtSeconds(hovered.point.current_travel_time)}</div>

--- a/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugSpaceTimeChart.tsx
@@ -21,8 +21,8 @@ type DebugBlock = {
   spaceStart: number;
   spaceEnd: number;
   zoneName: string;
-  trainName: string;
-  kind: 'other' | 'zone_update' | 'spacing_req';
+  sourceName: string;
+  kind: 'other' | 'work_schedule' | 'zone_update' | 'spacing_req';
 };
 
 type BlockLayerStyle = { fill: string; stroke: string };
@@ -31,6 +31,7 @@ const CHART_HEIGHT = 600;
 
 const KIND_LABEL: Record<DebugBlock['kind'], string> = {
   other: 'Other train',
+  work_schedule: 'Work schedule',
   zone_update: 'Zone update',
   spacing_req: 'Spacing requirement',
 };
@@ -58,6 +59,7 @@ function DebugBlocksLayer({ blocks, style }: { blocks: DebugBlock[]; style: Bloc
 
 const LAYER_STYLES: Record<DebugBlock['kind'], BlockLayerStyle> = {
   other: { fill: 'rgba(240, 128, 128, 0.5)', stroke: 'rgba(200, 60, 60, 0.9)' },
+  work_schedule: { fill: 'rgba(0, 0, 139, 0.3)', stroke: 'rgba(0, 0, 139, 0.9)' },
   zone_update: { fill: 'rgba(135, 206, 250, 0.5)', stroke: 'rgba(65, 105, 225, 0.9)' },
   spacing_req: { fill: 'rgba(244, 164, 96, 0.5)', stroke: 'rgba(210, 105, 30, 0.9)' },
 };
@@ -77,21 +79,22 @@ const DebugSpaceTimeChart = ({ simData }: DebugSpaceTimeChartProps) => {
     );
     const departureMs = Date.parse(simData.departure_time);
 
-    const otherBlocks: DebugBlock[] = simData.other_requirements.flatMap((req) => {
+    const otherBlocks: DebugBlock[] = [];
+    const workScheduleBlocks: DebugBlock[] = [];
+    for (const req of simData.other_requirements) {
       const pos = zoneMap.get(req.zone_name);
-      if (!pos) return [];
-      return [
-        {
-          timeStart: departureMs + req.begin_time,
-          timeEnd: departureMs + req.end_time,
-          spaceStart: pos.spaceStart,
-          spaceEnd: pos.spaceEnd,
-          zoneName: req.zone_name,
-          trainName: req.train_name ?? '',
-          kind: 'other',
-        },
-      ];
-    });
+      if (!pos) continue;
+      const isWorkSchedule = req.source?.type === 'WORK_SCHEDULE';
+      (isWorkSchedule ? workScheduleBlocks : otherBlocks).push({
+        timeStart: departureMs + req.begin_time,
+        timeEnd: departureMs + req.end_time,
+        spaceStart: pos.spaceStart,
+        spaceEnd: pos.spaceEnd,
+        zoneName: req.zone_name,
+        sourceName: req.source?.id ?? '(unknown)',
+        kind: isWorkSchedule ? 'work_schedule' : 'other',
+      });
+    }
 
     const finalOutput = simData.sim_output?.final_output;
 
@@ -113,7 +116,7 @@ const DebugSpaceTimeChart = ({ simData }: DebugSpaceTimeChartProps) => {
           spaceStart: pos.spaceStart,
           spaceEnd: pos.spaceEnd,
           zoneName: zone,
-          trainName: '',
+          sourceName: '',
           kind: 'zone_update',
         });
       }
@@ -130,7 +133,7 @@ const DebugSpaceTimeChart = ({ simData }: DebugSpaceTimeChartProps) => {
           spaceStart: pos.spaceStart,
           spaceEnd: pos.spaceEnd,
           zoneName: req.zone,
-          trainName: '',
+          sourceName: '',
           kind: 'spacing_req',
         });
       }
@@ -156,11 +159,17 @@ const DebugSpaceTimeChart = ({ simData }: DebugSpaceTimeChartProps) => {
           }
         : null;
 
-    const allBlocks = [...otherBlocks, ...zoneUpdateBlocks, ...spacingReqBlocks];
+    const allBlocks = [
+      ...otherBlocks,
+      ...workScheduleBlocks,
+      ...zoneUpdateBlocks,
+      ...spacingReqBlocks,
+    ];
 
     return {
       departureMs,
       otherBlocks,
+      workScheduleBlocks,
       zoneUpdateBlocks,
       spacingReqBlocks,
       allBlocks,
@@ -246,6 +255,10 @@ const DebugSpaceTimeChart = ({ simData }: DebugSpaceTimeChartProps) => {
             >
               <DebugBlocksLayer blocks={chartData.otherBlocks} style={LAYER_STYLES.other} />
               <DebugBlocksLayer
+                blocks={chartData.workScheduleBlocks}
+                style={LAYER_STYLES.work_schedule}
+              />
+              <DebugBlocksLayer
                 blocks={chartData.zoneUpdateBlocks}
                 style={LAYER_STYLES.zone_update}
               />
@@ -266,7 +279,7 @@ const DebugSpaceTimeChart = ({ simData }: DebugSpaceTimeChartProps) => {
         >
           <div>
             <strong>{KIND_LABEL[hoveredBlock.kind]}</strong>
-            {hoveredBlock.trainName && <span> — {hoveredBlock.trainName}</span>}
+            {hoveredBlock.sourceName && <span> — {hoveredBlock.sourceName}</span>}
           </div>
           <div className="debug-space-time-chart__tooltip-zone">{hoveredBlock.zoneName}</div>
         </div>

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4354,15 +4354,20 @@ export type SimilarTrainWaypoint = {
   id: string;
   stop: boolean;
 };
+export type RequirementType = 'TRAIN' | 'WORK_SCHEDULE';
+export type RequirementId = {
+  id: string;
+  type: RequirementType;
+};
 export type SimDebugConflictReport = {
   at: string;
   best_remaining_time: number;
-  caused_by: string;
   current_travel_time: number;
   lastOPName?: string | null;
   lat: number;
   lon: number;
   path_geometry?: GeoJsonLineString;
+  source?: null | RequirementId;
   time_lost: number;
 };
 export type SimDebugFailureReport = {
@@ -4377,7 +4382,7 @@ export type SimDebugEngineeringAllowanceRange = {
 export type SimDebugTrainZoneRequirement = {
   begin_time: number;
   end_time: number;
-  train_name?: string | null;
+  source?: null | RequirementId;
   zone_name: string;
 };
 export type CoreReportTrain = {

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -2939,6 +2939,11 @@ class ReplaceOperation(BaseModel):
     """
 
 
+class RequirementType(Enum):
+    TRAIN = "TRAIN"
+    WORK_SCHEDULE = "WORK_SCHEDULE"
+
+
 class RevokeBody(BaseModel):
     resource_id: int
     resource_type: Literal["infra"]
@@ -3233,13 +3238,6 @@ class SimDebugEngineeringAllowanceRange(BaseModel):
     added_duration: float
     from_: Annotated[float, Field(alias="from")]
     to: float
-
-
-class SimDebugTrainZoneRequirement(BaseModel):
-    begin_time: float
-    end_time: float
-    train_name: str | None = None
-    zone_name: str
 
 
 class SimDebugZoneLocation(BaseModel):
@@ -5003,6 +5001,11 @@ class ProjectWithStudies(Project):
     studies_count: Annotated[int, Field(ge=0)]
 
 
+class RequirementId(BaseModel):
+    id: str
+    type: RequirementType
+
+
 class Route(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5131,6 +5134,13 @@ class SignalExtensions(BaseModel):
         extra="forbid",
     )
     sncf: SignalSncfExtension | None = None
+
+
+class SimDebugTrainZoneRequirement(BaseModel):
+    begin_time: float
+    end_time: float
+    source: RequirementId | None = None
+    zone_name: str
 
 
 class FinalOutput(CoreReportTrain):
@@ -5920,12 +5930,12 @@ class Signal(BaseModel):
 class SimDebugConflictReport(BaseModel):
     at: AwareDatetime
     best_remaining_time: float
-    caused_by: str
     current_travel_time: float
     lastOPName: str | None = None
     lat: float
     lon: float
     path_geometry: GeoJsonLineString | None = None
+    source: RequirementId | None = None
     time_lost: float
 
 


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16272

The main changes:

* Editoast forwards work schedule IDs to core
* Core keeps tracks of these and uses it in conflict reports
* The conflict report format changes a bit to indicate if it's a train or work schedule
    * For easier backward compatibility, editoast returns either the old or new format as two optional fields
    * Same for the space time chart data
* Front:
    * In the space-time chart, the work schedules are displayed in dark blue
    * On the map, the hover tooltip indicates the conflict type

Note: on the first screenshot, the work schedule appears darker than it should be, that's because the work schedule appears 12 times in my DB and each entry is transparent and overlapping. That may be because there's something wrong in my work schedule export script, but there's also a real chance our production DB have repeated work schedules. We'd see that more clearly once this is available in internal environments.

 
<img width="1004" height="336" alt="image" src="https://github.com/user-attachments/assets/7f2d5ece-388c-4bc8-94d6-c66837230e05" />
<img width="232" height="133" alt="image" src="https://github.com/user-attachments/assets/799c9666-2f9c-4377-ae9b-abb55d01a6a2" />
