### PR TITLE
python: move remaining schemas to `osrd_schemas_auto`

### DIFF
--- a/osrd_schemas_auto/osrd_schemas_auto/external_generated_inputs.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/external_generated_inputs.py
@@ -1,0 +1,34 @@
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+from .infra import TrackRange
+
+
+class ElectricalProfile(BaseModel):
+    """This class is used to model the power loss along a electrification (thus along ranges of track sections).
+    There should be one value per power class, on every electrified track."""
+
+    value: str = Field(description="Category of power loss along the range")
+    power_class: str = Field(
+        description="Category of rolling stock power usage this profile applies to"
+    )
+    track_ranges: List[TrackRange] = Field(
+        description="List of locations where this profile is applied"
+    )
+
+
+class ElectricalProfileSet(BaseModel):
+    """This class is used to represent a set of electrical profiles, to use in simulation along an infrastructure."""
+
+    levels: List[ElectricalProfile] = Field(
+        description="The list of electrical profiles"
+    )
+    level_order: Dict[str, List[str]] = Field(
+        description="""A mapping from electrification modes to the electrical profile levels
+                    in decreasing order of magnitude"""
+    )
+
+
+if __name__ == "__main__":
+    print(ElectricalProfileSet.schema_json(indent=4))

--- a/osrd_schemas_auto/osrd_schemas_auto/infra.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/infra.py
@@ -1,0 +1,795 @@
+from enum import Enum
+from itertools import product
+from typing import Annotated, List, Literal, Mapping, Optional, Type, Union, get_args
+
+from geojson_pydantic import LineString
+from pydantic import BaseModel, Field, StringConstraints, create_model, model_validator
+from pydantic.fields import FieldInfo
+
+from .models import Endpoint
+
+ALL_OBJECT_TYPES = []
+
+RAILJSON_INFRA_VERSION_TYPE = Literal["3.5.2"]
+RAILJSON_INFRA_VERSION = get_args(RAILJSON_INFRA_VERSION_TYPE)[0]
+
+# Traits
+# Used as an input model in the definition of the following classes.
+
+Identifier = Annotated[str, StringConstraints(min_length=1, max_length=255)]
+NonBlankStr = Annotated[str, StringConstraints(min_length=1)]
+
+
+class DetectorReference(BaseModel):
+    type: Literal["Detector"] = "Detector"
+    id: Identifier = Field(description="Identifier of the detector")
+
+
+class BufferStopReference(BaseModel):
+    type: Literal["BufferStop"] = "BufferStop"
+    id: Identifier = Field(description="Identifier of the buffer stop")
+
+
+Waypoint = Annotated[
+    Union[DetectorReference, BufferStopReference], Field(discriminator="type")
+]
+
+
+class TrackLocationTrait(BaseModel):
+    """
+    This class is used to define objects that associated as point on the infrastructure.
+    """
+
+    track: Identifier = Field(
+        description="Reference to the track section on which the object is located"
+    )
+    position: float = Field(
+        description="Offset of the point in meters to the beginning of the track section",
+        ge=0,
+    )
+
+
+class BaseObjectTrait(BaseModel):
+    """
+    This class is used to define and identify objects that associated on the infrastructure.
+    """
+
+    id: Identifier = Field(description="Unique identifier of the object")
+
+
+class GeometryLineTrait(BaseModel):
+    """
+    This trait defines a geometric object of continuous line type.
+    """
+
+    geo: LineString = Field(
+        description="Geographic coordinates of the corresponding object"
+    )
+
+
+# Objects and utils used to generate an infra json.
+
+
+class Direction(str, Enum):
+    """
+    This is the description of the direction (increasing or decreasing profile).
+    """
+
+    START_TO_STOP = "START_TO_STOP"
+    STOP_TO_START = "STOP_TO_START"
+
+
+class ApplicableDirections(str, Enum):
+    """
+    This is used to know the direction of application of certain objects
+    """
+
+    START_TO_STOP = "START_TO_STOP"
+    STOP_TO_START = "STOP_TO_START"
+    BOTH = "BOTH"
+
+
+class Side(str, Enum):
+    """
+    This class describes the side of the track where the signal is located.
+    """
+
+    LEFT = "LEFT"
+    RIGHT = "RIGHT"
+    CENTER = "CENTER"
+
+
+class LoadingGaugeType(str, Enum):
+    """
+    This class allows to know the category of the loading gauge.
+    """
+
+    G1 = "G1"
+    G2 = "G2"
+    GA = "GA"
+    GB = "GB"
+    GB1 = "GB1"
+    GC = "GC"
+    FR3_3 = "FR3.3"
+    FR3_3_GB_G2 = "FR3.3/GB/G2"
+    GLOTT = "GLOTT"
+
+
+class TrackRange(BaseModel):
+    """
+    This class is used to define track ranges that are associated with certain classes in the infrastructure.
+    """
+
+    track: Identifier = Field(description="Identifier of the track section")
+    begin: float = Field(
+        description="Begin offset in meters of the corresponding track section", ge=0
+    )
+    end: float = Field(
+        description="End offset in meters of the corresponding track section", ge=0
+    )
+
+    @model_validator(mode="after")
+    def check_range(self):
+        assert self.begin <= self.end, "expected: begin <= end"
+        return self
+
+    def length(self) -> float:
+        return abs(self.begin - self.end)
+
+    def overlaps(self, other: "TrackRange") -> bool:
+        """
+        Returns true if the two track ranges overlap.
+        """
+        return (
+            self.track == other.track
+            and self.begin < other.end
+            and other.begin < self.end
+        )
+
+
+class DirectionalTrackRange(TrackRange):
+    """
+    A directional track range is a track range with an associated direction.
+    """
+
+    direction: Direction = Field(description="Description of the direction")
+
+    @staticmethod
+    def make(track, begin, end) -> "DirectionalTrackRange":
+        """
+        This function return the directional track range.
+        It allows to generate the meaning according to the begin and end attributes.
+        """
+        return DirectionalTrackRange(
+            track=track,
+            begin=min(begin, end),
+            end=max(begin, end),
+            direction=Direction.START_TO_STOP
+            if begin < end
+            else Direction.STOP_TO_START,
+        )
+
+    def get_begin(self) -> float:
+        """
+        This function return the begin offset of the track range taking into account the direction.
+        The returned value can be greatest than get_end().
+        """
+        return self.begin if self.direction == Direction.START_TO_STOP else self.end
+
+    def get_end(self) -> float:
+        """
+        This function return the end offset of the track range taking into account the direction.
+        The returned value can be smaller than get_begin().
+        """
+        return self.end if self.direction == Direction.START_TO_STOP else self.begin
+
+
+class ApplicableDirectionsTrackRange(TrackRange):
+    """
+    An applicable directions track range is a track range with associated directions.
+    """
+
+    applicable_directions: ApplicableDirections = Field(
+        description="Direction where the corresponding object is applied"
+    )
+
+    @model_validator(mode="after")
+    def check_range(self):
+        assert self.begin < self.end, "expected: begin < end"
+        return self
+
+
+class OperationalPointPart(TrackLocationTrait):
+    """
+    Operational point part is a single point on the infrastructure. It's linked to an operational point.
+    """
+
+    local_track_name: NonBlankStr = Field(
+        description="Local track name for this operational point part"
+    )
+
+
+class OperationalPoint(BaseObjectTrait):
+    """
+    This class describes the operational points of the corresponding infra.
+    """
+
+    parts: List[OperationalPointPart]
+    weight: Optional[int] = Field(
+        description="represents the significance of a PR", ge=0, default=None
+    )
+    plc: Optional[NonBlankStr] = Field(
+        description="Primary Location Code : https://rne.eu/it/products/ccs/crd/"
+    )
+
+
+class LevelCrossingPart(TrackLocationTrait):
+    """
+    Level crossing part is a single point on the infrastructure.
+    It holds information about pedal offsets relative to this point.
+    It's linked to a level crossing.
+    """
+
+    pedal_upstream: int = Field(
+        description="Offset in mm of the upstream pedal from the main position",
+        ge=0,
+    )
+    pedal_downstream: int = Field(
+        description="Offset in mm of the downstream pedal from the main position",
+        ge=0,
+    )
+
+
+class LevelCrossing(BaseObjectTrait):
+    """
+    This class describes the level crossings of the corresponding infra.
+    """
+
+    name: NonBlankStr = Field(description="Name of the level crossing")
+    short_zone_length: int = Field(description="Length of the short zone in mm", ge=0)
+    parts: List[LevelCrossingPart]
+
+
+class TrackEndpoint(BaseModel):
+    """
+    This class is used to define the endpoint (begin or end) of the considered track on the infrastructure.
+    """
+
+    endpoint: Endpoint = Field(
+        description="Relative position of the considered end point"
+    )
+    track: Identifier = Field(description="Identifier and type of the track")
+
+
+class Route(BaseObjectTrait):
+    """
+    This class is used to describe routes on the infrastructure.
+    """
+
+    entry_point: Waypoint
+    entry_point_direction: Direction = Field(
+        description="Direction of the route at the entry point"
+    )
+    exit_point: Waypoint
+    release_detectors: List[Identifier] = Field(
+        description="Detector allowing the release of resources reserved from the beginning of the route until this one"
+    )
+    switches_directions: Mapping[Identifier, Identifier] = Field(
+        description="Switches position part of the route"
+    )
+
+
+class SwitchPortConnection(BaseModel):
+    """
+    This class allows to know the connection between each port in switch type.
+    The connection is always bidirectional.
+    """
+
+    src: Identifier = Field(description="Port name that is source of the connection")
+    dst: Identifier = Field(
+        description="Port name that is destination of the connection"
+    )
+
+    @classmethod
+    def from_strs(cls, src: str, dst: str):
+        return cls(src=src, dst=dst)
+
+
+class SwitchType(BaseObjectTrait):
+    """
+    Switch types are used to define what kind of switch is used in the infrastructure.
+    A switch type is defined by a list of ports and groups which are the possible configurations of the switch.
+    """
+
+    ports: List[Identifier] = Field(
+        min_length=1, description="List of ports. Ports map to the ends of switches"
+    )
+    groups: Mapping[Identifier, List[SwitchPortConnection]] = Field(
+        description="Connection between and according ports"
+    )
+
+    @classmethod
+    def new(
+        cls,
+        id: Identifier,
+        ports: List[Identifier],
+        groups: Mapping[Identifier, List[SwitchPortConnection]],
+    ):
+        return cls(id=id, ports=ports, groups=groups)
+
+    @classmethod
+    def from_strs(
+        cls, id: str, ports: List[str], groups: Mapping[str, List[SwitchPortConnection]]
+    ):
+        return cls(
+            id=id,
+            ports=[e for e in ports],
+            groups={k: v for k, v in groups.items()},
+        )
+
+    def to_dict(self):
+        groups_dict = {}
+        for group_id, group_connections in self.groups.items():
+            connections_list = []
+            for connection in group_connections:
+                connections_list.append({"src": connection.src, "dst": connection.dst})
+            groups_dict[group_id] = connections_list
+
+        return {self.id: {"ports": self.ports, "groups": groups_dict}}
+
+
+class Switch(BaseObjectTrait):
+    """
+    Switches are devices used for track changes.
+    """
+
+    switch_type: Identifier = Field(
+        description="Identifier and type of the switch type"
+    )
+    group_change_delay: float = Field(
+        description="Time it takes to change which group of the switch is activated",
+        ge=0,
+    )
+    ports: Mapping[Identifier, TrackEndpoint] = Field(
+        description="Location of different ports according to track sections"
+    )
+
+
+class SpeedSection(BaseObjectTrait):
+    """
+    Speed sections are recognized by their identifiers and are in meters per second.
+    """
+
+    speed_limit: Optional[float] = Field(
+        description="Speed limit (m/s) applied by default to trains that aren't in any specified category",
+        gt=0,
+        default=None,
+    )
+    speed_limit_by_tag: Mapping[NonBlankStr, float] = Field(
+        description="Speed limit (m/s) applied to trains with a given tag"
+    )
+    track_ranges: List[ApplicableDirectionsTrackRange] = Field(
+        description="List of locations where speed section is applied"
+    )
+    on_routes: Optional[List[Identifier]] = Field(
+        description="""A list of routes the speed limit is enforced on.
+When empty or None, the speed limit is enforced regardless of the route.""",
+        default=None,
+    )
+
+
+class Electrification(BaseObjectTrait):
+    """
+    An electrification corresponds to a set of cables designed to power
+    electric trains by capturing the current through the use
+    of a pantograph. Electrification is identified by its identifier.
+    """
+
+    voltage: NonBlankStr = Field(
+        description="Type of power supply (in Volts) used for electrification"
+    )
+    track_ranges: List[ApplicableDirectionsTrackRange] = Field(
+        description="List of locations where the voltage is applied"
+    )
+
+
+class Curve(BaseModel):
+    """This class is used to define the curve object.
+    A curve correspond at radius of curvature in the part of corresponding track section."""
+
+    radius: float = Field(
+        description="Corresponding radius of curvature measured in meters"
+    )
+    begin: float = Field(
+        description="Offset in meters corresponding at the beginning of the corresponding radius in a track section ",
+        ge=0,
+    )
+    end: float = Field(
+        description="Offset in meters corresponding at the end of the corresponding radius in a track section",
+        ge=0,
+    )
+
+    @model_validator(mode="after")
+    def check_range(self):
+        assert self.begin < self.end, "expected: begin < end"
+        return self
+
+
+class Slope(BaseModel):
+    """
+    This class is used to define the slope object.
+    A slope correspond at the gradient in the part of corresponding track section.
+    The gradient can be positive (case of ramp) or negative (slope case)
+    """
+
+    gradient: float = Field(
+        description="Corresponding gradient, measured in meters per kilometers"
+    )
+    begin: float = Field(
+        description="Offset in meters corresponding at the beginning of the corresponding gradient in a track section",
+        ge=0,
+    )
+    end: float = Field(
+        description="Offset in meters corresponding at the end of the corresponding gradient in a track section",
+        ge=0,
+    )
+
+    @model_validator(mode="after")
+    def check_range(self):
+        assert self.begin < self.end, "expected: begin < end"
+        return self
+
+
+class LoadingGaugeLimit(BaseModel):
+    """This class is used to define loading gauge limit.
+    It represents a restriction on the trains according to their categories of loading gauge
+    and the type of the corresponding rolling stock.
+    """
+
+    category: LoadingGaugeType = Field(
+        description="Category of loading gauge for the corresponding rolling stock"
+    )
+    begin: float = Field(
+        description="Offset in meters corresponding at the beginning of the corresponding loading gauge limit",
+        ge=0,
+    )
+    end: float = Field(
+        description="Offset in meters corresponding at the end of the corresponding loading gauge limit",
+        ge=0,
+    )
+
+
+class TrackSection(BaseObjectTrait, GeometryLineTrait):
+    """
+    A track section is a piece of track and is the tracking system used in OSRD to locate a point.
+    A track section is identified by his unique id and its coordinates (geographic).
+    """
+
+    length: float = Field(
+        description="Value of the length of the track section in meters", gt=0
+    )
+    slopes: List[Slope] = Field(
+        description="List of slopes of corresponding track section"
+    )
+    curves: List[Curve] = Field(
+        description="List of curves of corresponding track section"
+    )
+    loading_gauge_limits: List[LoadingGaugeLimit] = Field(
+        default_factory=list,
+        description="List of loading gauge limits of corresponding track section",
+    )
+
+
+class ConditionalParameter(BaseModel):
+    on_route: Identifier = Field(
+        description="Route on which the parameters are applied"
+    )
+    parameters: Mapping[NonBlankStr, NonBlankStr] = Field(
+        description="List of key value parameters, which are defined per signaling system"
+    )
+
+
+class LogicalSignal(BaseModel):
+    """A logical signal is what displays something, whereas a physical signal is a group of logical signals"""
+
+    signaling_system: str = Field(description="The signal's output signaling system")
+    next_signaling_systems: List[str] = Field(
+        description="The list of allowed input signaling systems"
+    )
+    settings: Mapping[NonBlankStr, NonBlankStr] = Field(
+        description="A list of key value parameters, which are defined per signaling system"
+    )
+    default_parameters: Mapping[NonBlankStr, NonBlankStr] = Field(
+        description="A list of default parameters (in regards to routes), which are defined per signaling system"
+    )
+    conditional_parameters: List[ConditionalParameter] = Field(
+        description="A list of conditional parameters, which are defined per signaling system"
+    )
+
+
+class Signal(BaseObjectTrait, TrackLocationTrait):
+    """This class is used to describe the signal.
+    A signal is characterized by its id and its corresponding track.
+    By default, the signal is located at the center of the track.
+    """
+
+    direction: Direction = Field(description="Direction of use of the signal")
+    sight_distance: float = Field(
+        description="Visibility distance of the signal in meters", ge=0
+    )
+    logical_signals: List[LogicalSignal] = Field(
+        description="Logical signals bundled into this physical signal",
+        default_factory=list,
+    )
+
+
+class BufferStop(BaseObjectTrait, TrackLocationTrait):
+    """This class defines the buffer stop object.
+    A buffer stop is a device placed at the end of a dead-end road
+    to stop any drifting trains from continuing off the road.
+    A buffer stop is characterized by its id and its corresponding track.
+    """
+
+    def ref(self):
+        return BufferStopReference(type="BufferStop", id=self.id)
+
+
+class Detector(BaseObjectTrait, TrackLocationTrait):
+    """This class defines detector object.
+    A detector is characterized by its id and its corresponding track.
+    A detector is used to locate a train
+    in order to consider the section as occupied when there is a train.
+    """
+
+    def ref(self):
+        return DetectorReference(type="Detector", id=self.id)
+
+
+class Sign(TrackLocationTrait):
+    """This class is used to define signs.
+    This is a physical, punctual, cosmetic object.
+    """
+
+    side: Side = Field(Side.CENTER, description="Side of the sign on the track")
+    direction: Direction = Field(
+        Direction.START_TO_STOP, description="Direction of the sign on the track"
+    )
+    type: NonBlankStr = Field(description="Precise the type of the sign")
+    value: str = Field(
+        description="If the sign is an announcement, precise the value(s)", default=""
+    )
+    kp: str = Field(description="Kilometric point of the sign", default="")
+
+
+class NeutralSection(BaseObjectTrait):
+    """
+    Neutral sections are portions of track where trains aren't allowed to pull power from electrifications.
+    They have to rely on inertia to cross such sections.
+
+    In practice, neutral sections are delimited by signs. In OSRD, neutral sections are directional
+    to allow accounting for different sign placement depending on the direction.
+
+    For more details see [the documentation](https://osrd.fr/en/docs/explanation/neutral_sections/).
+    """
+
+    announcement_track_ranges: List[DirectionalTrackRange] = Field(
+        description="List of locations where the upcoming neutral section is announced but not yet crossed",
+        default_factory=list,
+    )
+    track_ranges: List[DirectionalTrackRange] = Field(
+        description="List of locations where the train cannot pull power from electrifications",
+        min_length=1,
+    )
+    lower_pantograph: bool = Field(
+        description="Whether or not trains need to lower their pantograph in the section"
+    )
+
+    @model_validator(mode="after")
+    def check_no_overlap(self):
+        for tr, atr in product(self.track_ranges, self.announcement_track_ranges):
+            assert not tr.overlaps(atr), (
+                "track_ranges and announcement_track_ranges should not overlap"
+            )
+        return self
+
+
+class RailJsonInfra(BaseModel):
+    """This class is used to build an infra."""
+
+    version: RAILJSON_INFRA_VERSION_TYPE = Field(
+        default=RAILJSON_INFRA_VERSION, description="Version of the schema"
+    )
+    operational_points: List[OperationalPoint] = Field(
+        description="List of operational points of the corresponding infra"
+    )
+    level_crossings: List[LevelCrossing] = Field(
+        description="List of level crossings of the corresponding infra"
+    )
+    routes: List[Route] = Field(description="Routes of the infra")
+    extended_switch_types: List[SwitchType] = Field(
+        default=[],
+        description="Switch types of the infra that can be added by the user",
+    )
+    switches: List[Switch] = Field(description="Switches of the infra")
+    track_sections: List[TrackSection] = Field(
+        description="Track sections of the infra"
+    )
+    speed_sections: List[SpeedSection] = Field(
+        description="Speed sections of the infra"
+    )
+    electrifications: List[Electrification] = Field(
+        description="Electrifications of the infra"
+    )
+    signals: List[Signal] = Field(description="Signals of the infra")
+    buffer_stops: List[BufferStop] = Field(description="Buffer stops of the infra")
+    detectors: List[Detector] = Field(description="Detectors of the infra")
+    neutral_sections: List[NeutralSection] = Field(
+        description="Neutral sections of the infra"
+    )
+
+
+for t in BaseObjectTrait.__subclasses__():
+    ALL_OBJECT_TYPES.append(t)
+
+# Extensions
+
+
+def register_extension(object: Type[BaseModel], name):
+    """
+    This decorator is used to easily add an extension to an existing object.
+    Example:
+
+    ```
+    @register_extension(TrackSection, "my_extension")
+    class TrackSectionMyExtension(BaseModel):
+        ...
+    ```
+
+    This will add the optional dictionary field `extensions` to the `TrackSection` class.
+    This dictionary can contain the field `my_extension` of type `TrackSectionMyExtension`.
+    """
+
+    if "extensions" not in object.model_fields:
+        extensions_type = create_model(object.__name__ + "Extensions")
+        extensions_type.__pydantic_parent_namespace__ = (
+            object.__pydantic_parent_namespace__
+        )
+        object.model_fields["extensions"] = FieldInfo(
+            annotation=extensions_type,
+            default=None,
+        )
+
+    def register_extension(extension):
+        extensions_field = object.model_fields["extensions"]
+        assert extensions_field.annotation is not None and issubclass(
+            extensions_field.annotation, BaseModel
+        )
+        if name in extensions_field.annotation.model_fields:
+            raise RuntimeError(
+                f"Extension '{name}' already registered for {object.__name__}"
+            )
+
+        extensions_field.annotation.model_fields[name] = FieldInfo(
+            annotation=Optional[extension],  # type: ignore # This is how <type> | None is handled by pydantic
+            default=None,
+        )
+        return extension
+
+    return register_extension
+
+
+@register_extension(object=TrackSection, name="sncf")
+class TrackSectionSncfExtension(BaseModel):
+    line_code: int = Field(
+        description="Code of the line used by the corresponding track section"
+    )
+    line_name: NonBlankStr = Field(
+        description="Name of the line used by the corresponding track section"
+    )
+    track_number: int = Field(
+        description="Number corresponding to the track used", ge=0
+    )
+    track_name: NonBlankStr = Field(description="Name corresponding to the track used")
+
+
+@register_extension(object=TrackSection, name="source")
+class TrackSectionSourceExtension(BaseModel):
+    name: str = Field(description="Name of the source")
+    id: str = Field(description="ID used for the line in the source")
+
+
+@register_extension(object=OperationalPoint, name="sncf")
+class OperationalPointSncfExtension(BaseModel):
+    ci: int = Field(description="THOR immutable code of the operational point")
+    ch: str = Field(
+        description="THOR site code of the operational point",
+        min_length=1,
+        max_length=2,
+    )
+    ch_short_label: NonBlankStr = Field(
+        description="THOR site code short label of the operational point"
+    )
+    ch_long_label: NonBlankStr = Field(
+        description="THOR site code long label of the operational point"
+    )
+    trigram: str = Field(
+        description="Unique SNCF trigram of the operational point",
+        min_length=1,
+        max_length=3,
+    )
+
+
+@register_extension(object=OperationalPointPart, name="sncf")
+class OperationalPointPartSncfExtension(BaseModel):
+    kp: str = Field(description="Kilometric point of the operational point part")
+
+
+@register_extension(object=OperationalPoint, name="identifier")
+class OperationalPointIdentifierExtension(BaseModel):
+    name: NonBlankStr = Field(description="Name of the operational point")
+    uic: int = Field(
+        description="International Union of Railways code of the operational point"
+    )
+
+
+@register_extension(object=Switch, name="sncf")
+class SwitchSncfExtension(BaseModel):
+    label: NonBlankStr = Field(description="Identifier of the switch")
+
+
+@register_extension(object=Signal, name="sncf")
+class SignalSncfExtension(BaseModel):
+    label: str
+    side: Side = Field(Side.CENTER, description="Side of the signal on the track")
+    kp: str = Field(description="Kilometric point of the signal")
+
+
+@register_extension(object=SpeedSection, name="psl_sncf")
+class SpeedSectionPslSncfExtension(BaseModel):
+    announcement: List[Sign] = Field(description="Precise the value(s) of the speed")
+    z: Sign = Field(description="Beginning of the psl speed section")
+    r: List[Sign] = Field(description="End of the psl speed section")
+
+
+@register_extension(object=NeutralSection, name="neutral_sncf")
+class NeutralSectionNeutralSncfExtension(BaseModel):
+    announcement: List[Sign] = Field(
+        description="Precise that there is bp/cc neutral section"
+    )
+    exe: Sign = Field(description="Beginning of the bp/cc neutral section")
+    end: List[Sign] = Field(description="End of the bp/cc neutral section")
+    rev: List[Sign] = Field(description="REV of the bp/cc neutral section")
+
+
+@register_extension(object=BufferStop, name="sncf")
+class BufferStopSncfExtension(BaseModel):
+    kp: str = Field(description="Kilometric point of the buffer stop")
+
+
+@register_extension(object=Detector, name="sncf")
+class DetectorSncfExtension(BaseModel):
+    kp: str = Field(description="Kilometric point of the detector")
+
+
+def recursively_rebuild(model: Type[BaseModel]):
+    for field in model.model_fields.values():
+        if field.annotation is None:
+            continue
+        try:
+            child_model = get_args(field.annotation)[0]
+        except (TypeError, IndexError):
+            child_model = field.annotation
+        if isinstance(child_model, type) and issubclass(child_model, BaseModel):
+            recursively_rebuild(child_model)
+    model.model_rebuild(force=True)
+
+
+# Needed since we dynamically created classes
+recursively_rebuild(RailJsonInfra)
+
+
+if __name__ == "__main__":
+    from json import dumps
+
+    # sort keys in order to diff correctly in the CI
+    print(dumps(RailJsonInfra.model_json_schema(), indent=4, sort_keys=True))

