### PR TITLE
front: add usekeyboardshortcuts integration tests

### DIFF
--- a/front/src/utils/hooks/__tests__/useKeyboardShortcuts.spec.ts
+++ b/front/src/utils/hooks/__tests__/useKeyboardShortcuts.spec.ts
@@ -1,29 +1,36 @@
 import { useRef } from 'react';
 
-import { renderHook } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { handleKeyboardEvents, type Shortcut } from '../useKeyboardShortcuts';
+import useKeyboardShortcuts, { handleKeyboardEvents, type Shortcut } from '../useKeyboardShortcuts';
 
 describe('handleKeyboardEvents', () => {
   let handlerMock: () => void;
 
+  const { result } = renderHook(() => {
+    const registery = useRef<Record<string, Shortcut>>({});
+    return { registery };
+  });
+
+  const handleEvent = (event: KeyboardEvent) =>
+    handleKeyboardEvents(event, result.current.registery);
+
   beforeEach(() => {
     vi.clearAllMocks();
     handlerMock = vi.fn();
-    const { result } = renderHook(() => {
-      const registery = useRef<Record<string, Shortcut>>({});
-      return { registery };
-    });
+
     // Register a shortcut for testing
-    document.addEventListener('keydown', (event) =>
-      handleKeyboardEvents(event, result.current.registery)
-    );
+    document.addEventListener('keydown', handleEvent);
     result.current.registery.current['Ctrl-KeyS'] = {
       code: 'KeyS',
       optionalKeys: { ctrlKey: true },
       handler: handlerMock,
     };
+  });
+
+  afterEach(() => {
+    document.removeEventListener('keydown', handleEvent);
   });
 
   it('should call the handler when the correct shortcut is pressed', () => {
@@ -53,9 +60,95 @@ describe('handleKeyboardEvents', () => {
       const event = new KeyboardEvent('keydown', {
         code: 'KeyS',
         ctrlKey: true,
+        bubbles: true, // Ensure the event bubbles up to the document
       });
       input.dispatchEvent(event);
       expect(handlerMock).not.toHaveBeenCalled();
     }
   );
+});
+
+describe('useKeyboardShortcuts', () => {
+  const handlerMock1 = vi.fn();
+  const handlerMock2 = vi.fn();
+
+  const { result } = renderHook(() => useKeyboardShortcuts());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should register a shortcut', () => {
+    result.current.register({
+      code: 'KeyS',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock1,
+    });
+
+    fireEvent.keyDown(document.body, { code: 'KeyS', ctrlKey: true });
+
+    expect(handlerMock1).toHaveBeenCalled();
+  });
+
+  it('should unregister a shortcut', () => {
+    const handlerMock = vi.fn();
+
+    result.current.register({
+      code: 'KeyS',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock,
+    });
+
+    fireEvent.keyDown(document.body, { code: 'KeyS', ctrlKey: true });
+
+    result.current.unRegister({
+      code: 'KeyS',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock,
+    });
+
+    fireEvent.keyDown(document.body, { code: 'KeyS', ctrlKey: true });
+
+    expect(handlerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not register the same shortcut twice', () => {
+    const handlerMock = vi.fn();
+
+    result.current.register({
+      code: 'KeyS',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock,
+    });
+
+    result.current.register({
+      code: 'KeyS',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock,
+    });
+
+    fireEvent.keyDown(document.body, { code: 'KeyS', ctrlKey: true });
+
+    expect(handlerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle multiple shortcuts', () => {
+    result.current.register({
+      code: 'KeyS',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock1,
+    });
+
+    result.current.register({
+      code: 'KeyV',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock2,
+    });
+
+    fireEvent.keyDown(document.body, { code: 'KeyS', ctrlKey: true });
+    fireEvent.keyDown(document.body, { code: 'KeyV', ctrlKey: true });
+
+    expect(handlerMock1).toHaveBeenCalled();
+    expect(handlerMock2).toHaveBeenCalled();
+  });
 });

--- a/front/src/utils/hooks/__tests__/useKeyboardShortcuts.spec.ts
+++ b/front/src/utils/hooks/__tests__/useKeyboardShortcuts.spec.ts
@@ -1,0 +1,61 @@
+import { useRef } from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { handleKeyboardEvents, type Shortcut } from '../useKeyboardShortcuts';
+
+describe('handleKeyboardEvents', () => {
+  let handlerMock: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlerMock = vi.fn();
+    const { result } = renderHook(() => {
+      const registery = useRef<Record<string, Shortcut>>({});
+      return { registery };
+    });
+    // Register a shortcut for testing
+    document.addEventListener('keydown', (event) =>
+      handleKeyboardEvents(event, result.current.registery)
+    );
+    result.current.registery.current['Ctrl-KeyS'] = {
+      code: 'KeyS',
+      optionalKeys: { ctrlKey: true },
+      handler: handlerMock,
+    };
+  });
+
+  it('should call the handler when the correct shortcut is pressed', () => {
+    const event = new KeyboardEvent('keydown', {
+      code: 'KeyS',
+      ctrlKey: true,
+    });
+    document.dispatchEvent(event);
+    expect(handlerMock).toHaveBeenCalled();
+  });
+
+  it.each([
+    { code: 'KeyI', metaKey: true, altKey: true },
+    { code: 'KeyC', ctrlKey: true },
+    { code: 'KeyC', metaKey: true },
+  ])('should not call the handler when the wrong shortcut is pressed', (eventProps) => {
+    const event = new KeyboardEvent('keydown', eventProps);
+    document.dispatchEvent(event);
+    expect(handlerMock).not.toHaveBeenCalled();
+  });
+
+  it.each([{ tag: 'input' }, { tag: 'textarea' }])(
+    'should not call the handler when the event target is an input or textarea',
+    ({ tag }) => {
+      const input = document.createElement(tag);
+      document.body.appendChild(input);
+      const event = new KeyboardEvent('keydown', {
+        code: 'KeyS',
+        ctrlKey: true,
+      });
+      input.dispatchEvent(event);
+      expect(handlerMock).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/front/src/utils/hooks/useKeyboardShortcuts.ts
+++ b/front/src/utils/hooks/useKeyboardShortcuts.ts
@@ -92,16 +92,16 @@ export default function useKeyboardShortcuts(shortcuts?: Shortcut[]): {
     [registery]
   );
 
+  const eventFunction = (event: KeyboardEvent) => handleKeyboardEvents(event, registery);
+
   useEffect(() => {
     // register shortcuts given at initialization
     shortcuts?.forEach((s) => register(s));
 
-    document.body.addEventListener('keydown', (event) => handleKeyboardEvents(event, registery));
+    document.body.addEventListener('keydown', eventFunction);
     return () => {
       registery.current = {};
-      document.body.removeEventListener('keydown', (event) =>
-        handleKeyboardEvents(event, registery)
-      );
+      document.body.removeEventListener('keydown', eventFunction);
     };
   }, []);
 

--- a/front/src/utils/hooks/useKeyboardShortcuts.ts
+++ b/front/src/utils/hooks/useKeyboardShortcuts.ts
@@ -14,7 +14,7 @@ export type Shortcut = {
   handler: () => void;
 };
 
-function shortcutRegistryKey(code: string, optionalKeys?: OptionalKeys): string {
+export function shortcutRegistryKey(code: string, optionalKeys?: OptionalKeys): string {
   return [
     optionalKeys?.ctrlKey && 'Ctrl',
     optionalKeys?.shiftKey && 'Shift',
@@ -25,7 +25,53 @@ function shortcutRegistryKey(code: string, optionalKeys?: OptionalKeys): string 
     .join('-');
 }
 
-export default function useKeyboardShortcuts(shortcuts?: Shortcut[]) {
+// Listen keyboard event on document
+export const handleKeyboardEvents = (
+  event: KeyboardEvent,
+  registery: React.RefObject<Record<string, Shortcut>>
+) => {
+  if (event.target instanceof Element) {
+    // prevent keyboard shortcut execution in text inputs.
+    if (event.target.matches('input, textarea')) return;
+
+    // disable the handler for chrome developer tools
+    if (event.code === 'KeyI' && event.metaKey && event.altKey) return;
+
+    // disable the handler for copy keyboard shortcut (ctrl+c, cmd+c)
+    if (event.code === 'KeyC' && (event.metaKey || event.ctrlKey)) return;
+  }
+
+  const shortcutKey = shortcutRegistryKey(event.code, {
+    shiftKey: event.shiftKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+  });
+  const shortcut = registery.current[shortcutKey];
+  if (shortcut) {
+    shortcut.handler();
+    event.preventDefault();
+  }
+};
+
+/**
+ * Custom hook to manage keyboard shortcuts application.
+ * It allows you to register and unregister keyboard shortcuts,
+ * and handles the execution of the corresponding handlers when the specified key combinations are pressed.
+ *
+ * Registry is stored in a ref to avoid unnecessary re-renders when shortcuts are registered or unregistered.
+ *
+ * The hook listens for keyboard events on the document body and checks if the pressed key combination matches any registered shortcut.
+ * If a match is found, the corresponding handler is executed, and the default behavior of the event is prevented.
+ *
+ * @param shortcuts - An optional array of shortcuts to register when the hook is initialized.
+ * Each shortcut should include a `code` representing the key code, an optional `optionalKeys` object specifying modifier keys (shift, ctrl, meta), and a `handler` function to execute when the shortcut is triggered.
+ * @return An object containing the current registry of shortcuts (as a read-only record), and functions to register and unregister shortcuts.
+ */
+export default function useKeyboardShortcuts(shortcuts?: Shortcut[]): {
+  registery: Readonly<Record<string, Shortcut>>;
+  register: (shortcut: Shortcut) => void;
+  unRegister: (shortcut: Shortcut) => void;
+} {
   const registery = useRef<Record<string, Shortcut>>({});
 
   const register = useCallback(
@@ -50,34 +96,12 @@ export default function useKeyboardShortcuts(shortcuts?: Shortcut[]) {
     // register shortcuts given at initialization
     shortcuts?.forEach((s) => register(s));
 
-    // Listen keyboard event on document
-    const handleKeyboardEvents = (event: KeyboardEvent) => {
-      if (event.target instanceof Element) {
-        // prevent keyboard shortcut execution in text inputs.
-        if (event.target.matches('input, textarea')) return;
-
-        // disable the handler for chrome developer tools
-        if (event.code === 'KeyI' && event.metaKey && event.altKey) return;
-
-        // disable the handler for copy keyboard shortcut (ctrl+c, cmd+c)
-        if (event.code === 'KeyC' && (event.metaKey || event.ctrlKey)) return;
-      }
-
-      const shortcutKey = shortcutRegistryKey(event.code, {
-        shiftKey: event.shiftKey,
-        ctrlKey: event.ctrlKey,
-        metaKey: event.metaKey,
-      });
-      const shortcut = registery.current[shortcutKey];
-      if (shortcut) {
-        shortcut.handler();
-        event.preventDefault();
-      }
-    };
-    document.body.addEventListener('keydown', handleKeyboardEvents);
+    document.body.addEventListener('keydown', (event) => handleKeyboardEvents(event, registery));
     return () => {
       registery.current = {};
-      document.body.removeEventListener('keydown', handleKeyboardEvents);
+      document.body.removeEventListener('keydown', (event) =>
+        handleKeyboardEvents(event, registery)
+      );
     };
   }, []);
 


### PR DESCRIPTION
the first commit is about extracting `handleKeyboardEvents` from `useKeyboardShortcuts` in order to add some unit tests for it

the second commit is about the integration test for `useKeyboardShortcuts`, it uses [`fireEvent`](https://testing-library.com/docs/dom-testing-library/api-events/) to mock the user behavior by firing a key event on the dom, I tried first with `document.dispatchEvent()` without any success, at last `fireEvent` is provided by the RTL library so I bet it's more convenient.

close #16697 