### PR TITLE
front: tests: validate that the pdf includes a trace id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
       VALKEY_URL: "redis://valkey"
       DATABASE_URL: "postgres://osrd:password@postgres/osrd"
       OSRDYNE_API_URL: "http://osrdyne:4242/"
-      TELEMETRY_KIND: "none"
+      TELEMETRY_KIND: "opentelemetry"
       TELEMETRY_ENDPOINT: "http://jaeger:4317"
       OSRD_MQ_URL: "amqp://osrd:password@rabbitmq:5672/%2f"
       FGA_API_URL: "http://openfga:8091"
@@ -245,8 +245,6 @@ services:
   jaeger:
     image: jaegertracing/jaeger:latest
     container_name: osrd-jaeger
-    profiles:
-      - telemetry
     restart: unless-stopped
     ports:
       - "4317:4317"

--- a/docker/docker-compose.telemetry.yml
+++ b/docker/docker-compose.telemetry.yml
@@ -1,8 +1,0 @@
-services:
-  core:
-    environment:
-      CORE_MONITOR_TYPE: "opentelemetry"
-
-  editoast:
-    environment:
-      TELEMETRY_KIND: "opentelemetry"

--- a/front/tests/utils/pdf-parser.ts
+++ b/front/tests/utils/pdf-parser.ts
@@ -102,6 +102,9 @@ export function verifySimulationContent(pdfText: string, expectedSimulation: Pdf
     expectedSimulation.simulationDetails.disclaimer,
   ];
   textChecks.forEach((check) => expect(pdfText).toContain(check));
+
+  // Verify that a trace ID (32-char hex from the traceparent header) was included in the PDF
+  expect(pdfText, 'missing trace ID in the PDF').toMatch(/[0-9a-f]{32}/);
 }
 
 /**

--- a/osrd-compose
+++ b/osrd-compose
@@ -21,7 +21,6 @@ Flags (optional, can be combined):
   sw           Enable single worker mode (docker/docker-compose.single-worker.yml)
   host         Use host networking mode (docker/docker-compose.host.yml)
   playwright   Start playwright container with the stack (docker/docker-compose.playwright.yml)
-  telemetry    Activate telemetry on the webservices and start Jaeger (docker/docker-compose.telemetry.yml)
   default      Reset to base configuration only and clear saved state
 
 Examples:
@@ -62,7 +61,7 @@ while [[ $# -gt 0 ]]; do
             DEFAULT_FLAG=true
             shift
             ;;
-        dev-front|ext-front|sw|host|playwright|telemetry)
+        dev-front|ext-front|sw|host|playwright)
             flags+=("$1")
             shift
             ;;
@@ -152,11 +151,6 @@ if has_flag "playwright"; then
     export PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION
 
     compose_files+=("$OVERRIDE_DIR/docker-compose.playwright.yml")
-fi
-
-if has_flag "telemetry"; then
-    compose_files+=("$OVERRIDE_DIR/docker-compose.telemetry.yml")
-    export COMPOSE_PROFILES=telemetry
 fi
 
 


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/16951

The test itself is just looking for a 32 char hex string, it's not very precise but we don't have a `trace_id: ` prefix to attach to. I did check that the test fails when it's missing. And because the test line can be unclear, I've put an actual error message.

And `osrd-compose` now enables editoast telemetry by default. It does cause editoast to log some errors, but the test now pass. I'm a little less sure about this change, but at least it's important that the tests pass with the default config. We can discuss that part further. 