### PR TITLE
editoast: views: handle rolling stock resource in `POST /authz/grants/me`

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -127,6 +127,7 @@ pub enum InfraGrant {
     fga::Type,
     fga::User,
     fga::Object,
+    derive_more::Display,
     derive_more::From,
     derive_more::FromStr,
     derive_more::Deref,

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -1,18 +1,18 @@
+use futures::FutureExt;
 use std::collections::HashSet;
 
 use fga::model::Relation as _;
-use futures::FutureExt;
-
-use crate::Role;
-use crate::RollingStock;
-use crate::Subject;
-
-use crate::User;
-use crate::model::RollingStockPrivilege;
-use crate::v2::Actor;
 
 use super::Check;
 use super::Protected;
+use crate::Group;
+use crate::Role;
+use crate::RollingStock;
+use crate::RollingStockGrant;
+use crate::Subject;
+use crate::User;
+use crate::model::RollingStockPrivilege;
+use crate::v2::Actor;
 
 pub fn rolling_stock_privileges(
     user: User,
@@ -66,9 +66,83 @@ pub fn rolling_stock_privileges(
     ))
 }
 
+/// Returns the effective (maximum) grant a subject has on an [RollingStock], if any
+///
+/// A given user may have multiple grants on the same resource. This can happen
+/// if a user inherits a grant from one of its groups and also has a direct grant.
+/// Inherited grants are not the same thing as privileges: they do not have the same semantic,
+/// are not represented by the same enum, do no work on the same scale nor in the same way.
+///
+/// Groups only have direct grants. If multiple direct grants are found, this protected operation will panic.
+pub fn rolling_stock_effective_grant(
+    subject: Subject,
+    rolling_stock: RollingStock,
+) -> Protected<Option<RollingStockGrant>> {
+    Protected::new(move |openfga| {
+        async move {
+            let (is_reader, is_writer, is_owner) = match &subject {
+                Subject::User(user) => {
+                    openfga
+                        .checks((
+                            RollingStock::reader().check(user, &rolling_stock),
+                            RollingStock::writer().check(user, &rolling_stock),
+                            RollingStock::owner().check(user, &rolling_stock),
+                        ))
+                        .await?
+                }
+                Subject::Group(group) => {
+                    let (is_reader, is_writer, is_owner) = openfga
+                        .checks((
+                            RollingStock::reader()
+                                .check(Group::member().userset(group), &rolling_stock),
+                            RollingStock::writer()
+                                .check(Group::member().userset(group), &rolling_stock),
+                            RollingStock::owner()
+                                .check(Group::member().userset(group), &rolling_stock),
+                        ))
+                        .await?;
+                    if matches!(
+                        (is_reader, is_writer, is_owner),
+                        (true, true, _) | (true, _, true) | (_, true, true)
+                    ) {
+                        tracing::error!(
+                            is_reader,
+                            is_writer,
+                            is_owner,
+                            ?subject,
+                            resource = ?rolling_stock,
+                            "Group has multiple direct grants on the same resource"
+                        );
+                        panic!(
+                            "Group {subject:?} has multiple direct grants on the same resource {rolling_stock:?}, which is not supposed to happen by design. \n\
+                            While a user may have inherited grants from one of their groups, groups do not have inherited grants. \n\
+                            Detected direct grants: reader: {is_reader}, writer: {is_writer}, owner: {is_owner}"
+                        );
+                    }
+                    (is_reader, is_writer, is_owner)
+                }
+            };
+            Ok(is_owner
+                .then_some(RollingStockGrant::Owner)
+                .or_else(|| is_writer.then_some(RollingStockGrant::Writer))
+                .or_else(|| is_reader.then_some(RollingStockGrant::Reader)))
+        }
+        .boxed()
+    })
+    .with_check(Check::SubjectExists(subject))
+    .with_check(Check::RollingStockExists(rolling_stock))
+    .with_check(Check::HasRollingStockPrivilege(
+        Actor::Issuer,
+        RollingStockPrivilege::CanRead,
+        rolling_stock,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::User;
     use crate::v2::TestClientExt as _;
+    use crate::v2::special_authorizers::Authorize;
 
     use super::*;
 
@@ -120,6 +194,43 @@ mod tests {
                 RollingStockPrivilege::CanRevoke,
             ])
         );
+    }
+
+    #[tokio::test]
+    async fn rolling_stock_effective_grant_direct_and_inherited() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        openfga
+            .write_tuples(&[RollingStock::reader().tuple(&User(1), &RollingStock(1))])
+            .await
+            .unwrap();
+
+        let grant = rolling_stock_effective_grant(Subject::user(1), RollingStock(1))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(grant, Some(RollingStockGrant::Reader));
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(
+                &RollingStock::owner().tuple(Group::member().userset(&Group(1)), &RollingStock(1)),
+            )
+            .execute()
+            .await
+            .unwrap();
+
+        let grant = rolling_stock_effective_grant(Subject::user(1), RollingStock(1))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
+        assert_eq!(grant, Some(RollingStockGrant::Owner));
     }
 
     #[tokio::test]

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -18,6 +18,7 @@ use crate::v2::infra_effective_grant;
 use crate::v2::infra_granted_subjects;
 use crate::v2::infra_privileges;
 use crate::v2::infra_revoke_grant;
