### PR TITLE
editoast: replace infra grant in views

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -114,7 +114,7 @@ pub struct User(pub i64);
 )]
 pub struct Group(pub i64);
 
-#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
@@ -129,18 +129,7 @@ pub enum InfraPrivilege {
 }
 
 #[derive(
-    Debug,
-    Display,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    ToSchema,
+    Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
@@ -184,7 +173,7 @@ pub struct RollingStock(pub i64);
 )]
 pub struct Infra(pub i64);
 
-#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
@@ -199,18 +188,7 @@ pub enum RollingStockPrivilege {
 }
 
 #[derive(
-    Debug,
-    Display,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    ToSchema,
+    Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -202,6 +202,40 @@ impl<T: Send + 'static> Protected<T> {
     }
 }
 
+impl<T: Send + 'static> Protected<Option<T>> {
+    pub fn map_some_into<E>(self) -> Protected<Option<E>>
+    where
+        E: Send + 'static,
+        T: Into<E>,
+    {
+        self.map(move |_, val| async move { Ok(val.map(T::into)) }.boxed())
+    }
+}
+
+impl<T> Protected<T>
+where
+    T: IntoIterator + Send + 'static,
+    <T as IntoIterator>::Item: Send + 'static,
+{
+    pub fn collect_into<C>(self) -> Protected<C>
+    where
+        C: Send + 'static,
+        C: IntoIterator,
+        C: FromIterator<<C as IntoIterator>::Item>,
+        <T as IntoIterator>::Item: Into<<C as IntoIterator>::Item>,
+    {
+        self.map(move |_, val| {
+            async move {
+                Ok(val
+                    .into_iter()
+                    .map(<T as IntoIterator>::Item::into)
+                    .collect::<C>())
+            }
+            .boxed()
+        })
+    }
+}
+
 impl<T: Default> Default for Protected<T> {
     fn default() -> Self {
         Self::new(|_| async { Ok(T::default()) }.boxed())

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -106,6 +106,7 @@ paths:
                 type: string
                 enum:
                 - infra
+                - rolling_stock
         required: true
       responses:
         '200':
@@ -123,7 +124,7 @@ paths:
                     - grant
                     properties:
                       grant:
-                        $ref: '#/components/schemas/InfraGrant'
+                        $ref: '#/components/schemas/StandardGrant'
                       id:
                         type: integer
                         format: int64
@@ -131,6 +132,7 @@ paths:
                   type: string
                   enum:
                   - infra
+                  - rolling_stock
   /authz/me/groups:
     get:
       tags:
@@ -172,6 +174,7 @@ paths:
                 type: string
                 enum:
                 - infra
+                - rolling_stock
         required: true
       responses:
         '200':
@@ -191,7 +194,7 @@ paths:
                       privileges:
                         type: array
                         items:
-                          $ref: '#/components/schemas/InfraPrivilege'
+                          $ref: '#/components/schemas/StandardPrivilege'
                         uniqueItems: true
                       resource_id:
                         type: integer
@@ -200,6 +203,7 @@ paths:
                   type: string
                   enum:
                   - infra
+                  - rolling_stock
   /authz/user/info:
     post:
       tags:
@@ -297,7 +301,7 @@ paths:
                   - grant
                   properties:
                     grant:
-                      $ref: '#/components/schemas/InfraGrant'
+                      $ref: '#/components/schemas/StandardGrant'
                     id:
                       type: integer
                       format: int64
@@ -10404,7 +10408,7 @@ components:
       - grant
       properties:
         grant:
-          $ref: '#/components/schemas/InfraGrant'
+          $ref: '#/components/schemas/StandardGrant'
         resource_id:
           type: integer
           format: int64
@@ -10673,12 +10677,6 @@ components:
             - unused_port
           port_name:
             type: string
-    InfraGrant:
-      type: string
-      enum:
-      - READER
-      - WRITER
-      - OWNER
     InfraObject:
       oneOf:
       - type: object
@@ -10848,16 +10846,6 @@ components:
           $ref: '#/components/schemas/PathfindingTrackLocationInput'
         starting:
           $ref: '#/components/schemas/PathfindingTrackLocationInput'
-    InfraPrivilege:
-      type: string
-      enum:
-      - can_read
-      - can_share_read
-      - can_write
-      - can_share_write
-      - can_delete
-      - can_share_ownership
-      - can_revoke
     InitialSpeedChangeGroup:
       type: object
       required:
@@ -12761,6 +12749,7 @@ components:
       type: string
       enum:
       - infra
+      - rolling_stock
     RevokeBody:
       type: object
       required:
@@ -14674,6 +14663,22 @@ components:
         z:
           $ref: '#/components/schemas/Sign'
       additionalProperties: false
+    StandardGrant:
+      type: string
+      enum:
+      - READER
+      - WRITER
+      - OWNER
+    StandardPrivilege:
+      type: string
+      enum:
+      - can_read
+      - can_share_read
+      - can_write
+      - can_share_write
+      - can_delete
+      - can_share_ownership
+      - can_revoke
     StartTimeChangeGroup:
       type: object
       required:

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -6,6 +6,8 @@ use crate::authorizers::UserAuthorizer;
 use crate::authorizers::impossible;
 use crate::error::Result;
 use crate::views::Authentication;
+use crate::views::authz::resources::StandardGrant;
+use crate::views::authz::resources::StandardPrivilege;
 use ::authz;
 use ::authz::InfraGrant;
 use ::authz::InfraPrivilege;
@@ -39,6 +41,8 @@ use super::AuthenticationExt;
 use super::AuthorizationError;
 use super::AuthorizerError;
 
+mod resources;
+
 #[derive(Serialize, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Debug))]
 enum SubjectType {
@@ -52,6 +56,7 @@ enum SubjectType {
 #[cfg_attr(test, derive(Debug))]
 pub(in crate::views) enum ResourceType {
     Infra,
+    RollingStock,
 }
 
 #[derive(Debug, thiserror::Error, EditoastError)]
@@ -281,7 +286,7 @@ pub(in crate::views) async fn users_info(
 #[cfg_attr(test, derive(Deserialize, PartialEq, Eq))]
 pub(in crate::views) struct ResourcePrivileges {
     resource_id: i64,
-    privileges: HashSet<InfraPrivilege>,
+    privileges: HashSet<StandardPrivilege>,
 }
 
 #[editoast_derive::route]
@@ -327,8 +332,11 @@ pub(in crate::views) async fn user_privileges(
         .flatten();
     if let Some(user) = user {
         let infras = infra_ids.map(authz::Infra);
-        let protected_privileges =
-            infras.map(|infra| v2::infra_privileges(user, infra).zip(v2::Protected::value(infra)));
+        let protected_privileges = infras.map(|infra| {
+            v2::infra_privileges(user, infra)
+                .collect_into::<HashSet<StandardPrivilege>>()
+                .zip(v2::Protected::value(infra))
+        });
         let authorizer =
             crate::authorizers::UserAuthorizer::new(user, roles, regulator.openfga(), conn);
         let accesses = authorizer.authorize_all(protected_privileges).await?;
@@ -368,12 +376,12 @@ pub(in crate::views) async fn user_privileges(
         result_infras.extend(infras.into_iter().map(|infra| ResourcePrivileges {
             resource_id: infra.id,
             privileges: HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership,
             ]),
         }));
     }
@@ -385,7 +393,7 @@ pub(in crate::views) async fn user_privileges(
 #[cfg_attr(test, derive(Debug, Deserialize, PartialEq))]
 pub(in crate::views) struct UserResourceGrant {
     id: i64,
-    grant: InfraGrant,
+    grant: StandardGrant,
 }
 
 #[editoast_derive::route]
@@ -423,6 +431,7 @@ pub(in crate::views) async fn user_grants(
                 authz::Subject::user(user),
                 authz::Infra(*infra_id),
             )
+            .map_some_into::<StandardGrant>()
             .authorize(&authorizer)
             .await?;
             let grant = match grant_access.access().await? {
@@ -471,7 +480,7 @@ pub(in crate::views) struct SubjectGrant {
     id: i64,
     name: String,
     r#type: SubjectType,
-    grant: InfraGrant,
+    grant: StandardGrant,
 }
 
 #[editoast_derive::route]
@@ -527,6 +536,7 @@ pub(in crate::views) async fn my_grants_on_resource(
                     rejection => impossible!(rejection),
                 })?
         }
+        ResourceType::RollingStock => todo!(),
     };
 
     // NOTE: the same subject can appear in multiple lists. This can happen
@@ -600,7 +610,8 @@ pub(in crate::views) async fn my_grants_on_resource(
             };
             let grant = subjects_grant
                 .remove(&id)
-                .expect("subjects_id is a subset of subjects_grant keys by construction");
+                .expect("subjects_id is a subset of subjects_grant keys by construction")
+                .into();
             Some(SubjectGrant {
                 id,
                 name,
@@ -618,7 +629,7 @@ pub(in crate::views) struct GrantBody {
     resource_type: ResourceType,
     resource_id: i64,
     subject_id: i64,
-    grant: InfraGrant,
+    grant: StandardGrant,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -705,14 +716,18 @@ pub(in crate::views) async fn update_grants(
                         match &auth {
                             Authentication::Authenticated(authorizer) => {
                                 authorizer
-                                    .give_infra_grant(subject, &authz::Infra(resource_id), grant)
+                                    .give_infra_grant(
+                                        subject,
+                                        &authz::Infra(resource_id),
+                                        grant.into(),
+                                    )
                                     .await
                             }
                             Authentication::SkipAuthorization { .. } => regulator
                                 .give_infra_grant_unchecked(
                                     subject,
                                     &authz::Infra(resource_id),
-                                    grant,
+                                    grant.into(),
                                 )
                                 .await
                                 .map(Authorization::Granted),
@@ -722,6 +737,7 @@ pub(in crate::views) async fn update_grants(
                         }?
                         .allowed()?;
                     }
+                    ResourceType::RollingStock => todo!(),
                 }
             }
             Ok(StatusCode::CREATED)
@@ -754,6 +770,7 @@ pub(in crate::views) async fn update_grants(
                         }?
                         .allowed()?;
                     }
+                    ResourceType::RollingStock => todo!(),
                 }
             }
             Ok(StatusCode::NO_CONTENT)
@@ -841,26 +858,26 @@ mod tests {
         assert_eq!(
             privileges.remove(&infra1).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership,
             ])
         );
         assert_eq!(
             privileges.remove(&infra2).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
             ])
         );
         assert_eq!(
             privileges.remove(&infra3).unwrap(),
-            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead])
+            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead])
         );
         assert_eq!(privileges.remove(&infra4).unwrap(), HashSet::from([]));
         assert!(!privileges.contains_key(&infra_unused));
