### PR TITLE
editoast: introduce standard grants and rolling stock resource type in `views/authz` endpoints

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -106,6 +106,7 @@ paths:
                 type: string
                 enum:
                 - infra
+                - rolling_stock
         required: true
       responses:
         '200':
@@ -131,6 +132,7 @@ paths:
                   type: string
                   enum:
                   - infra
+                  - rolling_stock
   /authz/me/groups:
     get:
       tags:
@@ -172,6 +174,7 @@ paths:
                 type: string
                 enum:
                 - infra
+                - rolling_stock
         required: true
       responses:
         '200':
@@ -200,6 +203,7 @@ paths:
                   type: string
                   enum:
                   - infra
+                  - rolling_stock
   /authz/user/info:
     post:
       tags:
@@ -12682,6 +12686,7 @@ components:
       type: string
       enum:
       - infra
+      - rolling_stock
     RevokeBody:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -124,7 +124,7 @@ paths:
                     - grant
                     properties:
                       grant:
-                        $ref: '#/components/schemas/InfraGrant'
+                        $ref: '#/components/schemas/StandardGrant'
                       id:
                         type: integer
                         format: int64
@@ -194,7 +194,7 @@ paths:
                       privileges:
                         type: array
                         items:
-                          $ref: '#/components/schemas/InfraPrivilege'
+                          $ref: '#/components/schemas/StandardPrivilege'
                         uniqueItems: true
                       resource_id:
                         type: integer
@@ -299,14 +299,17 @@ paths:
                   - name
                   - type
                   - grant
+                  - resource_type
                   properties:
                     grant:
-                      $ref: '#/components/schemas/InfraGrant'
+                      $ref: '#/components/schemas/StandardGrant'
                     id:
                       type: integer
                       format: int64
                     name:
                       type: string
+                    resource_type:
+                      $ref: '#/components/schemas/ResourceType'
                     type:
                       $ref: '#/components/schemas/SubjectType'
   /catalog_entries:
@@ -10330,7 +10333,7 @@ components:
       - grant
       properties:
         grant:
-          $ref: '#/components/schemas/InfraGrant'
+          $ref: '#/components/schemas/StandardGrant'
         resource_id:
           type: integer
           format: int64
@@ -10599,12 +10602,6 @@ components:
             - unused_port
           port_name:
             type: string
-    InfraGrant:
-      type: string
-      enum:
-      - READER
-      - WRITER
-      - OWNER
     InfraObject:
       oneOf:
       - type: object
@@ -10774,15 +10771,6 @@ components:
           $ref: '#/components/schemas/PathfindingTrackLocationInput'
         starting:
           $ref: '#/components/schemas/PathfindingTrackLocationInput'
-    InfraPrivilege:
-      type: string
-      enum:
-      - can_read
-      - can_share_read
-      - can_write
-      - can_share_write
-      - can_delete
-      - can_share_ownership
     InitialSpeedChangeGroup:
       type: object
       required:
@@ -14597,6 +14585,21 @@ components:
         z:
           $ref: '#/components/schemas/Sign'
       additionalProperties: false
+    StandardGrant:
+      type: string
+      enum:
+      - READER
+      - WRITER
+      - OWNER
+    StandardPrivilege:
+      type: string
+      enum:
+      - can_read
+      - can_share_read
+      - can_write
+      - can_share_write
+      - can_delete
+      - can_share_ownership
     StartTimeChangeGroup:
       type: object
       required:

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -28,7 +28,11 @@ mod version;
 pub mod work_schedules;
 mod worker_load;
 
+use serde::Deserialize;
+use serde::Serialize;
 pub use server::*;
+use strum::Display;
+use utoipa::ToSchema;
 
 #[cfg(test)]
 mod test_app;
@@ -462,6 +466,112 @@ pub enum Authentication {
         identity: Option<String>,
         name: Option<String>,
     },
