### PR TITLE
editoast: authz: simplify `Check`s with `enum Actor`

### DIFF
--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -41,13 +41,24 @@ pub struct Protected<T> {
     pub checks: HashSet<Check>,
 }
 
+/// The actor to which some [Check]s applies
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Actor {
+    /// The user from which the protected operation originates
+    ///
+    /// Such user is provided by the [Authorizer] authorizing the operation.
+    Issuer,
+    /// A specific user
+    User(User),
+}
+
 /// A check to ensure data consistency and permission workflow consistency
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Check {
-    /// The issuer needs a role to perform the operation
-    IssuerHasRole(Role),
-    /// The issuer needs an infra privilege to perform the operation
-    IssuerHasInfraPrivilege(InfraPrivilege, Infra),
+    /// The actor needs a role to perform the operation
+    HasRole(Actor, Role),
+    /// The actor needs an infra privilege to perform the operation
+    HasInfraPrivilege(Actor, InfraPrivilege, Infra),
     /// The subject must exist in PostgreSQL
     SubjectExists(Subject),
     /// The infra must exist in PostgreSQL

--- a/editoast/authz/src/v2/group.rs
+++ b/editoast/authz/src/v2/group.rs
@@ -8,6 +8,7 @@ use itertools::Itertools as _;
 use crate::Group;
 use crate::Role;
 use crate::User;
+use crate::v2::Actor;
 use crate::v2::Check;
 use crate::v2::Protected;
 
@@ -53,7 +54,7 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
             .boxed()
         })
         .with_check_iter(user_exists_checks)
-        .with_check(Check::IssuerHasRole(Role::Admin))
+        .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
 }
 
 /// Removes some members from a group
@@ -78,7 +79,7 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
             .boxed()
         })
         .with_check_iter(user_exists_checks)
-        .with_check(Check::IssuerHasRole(Role::Admin))
+        .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
 }
 
 #[cfg(test)]

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -12,6 +12,7 @@ use crate::InfraPrivilege;
 use crate::Role;
 use crate::Subject;
 use crate::User;
+use crate::v2::Actor;
 use crate::v2::Check;
 use crate::v2::Protected;
 
@@ -132,7 +133,11 @@ pub fn infra_effective_grant(subject: Subject, infra: Infra) -> Protected<Option
     })
     .with_check(Check::SubjectExists(subject))
     .with_check(Check::InfraExists(infra))
-    .with_check(Check::IssuerHasInfraPrivilege(InfraPrivilege::CanRead, infra))
+    .with_check(Check::HasInfraPrivilege(
+        Actor::Issuer,
+        InfraPrivilege::CanRead,
+        infra,
+    ))
 }
 
 pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPrivilege>> {
@@ -172,7 +177,8 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
     })
     .with_check(Check::InfraExists(infra))
     .with_check(Check::SubjectExists(Subject::user(user)))
-    .with_check(Check::IssuerHasInfraPrivilege(
+    .with_check(Check::HasInfraPrivilege(
+        Actor::Issuer,
         InfraPrivilege::CanRead,
         infra,
     ))
@@ -239,7 +245,8 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
             }
             .boxed()
         })
-        .with_check(Check::IssuerHasInfraPrivilege(
+        .with_check(Check::HasInfraPrivilege(
+            Actor::Issuer,
             InfraPrivilege::CanRead,
             infra,
         ))

--- a/editoast/authz/src/v2/roles.rs
+++ b/editoast/authz/src/v2/roles.rs
@@ -7,6 +7,7 @@ use crate::Group;
 use crate::Role;
 use crate::Subject;
 use crate::User;
+use crate::v2::Actor;
 use crate::v2::Check;
 use crate::v2::Protected;
 
@@ -50,7 +51,7 @@ pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
             }
             .boxed()
         })
-        .with_check(Check::IssuerHasRole(Role::Admin))
+        .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
 }
 
 /// Removes the specified roles from the subject
@@ -80,7 +81,7 @@ pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
             }
             .boxed()
         })
-        .with_check(Check::IssuerHasRole(Role::Admin))
+        .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
 }
 
 #[cfg(test)]

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,6 +1,7 @@
 use std::convert::Infallible;
 
 use authz::v2::Access;
+use authz::v2::Actor;
 use authz::v2::Authorizer;
 use authz::v2::Check;
 use authz::v2::Protected;