@@ -908,22 +925,22 @@ mod tests {
             .collect::<HashMap<_, _>>();
         assert_eq!(
             privileges.remove(&infra1).unwrap(),
-            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead])
+            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead])
         );
         assert_eq!(privileges.remove(&infra2).unwrap(), HashSet::from([]));
         assert_eq!(
             privileges.remove(&infra3).unwrap(),
-            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead,])
+            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead,])
         );
         assert_eq!(
             privileges.remove(&infra4).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership
             ])
         );
         assert!(!privileges.contains_key(&infra_unused));
@@ -953,12 +970,12 @@ mod tests {
         assert_eq!(
             privileges.remove(&infra).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership,
             ])
         );
     }
@@ -991,7 +1008,7 @@ mod tests {
             response.get(&ResourceType::Infra).unwrap(),
             &[UserResourceGrant {
                 id: infra.id,
-                grant: InfraGrant::Reader
+                grant: StandardGrant::Reader
             }]
         );
 
@@ -1018,7 +1035,7 @@ mod tests {
             response.get(&ResourceType::Infra).unwrap(),
             &[UserResourceGrant {
                 id: infra.id,
-                grant: InfraGrant::Writer
+                grant: StandardGrant::Writer
             }]
         );
     }
@@ -1106,11 +1123,11 @@ mod tests {
             .map(|SubjectGrant { id, grant, .. }| (id, grant))
             .collect::<HashMap<_, _>>();
 
-        assert_eq!(grants.get(&alice.id), Some(&InfraGrant::Writer)); // group grants can supersede direct user grants
-        assert_eq!(grants.get(&bob.id), Some(&InfraGrant::Owner)); // but do not override them
-        assert_eq!(grants.get(&tom.id), Some(&InfraGrant::Owner)); // direct user grant
-        assert_eq!(grants.get(&jerry.id), Some(&InfraGrant::Reader)); // likewise
-        assert_eq!(grants.get(&alice_and_bob.id), Some(&InfraGrant::Writer)); // group direct grant
+        assert_eq!(grants.get(&alice.id), Some(&StandardGrant::Writer)); // group grants can supersede direct user grants
+        assert_eq!(grants.get(&bob.id), Some(&StandardGrant::Owner)); // but do not override them
+        assert_eq!(grants.get(&tom.id), Some(&StandardGrant::Owner)); // direct user grant
+        assert_eq!(grants.get(&jerry.id), Some(&StandardGrant::Reader)); // likewise
+        assert_eq!(grants.get(&alice_and_bob.id), Some(&StandardGrant::Writer)); // group direct grant
         assert_eq!(grants.get(&tom_and_jerry.id), None); // no group grant (not even there in the response)
     }
 

