### PR TITLE
front: fix operational-point sort stability

### DIFF
--- a/front/src/common/Map/Search/__tests__/sortOperationalPoints.spec.ts
+++ b/front/src/common/Map/Search/__tests__/sortOperationalPoints.spec.ts
@@ -112,4 +112,10 @@ describe('sortOperationalPointsFromNameAndUicSearch', () => {
     const b = { ...baseOp, uic: 0, main_code: 'a' };
     expect(sortWithQuery(a, b)).toEqual(0);
   });
+
+  it('should not depend on argument order', () => {
+    const a = { ...baseOp, is_passenger_station: true, secondary_code: 'AA' };
+    const b = { ...baseOp, is_passenger_station: true, secondary_code: 'BB' };
+    expect(sortWithQuery(a, b)).toEqual(-sortWithQuery(b, a));
+  });
 });

--- a/front/src/common/Map/Search/sortOperationalPoints.ts
+++ b/front/src/common/Map/Search/sortOperationalPoints.ts
@@ -1,26 +1,17 @@
 import type { SearchResultItemOperationalPoint } from 'common/api/osrdEditoastApi';
 
-/** Sort two operational points alphabetically first by name, then by secondary code (prioritizing passenger station) */
+/**
+ * Sort two operational points alphabetically first by name, then by whether
+ * they are passenger stations (by putting passenger stations first), then by
+ * secondary code.
+ */
 const sortOperationalPointsByNameAndSecondaryCode = (
   a: SearchResultItemOperationalPoint,
   b: SearchResultItemOperationalPoint
-) => {
-  const nameComparison = a.name.localeCompare(b.name);
-  if (nameComparison !== 0) {
-    return nameComparison;
-  }
-
-  const secondaryCodeA = a.secondary_code ?? '';
-  const secondaryCodeB = b.secondary_code ?? '';
-
-  if (a.is_passenger_station) {
-    return -1;
-  }
-  if (b.is_passenger_station) {
-    return 1;
-  }
-  return secondaryCodeA.localeCompare(secondaryCodeB);
-};
+) =>
+  a.name.localeCompare(b.name) ||
+  Number(b.is_passenger_station) - Number(a.is_passenger_station) ||
+  (a.secondary_code ?? '').localeCompare(b.secondary_code ?? '');
 
 /** Sort two operational points alphabetically first by main code, then by name, then by secondary code (prioritizing passenger station) */
 export const sortOperationalPointsFromMainCodeSearch = (


### PR DESCRIPTION
Follows https://github.com/OpenRailAssociation/osrd/pull/16799#discussion_r3318490476

Before, if two operational points had the same name and both had main CH codes, sortOperationalPointsByNameAndCh would return contradicting results, e.g. A < B and B < A depending on the order of the arguments.

- [x] add tests in `front/src/common/Map/Search/__tests__/sortOperationalPoints.spec.ts`
- [ ] ~~add a repro in the description?~~ feel free to ask but it doesn't look easy