+}
+
+#[derive(
+    Debug,
+    Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    ToSchema,
+)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+enum StandardGrant {
+    Reader,
+    Writer,
+    Owner,
+}
+
+#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+#[allow(clippy::enum_variant_names)]
+enum StandardPrivilege {
+    CanRead,
+    CanShareRead,
+    CanWrite,
+    CanShareWrite,
+    CanDelete,
+    CanShareOwnership,
+}
+
+impl From<::authz::InfraGrant> for StandardGrant {
+    fn from(value: ::authz::InfraGrant) -> Self {
+        match value {
+            ::authz::InfraGrant::Reader => StandardGrant::Reader,
+            ::authz::InfraGrant::Writer => StandardGrant::Writer,
+            ::authz::InfraGrant::Owner => StandardGrant::Owner,
+        }
+    }
+}
+
+impl From<::authz::RollingStockGrant> for StandardGrant {
+    fn from(value: ::authz::RollingStockGrant) -> Self {
+        match value {
+            ::authz::RollingStockGrant::Reader => StandardGrant::Reader,
+            ::authz::RollingStockGrant::Writer => StandardGrant::Writer,
+            ::authz::RollingStockGrant::Owner => StandardGrant::Owner,
+        }
+    }
+}
+
+impl From<::authz::InfraPrivilege> for StandardPrivilege {
+    fn from(value: ::authz::InfraPrivilege) -> Self {
+        match value {
+            ::authz::InfraPrivilege::CanRead => StandardPrivilege::CanRead,
+            ::authz::InfraPrivilege::CanShareRead => StandardPrivilege::CanShareRead,
+            ::authz::InfraPrivilege::CanWrite => StandardPrivilege::CanWrite,
+            ::authz::InfraPrivilege::CanShareWrite => StandardPrivilege::CanShareWrite,
+            ::authz::InfraPrivilege::CanDelete => StandardPrivilege::CanDelete,
+            ::authz::InfraPrivilege::CanShareOwnership => StandardPrivilege::CanShareOwnership,
+        }
+    }
+}
+
+impl From<StandardGrant> for ::authz::InfraGrant {
+    fn from(value: StandardGrant) -> Self {
+        match value {
+            StandardGrant::Reader => ::authz::InfraGrant::Reader,
+            StandardGrant::Writer => ::authz::InfraGrant::Writer,
+            StandardGrant::Owner => ::authz::InfraGrant::Owner,
+        }
+    }
+}
+
+impl From<StandardPrivilege> for ::authz::InfraPrivilege {
+    fn from(value: StandardPrivilege) -> Self {
+        match value {
+            StandardPrivilege::CanRead => ::authz::InfraPrivilege::CanRead,
+            StandardPrivilege::CanShareRead => ::authz::InfraPrivilege::CanShareRead,
+            StandardPrivilege::CanWrite => ::authz::InfraPrivilege::CanWrite,
+            StandardPrivilege::CanShareWrite => ::authz::InfraPrivilege::CanShareWrite,
+            StandardPrivilege::CanDelete => ::authz::InfraPrivilege::CanDelete,
+            StandardPrivilege::CanShareOwnership => ::authz::InfraPrivilege::CanShareOwnership,
+        }
+    }
+}
+
+impl From<::authz::RollingStockPrivilege> for StandardPrivilege {
+    fn from(value: ::authz::RollingStockPrivilege) -> Self {
+        match value {
+            ::authz::RollingStockPrivilege::CanRead => StandardPrivilege::CanRead,
+            ::authz::RollingStockPrivilege::CanShareRead => StandardPrivilege::CanShareRead,
+            ::authz::RollingStockPrivilege::CanWrite => StandardPrivilege::CanWrite,
+            ::authz::RollingStockPrivilege::CanShareWrite => StandardPrivilege::CanShareWrite,
+            ::authz::RollingStockPrivilege::CanDelete => StandardPrivilege::CanDelete,
+            ::authz::RollingStockPrivilege::CanShareOwnership => {
+                StandardPrivilege::CanShareOwnership
+            }
+        }
+    }
 }
 
 impl Authentication {

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -52,6 +52,7 @@ enum SubjectType {
 #[cfg_attr(test, derive(Debug))]
 pub(in crate::views) enum ResourceType {
     Infra,
+    RollingStock,
 }
 
 #[derive(Debug, thiserror::Error, EditoastError)]
@@ -526,7 +527,8 @@ pub(in crate::views) async fn my_grants_on_resource(
                     },
                     rejection => impossible!(rejection),
                 })?
-        }
+        },
+        ResourceType::RollingStock => todo!(),
     };
 
     // NOTE: the same subject can appear in multiple lists. This can happen
@@ -722,6 +724,7 @@ pub(in crate::views) async fn update_grants(
                         }?
                         .allowed()?;
                     }
+                    ResourceType::RollingStock => todo!(),
                 }
             }
             Ok(StatusCode::CREATED)
@@ -754,6 +757,7 @@ pub(in crate::views) async fn update_grants(
                         }?
                         .allowed()?;
                     }
