### PR TITLE
front: force refetch train schedules in loadNgeDto after deletion

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -741,7 +741,7 @@ export const loadNgeDto = async (
   const pacedTrainsPromise = dispatch(
     osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.initiate(
       { timetableId },
-      { subscribe: false }
+      { subscribe: false, forceRefetch: true }
     )
   );
   const pacedTrains = (await pacedTrainsPromise.unwrap()).filter(
@@ -757,7 +757,7 @@ export const loadNgeDto = async (
   const pacedTrainRoundTripsPromise = dispatch(
     osrdEditoastApi.endpoints.getTimetableByIdRoundTripsTrainSchedules.initiate(
       { id: timetableId },
-      { subscribe: false }
+      { subscribe: false, forceRefetch: true }
     )
   );
   const { results: pacedTrainRoundTrips } = await pacedTrainRoundTripsPromise.unwrap();


### PR DESCRIPTION
fix https://github.com/OpenRailAssociation/osrd/issues/16735

---

Make a fresh timetable request every time we load nge dto to account for deleted schedule inside NGE.