--- a/osrd_schemas_auto/osrd_schemas_auto/switch_type.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/switch_type.py
@@ -1,0 +1,49 @@
+from .infra import SwitchPortConnection, SwitchType
+
+_spc = SwitchPortConnection.from_strs
+
+
+POINT_SWITCH: SwitchType = SwitchType.from_strs(
+    "point_switch",
+    ["A", "B1", "B2"],
+    {"A_B2": [_spc("A", "B2")], "A_B1": [_spc("A", "B1")]},
+)
+
+LINK: SwitchType = SwitchType.from_strs(
+    "link", ["A", "B"], {"STATIC": [_spc("A", "B")]}
+)
+CROSSING: SwitchType = SwitchType.from_strs(
+    "crossing",
+    ["A1", "B1", "A2", "B2"],
+    {"STATIC": [_spc("A1", "B1"), _spc("A2", "B2")]},
+)
+
+SINGLE_SLIP_SWITCH: SwitchType = SwitchType.from_strs(
+    "single_slip_switch",
+    ["A1", "B1", "A2", "B2"],
+    {
+        "STATIC": [_spc("A1", "B1"), _spc("A2", "B2")],
+        "A1_B2": [_spc("A1", "B2")],
+    },
+)
+
+DOUBLE_SLIP_SWITCH: SwitchType = SwitchType.from_strs(
+    "double_slip_switch",
+    ["A1", "B1", "A2", "B2"],
+    {
+        "A1_B1": [_spc("A1", "B1")],
+        "A1_B2": [_spc("A1", "B2")],
+        "A2_B1": [_spc("A2", "B1")],
+        "A2_B2": [_spc("A2", "B2")],
+    },
+)
+
+
+def builtin_node_types():
+    return {
+        **LINK.to_dict(),
+        **POINT_SWITCH.to_dict(),
+        **SINGLE_SLIP_SWITCH.to_dict(),
+        **DOUBLE_SLIP_SWITCH.to_dict(),
+        **CROSSING.to_dict(),
+    }