+                    ResourceType::RollingStock => todo!(),
                 }
             }
             Ok(StatusCode::NO_CONTENT)

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -6,6 +6,8 @@ use crate::authorizers::UserAuthorizer;
 use crate::authorizers::impossible;
 use crate::error::Result;
 use crate::views::Authentication;
+use crate::views::StandardGrant;
+use crate::views::StandardPrivilege;
 use ::authz;
 use ::authz::InfraGrant;
 use ::authz::InfraPrivilege;
@@ -282,7 +284,7 @@ pub(in crate::views) async fn users_info(
 #[cfg_attr(test, derive(Deserialize, PartialEq, Eq))]
 pub(in crate::views) struct ResourcePrivileges {
     resource_id: i64,
-    privileges: HashSet<InfraPrivilege>,
+    privileges: HashSet<StandardPrivilege>,
 }
 
 #[editoast_derive::route]
@@ -336,6 +338,10 @@ pub(in crate::views) async fn user_privileges(
         for access in v2::Access::access_all(accesses).await? {
             match access {
                 Ok((privileges, infra)) => {
+                    let privileges = privileges
+                        .into_iter()
+                        .map(StandardPrivilege::from)
+                        .collect::<HashSet<_>>();
                     result_infras.push(ResourcePrivileges {
                         resource_id: *infra,
                         privileges,
@@ -369,12 +375,12 @@ pub(in crate::views) async fn user_privileges(
         result_infras.extend(infras.into_iter().map(|infra| ResourcePrivileges {
             resource_id: infra.id,
             privileges: HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership,
             ]),
         }));
     }
@@ -386,7 +392,7 @@ pub(in crate::views) async fn user_privileges(
 #[cfg_attr(test, derive(Debug, Deserialize, PartialEq))]
 pub(in crate::views) struct UserResourceGrant {
     id: i64,
-    grant: InfraGrant,
+    grant: StandardGrant,
 }
 
 #[editoast_derive::route]
@@ -442,7 +448,8 @@ pub(in crate::views) async fn user_grants(
                     unreachable!("{subject} exists or race condition")
                 }
                 Err(check) => impossible!(check),
-            };
+            }
+            .into();
             response
                 .entry(ResourceType::Infra)
                 .or_default()
@@ -472,7 +479,8 @@ pub(in crate::views) struct SubjectGrant {
     id: i64,
     name: String,
     r#type: SubjectType,
-    grant: InfraGrant,
+    grant: StandardGrant,
+    resource_type: ResourceType,
 }
 
 #[editoast_derive::route]
@@ -527,7 +535,7 @@ pub(in crate::views) async fn my_grants_on_resource(
                     },
                     rejection => impossible!(rejection),
                 })?
-        },
+        }
         ResourceType::RollingStock => todo!(),
     };
 
@@ -539,9 +547,9 @@ pub(in crate::views) async fn my_grants_on_resource(
     // is important to ensure the higher grant is kept in case of duplicates (last item wins).
     let mut subjects_grant = readers
         .into_iter()
-        .map(|s| (s, InfraGrant::Reader))
-        .chain(writers.into_iter().map(|s| (s, InfraGrant::Writer)))
-        .chain(owners.into_iter().map(|s| (s, InfraGrant::Owner)))
+        .map(|s| (s, StandardGrant::Reader))
+        .chain(writers.into_iter().map(|s| (s, StandardGrant::Writer)))
+        .chain(owners.into_iter().map(|s| (s, StandardGrant::Owner)))
         .map(|(subject, grant)| match subject {
             authz::Subject::User(authz::User(id)) => (id, grant),
             authz::Subject::Group(authz::Group(id)) => (id, grant),
@@ -608,6 +616,7 @@ pub(in crate::views) async fn my_grants_on_resource(
                 name,
                 r#type,
                 grant,
+                resource_type,
             })
         })
         .collect_vec();
@@ -620,7 +629,7 @@ pub(in crate::views) struct GrantBody {
     resource_type: ResourceType,
     resource_id: i64,
     subject_id: i64,
-    grant: InfraGrant,
+    grant: StandardGrant,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -699,6 +708,7 @@ pub(in crate::views) async fn update_grants(
                 grant,
             } in grants
             {
+                let grant: InfraGrant = grant.into();
                 let subject = subjects
                     .get(&subject_id)
                     .ok_or_else(|| AuthzError::UnknownSubject { subject_id })?;
@@ -845,26 +855,26 @@ mod tests {
         assert_eq!(
             privileges.remove(&infra1).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership,
             ])
         );
         assert_eq!(
             privileges.remove(&infra2).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
             ])
         );
         assert_eq!(
             privileges.remove(&infra3).unwrap(),
-            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead])
+            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead])
         );
         assert_eq!(privileges.remove(&infra4).unwrap(), HashSet::from([]));
         assert!(!privileges.contains_key(&infra_unused));