--- a/editoast/src/views/authz/resources.rs
+++ b/editoast/src/views/authz/resources.rs
@@ -1,0 +1,92 @@
+use authz::InfraGrant;
+use authz::InfraPrivilege;
+use authz::RollingStockGrant;
+use authz::RollingStockPrivilege;
+use serde::Deserialize;
+use serde::Serialize;
+use strum::Display;
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub(super) enum StandardGrant {
+    Reader,
+    Writer,
+    Owner,
+}
+
+#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+#[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
+pub(super) enum StandardPrivilege {
+    CanRead,
+    CanShareRead,
+    CanWrite,
+    CanShareWrite,
+    CanDelete,
+    CanShareOwnership,
+    CanRevoke,
+}
+
+macro_rules! impl_standard_privilege_from_into {
+    ($ty:path) => {
+        impl From<$ty> for StandardPrivilege {
+            fn from(privilege: $ty) -> Self {
+                match privilege {
+                    <$ty>::CanRead => Self::CanRead,
+                    <$ty>::CanShareRead => Self::CanShareRead,
+                    <$ty>::CanWrite => Self::CanWrite,
+                    <$ty>::CanShareWrite => Self::CanShareWrite,
+                    <$ty>::CanDelete => Self::CanDelete,
+                    <$ty>::CanShareOwnership => Self::CanShareOwnership,
+                    <$ty>::CanRevoke => Self::CanRevoke,
+                }
+            }
+        }
+
+        impl From<StandardPrivilege> for $ty {
+            fn from(privilege: StandardPrivilege) -> Self {
+                match privilege {
+                    StandardPrivilege::CanRead => Self::CanRead,
+                    StandardPrivilege::CanShareRead => Self::CanShareRead,
+                    StandardPrivilege::CanWrite => Self::CanWrite,
+                    StandardPrivilege::CanShareWrite => Self::CanShareWrite,
+                    StandardPrivilege::CanDelete => Self::CanDelete,
+                    StandardPrivilege::CanShareOwnership => Self::CanShareOwnership,
+                    StandardPrivilege::CanRevoke => Self::CanRevoke,
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_standard_grant_from_into {
+    ($ty:path) => {
+        impl From<$ty> for StandardGrant {
+            fn from(grant: $ty) -> Self {
+                match grant {
+                    <$ty>::Reader => Self::Reader,
+                    <$ty>::Writer => Self::Writer,
+                    <$ty>::Owner => Self::Owner,
+                }
+            }
+        }
+
+        impl From<StandardGrant> for $ty {
+            fn from(grant: StandardGrant) -> Self {
+                match grant {
+                    StandardGrant::Reader => Self::Reader,
+                    StandardGrant::Writer => Self::Writer,
+                    StandardGrant::Owner => Self::Owner,
+                }
+            }
+        }
+    };
+}
+
+impl_standard_privilege_from_into!(RollingStockPrivilege);
+impl_standard_privilege_from_into!(InfraPrivilege);
+impl_standard_grant_from_into!(RollingStockGrant);
+impl_standard_grant_from_into!(InfraGrant);

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1603,7 +1603,7 @@ export type GetAuthzMeApiArg = void;
 export type PostAuthzMeGrantsApiResponse =
   /** status 200 Get grants info of the current user for the given resources in body */ {
     [key: string]: {
-      grant: InfraGrant;
+      grant: StandardGrant;
       id: number;
     }[];
   };
@@ -1622,7 +1622,7 @@ export type GetAuthzMeGroupsApiArg = void;
 export type PostAuthzMePrivilegesApiResponse =
   /** status 200 The privileges of the user sending the request over each requested resource. The resource is omitted if it does not exist. An empty privileges list is returned if the user has no privileges over it. */ {
     [key: string]: {
-      privileges: InfraPrivilege[];
+      privileges: StandardPrivilege[];
       resource_id: number;
     }[];
   };
@@ -1652,7 +1652,7 @@ export type PostAuthzUserInfoApiArg = {
 };
 export type GetAuthzByResourceTypeAndResourceIdApiResponse =
   /** status 200 Get list of user that have a grant on the resource */ {
-    grant: InfraGrant;
+    grant: StandardGrant;
     id: number;
     name: string;
     type: SubjectType;
@@ -2879,10 +2879,10 @@ export type PostWorkerLoadApiArg = {
     timetable_id?: number | null;
   };
 };
-export type InfraGrant = 'READER' | 'WRITER' | 'OWNER';
-export type ResourceType = 'infra';
+export type StandardGrant = 'READER' | 'WRITER' | 'OWNER';
+export type ResourceType = 'infra' | 'rolling_stock';
 export type GrantBody = {
-  grant: InfraGrant;
+  grant: StandardGrant;
   resource_id: number;
   resource_type: ResourceType;
   subject_id: number;
@@ -2893,7 +2893,7 @@ export type RevokeBody = {
   subject_id: number;
 };
 export type Role = 'Admin' | 'Stdcm' | 'OperationalStudies';
-export type InfraPrivilege =
+export type StandardPrivilege =
   | 'can_read'
   | 'can_share_read'
   | 'can_write'

--- a/front/src/common/authorization/hooks/useAuthz.tsx
+++ b/front/src/common/authorization/hooks/useAuthz.tsx
@@ -99,7 +99,19 @@ export default function useAuthz() {
    */
   const checkUserPrivileges = useCallback(
     async (resourceType: ResourceType, resourceId: number, privileges: Privilege[]) => {
-      const result = await getUserPrivileges({ [resourceType]: [resourceId] });
+      let infras: number[];
+      let rolling_stocks: number[];
+      switch (resourceType) {
+        case 'rolling_stock':
+          infras = [];
+          rolling_stocks = [resourceId];
+          break;
+        case 'infra':
+          infras = [resourceId];
+          rolling_stocks = [];
+          break;
+      }
+      const result = await getUserPrivileges({ infra: infras, rolling_stock: rolling_stocks });
       const userPrivileges = result[resourceType] ? result[resourceType][resourceId] : new Set();
       return privileges.every((privilege) => userPrivileges.has(privilege));
     },

--- a/front/src/common/authorization/types.ts
+++ b/front/src/common/authorization/types.ts
@@ -1,15 +1,15 @@
 import type {
   GetAuthzByResourceTypeAndResourceIdApiResponse,
-  InfraGrant,
-  InfraPrivilege,
+  StandardGrant,
+  StandardPrivilege,
   ResourceType as ResourceTypeApi,
 } from 'common/api/osrdEditoastApi';
 
 import type { SUBJECT_TYPES } from './consts';
 
 export type SubjectType = `${SUBJECT_TYPES}`;
-export type Grant = InfraGrant;
+export type Grant = StandardGrant;
 export type ResourceType = ResourceTypeApi;
 export type Subject = Omit<GetAuthzByResourceTypeAndResourceIdApiResponse[0], 'grant'>;
 export type SubjectWithGrant = Subject & { grant: Grant };
-export type Privilege = InfraPrivilege;
+export type Privilege = StandardPrivilege;

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
@@ -36,7 +36,10 @@ const InfraSelectorModalBodyEdition = ({
   // Get the user privileges for infras
   const { getUserPrivileges } = useAuthz();
   const userPrivilegesByInfraId = useAsyncMemo(async () => {
-    const data = await getUserPrivileges({ infra: infrasList.map((infra) => infra.id) });
+    const data = await getUserPrivileges({
+      rolling_stock: [],
+      infra: infrasList.map((infra) => infra.id),
+    });
     return data.infra || {};
     // redraw is in the deps to force the reload of the privileges when the user changes his own grant
   }, [getUserPrivileges, JSON.stringify(infrasList.map((infra) => infra.id))]);

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
@@ -57,7 +57,7 @@ const InfraSelectorModalBodyStandard = ({
 
   // Get the user privileges for infras
   const userPrivilegesByInfraId = useAsyncMemo(async () => {
-    const data = await getUserPrivileges({ infra: infraIdsList });
+    const data = await getUserPrivileges({ rolling_stock: [], infra: infraIdsList });
     return data.infra || {};
     // redraw is in the deps to force the reload of the privileges when the user changes his own grant
   }, [getUserPrivileges, infraIdsList, redraw]);

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -2458,25 +2458,9 @@ class InfraErrorTypeUnusedPort(BaseModel):
     port_name: str
 
 
-class InfraGrant(Enum):
-    READER = "READER"
-    WRITER = "WRITER"
-    OWNER = "OWNER"
-
-
 class InfraObjectElectrification(BaseModel):
     obj_type: Literal["Electrification"]
     railjson: Electrification
-
-
-class InfraPrivilege(Enum):
-    can_read = "can_read"
-    can_share_read = "can_share_read"
-    can_write = "can_write"
-    can_share_write = "can_share_write"
-    can_delete = "can_delete"
-    can_share_ownership = "can_share_ownership"
-    can_revoke = "can_revoke"
 
 
 class InitialSpeedChangeGroup(BaseModel):
@@ -2954,9 +2938,14 @@ class RequirementType(Enum):
     WORK_SCHEDULE = "WORK_SCHEDULE"
 
 
+class ResourceType(Enum):
+    infra = "infra"
+    rolling_stock = "rolling_stock"
+
+
 class RevokeBody(BaseModel):
     resource_id: int
-    resource_type: Literal["infra"]
+    resource_type: ResourceType
     subject_id: int
 
 
@@ -3503,6 +3492,22 @@ class SpeedSectionPslSncfExtension(BaseModel):
     announcement: list[Sign]
     r: list[Sign]
     z: Sign
+
+
+class StandardGrant(Enum):
+    READER = "READER"
+    WRITER = "WRITER"
+    OWNER = "OWNER"
+
+
+class StandardPrivilege(Enum):
+    can_read = "can_read"
+    can_share_read = "can_share_read"
+    can_write = "can_write"
+    can_share_write = "can_share_write"
+    can_delete = "can_delete"
+    can_share_ownership = "can_share_ownership"
+    can_revoke = "can_revoke"
 
 
 class StartTimeChangeGroup(BaseModel):
@@ -4699,9 +4704,9 @@ class GeoJsonPoint(RootModel[PointGeometry]):
 
 
 class GrantBody(BaseModel):
-    grant: InfraGrant
+    grant: StandardGrant
     resource_id: int
-    resource_type: Literal["infra"]
+    resource_type: ResourceType
     subject_id: int
 
 


### PR DESCRIPTION
Expose `StandardPrivilege` and `StandardGrant` instead of `InfraPrivilege` and `InfraGrant` to the Frontend