+use crate::v2::rolling_stock_effective_grant;
 use crate::v2::rolling_stock_privileges;
 use crate::v2::special_authorizers;
 
@@ -41,6 +42,11 @@ pub trait TestClientExt {
         user: User,
         rolling_stock: RollingStock,
     ) -> HashSet<RollingStockPrivilege>;
+    async fn rolling_stock_effective_grant(
+        &self,
+        subject: Subject,
+        rolling_stock: RollingStock,
+    ) -> Option<RollingStockGrant>;
     // TODO use the protected operation once authz::v2 has a proper way to give grants on rolling stocks
     async fn give_rolling_stock_grant(
         &self,
@@ -148,6 +154,17 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(rolling_stock_privileges(user, rolling_stock))
+            .await
+            .unwrap()
+    }
+    async fn rolling_stock_effective_grant(
+        &self,
+        subject: Subject,
+        rolling_stock: RollingStock,
+    ) -> Option<RollingStockGrant> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(rolling_stock_effective_grant(subject, rolling_stock))
             .await
             .unwrap()
     }

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use fga::fga;
 use fga::model::Relation as _;
 
 use crate::Group;
@@ -8,9 +9,10 @@ use crate::InfraGrant;
 use crate::InfraPrivilege;
 use crate::Role;
 use crate::RollingStock;
+use crate::RollingStockGrant;
+use crate::RollingStockPrivilege;
 use crate::Subject;
 use crate::User;
-use crate::model::RollingStockPrivilege;
 use crate::v2::infra_direct_grant;
 use crate::v2::infra_effective_grant;
 use crate::v2::infra_granted_subjects;
@@ -39,6 +41,13 @@ pub trait TestClientExt {
         user: User,
         rolling_stock: RollingStock,
     ) -> HashSet<RollingStockPrivilege>;