@@ -912,22 +922,22 @@ mod tests {
             .collect::<HashMap<_, _>>();
         assert_eq!(
             privileges.remove(&infra1).unwrap(),
-            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead])
+            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead])
         );
         assert_eq!(privileges.remove(&infra2).unwrap(), HashSet::from([]));
         assert_eq!(
             privileges.remove(&infra3).unwrap(),
-            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead,])
+            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead,])
         );
         assert_eq!(
             privileges.remove(&infra4).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership
             ])
         );
         assert!(!privileges.contains_key(&infra_unused));
@@ -957,12 +967,12 @@ mod tests {
         assert_eq!(
             privileges.remove(&infra).unwrap(),
             HashSet::from([
-                InfraPrivilege::CanRead,
-                InfraPrivilege::CanShareRead,
-                InfraPrivilege::CanWrite,
-                InfraPrivilege::CanShareWrite,
-                InfraPrivilege::CanDelete,
-                InfraPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+                StandardPrivilege::CanWrite,
+                StandardPrivilege::CanShareWrite,
+                StandardPrivilege::CanDelete,
+                StandardPrivilege::CanShareOwnership,
             ])
         );
     }
@@ -995,7 +1005,7 @@ mod tests {
             response.get(&ResourceType::Infra).unwrap(),
             &[UserResourceGrant {
                 id: infra.id,
-                grant: InfraGrant::Reader
+                grant: StandardGrant::Reader
             }]
         );
 
@@ -1022,7 +1032,7 @@ mod tests {
             response.get(&ResourceType::Infra).unwrap(),
             &[UserResourceGrant {
                 id: infra.id,
-                grant: InfraGrant::Writer
+                grant: StandardGrant::Writer
             }]
         );
     }
@@ -1110,11 +1120,11 @@ mod tests {
             .map(|SubjectGrant { id, grant, .. }| (id, grant))
             .collect::<HashMap<_, _>>();
 
-        assert_eq!(grants.get(&alice.id), Some(&InfraGrant::Writer)); // group grants can supersede direct user grants
-        assert_eq!(grants.get(&bob.id), Some(&InfraGrant::Owner)); // but do not override them
-        assert_eq!(grants.get(&tom.id), Some(&InfraGrant::Owner)); // direct user grant
-        assert_eq!(grants.get(&jerry.id), Some(&InfraGrant::Reader)); // likewise
-        assert_eq!(grants.get(&alice_and_bob.id), Some(&InfraGrant::Writer)); // group direct grant
+        assert_eq!(grants.get(&alice.id), Some(&StandardGrant::Writer)); // group grants can supersede direct user grants
+        assert_eq!(grants.get(&bob.id), Some(&StandardGrant::Owner)); // but do not override them
+        assert_eq!(grants.get(&tom.id), Some(&StandardGrant::Owner)); // direct user grant
+        assert_eq!(grants.get(&jerry.id), Some(&StandardGrant::Reader)); // likewise
+        assert_eq!(grants.get(&alice_and_bob.id), Some(&StandardGrant::Writer)); // group direct grant
         assert_eq!(grants.get(&tom_and_jerry.id), None); // no group grant (not even there in the response)
     }
 
@@ -1142,7 +1152,7 @@ mod tests {
                     "subject_id": *writer,
                     "resource_type": ResourceType::Infra,
                     "resource_id": *infra,
-                    "grant": InfraGrant::Writer
+                    "grant": StandardGrant::Writer
                 }
             ]
         }));
@@ -1202,13 +1212,13 @@ mod tests {
                     "subject_id": *alice_and_bob,
                     "resource_type": ResourceType::Infra,
                     "resource_id": *infra,
-                    "grant": InfraGrant::Writer
+                    "grant": StandardGrant::Writer
                 },
                 {
                     "subject_id": *bob,
                     "resource_type": ResourceType::Infra,
                     "resource_id": *infra,
-                    "grant": InfraGrant::Reader
+                    "grant": StandardGrant::Reader
                 }
             ]
         })))