@@ -40,7 +41,7 @@ impl SystemAuthorizer<'_> {
                 (!editoast_models::Infra::exists(conn, **infra).await?).then_some(check)
             }
             // checked by UserAuthorizer
-            Check::IssuerHasRole(_) | Check::IssuerHasInfraPrivilege(_, _) => None,
+            Check::HasRole(..) | Check::HasInfraPrivilege(..) => None,
         })
     }
 }
@@ -94,17 +95,31 @@ impl<'c> UserAuthorizer<'c> {
         }
     }
 
+    fn actor_user<'a>(&'a self, actor: &'a Actor) -> &'a authz::User {
+        match actor {
+            Actor::Issuer => &self.user,
+            Actor::User(user) => user,
+        }
+    }
+
     #[tracing::instrument(target = "UserAutorizer::check", skip_all, fields(?check, issuer = ?self.user, roles = ?self.roles), ret(level = "trace"), err)]
     async fn check<'ch>(
         &self,
         check: &'ch Check,
     ) -> Result<Option<&'ch Check>, authz::v2::OpenFgaError> {
         Ok(match check {
-            Check::IssuerHasRole(role) if !self.roles.contains(role) => Some(check),
-            Check::IssuerHasRole(_) => None,
+            Check::HasRole(Actor::Issuer, role) if !self.roles.contains(role) => Some(check),
+            Check::HasRole(Actor::Issuer, _) => None,
+            Check::HasRole(Actor::User(user), role) => {
+                let Ok(roles) = authz::v2::subject_roles(authz::Subject::User(*user))
+                    .access_authorized::<Infallible>(self.openfga)
+                    .access()
+                    .await?;
+                (!roles.contains(role)).then_some(check)
+            }
 
-            Check::IssuerHasInfraPrivilege(privilege, infra) => {
-                let Ok(privileges) = authz::v2::infra_privileges(self.user, *infra)
+            Check::HasInfraPrivilege(actor, privilege, infra) => {
+                let Ok(privileges) = authz::v2::infra_privileges(*self.actor_user(actor), *infra)
                     .access_authorized::<Infallible>(self.openfga)
                     .access()
                     .await?;

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -12,6 +12,7 @@ use ::authz::InfraPrivilege;
 use ::authz::Role;
 use authz::Authorization;
 use authz::v2;
+use authz::v2::Actor;
 use authz::v2::Authorizer;
 use authz::v2::Check;
 use axum::Extension;
@@ -343,7 +344,7 @@ pub(in crate::views) async fn user_privileges(
                     // not an error under the target API
                     // (though maybe we should revisit it?)
                 }
-                Err(Check::IssuerHasInfraPrivilege(InfraPrivilege::CanRead, infra)) => {
+                Err(Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, infra)) => {
                     result_infras.push(ResourcePrivileges {
                         resource_id: *infra,
                         privileges: HashSet::new(),
@@ -352,7 +353,7 @@ pub(in crate::views) async fn user_privileges(
                 Err(Check::SubjectExists(authz::Subject::User(_))) => {
                     panic!("race condition: user deleted");
                 }
-                Err(check @ Check::IssuerHasInfraPrivilege(_, _)) | Err(check) => {
+                Err(check @ Check::HasInfraPrivilege(_, _, _)) | Err(check) => {
                     impossible!(check)
                 }
             }
@@ -431,7 +432,7 @@ pub(in crate::views) async fn user_grants(
                     tracing::warn!(%infra, "non-existent infra — skipping");
                     continue;
                 }
-                Err(Check::IssuerHasInfraPrivilege(privilege, infra)) => {
+                Err(Check::HasInfraPrivilege(Actor::Issuer, privilege, infra)) => {
                     debug_assert_eq!(privilege, InfraPrivilege::CanRead);
                     tracing::warn!(%infra, "user cannot read infra — skipping");
                     continue;
@@ -517,7 +518,7 @@ pub(in crate::views) async fn my_grants_on_resource(
                 .access()
                 .await?
                 .map_err(|err| match err {
-                    Check::IssuerHasInfraPrivilege(InfraPrivilege::CanRead, ..) => {
+                    Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, ..) => {
                         AuthzError::Authz(AuthorizationError::Forbidden)
                     }
                     Check::InfraExists(_) => AuthzError::UnknownResource {


### PR DESCRIPTION
We won't have to duplicate similar checks for both the issuer and random users.