### PR TITLE
chart: add labels to editoast jobs

### DIFF
--- a/chart/templates/editoast/cronjob.yaml
+++ b/chart/templates/editoast/cronjob.yaml
@@ -24,6 +24,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- toYaml ($mergedLabels | default dict) | nindent 12 }}
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:


### PR DESCRIPTION
Currently labels were only applied to the cronjob but not the jobs it self (which is required).