### PR TITLE
front: properly check types on lint

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -140,12 +140,12 @@
     "vitest": "^4.1.6"
   },
   "scripts": {
-    "compile": "tsc -b",
+    "compile": "tsc",
     "start": "vite",
     "start-container": "vite --host",
     "build": "npm run build --workspaces --if-present && vite build",
     "test": "npm run test --workspaces --if-present && vitest",
-    "lint": "npm run lint --workspaces --if-present && oxlint . --max-warnings 0 --ignore-pattern 'ui/**' && oxfmt . --check",
+    "lint": "npm run lint --workspaces --if-present && tsc && oxlint . --max-warnings 0 --ignore-pattern 'ui/**' && oxfmt . --check",
     "lint-fix": "npm run lint:fix --workspaces --if-present && oxlint . --fix --ignore-pattern 'ui/**' && oxfmt . --write",
     "generate-types": "exec scripts/generate-types.sh",
     "e2e-tests": "playwright test",

--- a/front/package.json
+++ b/front/package.json
@@ -140,7 +140,6 @@
     "vitest": "^4.1.6"
   },
   "scripts": {
-    "compile": "tsc",
     "start": "vite",
     "start-container": "vite --host",
     "build": "npm run build --workspaces --if-present && vite build",

--- a/front/ui/storybook/package.json
+++ b/front/ui/storybook/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf storybook-static",
     "start": "storybook dev -p 6006",
     "build": "storybook build",
-    "lint": "oxlint . --max-warnings 0 && oxfmt . --check",
+    "lint": "tsc && oxlint . --max-warnings 0 && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "dependencies": {

--- a/front/ui/ui-charts/package.json
+++ b/front/ui/ui-charts/package.json
@@ -32,7 +32,7 @@
     "watch": "rollup -c -w",
     "test": "vitest run",
     "prepublishOnly": "npm run clean && npm run build",
-    "lint": "oxlint . --max-warnings 0 && oxfmt . --check",
+    "lint": "tsc && oxlint . --max-warnings 0 && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "peerDependencies": {

--- a/front/ui/ui-core/package.json
+++ b/front/ui/ui-core/package.json
@@ -32,7 +32,7 @@
     "watch": "rollup -c -w",
     "test": "vitest run",
     "prepublishOnly": "npm run clean && npm run build",
-    "lint": "oxlint . --max-warnings 0  && oxfmt . --check",
+    "lint": "tsc && oxlint . --max-warnings 0  && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "peerDependencies": {

--- a/front/ui/ui-warped-map/package.json
+++ b/front/ui/ui-warped-map/package.json
@@ -29,7 +29,7 @@
     "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
-    "lint": "oxlint . --max-warnings 0 && oxfmt . --check",
+    "lint": "tsc && oxlint . --max-warnings 0 && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "dependencies": {


### PR DESCRIPTION
We should always make sure that Typescript do not raise type errors in our CI pipeline. As we disabled `vite-plugin-checker` in the build task and we don't use tsc anymore to build our codebase, it's necessary to explicitly call it to do so.

Let's note that this slows down our CI pipeline a _little_ bit, but this will be canceled as soon as we will move to Typescript 7 (can't wait).

Prevents #15657 from happening in the first place.