### PR TITLE
editoast: apply `tokio::test` decorator first

### DIFF
--- a/editoast/editoast_models/src/train_schedule.rs
+++ b/editoast/editoast_models/src/train_schedule.rs
@@ -627,10 +627,9 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
     #[case::created(TrainScheduleException::fixture_created("key_1", None))]
-    #[tokio::test]
     #[case::modified(TrainScheduleException::fixture_created("key_2", Some(0)))]
+    #[tokio::test]
     async fn paced_train_apply_exception(#[case] exception: TrainScheduleException) {
         let exception: schemas::TrainScheduleException = exception.into();
         let paced_train = create_paced_train();

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -335,34 +335,31 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::both_none(
         None,
         None,
         make_datetime("2000-01-01 11:59:59Z"),
         make_datetime("2000-02-03 00:00:01Z")
     )]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::begin_none(
         None,
         Some(make_datetime("2000-02-01 00:00:00Z")),
         make_datetime("2000-01-01 11:59:59Z"),
         make_datetime("2000-02-01 00:00:00Z")
     )]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::end_none(
         Some(make_datetime("2000-02-01 08:00:00Z")),
         None,
         make_datetime("2000-02-01 08:00:00Z"),
         make_datetime("2000-02-03 00:00:01Z")
     )]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::both_some(
         Some(make_datetime("2000-02-01 08:00:00Z")),
         Some(make_datetime("2000-05-22 09:00:50Z")),
         make_datetime("2000-02-01 08:00:00Z"),
         make_datetime("2000-05-22 09:00:50Z")
     )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_search_window(
         #[case] search_window_begin: Option<DateTime<Utc>>,
         #[case] search_window_end: Option<DateTime<Utc>>,
@@ -409,15 +406,13 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::both_some(
         Some(make_datetime("2000-02-01 08:00:00Z")),
         Some(make_datetime("2000-02-01 00:00:00Z"))
     )]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::end_none(Some(make_datetime("2000-03-01 00:00:00Z")), None)]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::begin_none(None, Some(make_datetime("2000-01-01 08:00:00Z")))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_search_window_incompatible_dates(
         #[case] search_window_begin: Option<DateTime<Utc>>,
         #[case] search_window_end: Option<DateTime<Utc>>,

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1068,10 +1068,9 @@ pub mod tests {
     }
 
     #[rstest::rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TA0", 1000000)]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TD1", 15500000)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_work(#[case] track: &str, #[case] offset: u64) {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
@@ -1252,10 +1251,9 @@ pub mod tests {
     }
 
     #[rstest::rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(15_000_000, 14000.0, 0)] // op at 14000m on TD0, split at 15000m -> stays on left at 14000m
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(10_000_000, 4000.0, 1)] // op at 14000m on TD0, split at 10000m -> goes to right at 4000m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_operational_point(
         #[case] offset: u64,
         #[case] expected_position: f64,
@@ -1296,10 +1294,9 @@ pub mod tests {
     }
 
     #[rstest::rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("DD0_5", 7887.5, 0)] // detector at 7887.5m on TD0, split at 15000m -> stays on left at 7887.5m
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("DD0_10", 575.0, 1)] // detector at 15575m on TD0, split at 15000m -> goes to right at 575m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_detectors(
         #[case] detector_id: &str,
         #[case] expected_position: f64,
@@ -1332,10 +1329,9 @@ pub mod tests {
     }
 
     #[rstest::rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TH1", 2_000_000, "buffer_stop.7", 3000.0, 1)] // buffer stop at 5000m on TH1, split at 2000m -> goes to right at 3000m
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TA2", 1_000_000, "buffer_stop.2", 0.0, 0)] // buffer stop at 0m on TA2, split at 1000m -> stays on left at 0m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_buffer_stops(
         #[case] track: &str,
         #[case] offset: u64,
@@ -1370,10 +1366,9 @@ pub mod tests {
     }
 
     #[rstest::rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("SA6_1", 1780.0, 0)] // signal at 1780m on TA6, split at 2000m -> stays on left at 1780m
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("SA6_2", 1380.0, 1)] // signal at 3380m on TA6, split at 2000m -> goes to right at 1380m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_signals(
         #[case] signal_id: &str,
         #[case] expected_position: f64,
@@ -1406,10 +1401,9 @@ pub mod tests {
     }
 
     #[rstest::rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TC0", 500_000, 125.0, 0)] // part at 125m on TC0, split at 500m -> stays on left at 125m
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("TC1", 100_000, 20.0, 1)] // part at 120m on TC1, split at 100m -> goes to right at 20m
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_with_level_crossings(
         #[case] track: &str,
         #[case] offset: u64,

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -262,14 +262,11 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("http://localhost:8090", "http://localhost:8090/")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("http://localhost:8090/", "http://localhost:8090/")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("http://localhost:8090/test", "http://localhost:8090/test/")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case("http://localhost:8090/test/", "http://localhost:8090/test/")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn layer_success(#[case] root_url: &str, #[case] expected_root_url: &str) {
         let root_url = Url::parse(root_url).unwrap();
         let expected_root_url = Url::parse(expected_root_url).unwrap();

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -539,7 +539,6 @@ pub mod tests {
     }
 
     #[rstest]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::one_work_schedule_with_two_track_ranges(
         vec![
             vec![
@@ -551,7 +550,6 @@ pub mod tests {
             vec![(0, 150000)],
         ]
     )]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::one_work_schedule_with_two_disjoint_track_ranges(
         vec![
             vec![
@@ -563,7 +561,6 @@ pub mod tests {
             vec![(0, 100000), (300000, 400000)],
         ]
     )]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::one_work_schedule_but_no_intersection(
         vec![
             vec![
@@ -572,7 +569,6 @@ pub mod tests {
         ],
         vec![]
     )]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case::two_work_schedules(
         vec![
             vec![
@@ -586,6 +582,7 @@ pub mod tests {
             vec![(350000, 400000)]
         ],
     )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_project_path_on_ws_group(
         #[case] work_schedule_track_ranges: Vec<Vec<TrackRange>>,
         #[case] expected_path_position_ranges: Vec<Vec<(u64, u64)>>,


### PR DESCRIPTION
When decorator `tokio::test` is applied first, it doesn’t need to be repeated for each `rstest::case` since the function already has been transformed into a sync function.