### PR TITLE
editoast: avoid name collisions in `osrd_schemas_auto`

### DIFF
--- a/editoast/common/src/geometry.rs
+++ b/editoast/common/src/geometry.rs
@@ -60,36 +60,42 @@ mod serde_remotes {
     #[derive(Serialize, ToSchema)]
     #[serde(tag = "type", content = "coordinates")]
     pub(super) enum GeoJsonPoint {
+        #[schema(title = "PointGeometry")]
         Point(GeoJsonPointValue),
     }
 
     #[derive(Serialize, ToSchema)]
     #[serde(tag = "type", content = "coordinates")]
     pub(super) enum GeoJsonMultiPoint {
+        #[schema(title = "MultiPointGeometry")]
         MultiPoint(GeoJsonMultiPointValue),
     }
 
     #[derive(Serialize, ToSchema)]
     #[serde(tag = "type", content = "coordinates")]
     pub(super) enum GeoJsonLineString {
+        #[schema(title = "LineStringGeometry")]
         LineString(GeoJsonLineStringValue),
     }
 
     #[derive(Serialize, ToSchema)]
     #[serde(tag = "type", content = "coordinates")]
     pub(super) enum GeoJsonMultiLineString {
+        #[schema(title = "MultiLineStringGeometry")]
         MultiLineString(GeoJsonMultiLineStringValue),
     }
 
     #[derive(Serialize, ToSchema)]
     #[serde(tag = "type", content = "coordinates")]
     pub(super) enum GeoJsonPolygon {
+        #[schema(title = "PolygonGeometry")]
         Polygon(GeoJsonPolygonValue),
     }
 
     #[derive(Serialize, ToSchema)]
     #[serde(tag = "type", content = "coordinates")]
     pub(super) enum GeoJsonMultiPolygon {
+        #[schema(title = "MultiPolygonGeometry")]
         MultiPolygon(GeoJsonMultiPolygonValue),
     }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5421,6 +5421,40 @@ components:
           type: integer
           format: int64
           minimum: 0
+    CoreOperationalPointOnPath:
+      type: object
+      description: Operational point along a path.
+      required:
+      - id
+      - part
+      - position
+      - weight
+      properties:
+        extensions:
+          $ref: '#/components/schemas/OperationalPointExtensions'
+          description: Extensions associated to the operational point
+        id:
+          oneOf:
+          - type: string
+            maxLength: 255
+            minLength: 1
+          description: Id of the operational point
+        part:
+          $ref: '#/components/schemas/OperationalPointPart'
+          description: The part along the path
+        position:
+          type: integer
+          format: int64
+          description: Distance from the beginning of the path in mm
+          minimum: 0
+        weight:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: Importance of the operational point
+          maximum: 100
+          minimum: 0
     CorePathfindingInputError:
       oneOf:
       - type: object
@@ -10177,6 +10211,7 @@ components:
     GeoJsonLineString:
       oneOf:
       - type: object
+        title: LineStringGeometry
         required:
         - coordinates
         - type
@@ -10194,6 +10229,7 @@ components:
     GeoJsonMultiLineString:
       oneOf:
       - type: object
+        title: MultiLineStringGeometry
         required:
         - coordinates
         - type
@@ -10211,6 +10247,7 @@ components:
     GeoJsonMultiPoint:
       oneOf:
       - type: object
+        title: MultiPointGeometry
         required:
         - coordinates
         - type
@@ -10228,6 +10265,7 @@ components:
     GeoJsonMultiPolygon:
       oneOf:
       - type: object
+        title: MultiPolygonGeometry
         required:
         - coordinates
         - type
@@ -10245,6 +10283,7 @@ components:
     GeoJsonPoint:
       oneOf:
       - type: object
+        title: PointGeometry
         required:
         - coordinates
         - type
@@ -10263,6 +10302,7 @@ components:
     GeoJsonPolygon:
       oneOf:
       - type: object
+        title: PolygonGeometry
         required:
         - coordinates
         - type
@@ -11179,8 +11219,7 @@ components:
         boundaries:
           type: array
           items:
-            type: string
-            minLength: 1
+            $ref: '#/components/schemas/NonBlankString'
         values:
           type: array
           items:
@@ -11466,23 +11505,25 @@ components:
         identifier:
           oneOf:
           - type: 'null'
-          - type: object
-            required:
-            - name
-            - uic
-            properties:
-              name:
-                type: string
-                minLength: 1
-              uic:
-                type: integer
-                format: int32
-                minimum: 0
-            additionalProperties: false
+          - $ref: '#/components/schemas/OperationalPointIdentifierExtension'
         sncf:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/OperationalPointSncfExtension'
+      additionalProperties: false
+    OperationalPointIdentifierExtension:
+      type: object
+      required:
+      - name
+      - uic
+      properties:
+        name:
+          type: string
+          minLength: 1
+        uic:
+          type: integer
+          format: int32
+          minimum: 0
       additionalProperties: false
     OperationalPointPart:
       type: object
@@ -11986,39 +12027,7 @@ components:
         operational_points:
           type: array
           items:
-            type: object
-            description: Operational point along a path.
-            required:
-            - id
-            - part
-            - position
-            - weight
-            properties:
-              extensions:
-                $ref: '#/components/schemas/OperationalPointExtensions'
-                description: Extensions associated to the operational point
-              id:
-                oneOf:
-                - type: string
-                  maxLength: 255
-                  minLength: 1
-                description: Id of the operational point
-              part:
-                $ref: '#/components/schemas/OperationalPointPart'
-                description: The part along the path
-              position:
-                type: integer
-                format: int64
-                description: Distance from the beginning of the path in mm
-                minimum: 0
-              weight:
-                type:
-                - integer
-                - 'null'
-                format: int32
-                description: Importance of the operational point
-                maximum: 100
-                minimum: 0
+            $ref: '#/components/schemas/CoreOperationalPointOnPath'
           description: Operational points along the path
         slopes:
           oneOf:
@@ -12190,27 +12199,8 @@ components:
         timing_data:
           oneOf:
           - type: 'null'
-          - type: object
-            required:
-            - arrival_time
-            - arrival_time_tolerance_before
-            - arrival_time_tolerance_after
-            properties:
-              arrival_time:
-                type: string
-                format: date-time
-                description: Time at which the train should arrive at the location
-              arrival_time_tolerance_after:
-                type: integer
-                format: int64
-                description: The train may arrive up to this duration after the expected arrival time
-                minimum: 0
-              arrival_time_tolerance_before:
-                type: integer
-                format: int64
-                description: The train may arrive up to this duration before the expected arrival time
-                minimum: 0
-          description: Time at which the train should arrive at the location, if specified
+          - $ref: '#/components/schemas/StepTimingData'
+            description: Time at which the train should arrive at the location, if specified
     PathfindingOutput:
       type: object
       required:
@@ -12221,9 +12211,7 @@ components:
         detectors:
           type: array
           items:
-            type: string
-            maxLength: 255
-            minLength: 1
+            $ref: '#/components/schemas/Identifier'
         switches_directions:
           type: object
           additionalProperties:
@@ -13489,21 +13477,23 @@ components:
         track_sections:
           type: array
           items:
-            type: object
-            required:
-            - track
-            - position
-            properties:
-              position:
-                type: number
-                format: double
-              track:
-                type: string
+            $ref: '#/components/schemas/SearchResultItemOperationalPointTrackSections'
         trigram:
           type: string
         uic:
           type: integer
           format: int64
+    SearchResultItemOperationalPointTrackSections:
+      type: object
+      required:
+      - track
+      - position
+      properties:
+        position:
+          type: number
+          format: double
+        track:
+          type: string
     SearchResultItemProject:
       type: object
       description: A search result item for a query with `object = "project"`
@@ -14896,6 +14886,27 @@ components:
           - integer
           - 'null'
           format: int64
+    StepTimingData:
+      type: object
+      required:
+      - arrival_time
+      - arrival_time_tolerance_before
+      - arrival_time_tolerance_after
+      properties:
+        arrival_time:
+          type: string
+          format: date-time
+          description: Time at which the train should arrive at the location
+        arrival_time_tolerance_after:
+          type: integer
+          format: int64
+          description: The train may arrive up to this duration after the expected arrival time
+          minimum: 0
+        arrival_time_tolerance_before:
+          type: integer
+          format: int64
+          description: The train may arrive up to this duration before the expected arrival time
+          minimum: 0
     Study:
       type: object
       required:

--- a/editoast/schemas/src/infra/operational_point.rs
+++ b/editoast/schemas/src/infra/operational_point.rs
@@ -54,7 +54,6 @@ pub struct OperationalPointPartSncfExtension {
 #[serde(deny_unknown_fields)]
 pub struct OperationalPointExtensions {
     pub sncf: Option<OperationalPointSncfExtension>,
-    #[schema(inline)]
     pub identifier: Option<OperationalPointIdentifierExtension>,
 }
 

--- a/editoast/schemas/src/train_schedule/margins.rs
+++ b/editoast/schemas/src/train_schedule/margins.rs
@@ -11,7 +11,6 @@ use utoipa::ToSchema;
 #[educe(Default)]
 #[serde(remote = "Self")]
 pub struct Margins {
-    #[schema(inline)]
     pub boundaries: Vec<NonBlankString>,
     #[educe(Default = vec![MarginValue::default()])]
     /// The values of the margins. Must contains one more element than the boundaries

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -62,7 +62,6 @@ pub(in crate::views) struct InfraPathfindingInput {
 #[derive(Debug, Default, Clone, Serialize, ToSchema)]
 pub(in crate::views) struct PathfindingOutput {
     track_ranges: Vec<DirectionalTrackRange>,
-    #[schema(inline)]
     detectors: Vec<Identifier>,
     #[schema(inline)]
     switches_directions: HashMap<Identifier, Identifier>,

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -51,7 +51,6 @@ pub(in crate::views) struct PathProperties {
     #[schema(value_type = GeoJsonLineString)]
     geometry: Geometry,
     /// Operational points along the path
-    #[schema(inline)]
     operational_points: Vec<OperationalPointOnPath>,
     /// Zones along the path
     #[schema(inline)]

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -491,7 +491,6 @@ pub(super) struct SearchResultItemOperationalPoint {
     #[schema(value_type = GeoJsonPoint)]
     geographic: Geometry,
     #[search(sql = "OP.data->'parts'")]
-    #[schema(inline)]
     track_sections: Vec<SearchResultItemOperationalPointTrackSections>,
 }
 #[derive(Serialize, ToSchema)]

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -40,7 +40,6 @@ pub(crate) struct PathfindingItem {
     /// The associated location
     pub(crate) location: PathItemLocation,
     /// Time at which the train should arrive at the location, if specified
-    #[schema(inline)]
     pub(crate) timing_data: Option<StepTimingData>,
 }
 

--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -13,7 +13,7 @@ import {
 } from 'applications/stdcm/types';
 import {
   osrdRailwayManagerApi,
-  type LoadingGaugeType,
+  type RmiLoadingGaugeType,
   type PostSendLastMinuteRequestApiArg,
   type SimulationReport,
   type SendLastMinuteRequestResponse,
@@ -257,7 +257,7 @@ const SendToRailwayManagerModal = ({
     const simulationReport: SimulationReport = {
       rolling_stock: consist.tractionEngine.name,
       towed_rolling_stock: consist.towedRollingStock?.name,
-      loading_gauge_type: consist.loadingGauge as LoadingGaugeType,
+      loading_gauge_type: consist.loadingGauge as RmiLoadingGaugeType,
       speed_limit_tags: consist.speedLimitByTag,
       total_mass: tToKg(consist.totalMass),
       max_speed: kmhToMs(consist.maxSpeed),

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3029,6 +3029,10 @@ export type NeutralSection = {
   lower_pantograph: boolean;
   track_ranges: DirectionalTrackRange[];
 };
+export type OperationalPointIdentifierExtension = {
+  name: string;
+  uic: number;
+};
 export type OperationalPointSncfExtension = {
   ch: string;
   ch_long_label: string;
@@ -3037,10 +3041,7 @@ export type OperationalPointSncfExtension = {
   trigram: string;
 };
 export type OperationalPointExtensions = {
-  identifier?: null | {
-    name: string;
-    uic: number;
-  };
+  identifier?: null | OperationalPointIdentifierExtension;
   sncf?: null | OperationalPointSncfExtension;
 };
 export type OperationalPointPartSncfExtension = {
@@ -3523,6 +3524,18 @@ export type InfraObjectWithGeometry = {
   obj_id: string;
   railjson: object;
 };
+export type CoreOperationalPointOnPath = {
+  /** Extensions associated to the operational point */
+  extensions?: OperationalPointExtensions;
+  /** Id of the operational point */
+  id: string;
+  /** The part along the path */
+  part: OperationalPointPart;
+  /** Distance from the beginning of the path in mm */
+  position: number;
+  /** Importance of the operational point */
+  weight: number | null;
+};
 export type PathProperties = {
   /** Curves along the path */
   curves: {
@@ -3555,18 +3568,7 @@ export type PathProperties = {
   /** Geometry of the path */
   geometry: GeoJsonLineString;
   /** Operational points along the path */
-  operational_points: {
-    /** Extensions associated to the operational point */
-    extensions?: OperationalPointExtensions;
-    /** Id of the operational point */
-    id: string;
-    /** The part along the path */
-    part: OperationalPointPart;
-    /** Distance from the beginning of the path in mm */
-    position: number;
-    /** Importance of the operational point */
-    weight: number | null;
-  }[];
+  operational_points: CoreOperationalPointOnPath[];
   /** Slopes along the path */
   slopes: {
     /** List of `n` boundaries of the ranges.
@@ -3598,8 +3600,9 @@ export type PathPropertiesInput = {
   /** List of track sections */
   track_section_ranges: CoreTrackRange[];
 };
+export type Identifier = string;
 export type PathfindingOutput = {
-  detectors: string[];
+  detectors: Identifier[];
   switches_directions: {
     [key: string]: string;
   };
@@ -3765,7 +3768,6 @@ export type RoutePath = {
   }[];
   track_ranges: DirectionalTrackRange[];
 };
-export type Identifier = string;
 export type LightModeEffortCurves = {
   is_electric: boolean;
 };
@@ -4215,6 +4217,10 @@ export type SearchResultItemTrack = {
   line_code: number;
   line_name: string;
 };
+export type SearchResultItemOperationalPointTrackSections = {
+  position: number;
+  track: string;
+};
 export type SearchResultItemOperationalPoint = {
   ch: string;
   ci: number;
@@ -4222,10 +4228,7 @@ export type SearchResultItemOperationalPoint = {
   infra_id: number;
   name: string;
   obj_id: string;
-  track_sections: {
-    position: number;
-    track: string;
-  }[];
+  track_sections: SearchResultItemOperationalPointTrackSections[];
   trigram: string;
   uic: number;
 };
@@ -4276,7 +4279,7 @@ export type SearchResultItemScenario = {
   train_schedules_count: number;
 };
 export type Margins = {
-  boundaries: string[];
+  boundaries: NonBlankString[];
   /** The values of the margins. Must contains one more element than the boundaries
     Can be a percentage `X%` or a time in minutes per 100 kilometer `Xmin/100km` */
   values: string[];
@@ -4729,20 +4732,20 @@ export type ConsistSchedule = {
     It should contain one more element than boundaries */
   values: ConsistConfiguration[];
 };
+export type StepTimingData = {
+  /** Time at which the train should arrive at the location */
+  arrival_time: string;
+  /** The train may arrive up to this duration after the expected arrival time */
+  arrival_time_tolerance_after: number;
+  /** The train may arrive up to this duration before the expected arrival time */
+  arrival_time_tolerance_before: number;
+};
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */
   duration?: number | null;
   /** The associated location */
   location: PathItemLocation;
-  /** Time at which the train should arrive at the location, if specified */
-  timing_data?: null | {
-    /** Time at which the train should arrive at the location */
-    arrival_time: string;
-    /** The train may arrive up to this duration after the expected arrival time */
-    arrival_time_tolerance_after: number;
-    /** The train may arrive up to this duration before the expected arrival time */
-    arrival_time_tolerance_before: number;
-  };
+  timing_data?: null | StepTimingData;
 };
 export type Distribution = 'STANDARD' | 'MARECO';
 export type ConstraintDistributionChangeGroup = {

--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -307,7 +307,7 @@ export type SendLastMinuteRequestResponse = {
   request_identifier: string;
   created_request_url: string | null;
 };
-export type LoadingGaugeType = 'GA' | 'GB';
+export type RmiLoadingGaugeType = 'GA' | 'GB';
 export type ConsistChange = {
   rolling_stock: string;
   towed_rolling_stock?: string | null;
@@ -351,7 +351,7 @@ export type CourseType = string;
 export type SimulationReport = {
   rolling_stock: string;
   towed_rolling_stock?: string | null;
-  loading_gauge_type: LoadingGaugeType;
+  loading_gauge_type: RmiLoadingGaugeType;
   speed_limit_tags: string;
   /** Total mass of the train in kg */
   total_mass: number;

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -2536,22 +2536,6 @@ class LoadingGaugeType(Enum):
     GLOTT = "GLOTT"
 
 
-class Boundary1(RootModel[str]):
-    root: Annotated[str, Field(min_length=1)]
-
-
-class Margins(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    boundaries: list[Boundary1]
-    values: Annotated[list[str], Field(examples=[["5%", "2min/100km"]])]
-    """
-    The values of the margins. Must contains one more element than the boundaries
-    Can be a percentage `X%` or a time in minutes per 100 kilometer `Xmin/100km`
-    """
-
-
 class MoveOperation(BaseModel):
     """
     JSON Patch 'move' operation representation
@@ -2613,7 +2597,7 @@ class OperationDelete(BaseModel):
     operation_type: Literal["DELETE"]
 
 
-class Identifier1(BaseModel):
+class OperationalPointIdentifierExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -2750,16 +2734,12 @@ class PatchOperationCopyOperation(CopyOperation):
     op: Literal["copy"]
 
 
-class Boundary2(RootModel[int]):
-    root: Annotated[int, Field(ge=0)]
-
-
 class Curves(BaseModel):
     """
     Property f64 values along a path. Each value is associated to a range of the path.
     """
 
-    boundaries: list[Boundary2]
+    boundaries: list[Boundary]
     """
     List of `n` boundaries of the ranges.
     A boundary is a distance from the beginning of the path in mm.
@@ -2801,7 +2781,7 @@ class Electrifications(BaseModel):
     Electrification property along a path. Each value is associated to a range of the path.
     """
 
-    boundaries: list[Boundary2]
+    boundaries: list[Boundary]
     """
     List of `n` boundaries of the ranges.
     A boundary is a distance from the beginning of the path in mm.
@@ -2821,7 +2801,7 @@ class Slopes(BaseModel):
     Property f64 values along a path. Each value is associated to a range of the path.
     """
 
-    boundaries: list[Boundary2]
+    boundaries: list[Boundary]
     """
     List of `n` boundaries of the ranges.
     A boundary is a distance from the beginning of the path in mm.
@@ -2837,7 +2817,7 @@ class Zones(BaseModel):
     Zones along a path. Each value is associated to a range of the path.
     """
 
-    boundaries: list[Boundary2]
+    boundaries: list[Boundary]
     """
     List of `n` boundaries of the ranges.
     A boundary is a distance from the beginning of the path in mm.
@@ -2853,31 +2833,8 @@ class PathfindingFailureInternalError(BaseModel):
     failed_status: Literal["internal_error"]
 
 
-class TimingData(BaseModel):
-    """
-    Time at which the train should arrive at the location, if specified
-    """
-
-    arrival_time: AwareDatetime
-    """
-    Time at which the train should arrive at the location
-    """
-    arrival_time_tolerance_after: Annotated[int, Field(ge=0)]
-    """
-    The train may arrive up to this duration after the expected arrival time
-    """
-    arrival_time_tolerance_before: Annotated[int, Field(ge=0)]
-    """
-    The train may arrive up to this duration before the expected arrival time
-    """
-
-
-class Detector1(RootModel[str]):
-    root: Annotated[str, Field(max_length=255, min_length=1)]
-
-
 class PathfindingOutput(BaseModel):
-    detectors: list[Detector1]
+    detectors: list[Identifier]
     switches_directions: dict[str, str]
     track_ranges: list[DirectionalTrackRange]
 
@@ -3157,7 +3114,7 @@ class ScheduleItem(BaseModel):
     stop_for: timedelta | None = None
 
 
-class TrackSection2(BaseModel):
+class SearchResultItemOperationalPointTrackSections(BaseModel):
     position: float
     track: str
 
@@ -3312,7 +3269,7 @@ class ElectricalProfileValueProfile(BaseModel):
 
 
 class ElectricalProfiles(BaseModel):
-    boundaries: list[Boundary2]
+    boundaries: list[Boundary]
     """
     List of `n` boundaries of the ranges (block path).
     A boundary is a distance from the beginning of the path in mm.
@@ -3370,7 +3327,7 @@ class Mrsp(BaseModel):
     A MRSP computation result (Most Restrictive Speed Profile)
     """
 
-    boundaries: list[Boundary2]
+    boundaries: list[Boundary]
     """
     List of `n` boundaries of the ranges (block path).
     A boundary is a distance from the beginning of the path in mm.
@@ -3626,6 +3583,21 @@ class StdcmSearchEnvironmentResponse(BaseModel):
     temporary_speed_limit_group_id: int | None = None
     timetable_id: int
     work_schedule_group_id: int | None = None
+
+
+class StepTimingData(BaseModel):
+    arrival_time: AwareDatetime
+    """
+    Time at which the train should arrive at the location
+    """
+    arrival_time_tolerance_after: Annotated[int, Field(ge=0)]
+    """
+    The train may arrive up to this duration after the expected arrival time
+    """
+    arrival_time_tolerance_before: Annotated[int, Field(ge=0)]
+    """
+    The train may arrive up to this duration before the expected arrival time
+    """
 
 
 class SubjectType(Enum):
@@ -3935,7 +3907,7 @@ class ConsistChange(BaseModel):
     """
 
 
-class LoadingGaugeType1(Enum):
+class RmiLoadingGaugeType(Enum):
     GA = "GA"
     GB = "GB"
 
@@ -3949,7 +3921,7 @@ class Location(BaseModel):
     secondary_code: Annotated[str, Field(title="Secondary Code")]
 
 
-class TimingData1(BaseModel):
+class TimingData(BaseModel):
     """
     Indicates the departure or arrival time as well as the tolerances.
     """
@@ -3989,7 +3961,7 @@ class RequestedStep(BaseModel):
     Duration in ms
     """
     location: Location
-    timing_data: TimingData1 | None = None
+    timing_data: TimingData | None = None
     type: StepType | None = None
 
 
@@ -4022,7 +3994,7 @@ class SimulationReport(BaseModel):
     towed_rolling_stock: Annotated[str | None, Field(title="Towed Rolling Stock")] = (
         None
     )
-    loading_gauge_type: LoadingGaugeType1
+    loading_gauge_type: RmiLoadingGaugeType
     speed_limit_tags: Annotated[str, Field(title="Speed Limit Tags")]
     total_mass: Annotated[int, Field(title="Total Mass")]
     """
@@ -4685,13 +4657,13 @@ class EtcsBrakeParams(BaseModel):
     """
 
 
-class GeoJsonPoint1(BaseModel):
+class PointGeometry(BaseModel):
     coordinates: list[float]
     type: Literal["Point"]
 
 
-class GeoJsonPoint(RootModel[GeoJsonPoint1]):
-    root: GeoJsonPoint1
+class GeoJsonPoint(RootModel[PointGeometry]):
+    root: PointGeometry
 
 
 class GrantBody(BaseModel):
@@ -4781,6 +4753,18 @@ class MacroNoteResponse(BaseModel):
     y: int
 
 
+class Margins(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    boundaries: list[NonBlankString]
+    values: Annotated[list[str], Field(examples=[["5%", "2min/100km"]])]
+    """
+    The values of the margins. Must contains one more element than the boundaries
+    Can be a percentage `X%` or a time in minutes per 100 kilometer `Xmin/100km`
+    """
+
+
 class ModeEffortCurves(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4820,7 +4804,7 @@ class OperationalPointExtensions(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    identifier: Identifier1 | None = None
+    identifier: OperationalPointIdentifierExtension | None = None
     sncf: OperationalPointSncfExtension | None = None
 
 
@@ -4950,10 +4934,7 @@ class PathfindingItem(BaseModel):
     """
     The associated location
     """
-    timing_data: TimingData | None = None
-    """
-    Time at which the train should arrive at the location, if specified
-    """
+    timing_data: StepTimingData | None = None
 
 
 class Project(BaseModel):
@@ -5122,7 +5103,7 @@ class SearchResultItemOperationalPoint(BaseModel):
     infra_id: int
     name: str
     obj_id: str
-    track_sections: list[TrackSection2]
+    track_sections: list[SearchResultItemOperationalPointTrackSections]
     trigram: str
     uic: int
 
@@ -5464,40 +5445,40 @@ class EnergySourceBattery(BaseModel):
     max_output_power: SpeedDependantPower
 
 
-class GeoJsonLineString1(BaseModel):
+class LineStringGeometry(BaseModel):
     coordinates: list[list[float]]
     type: Literal["LineString"]
 
 
-class GeoJsonLineString(RootModel[GeoJsonLineString1]):
-    root: GeoJsonLineString1
+class GeoJsonLineString(RootModel[LineStringGeometry]):
+    root: LineStringGeometry
 
 
-class GeoJsonMultiLineString1(BaseModel):
+class MultiLineStringGeometry(BaseModel):
     coordinates: list[list[list[float]]]
     type: Literal["MultiLineString"]
 
 
-class GeoJsonMultiLineString(RootModel[GeoJsonMultiLineString1]):
-    root: GeoJsonMultiLineString1
+class GeoJsonMultiLineString(RootModel[MultiLineStringGeometry]):
+    root: MultiLineStringGeometry
 
 
-class GeoJsonMultiPoint1(BaseModel):
+class MultiPointGeometry(BaseModel):
     coordinates: list[list[float]]
     type: Literal["MultiPoint"]
 
 
-class GeoJsonMultiPoint(RootModel[GeoJsonMultiPoint1]):
-    root: GeoJsonMultiPoint1
+class GeoJsonMultiPoint(RootModel[MultiPointGeometry]):
+    root: MultiPointGeometry
 
 
-class GeoJsonPolygon1(BaseModel):
+class PolygonGeometry(BaseModel):
     coordinates: list[list[list[float]]]
     type: Literal["Polygon"]
 
 
-class GeoJsonPolygon(RootModel[GeoJsonPolygon1]):
-    root: GeoJsonPolygon1
+class GeoJsonPolygon(RootModel[PolygonGeometry]):
+    root: PolygonGeometry
 
 
 class InfraErrorTypeInvalidReference(BaseModel):
@@ -5741,64 +5722,6 @@ class PathItem(BaseModel):
     """
 
 
-class OperationalPoint2(BaseModel):
-    """
-    Operational point along a path.
-    """
-
-    extensions: OperationalPointExtensions | None = None
-    """
-    Extensions associated to the operational point
-    """
-    id: str
-    """
-    Id of the operational point
-    """
-    part: OperationalPointPart
-    """
-    The part along the path
-    """
-    position: Annotated[int, Field(ge=0)]
-    """
-    Distance from the beginning of the path in mm
-    """
-    weight: Annotated[int | None, Field(ge=0, le=100)] = None
-    """
-    Importance of the operational point
-    """
-
-
-class PathProperties(BaseModel):
-    """
-    Properties along a path. Each property is optional since it depends on what the user requests.
-    """
-
-    curves: Curves
-    """
-    Curves along the path
-    """
-    electrifications: Electrifications
-    """
-    Electrification modes and neutral section along the path
-    """
-    geometry: GeoJsonLineString
-    """
-    Geometry of the path
-    """
-    operational_points: list[OperationalPoint2]
-    """
-    Operational points along the path
-    """
-    slopes: Slopes
-    """
-    Slopes along the path
-    """
-    zones: Zones
-    """
-    Zones along the path
-    """
-
-
 class PathfindingFailurePathfindingInputError(BaseModel):
     failed_status: Literal["pathfinding_input_error"]
 
@@ -6006,17 +5929,6 @@ class SimDebugConflictReport(BaseModel):
     time_lost: float
 
 
-class SimDebugData(BaseModel):
-    departure_time: AwareDatetime
-    engineering_allowances_ranges: list[SimDebugEngineeringAllowanceRange]
-    other_requirements: list[SimDebugTrainZoneRequirement]
-    path_properties: PathProperties
-    sim_output: SimulationResponseSuccess | None = None
-    train_positions: list[float]
-    train_times: list[float]
-    zone_locations: list[SimDebugZoneLocation]
-
-
 class SimDebugFailureReport(BaseModel):
     closest_conflicts: list[SimDebugConflictReport]
     largest_conflicts: list[SimDebugConflictReport]
@@ -6077,6 +5989,33 @@ class TrackSectionModel(BaseModel):
     slopes: list[Slope]
 
 
+class CoreOperationalPointOnPath(BaseModel):
+    """
+    Operational point along a path.
+    """
+
+    extensions: OperationalPointExtensions | None = None
+    """
+    Extensions associated to the operational point
+    """
+    id: str
+    """
+    Id of the operational point
+    """
+    part: OperationalPointPart
+    """
+    The part along the path
+    """
+    position: Annotated[int, Field(ge=0)]
+    """
+    Distance from the beginning of the path in mm
+    """
+    weight: Annotated[int | None, Field(ge=0, le=100)] = None
+    """
+    Importance of the operational point
+    """
+
+
 class PathfindingNotFoundIncompatibleConstraints(BaseModel):
     error_type: Literal["incompatible_constraints"]
     incompatible_constraints: CoreIncompatibleConstraints
@@ -6099,13 +6038,13 @@ class CorePathfindingNotFound(
     )
 
 
-class GeoJsonMultiPolygon1(BaseModel):
+class MultiPolygonGeometry(BaseModel):
     coordinates: list[list[list[list[float]]]]
     type: Literal["MultiPolygon"]
 
 
-class GeoJsonMultiPolygon(RootModel[GeoJsonMultiPolygon1]):
-    root: GeoJsonMultiPolygon1
+class GeoJsonMultiPolygon(RootModel[MultiPolygonGeometry]):
+    root: MultiPolygonGeometry
 
 
 class InfraError(BaseModel):
@@ -6170,6 +6109,37 @@ class PathAndScheduleChangeGroup(BaseModel):
     path: list[PathItem]
     power_restrictions: list[PowerRestrictionItem]
     schedule: list[ScheduleItem]
+
+
+class PathProperties(BaseModel):
+    """
+    Properties along a path. Each property is optional since it depends on what the user requests.
+    """
+
+    curves: Curves
+    """
+    Curves along the path
+    """
+    electrifications: Electrifications
+    """
+    Electrification modes and neutral section along the path
+    """
+    geometry: GeoJsonLineString
+    """
+    Geometry of the path
+    """
+    operational_points: list[CoreOperationalPointOnPath]
+    """
+    Operational points along the path
+    """
+    slopes: Slopes
+    """
+    Slopes along the path
+    """
+    zones: Zones
+    """
+    Zones along the path
+    """
 
 
 class PathfindingFailurePathfindingNotFound(BaseModel):
@@ -6279,6 +6249,17 @@ class SearchResultItem(
     """
     A search result item that depends on the query's `object`
     """
+
+
+class SimDebugData(BaseModel):
+    departure_time: AwareDatetime
+    engineering_allowances_ranges: list[SimDebugEngineeringAllowanceRange]
+    other_requirements: list[SimDebugTrainZoneRequirement]
+    path_properties: PathProperties
+    sim_output: SimulationResponseSuccess | None = None
+    train_positions: list[float]
+    train_times: list[float]
+    zone_locations: list[SimDebugZoneLocation]
 
 
 class ResponsePathfindingFailed(BaseModel):

--- a/railway_manager_interface/openapi.yaml
+++ b/railway_manager_interface/openapi.yaml
@@ -139,12 +139,12 @@ components:
       - total_length
       title: ConsistChange
       description: New consist to use from a request step onward.
-    LoadingGaugeType:
+    RmiLoadingGaugeType:
       type: string
       enum:
       - GA
       - GB
-      title: LoadingGaugeType
+      title: RmiLoadingGaugeType
     Location:
       properties:
         uic:
@@ -253,7 +253,7 @@ components:
           - 'null'
           title: Towed Rolling Stock
         loading_gauge_type:
-          $ref: '#/components/schemas/LoadingGaugeType'
+          $ref: '#/components/schemas/RmiLoadingGaugeType'
         speed_limit_tags:
           type: string
           title: Speed Limit Tags


### PR DESCRIPTION
Many auto-generated Pydantic classes had numeric suffixes (`Boundary1`, `Detector1`, `Identifier1`, `TimingData1`, ...) because inline anonymous schemas collided with named top-level ones.
Drop unnecessary `#[schema(inline)]` so fields reference the existing named schemas, add explicit titles on `GeoJson` geometry variants, and rename the `railway_manager_interface` subset of `LoadingGaugeType` to `RaiMILoadingGaugeType`.