--- a/osrd_schemas_auto/osrd_schemas_auto/train_schedule.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/train_schedule.py
@@ -1,0 +1,224 @@
+from enum import Enum
+from typing import Annotated, List, Literal, Union
+
+from pydantic import BaseModel, Field, RootModel, StringConstraints
+
+# Labels
+
+
+class TrainScheduleLabels(RootModel):
+    """This class defines train schedule labels."""
+
+    root: List[Annotated[str, StringConstraints(max_length=128)]]
+
+
+# MRSP
+
+"""The MRSP is a static envelope giving the limit speed at each point to perform the standalone simulation."""
+
+
+class MRSPPoint(BaseModel):
+    """This class defines each point used to compute the Most restricted speed profile (MRSP)."""
+
+    position: float = Field(
+        description="Relative position of the point in meters with respect to the track section",
+        ge=0,
+    )
+    speed: float = Field(
+        description="Speed at the point considered in meters per second", ge=0
+    )
+
+
+class MRSP(RootModel):
+    """This class is used to compute the MRSP."""
+
+    root: List[MRSPPoint] = Field(
+        description="List of each point used to calculate the MRSP envelope"
+    )
+
+
+# Allowances
+"""Allowances are times added to the standalone simulation to take into account certain parameters that may occur.
+Otherwise, a train leaving late would always arrive late."""
+
+
+class AllowanceTimePerDistanceValue(BaseModel):
+    """This class defines the value (in minutes per 100 kilometers) of an allowance."""
+
+    value_type: Literal["time_per_distance"] = Field(default="time_per_distance")
+    minutes: float = Field(description="min/100km", gt=0)
+
+
+class AllowanceTimeValue(BaseModel):
+    """This class defines the value (in seconds) of an allowance."""
+
+    value_type: Literal["time"] = Field(default="time")
+    seconds: float = Field(description="s", gt=0)
+
+
+class AllowancePercentValue(BaseModel):
+    """This class defines the value (but in percentage) of an allowance."""
+
+    value_type: Literal["percentage"] = Field(default="percentage")
+    percentage: float = Field(description="%", gt=0)
+
+
+class AllowanceValue(RootModel):
+    """This class allows to choose the different present types of values used to apply an allowance."""
+
+    root: Union[
+        AllowanceTimeValue, AllowancePercentValue, AllowanceTimePerDistanceValue
+    ] = Field(discriminator="value_type")
+
+
+class AllowanceDistribution(str, Enum):
+    """This class defines the two distributions of allowances that can be applied to the standalone simulation.
+    The first one is STANDARD (linear), which means that an allowance is applied that will be the same for the whole simulation.
+    The second one is based on the MARECO algorithm, which consists in distributing the allowance as economically
+    as possible in terms of energy consumption.
+    """
+
+    mareco = "MARECO"
+    standard = "STANDARD"  # linear
+
+
+class RangeAllowance(BaseModel):
+    """This class defines the addition of an allowance between two specific points and not on the complete path."""
+
+    begin_position: float = Field(
+        description="Offset in meters corresponding to the beginning of the addition of the allowance",
+        ge=0,
+    )
+    end_position: float = Field(
+        description="Offset in meters corresponding to the end of the allowance", ge=0
+    )
+    value: AllowanceValue = Field(description="The type of value of the allowance")
+
+
+class EngineeringAllowance(RangeAllowance):
+    """This class determines the engineering allowance.
+    This corresponds to time added on a specific interval, in addition to the standard allowance,
+    but this time for operational reasons."""
+
+    allowance_type: Literal["engineering"] = Field(default="engineering")
+    distribution: AllowanceDistribution = Field(
+        description="The considered distribution of an allowance"
+    )
+    capacity_speed_limit: float = Field(
+        description="Speed (m/s) that cannot be exceeded (defaults to -1 for no maximum)",
+        default=-1,
+    )
+
+
+class StandardAllowance(BaseModel):
+    """This class determines the standard allowance.
+    This corresponds to additional time added to the basic standalone simulation to take into account
+    the inaccuracy of the speed measurement,
+    to compensate for the consequences of external incidents disrupting the theoretical run of the trains,
+    and to maintain the regularity of the traffic."""
+
+    allowance_type: Literal["standard"] = Field(default="standard")
+    default_value: AllowanceValue = Field(description="Type of value of the allowance")
+    ranges: List[RangeAllowance] = Field(
+        description="List of the different application ranges of the allowances"
+    )
+    distribution: AllowanceDistribution = Field(
+        description="The considered distribution of an allowance"
+    )
+    capacity_speed_limit: float = Field(
+        description="Speed (m/s) that cannot be exceeded (defaults to -1 for no maximum)",
+        default=-1,
+    )
+
+
+class Allowance(RootModel):
+    """This class allows to choose the two different types of allowance."""
+
+    root: Union[EngineeringAllowance, StandardAllowance] = Field(
+        discriminator="allowance_type"
+    )
+
+
+class Allowances(RootModel):
+    """This class defines all the final allowances contained on the considered path."""
+
+    root: List[Allowance] = Field(
+        description="List of all well-defined allowances of the path"
+    )
+
+
+# Scheduled points
+
+
+class ScheduledPoint(BaseModel):
+    """A schedule point is a point on the path where the train must be at a given time."""
+
+    path_offset: float = Field(
+        description="Offset on a path. If negative then represents the end of the path."
+    )
+    time: float = Field(
+        description="Time in seconds (elapsed since the train's departure) at which the train must be.",
+        ge=0,
+    )
+
+
+class ScheduledPoints(RootModel):
+    """A list of schedule point"""
+
+    root: List[ScheduledPoint] = Field(description="List of schedule point")
+
+
+# Power restrictions
+"""Power restrictions are used to limit the power consumption of trains on some parts of the infrastructure.
+Infrastructure managers use them to prevent power grid overloads.
+We model power restrictions by assigning some power restriction codes to some parts of the train path.
+Rolling stocks then have an attribute that maps power restriction codes to power usages."""
+
+
+class PowerRestrictionRange(BaseModel):
+    """A user-specified range of the train path where a power restriction is applied.
+    Ideally, this should come from infrastructure data."""
+
+    begin_position: float = Field(
+        description="Offset in meters from the beginning of the path", ge=0
+    )
+    end_position: float = Field(
+        description="Offset in meters from the beginning of the path", ge=0
+    )
+    power_restriction_code: str = Field(
+        description="The code of the power restriction to apply"
+    )
+
+
+class PowerRestrictionRanges(RootModel):
+    """A list of power restriction ranges."""
+
+    root: List[PowerRestrictionRange]
+
+
+class TrainScheduleOptions(BaseModel):
+    """Optional arguments :
+    - `use_electrical_profiles` : use the electrical profiles for the standalone simulation
+    - `use_speed_limits_for_simulation` : use the speed limits coming from the infrastructure for
+       the standalone simulation
+    - `stops_at_end_of_block` : stop the train at the next block-delimiting signal instead of on the waypoint
+
+    """
+
+    use_electrical_profiles: bool = Field(
+        default=False,
+        description="If true, the electrical profiles are used in the standalone simulation",
+    )
+    use_speed_limits_for_simulation: bool = Field(
+        default=True,
+        description="If false, the speed limits of the infrastructure are ignored in the standalone simulation",
+    )
+    stops_at_end_of_block: bool = Field(
+        default=False,
+        description="If true, stop positions will be shifted toward the next block-delimiting signal, \
+        staying in the same block and keeping the tail on the initial position",
+    )
+
+
+if __name__ == "__main__":
+    print(MRSP.schema_json(indent=2))