@@ -1269,7 +1279,7 @@ mod tests {
                     "subject_id": user.id,
                     "resource_type": ResourceType::Infra,
                     "resource_id": infra.id,
-                    "grant": InfraGrant::Owner
+                    "grant": StandardGrant::Owner
                 }
             ]
         }));
@@ -1298,7 +1308,7 @@ mod tests {
                     "subject_id": *user,
                     "resource_type": ResourceType::Infra,
                     "resource_id": *infra,
-                    "grant": InfraGrant::Owner
+                    "grant": StandardGrant::Owner
                 }
             ]
         }));

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1592,7 +1592,7 @@ export type GetAuthzMeApiArg = void;
 export type PostAuthzMeGrantsApiResponse =
   /** status 200 Get grants info of the current user for the given resources in body */ {
     [key: string]: {
-      grant: InfraGrant;
+      grant: StandardGrant;
       id: number;
     }[];
   };
@@ -1611,7 +1611,7 @@ export type GetAuthzMeGroupsApiArg = void;
 export type PostAuthzMePrivilegesApiResponse =
   /** status 200 The privileges of the user sending the request over each requested resource. The resource is omitted if it does not exist. An empty privileges list is returned if the user has no privileges over it. */ {
     [key: string]: {
-      privileges: InfraPrivilege[];
+      privileges: StandardPrivilege[];
       resource_id: number;
     }[];
   };
@@ -1641,9 +1641,10 @@ export type PostAuthzUserInfoApiArg = {
 };
 export type GetAuthzByResourceTypeAndResourceIdApiResponse =
   /** status 200 Get list of user that have a grant on the resource */ {
-    grant: InfraGrant;
+    grant: StandardGrant;
     id: number;
     name: string;
+    resource_type: ResourceType;
     type: SubjectType;
   }[];
 export type GetAuthzByResourceTypeAndResourceIdApiArg = {
@@ -2852,10 +2853,10 @@ export type PostWorkerLoadApiArg = {
     timetable_id?: number | null;
   };
 };
-export type InfraGrant = 'READER' | 'WRITER' | 'OWNER';
+export type StandardGrant = 'READER' | 'WRITER' | 'OWNER';
 export type ResourceType = 'infra' | 'rolling_stock';
 export type GrantBody = {
-  grant: InfraGrant;
+  grant: StandardGrant;
   resource_id: number;
   resource_type: ResourceType;
   subject_id: number;
@@ -2866,7 +2867,7 @@ export type RevokeBody = {
   subject_id: number;
 };
 export type Role = 'Admin' | 'Stdcm' | 'OperationalStudies';
-export type InfraPrivilege =
+export type StandardPrivilege =
   | 'can_read'
   | 'can_share_read'
   | 'can_write'

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2853,7 +2853,7 @@ export type PostWorkerLoadApiArg = {
   };
 };
 export type InfraGrant = 'READER' | 'WRITER' | 'OWNER';
