### PR TITLE
ui: Integration of the DurationInput component

### DIFF
--- a/front/ui/storybook/stories/ui-core/DurationInput.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/DurationInput.stories.tsx
@@ -1,0 +1,45 @@
+import { DurationInput } from '@osrd-project/ui-core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import '@osrd-project/ui-core/dist/theme.css';
+
+const meta: Meta<typeof DurationInput> = {
+  component: DurationInput,
+  args: {
+    units: ['h', 'm', 's'],
+    value: 0,
+    padChar: '0',
+  },
+  title: 'Core/DurationInput',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DurationInput>;
+
+export const Default: Story = {};
+
+export const Labeled: Story = {
+  args: {
+    label: 'How long are you willing to stay ?',
+  },
+};
+
+export const Hinted: Story = {
+  args: {
+    label: 'Your age',
+    hint: 'Only for really young people',
+    units: ['m', 's'],
+    max: 3_600_000,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    label: 'Your age',
+    hint: 'Only for really young people',
+    units: ['m', 's'],
+    max: 3_600_000,
+    small: true,
+  },
+};

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -1,0 +1,302 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+
+import cx from 'classnames';
+
+import FieldWrapper from './FieldWrapper';
+
+type UnitConfig = {
+  key: string;
+  label: string;
+  msPerUnit: number;
+  digits: number;
+};
+
+export type UnitProps = 'h' | 'm' | 's' | 'ms' | UnitConfig;
+
+type UnitSetting = UnitConfig & {
+  max: number;
+  padChar: string;
+};
+
+export type DurationInputProps = {
+  id: string;
+  units: UnitProps[];
+  value: number;
+  padChar: string;
+  onChange?: (ms: number) => void;
+  max: number;
+  small?: boolean;
+  hint?: string;
+  label?: string;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+const PRESETS: Record<string, Omit<UnitConfig, 'key'>> = {
+  h: { label: 'h', digits: 2, msPerUnit: 3_600_000 },
+  m: { label: 'm', digits: 2, msPerUnit: 60_000 },
+  s: { label: 's', digits: 2, msPerUnit: 1_000 },
+  ms: { label: 'ms', digits: 3, msPerUnit: 1 },
+};
+
+function normalizeUnits(units: UnitProps[], padChar: string, max: number): UnitSetting[] {
+  const configs: UnitConfig[] = units.map((u) => {
+    if (typeof u === 'string') {
+      return { key: u, ...PRESETS[u] };
+    }
+
+    const key = (u.key ?? u.label)!;
+    const base = PRESETS[key] ?? {};
+
+    return {
+      key,
+      label: u.label ?? base.label ?? key,
+      msPerUnit: u.msPerUnit ?? base.msPerUnit ?? 1,
+      digits: u.digits ?? base.digits ?? 2,
+    };
+  });
+
+  configs.sort((a, b) => b.msPerUnit - a.msPerUnit);
+  return configs.map((unit, idx) => {
+    const prev = idx > 0 ? configs[idx - 1] : null;
+    return {
+      ...unit,
+      digits: prev ? unit.digits : String(Math.floor(max / unit.msPerUnit)).length,
+      max: prev ? Math.floor(prev.msPerUnit / unit.msPerUnit) : Infinity,
+      padChar,
+    };
+  });
+}
+
+type FormattedValues = Record<string, string>;
+
+function toUnitField(ms: number, unit: UnitSetting): [string, string] {
+  const value = Math.floor(ms / (unit.msPerUnit || 1)) % unit.max;
+  return [unit.key, String(value || unit.padChar).padStart(unit.digits, unit.padChar)];
+}
+
+function toFormattedValues(units: UnitSetting[], ms: number): FormattedValues {
+  return Object.fromEntries(units.map((u) => toUnitField(ms, u)));
+}
+
+function toTotalMilliseconds(fields: UnitSetting[], values: FormattedValues): number {
+  return fields.reduce((acc, f) => {
+    const cleaned = values[f.key].replace(/[^0-9]/g, '');
+    const value = parseInt(cleaned, 10) || 0;
+    return acc + value * (f.msPerUnit || 1);
+  }, 0);
+}
+
+function useDurationInput({
+  units,
+  value,
+  onChange,
+  padChar,
+  max,
+}: Omit<DurationInputProps, 'id'>) {
+  const fields = useMemo(() => normalizeUnits(units, padChar, max), [units, padChar, max]);
+
+  const inputRefs = useRef<Record<string, HTMLInputElement>>({});
+
+  const [initialValue, setInitialValue] = useState(value);
+  const [formattedValues, setFormattedValues] = useState<FormattedValues>(() =>
+    toFormattedValues(fields, Math.min(max, value))
+  );
+
+  if (initialValue !== value) {
+    setInitialValue(value);
+    setFormattedValues(toFormattedValues(fields, Math.min(max, value)));
+  }
+
+  const focusField = useCallback((key: string) => {
+    requestAnimationFrame(() => {
+      inputRefs.current[key]?.focus();
+      inputRefs.current[key]?.select();
+    });
+  }, []);
+
+  const focusNext = useCallback(
+    (currentKey: string) => {
+      const idx = fields.findIndex((f) => f.key === currentKey);
+      const next = fields[idx + 1];
+      if (next) focusField(next.key);
+    },
+    [fields, focusField]
+  );
+
+  const focusPrevious = useCallback(
+    (currentKey: string) => {
+      const idx = fields.findIndex((f) => f.key === currentKey);
+      const previous = fields[idx - 1];
+      if (previous) focusField(previous.key);
+    },
+    [fields, focusField]
+  );
+
+  const emit = useCallback(
+    (nextValues: FormattedValues) => {
+      onChange?.(toTotalMilliseconds(fields, nextValues));
+    },
+    [fields, onChange]
+  );
+
+  const handleChange = useCallback(
+    (setting: UnitSetting, inputValue: string) => {
+      const cleaned = inputValue.replace(/[^0-9]/g, '').slice(0, setting.digits);
+      setFormattedValues((prev) => ({ ...prev, [setting.key]: cleaned }));
+      if (cleaned.length === setting.digits) {
+        focusNext(setting.key);
+      }
+    },
+    [focusNext]
+  );
+
+  const handleKeyDown = useCallback(
+    (setting: UnitSetting, e: React.KeyboardEvent<HTMLInputElement>) => {
+      const input = e.currentTarget;
+
+      if (!input) return;
+
+      if (e.key === 'ArrowRight' && input.selectionStart === input.value.length) {
+        e.preventDefault();
+        focusNext(setting.key);
+      }
+
+      if (e.key === 'ArrowLeft' && input.selectionStart === 0) {
+        e.preventDefault();
+        focusPrevious(setting.key);
+      }
+    },
+    [focusNext, focusPrevious]
+  );
+
+  const handleFocus = useCallback((setting: UnitSetting) => focusField(setting.key), [focusField]);
+
+  const handleBlur = useCallback(() => {
+    const ms = toTotalMilliseconds(fields, formattedValues);
+    const clamped = Math.min(max, ms);
+    const next = toFormattedValues(fields, clamped);
+    setFormattedValues(next);
+    emit(next);
+  }, [fields, formattedValues, max, emit]);
+
+  return {
+    fields,
+    formattedValues,
+    inputRefs,
+    handleChange,
+    handleFocus,
+    handleBlur,
+    handleKeyDown,
+  };
+}
+
+type UnitFieldProps = {
+  setting: UnitSetting;
+  value: string;
+  inputRef: (el: HTMLInputElement | null) => void;
+  onChange: (value: string) => void;
+  onFocus: () => void;
+  onBlur: () => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  tabIndex: number;
+};
+
+const UnitField = function UnitField({
+  setting,
+  value,
+  inputRef,
+  onChange,
+  onFocus,
+  onBlur,
+  onKeyDown,
+  tabIndex,
+}: UnitFieldProps) {
+  const { label, digits, padChar } = setting;
+  const placeholder = padChar.repeat(digits);
+
+  return (
+    <span className="unit-field">
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="numeric"
+        style={{
+          width: `${digits}ch`,
+        }}
+        tabIndex={tabIndex}
+        value={value}
+        placeholder={placeholder}
+        aria-label={label}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+      />
+      <span aria-hidden onClick={onFocus}>
+        {label}
+      </span>
+    </span>
+  );
+};
+
+/**
+ * Duration units can be set up via their shorthand strings (h, m, s, ms)
+ * or more precisely through objects.
+ * The value of the component is a number representing the milliseconds of the duration.
+ */
+const DurationInput = ({
+  id,
+  units = ['m', 's'],
+  value = 0,
+  onChange,
+  padChar = '0',
+  small = false,
+  max = 99 * 3_600_000, // 99 HOURS
+  label,
+  hint,
+  ...rest
+}: DurationInputProps) => {
+  const {
+    fields,
+    formattedValues,
+    inputRefs,
+    handleChange,
+    handleFocus,
+    handleBlur,
+    handleKeyDown,
+  } = useDurationInput({
+    units,
+    value,
+    onChange,
+    padChar,
+    max,
+  });
+
+  return (
+    <FieldWrapper id={id} label={label} hint={hint} small={small}>
+      <div
+        className={cx('ui-duration-input', { small })}
+        role="group"
+        aria-label="Duration Input"
+        {...rest}
+      >
+        {fields.map((setting, idx) => (
+          <UnitField
+            key={setting.key}
+            setting={setting}
+            value={formattedValues[setting.key]}
+            inputRef={(el) => {
+              if (el) inputRefs.current[setting.key] = el;
+            }}
+            tabIndex={idx === 0 ? 0 : -1}
+            onChange={(val) => handleChange(setting, val)}
+            onFocus={() => handleFocus(setting)}
+            onBlur={() => handleBlur()}
+            onKeyDown={(e) => handleKeyDown(setting, e)}
+          />
+        ))}
+      </div>
+    </FieldWrapper>
+  );
+};
+
+export default DurationInput;

--- a/front/ui/ui-core/src/index.ts
+++ b/front/ui/ui-core/src/index.ts
@@ -19,6 +19,7 @@ export {
   type SingleDatePickerProps,
 } from './components/DatePicker';
 export { default as Switch, SwitchProps } from './components/Switch';
+export { default as DurationInput, DurationInputProps } from './components/DurationInput';
 export { default as Input, InputProps } from './components/Input';
 export { default as PasswordInput, PasswordInputProps } from './components/PasswordInput';
 export { default as RadioButton, RadioButtonProps } from './components/RadioButton';

--- a/front/ui/ui-core/src/styles/inputs/duration-input.css
+++ b/front/ui/ui-core/src/styles/inputs/duration-input.css
@@ -1,0 +1,41 @@
+.ui-duration-input {
+  /* Dimensions */
+
+  --ui-duration-input-height: 2.5rem;
+  --ui-duration-input-padding: 0.5rem 0.75rem;
+
+  &.small {
+    --ui-duration-input-height: 1.75rem;
+    --ui-duration-input-padding: 0.188rem 0.5rem 0.188rem 0.438rem;
+  }
+
+  &:has(:focus-visible) {
+    box-shadow:
+      0px 1px 3px rgba(0, 0, 0, 0.5) inset,
+      0px 0px 0px 1px rgba(31, 27, 23, 1) inset;
+    @apply bg-white-25;
+  }
+
+  width: fit-content;
+  padding: var(--ui-duration-input-padding);
+  border-radius: 0.25rem;
+  box-shadow:
+    0 0 0 0.063rem rgba(148, 145, 142, 1) inset,
+    0 0.063rem 0.188rem rgba(0, 0, 0, 0.5) inset;
+
+  line-height: 1.25rem;
+  font-size: 0.875rem;
+
+  .unit-field {
+    line-height: 20px;
+    letter-spacing: 0;
+    height: var(--ui-duration-input-height);
+    input {
+      text-align: right;
+      outline: none;
+    }
+    span {
+      color: var(--color-grey-50);
+    }
+  }
+}

--- a/front/ui/ui-core/src/styles/inputs/index.css
+++ b/front/ui/ui-core/src/styles/inputs/index.css
@@ -1,6 +1,7 @@
 @import './checkbox.css';
 @import './comboBox.css';
 @import './datePicker.css';
+@import './duration-input.css';
 @import './fieldWrapper.css';
 @import './hint.css';
 @import './input.css';


### PR DESCRIPTION
This pull request satisfies the ACs of https://github.com/OpenRailAssociation/osrd/issues/16534


## Acceptance Criterias

- [x] Add a `DurationInput` component that takes a number of ms as a value and lets the user choose which units the component should decompose it into.
- [x] The component should work properly with hours and minutes set as units.
- [x] The component should match the [sketches](https://www.sketch.com/s/44a4dfe4-6ef5-4f9f-92d3-72b79136e5da/v/Pev5a1/p/40BF39F6-06B6-4BF3-9616-20FDE6FCE8C3/canvas?posX=-741.8453924666143&posY=-3571.623143726289&zoom=1.0149598121643066).
- [x] BONUS : Inputing a value above the maximum amount possible in a unit should clamp the value and pass it to the left if possible (ex: 90 minutes => 1 hour and 30 minutes)

Screenshots of the timetable header integration :

<img width="404" height="145" alt="Image" src="https://github.com/user-attachments/assets/8afa2cf7-2b32-41d0-afc4-f7831ed18a9b" />