### PR TITLE
front: remove references to removed flags

### DIFF
--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -249,7 +249,6 @@ export const formatStdcmPayload = (
 ): PostTimetableByIdStdcmApiArg => ({
   infra: validConfig.infraId,
   id: validConfig.timetableId,
-  returnDebugPayloads: false,
   body: {
     comfort: 'STANDARD',
     margin: createMargin(validConfig.margin),

--- a/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
+++ b/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
@@ -14,15 +14,12 @@ export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiAr
     ) => void
   ) => {
     try {
-      const response = await fetch(
-        `/api/timetable/${args.id}/stdcm?infra=${args.infra}${args.returnDebugPayloads === true ? '&return_debug_payloads' : ''}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(args.body),
-          signal: signal,
-        }
-      );
+      const response = await fetch(`/api/timetable/${args.id}/stdcm?infra=${args.infra}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(args.body),
+        signal: signal,
+      });
       if (!response.ok) {
         throw new Error(
           `Bad response from stdcm stream endpoint: ${response.status} ${response.statusText}`


### PR DESCRIPTION
Follow-up of https://github.com/OpenRailAssociation/osrd/pull/15657

There were some references to the removed flag left in the front, leaving them triggered warnings.