-export type ResourceType = 'infra';
+export type ResourceType = 'infra' | 'rolling_stock';
 export type GrantBody = {
   grant: InfraGrant;
   resource_id: number;

--- a/front/src/common/authorization/hooks/useAuthz.tsx
+++ b/front/src/common/authorization/hooks/useAuthz.tsx
@@ -99,7 +99,19 @@ export default function useAuthz() {
    */
   const checkUserPrivileges = useCallback(
     async (resourceType: ResourceType, resourceId: number, privileges: Privilege[]) => {
-      const result = await getUserPrivileges({ [resourceType]: [resourceId] });
+      let infras: number[];
+      let rolling_stocks: number[];
+      switch (resourceType) {
+        case 'rolling_stock':
+          infras = [];
+          rolling_stocks = [resourceId];
+          break;
+        case 'infra':
+          infras = [resourceId];
+          rolling_stocks = [];
+          break;
+      }
+      const result = await getUserPrivileges({ infra: infras, rolling_stock: rolling_stocks });
       const userPrivileges = result[resourceType] ? result[resourceType][resourceId] : new Set();
       return privileges.every((privilege) => userPrivileges.has(privilege));
     },

--- a/front/src/common/authorization/types.ts
+++ b/front/src/common/authorization/types.ts
@@ -1,15 +1,15 @@
 import type {
   GetAuthzByResourceTypeAndResourceIdApiResponse,
-  InfraGrant,
-  InfraPrivilege,
+  StandardGrant,
+  StandardPrivilege,
   ResourceType as ResourceTypeApi,
 } from 'common/api/osrdEditoastApi';
 
 import type { SUBJECT_TYPES } from './consts';
 
 export type SubjectType = `${SUBJECT_TYPES}`;
-export type Grant = InfraGrant;
+export type Grant = StandardGrant;
 export type ResourceType = ResourceTypeApi;
 export type Subject = Omit<GetAuthzByResourceTypeAndResourceIdApiResponse[0], 'grant'>;
 export type SubjectWithGrant = Subject & { grant: Grant };
-export type Privilege = InfraPrivilege;
+export type Privilege = StandardPrivilege;

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
@@ -36,7 +36,10 @@ const InfraSelectorModalBodyEdition = ({
   // Get the user privileges for infras
   const { getUserPrivileges } = useAuthz();
   const userPrivilegesByInfraId = useAsyncMemo(async () => {
-    const data = await getUserPrivileges({ infra: infrasList.map((infra) => infra.id) });
+    const data = await getUserPrivileges({
+      rolling_stock: [],
+      infra: infrasList.map((infra) => infra.id),
+    });
     return data.infra || {};
     // redraw is in the deps to force the reload of the privileges when the user changes his own grant
   }, [getUserPrivileges, JSON.stringify(infrasList.map((infra) => infra.id))]);

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
@@ -57,7 +57,7 @@ const InfraSelectorModalBodyStandard = ({
 
   // Get the user privileges for infras
   const userPrivilegesByInfraId = useAsyncMemo(async () => {
-    const data = await getUserPrivileges({ infra: infraIdsList });
+    const data = await getUserPrivileges({ rolling_stock: [], infra: infraIdsList });
     return data.infra || {};
     // redraw is in the deps to force the reload of the privileges when the user changes his own grant
   }, [getUserPrivileges, infraIdsList, redraw]);

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -2944,9 +2944,14 @@ class RequirementType(Enum):
     WORK_SCHEDULE = "WORK_SCHEDULE"
 
 
+class ResourceType(Enum):
+    infra = "infra"
+    rolling_stock = "rolling_stock"
+
+
 class RevokeBody(BaseModel):
     resource_id: int
-    resource_type: Literal["infra"]
+    resource_type: ResourceType
     subject_id: int
 
 
@@ -4667,7 +4672,7 @@ class GeoJsonPoint(RootModel[PointGeometry]):
 class GrantBody(BaseModel):
     grant: InfraGrant
     resource_id: int
-    resource_type: Literal["infra"]
+    resource_type: ResourceType
     subject_id: int
 
 

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -2449,24 +2449,9 @@ class InfraErrorTypeUnusedPort(BaseModel):
     port_name: str
 
 
-class InfraGrant(Enum):
-    READER = "READER"
-    WRITER = "WRITER"
-    OWNER = "OWNER"
-
-
 class InfraObjectElectrification(BaseModel):
     obj_type: Literal["Electrification"]
     railjson: Electrification
-
-
-class InfraPrivilege(Enum):
-    can_read = "can_read"
-    can_share_read = "can_share_read"
-    can_write = "can_write"
-    can_share_write = "can_share_write"
-    can_delete = "can_delete"
-    can_share_ownership = "can_share_ownership"
 
 
 class InitialSpeedChangeGroup(BaseModel):
@@ -3498,6 +3483,21 @@ class SpeedSectionPslSncfExtension(BaseModel):
     announcement: list[Sign]
     r: list[Sign]
     z: Sign
+
+
+class StandardGrant(Enum):
+    READER = "READER"
+    WRITER = "WRITER"
+    OWNER = "OWNER"
+
+
+class StandardPrivilege(Enum):
+    can_read = "can_read"
+    can_share_read = "can_share_read"
+    can_write = "can_write"
+    can_share_write = "can_share_write"
+    can_delete = "can_delete"
+    can_share_ownership = "can_share_ownership"
 
 
 class StartTimeChangeGroup(BaseModel):
@@ -4670,7 +4670,7 @@ class GeoJsonPoint(RootModel[PointGeometry]):
 
 
 class GrantBody(BaseModel):
-    grant: InfraGrant
+    grant: StandardGrant
     resource_id: int
     resource_type: ResourceType
     subject_id: int


### PR DESCRIPTION
This a small PR in preparation of handling rolling stock grants and privileges in the different endpoints.
- The first commit adds a new `RollingStock` variant to the resource types expected / returned by the authz endpoints.
- The second commit returns `StandardGrant`s instead of `InfraGrant`s in the authz endpoints (follow-up on this discussion: https://github.com/OpenRailAssociation/osrd/pull/16905#discussion_r3318371497)

