### PR TITLE
front: bump nge (several fixes)

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.22f20c436ffb1db903ac682ffa553641585317bb",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3599,9 +3599,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.22f20c436ffb1db903ac682ffa553641585317bb",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.22f20c436ffb1db903ac682ffa553641585317bb.tgz",
-      "integrity": "sha512-ePNpgo9q53apzqLoKqCXkPGY4uxD+CxGBYAE6LoSVyIE1ZN/wRd5eC/35/AeRlMZk6VdekTJ9w9N1JTYhkk9Sg=="
+      "version": "0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9.tgz",
+      "integrity": "sha512-a/G6ojtXHoQYoWtv9C78EsD8edvZohhNLDQuNNRWX+Ey2HRAhVETx9xmLVIAl7/txBhFbvnrAGlLb2Kjk3yA0w=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.22f20c436ffb1db903ac682ffa553641585317bb",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",


### PR DESCRIPTION
Retreive the 22 commits from "[chore(deps): bump nginxinc/nginx-unprivileged](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/b3f42cedfc97fd5bf38f4f647b14cc6fe87a6bf8)" to "[fix(service): missing initPortOrdering after trainrunSection deletion](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/00edded6e4ff5860e1b246602e32818043fb1e23)"

See commit history: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commits/main/

Close https://github.com/OpenRailAssociation/osrd/issues/15233