--- a/osrd_schemas_auto/pyproject.toml
+++ b/osrd_schemas_auto/pyproject.toml
@@ -7,7 +7,9 @@ requires-python = ">= 3.11"
 
 dependencies = [
   "datamodel-code-generator==0.35.0",
+  "geojson-pydantic ~= 1.0.0",
   "openapi-pydantic==0.5.1",
+  "pydantic >= 2.12.2",
   "pyyaml==6.0.3",
 ]
 

--- a/osrd_schemas_auto/uv.lock
+++ b/osrd_schemas_auto/uv.lock
@@ -109,6 +109,18 @@ wheels = [
 ]
 
 [[package]]
+name = "geojson-pydantic"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/a5/e1cbfaef7cef4c8fb95b9ba46faedc6dca3b115f44bb95ef4e89c4683756/geojson_pydantic-1.0.2.tar.gz", hash = "sha256:3179d665ad8763670681b73aded2228df20a1164951e9d7075be8f370eb681f4", size = 9180, upload-time = "2024-01-16T18:13:07.259Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d5/75118ba2f51bb5110066d5f8cc50c13b222f6ff6e75b0fc2ec1ee3bd6d48/geojson_pydantic-1.0.2-py3-none-any.whl", hash = "sha256:d7a7f8ff4ca27298f62d1af182f69ec85f9990b9db80fa7e0161be1de2a9ae0f", size = 8588, upload-time = "2024-01-16T18:13:04.026Z" },
+]
+
+[[package]]
 name = "inflect"
 version = "7.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -261,7 +273,9 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },
+    { name = "geojson-pydantic" },
     { name = "openapi-pydantic" },
+    { name = "pydantic" },
     { name = "pyyaml" },
 ]
 
@@ -274,7 +288,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "datamodel-code-generator", specifier = "==0.35.0" },
+    { name = "geojson-pydantic", specifier = "~=1.0.0" },
     { name = "openapi-pydantic", specifier = "==0.5.1" },
+    { name = "pydantic", specifier = ">=2.12.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
 ]
 

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -18,7 +18,7 @@ check = [
 [tool.pyright]
 include = ["railjson_generator"]
 exclude = ["**/__pycache__"]
-extraPaths = ["../../osrd_schemas_auto", "../osrd_schemas"]
+extraPaths = ["../../osrd_schemas_auto"]
 
 [tool.uv.sources]
 osrd-schemas = { path = "../osrd_schemas", editable = true }

--- a/python/railjson_generator/railjson_generator/external_generated_inputs.py
+++ b/python/railjson_generator/railjson_generator/external_generated_inputs.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from os import PathLike
 from typing import List
 
-from osrd_schemas import external_generated_inputs
+from osrd_schemas_auto import external_generated_inputs
 
 from railjson_generator.schema.infra.range_elements import TrackRange
 from railjson_generator.schema.infra.track_section import TrackSection

--- a/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from osrd_schemas import infra
-from osrd_schemas_auto import models
+from osrd_schemas_auto import infra, models
 
 from .direction import ApplicableDirection, Direction
 
@@ -73,7 +72,10 @@ class TrackRange(RangeElement):
 class DirectionalTrackRange(TrackRange):
     direction: Direction
 
-    def to_rjs(self):  # pyright: ignore[reportIncompatibleMethodOverride] - base TrackRange stays on osrd_schemas
+    # In osrd_schemas_auto's generated models, DirectionalTrackRange no longer subclasses
+    # TrackRange (it's a standalone model), so this override returns a type unrelated to the
+    # base to_rjs (infra.TrackRange). The incompatible override is intentional.
+    def to_rjs(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return models.DirectionalTrackRange(
             track=self.track.id,
             direction=models.Direction[self.direction.name],
@@ -86,7 +88,10 @@ class DirectionalTrackRange(TrackRange):
 class ApplicableDirectionsTrackRange(TrackRange):
     applicable_directions: ApplicableDirection
 
-    def to_rjs(self):  # pyright: ignore[reportIncompatibleMethodOverride] - base TrackRange stays on osrd_schemas
+    # Same as DirectionalTrackRange: the generated ApplicableDirectionsTrackRange is a
+    # standalone model and no longer subclasses TrackRange, so this override intentionally
+    # returns a type unrelated to the base to_rjs (infra.TrackRange).
+    def to_rjs(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         return models.ApplicableDirectionsTrackRange(
             track=self.track.id,
             applicable_directions=models.ApplicableDirections[

--- a/python/railjson_generator/railjson_generator/schema/infra/switch.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/switch.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from osrd_schemas_auto import models
-from osrd_schemas.switch_type import (
+from osrd_schemas_auto.switch_type import (
     CROSSING,
     DOUBLE_SLIP_SWITCH,
     LINK,

--- a/python/railjson_generator/railjson_generator/schema/simulation/train_schedule.py
+++ b/python/railjson_generator/railjson_generator/schema/simulation/train_schedule.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Union
 
-from osrd_schemas.train_schedule import (
+from osrd_schemas_auto.train_schedule import (
     AllowanceDistribution,
     AllowancePercentValue,
     AllowanceTimePerDistanceValue,

--- a/python/railjson_generator/railjson_generator/test_external_generated_inputs.py
+++ b/python/railjson_generator/railjson_generator/test_external_generated_inputs.py
@@ -1,4 +1,4 @@
-from osrd_schemas import external_generated_inputs, infra
+from osrd_schemas_auto import external_generated_inputs, infra
 
 from railjson_generator.external_generated_inputs import (
     ElectricalProfile,

--- a/python/railjson_generator/uv.lock
+++ b/python/railjson_generator/uv.lock
@@ -404,14 +404,18 @@ version = "0.1.0"
 source = { editable = "../../osrd_schemas_auto" }
 dependencies = [
     { name = "datamodel-code-generator" },
+    { name = "geojson-pydantic" },
     { name = "openapi-pydantic" },
+    { name = "pydantic" },
     { name = "pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "datamodel-code-generator", specifier = "==0.35.0" },
+    { name = "geojson-pydantic", specifier = "~=1.0.0" },
     { name = "openapi-pydantic", specifier = "==0.5.1" },
+    { name = "pydantic", specifier = ">=2.12.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
 ]
 

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -511,14 +511,18 @@ version = "0.1.0"
 source = { editable = "../osrd_schemas_auto" }
 dependencies = [
     { name = "datamodel-code-generator" },
+    { name = "geojson-pydantic" },
     { name = "openapi-pydantic" },
+    { name = "pydantic" },
     { name = "pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "datamodel-code-generator", specifier = "==0.35.0" },
+    { name = "geojson-pydantic", specifier = "~=1.0.0" },
     { name = "openapi-pydantic", specifier = "==0.5.1" },
+    { name = "pydantic", specifier = ">=2.12.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
 ]
 


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/15162

Copy files `infra`, `external_generated_inputs`, `switch_type` and `train_schedule` from `osrd_schemas` to `osrd_schemas_auto` (they can’t be auto-generated at the moment, and they add some additional checks).
Update `railjson_generator` imports so it no longer depends on `osrd_schemas`.