+    // TODO use the protected operation once authz::v2 has a proper way to give grants on rolling stocks
+    async fn give_rolling_stock_grant(
+        &self,
+        rolling_stock: RollingStock,
+        subject: Subject,
+        grant: RollingStockGrant,
+    );
 }
 
 impl TestClientExt for fga::Client {
@@ -141,5 +150,57 @@ impl TestClientExt for fga::Client {
             .access_value(rolling_stock_privileges(user, rolling_stock))
             .await
             .unwrap()
+    }
+    async fn give_rolling_stock_grant(
+        &self,
+        rolling_stock: RollingStock,
+        subject: Subject,
+        grant: RollingStockGrant,
+    ) {
+        match (grant, subject) {
+            (RollingStockGrant::Reader, Subject::User(user)) => {
+                self.write_tuples(&[RollingStock::reader()
+                    .tuple(&fga!(User:user), &fga!(RollingStock:rolling_stock))])
+                    .await
+            }
+            (RollingStockGrant::Writer, Subject::User(user)) => {
+                self.write_tuples(&[RollingStock::writer()
+                    .tuple(&fga!(User:user), &fga!(RollingStock:rolling_stock))])
+                    .await
+            }
+            (RollingStockGrant::Owner, Subject::User(user)) => {
+                self.write_tuples(&[RollingStock::owner()
+                    .tuple(&fga!(User:user), &fga!(RollingStock:rolling_stock))])
+                    .await
+            }
+            (RollingStockGrant::Reader, Subject::Group(group)) => {
+                self.prepare_writes()
+                    .write(
+                        &RollingStock::reader()
+                            .tuple(Group::member().userset(&group), &rolling_stock),
+                    )
+                    .execute()
+                    .await
+            }
+            (RollingStockGrant::Writer, Subject::Group(group)) => {
+                self.prepare_writes()
+                    .write(
+                        &RollingStock::writer()
+                            .tuple(Group::member().userset(&group), &rolling_stock),
+                    )
+                    .execute()
+                    .await
+            }
+            (RollingStockGrant::Owner, Subject::Group(group)) => {
+                self.prepare_writes()
+                    .write(
+                        &RollingStock::owner()
+                            .tuple(Group::member().userset(&group), &rolling_stock),
+                    )
+                    .execute()
+                    .await
+            }
+        }
+        .unwrap()
     }
 }

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -509,39 +509,57 @@ pub(in crate::views) async fn user_grants(
     let authorizer = UserAuthorizer::new(user, roles, regulator.openfga(), db_pool.get().await?);
 
     let mut response = HashMap::<_, Vec<UserResourceGrant>>::new();
-    if let Some(infra_ids) = body.get(&ResourceType::Infra) {
-        for infra_id in infra_ids {
-            let grant_access = authz::v2::infra_effective_grant(
-                authz::Subject::user(user),
-                authz::Infra(*infra_id),
-            )
-            .map_some_into::<StandardGrant>()
+    // TODO build all protected at once, zip them and batch send them with `authorize_all`
+    for (resource_type, ids) in &body {
+        for id in ids {
+            let grant_access = match resource_type {
+                ResourceType::Infra => {
+                    authz::v2::infra_effective_grant(authz::Subject::user(user), authz::Infra(*id))
+                        .map_some_into::<StandardGrant>()
+                }
+
+                ResourceType::RollingStock => authz::v2::rolling_stock_effective_grant(
+                    authz::Subject::user(user),
+                    authz::RollingStock(*id),
+                )
+                .map_some_into::<StandardGrant>(),
+            }
             .authorize(&authorizer)
+            .await?
+            .access()
             .await?;
-            let grant = match grant_access.access().await? {
+            let grant = match grant_access {
                 Ok(Some(grant)) => grant,
                 Ok(None) => continue,
                 Err(Check::InfraExists(infra)) => {
                     tracing::warn!(%infra, "non-existent infra — skipping");
                     continue;
                 }
-                Err(Check::HasInfraPrivilege(Actor::Issuer, privilege, infra)) => {
-                    debug_assert_eq!(privilege, InfraPrivilege::CanRead);
+                Err(Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, infra)) => {
                     tracing::warn!(%infra, "user cannot read infra — skipping");
+                    continue;
+                }
+                Err(Check::HasRollingStockPrivilege(
+                    Actor::Issuer,
+                    RollingStockPrivilege::CanRead,
+                    rolling_stock,
+                )) => {
+                    tracing::warn!(%rolling_stock, "user cannot read rolling stock — skipping");
                     continue;
                 }
                 Err(Check::SubjectExists(subject)) => {
                     unreachable!("{subject} exists or race condition")
                 }
+                Err(Check::RollingStockExists(rolling_stock)) => {
+                    tracing::warn!(%rolling_stock, "non-existent rolling stock — skipping");
+                    continue;
+                }
                 Err(check) => impossible!(check),
             };
             response
-                .entry(ResourceType::Infra)
+                .entry(*resource_type)
                 .or_default()
-                .push(UserResourceGrant {
-                    id: *infra_id,
-                    grant,
-                });
+                .push(UserResourceGrant { id: *id, grant });
         }
     }
 
@@ -933,20 +951,20 @@ pub(in crate::views) async fn list_groups(
 
 #[cfg(test)]
 mod tests {
+    use authz::RollingStockGrant;
+    use axum::http::StatusCode;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
     use std::collections::HashSet;
 
     use authz::v2::TestClientExt as _;
-    use axum::http::StatusCode;
-
-    use crate::fixtures::create_empty_infra;
-    use crate::views::test_app::test_app;
 
     use super::*;
+    use crate::fixtures::create_empty_infra;
+    use crate::fixtures::create_fast_rolling_stock;
     use crate::fixtures::create_small_infra;
     use crate::views::test_app::TestRequestExt;
-    use pretty_assertions::assert_eq;
-
-    use serde_json::json;
+    use crate::views::test_app::test_app;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn me_privileges() {
@@ -1118,26 +1136,31 @@ mod tests {
         let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let rs_with_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_with_grant").await;
+        let rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
+
         let user = app
             .user("test", "Test")
             .with_roles([Role::OperationalStudies])
             .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_rolling_stock_grant(rs_with_grant.id, RollingStockGrant::Reader)
             .create()
             .await;
 
-        // Ask the grant of the user for the infra
+        // Ask the grant of the user for the resources
         let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
             .post("/authz/me/grants")
             .by_user(user.as_ref())
             .json(&json!({
                 "infra": [infra.id],
+                "rolling_stock": [rs_with_grant.id],
             }))
             .await
             .assert_status_ok()
             .json();
 
-        // Check the direct grant is there
+        // Check the direct grants are there
         assert_eq!(
             response.get(&ResourceType::Infra).unwrap(),
             &[UserResourceGrant {
@@ -1145,31 +1168,46 @@ mod tests {
                 grant: StandardGrant::Reader
             }]
         );
+        assert_eq!(
+            response.get(&ResourceType::RollingStock).unwrap(),
+            &[UserResourceGrant {
+                id: rs_with_grant.id,
+                grant: StandardGrant::Reader
+            }]
+        );
 
-        let _group = app
-            .group("Group")
+        app.group("Group")
             .with_members([&user])
             .with_infra_grant(infra.id, InfraGrant::Writer)
+            .with_rolling_stock_grant(rs_with_grant.id, RollingStockGrant::Writer)
             .create()
             .await;
 
-        // Ask the grant of the user for the infra again
+        // Ask the grant of the user for the resources again
         let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
             .post("/authz/me/grants")
             .by_user(user.as_ref())
             .json(&json!({
                 "infra": [infra.id, infra_no_grant.id, infra_no_grant.id + 1000],
+                "rolling_stock": [rs_with_grant.id, rs_no_grant.id, rs_no_grant.id + 1000],
             }))
             .await
             .assert_status_ok()
             .json();
 
         // Check the inherited grant from the group has overridden by the user's direct grant
-        // Unreadable and non-existent infras are filtered out
+        // Unreadable and non-existent resources are filtered out
         assert_eq!(
             response.get(&ResourceType::Infra).unwrap(),
             &[UserResourceGrant {
                 id: infra.id,
+                grant: StandardGrant::Writer
+            }]
+        );
+        assert_eq!(
+            response.get(&ResourceType::RollingStock).unwrap(),
+            &[UserResourceGrant {
+                id: rs_with_grant.id,
                 grant: StandardGrant::Writer
             }]
         );

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -620,11 +620,7 @@ pub(in crate::views) async fn my_grants_on_resource(
                     rejection => impossible!(rejection),
                 })?
         }
-        ResourceType::RollingStock => {
-            panic!(
-                "not implemented yet, requires implementing rolling stock grants in OpenFGA and exposing them in the authorizer"
-            )
-        }
+        ResourceType::RollingStock => todo!(),
     };
 
     // NOTE: the same subject can appear in multiple lists. This can happen

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -487,7 +487,6 @@ impl<'a> UserBuilder<'a> {
         self
     }
 
-    #[expect(unused)]
     pub fn with_rolling_stock_grant(
         mut self,
         rolling_stock_id: i64,
@@ -581,7 +580,6 @@ impl<'a> GroupBuilder<'a> {
         self
     }
 
-    #[expect(unused)]
     pub fn with_rolling_stock_grant(
         mut self,
         rolling_stock_id: i64,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -2,6 +2,8 @@
 //! test axum server, database connection pool, and different mocking
 //! components.
 
+use authz::RollingStock;
+use authz::RollingStockGrant;
 use authz::v2;
 use authz::v2::TestClientExt;
 use authz::v2::special_authorizers;
@@ -452,6 +454,7 @@ pub struct UserBuilder<'a> {
     info: UserInfo,
     roles: HashSet<Role>,
     infras_grant: HashMap<i64, InfraGrant>,
+    rolling_stock_grants: HashMap<i64, RollingStockGrant>,
 }
 
 pub struct GroupBuilder<'a> {
@@ -460,6 +463,7 @@ pub struct GroupBuilder<'a> {
     roles: HashSet<Role>,
     members: HashSet<&'a authz::identity::User>,
     infras_grant: HashMap<i64, InfraGrant>,
+    rolling_stock_grants: HashMap<i64, RollingStockGrant>,
 }
 
 impl<'a> UserBuilder<'a> {
@@ -469,6 +473,7 @@ impl<'a> UserBuilder<'a> {
             info,
             roles: Default::default(),
             infras_grant: HashMap::default(),
+            rolling_stock_grants: HashMap::default(),
         }
     }
 
@@ -482,15 +487,28 @@ impl<'a> UserBuilder<'a> {
         self
     }
 
+    #[expect(unused)]
+    pub fn with_rolling_stock_grant(
+        mut self,
+        rolling_stock_id: i64,
+        grant: RollingStockGrant,
+    ) -> Self {
+        self.rolling_stock_grants.insert(rolling_stock_id, grant);
+        self
+    }
+
     pub async fn create(self) -> authz::identity::User {
         let Self {
             app,
             info,
             roles,
             infras_grant,
+            rolling_stock_grants,
         } = self;
 
-        if (!roles.is_empty() || !infras_grant.is_empty()) && !app.enable_authorization {
+        if (!roles.is_empty() || !infras_grant.is_empty() || !rolling_stock_grants.is_empty())
+            && !app.enable_authorization
+        {
             panic!("An OpenFGA model must be provided to grant a user roles or infra grants");
         }
         let regulator = &app.app_state.regulator;
@@ -518,6 +536,15 @@ impl<'a> UserBuilder<'a> {
                     .await
                     .expect("Infra grant should be given successfully")
             }
+            for (rolling_stock_id, grant) in rolling_stock_grants.into_iter() {
+                app.openfga()
+                    .give_rolling_stock_grant(
+                        RollingStock(rolling_stock_id),
+                        authz::Subject::User(authz::User(user.id)),
+                        grant,
+                    )
+                    .await;
+            }
         }
         authz::identity::User { info, id: user.id }
     }
@@ -531,6 +558,7 @@ impl<'a> GroupBuilder<'a> {
             roles: Default::default(),
             members: Default::default(),
             infras_grant: HashMap::default(),
+            rolling_stock_grants: HashMap::default(),
         }
     }
 
@@ -553,6 +581,16 @@ impl<'a> GroupBuilder<'a> {
         self
     }
 
+    #[expect(unused)]
+    pub fn with_rolling_stock_grant(
+        mut self,
+        rolling_stock_id: i64,
+        grant: RollingStockGrant,
+    ) -> Self {
+        self.rolling_stock_grants.insert(rolling_stock_id, grant);
+        self
+    }
+
     pub async fn create(self) -> authz::identity::Group {
         let Self {
             app,
@@ -560,8 +598,12 @@ impl<'a> GroupBuilder<'a> {
             roles,
             members,
             infras_grant,
+            rolling_stock_grants,
         } = self;
-        let needs_openfga = !roles.is_empty() || !members.is_empty() || !infras_grant.is_empty();
+        let needs_openfga = !roles.is_empty()
+            || !members.is_empty()
+            || !infras_grant.is_empty()
+            || !rolling_stock_grants.is_empty();
         if needs_openfga && !app.enable_authorization {
             panic!(
                 "An OpenFGA model must be provided to grant a group roles, members, or infra grants"
@@ -603,6 +645,11 @@ impl<'a> GroupBuilder<'a> {
                     .give_infra_grant_unchecked(&subject, &authz::Infra(infra_id), grant)
                     .await
                     .expect("Infra grant should be given successfully")
+            }
+            for (rolling_stock_id, grant) in rolling_stock_grants.into_iter() {
+                app.openfga()
+                    .give_rolling_stock_grant(RollingStock(rolling_stock_id), subject, grant)
+                    .await;
             }
         }
         group


### PR DESCRIPTION
Part of https://github.com/osrd-project/osrd-confidential/issues/1168. 

- Implement `authz::v2::rolling_stock::rolling_stock_effective_grant` (port of the equivalent `authz::v2::infra` method).
- Support rolling stocks resources in the endpoint `POST:/authz/grants/me`; update its tests.

The first commit allows to write rolling stock grants in the openfga store for testing purposes.