### PR TITLE
map curve visual states to style primitives

### DIFF
--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -2,6 +2,8 @@ import type { TrainMainCategory } from 'common/api/osrdEditoastApi';
 
 import type { CategoryColors } from './types';
 
+export const SELECTED_CURVE_COLOR = '#1844EF';
+export const SELECTED_CURVE_OUTLINE_COLOR = 'rgba(24, 68, 239, 0.1)';
 export const REST_BACKGROUND_COLOR = '#FFFFFF';
 
 export const DEFAULT_TRAIN_PATH_COLORS: CategoryColors = {

--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -4,6 +4,8 @@ import type { CategoryColors } from './types';
 
 export const SELECTED_CURVE_COLOR = '#1844EF';
 export const SELECTED_CURVE_OUTLINE_COLOR = 'rgba(24, 68, 239, 0.1)';
+export const DRAGGED_CURVE_COLOR = '#180F47';
+export const DRAGGED_CURVE_OUTLINE_COLOR = 'rgba(255, 247, 0, 0.4)';
 export const REST_BACKGROUND_COLOR = '#FFFFFF';
 
 export const DEFAULT_TRAIN_PATH_COLORS: CategoryColors = {

--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -2,6 +2,8 @@ import type { TrainMainCategory } from 'common/api/osrdEditoastApi';
 
 import type { CategoryColors } from './types';
 
+export const REST_BACKGROUND_COLOR = '#FFFFFF';
+
 export const DEFAULT_TRAIN_PATH_COLORS: CategoryColors = {
   normal: '#797671',
   hovered: '#494641',

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -606,6 +606,7 @@ const SpaceTimeChartWrapper = ({
                   color={style.color}
                   level={style.level}
                   border={style.outline}
+                  label={style.label}
                 />
               );
             })}

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -29,8 +29,10 @@ import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import { type PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { configureHandlePan } from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan';
+import getPathStyleV2 from 'modules/simulationResult/helpers/getPathStyleV2';
 import type {
   CurveStyleExceptionType,
+  CurveStyleInput,
   PathOperationalPoint,
   TrainSpaceTimeData,
   WaypointsPanelData,
@@ -72,7 +74,7 @@ import CurveSelectionSidePanel, {
 import cutSpaceTimeCurves from './helpers/cutSpaceTimeCurves';
 import formatSpaceTimeCurves from './helpers/formatSpaceTimeCurves';
 import getPanelOccurrenceCounts from './helpers/getPanelOccurrenceCounts';
-import getPathStyle from './helpers/getPathStyle';
+import getStdExceptionType from './helpers/getStdExceptionType';
 import makeProjectedTrains from './helpers/makeProjectedTrains';
 import { getOccupancyBlocks } from './helpers/utils';
 import ProjectionLoadingMessage from './ProjectionLoadingMessage';
@@ -134,6 +136,29 @@ type SpaceTimeChartWrapperProps = SpaceTimeChartWrapperBaseProps &
 
 export const MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT = 561;
 
+/**
+ * Builds the hover input for the curve-style helper. Chart hover wins over
+ * timetable hover: when the user is over a curve in the STD, the train list
+ * hover is ignored.
+ *
+ * TODO: add the TOD source (`from: 'tod'`) once the TOD emits hover events.
+ */
+const buildCurveHover = (
+  hoveredItem: HoveredItem | null,
+  hoveredTrainIdFromTimetable: TrainId | undefined
+): CurveStyleInput['hover'] => {
+  if (
+    hoveredItem &&
+    (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
+  ) {
+    return { trainId: hoveredItem.element.pathId as TrainId, from: 'std' };
+  }
+  if (hoveredTrainIdFromTimetable) {
+    return { trainId: hoveredTrainIdFromTimetable, from: 'timetable' };
+  }
+  return undefined;
+};
+
 const SpaceTimeChartWrapper = ({
   operationalPoints,
   trainScheduleProjections,
@@ -156,7 +181,8 @@ const SpaceTimeChartWrapper = ({
   const dispatch = useAppDispatch();
   const hoveredTrainId = useSelector(getHoveredTrainId);
   const isSimulationEnabled = useSelector(getIsSimulationEnabled);
-  const { id: selectedTrainId, by: selectedTrainBy } = useSelector(getSelectedTrain) || {};
+  const selection = useSelector(getSelectedTrain);
+  const { id: selectedTrainId, by: selectedTrainBy } = selection ?? {};
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
@@ -556,22 +582,33 @@ const SpaceTimeChartWrapper = ({
               (waypointsPanelData?.filteredWaypoints ?? operationalPoints).at(0)?.position || 0
             }
           >
-            {paths.map((path) => (
-              <PathLayer
-                key={`${path.id}-${path.points[0]?.position}`}
-                path={path}
-                // TODO: forward `panelSelectionMode` to getPathStyle when the
-                // curve-style mapping ticket needs it to pick which occurrences
-                // are highlighted in blue.
-                {...getPathStyle(
-                  hoveredItem,
-                  path,
-                  !!draggingState,
-                  selectedTrainId,
-                  hoveredTrainId
-                )}
-              />
-            ))}
+            {paths.map((path) => {
+              const hover = buildCurveHover(hoveredItem, hoveredTrainId);
+              const trainId = path.id as TrainId;
+              const style = getPathStyleV2(
+                {
+                  chart: 'std',
+                  train: {
+                    id: trainId,
+                    isDragging: draggingState?.draggedTrain.id === trainId,
+                    exceptionType: getStdExceptionType(trainSchedulesWithDetailsById, trainId),
+                  },
+                  selection,
+                  panelMode: panelSelectionMode,
+                  hover,
+                },
+                { colors: path.colors, isSimulated: path.isSimulated }
+              );
+              return (
+                <PathLayer
+                  key={`${path.id}-${path.points[0]?.position}`}
+                  path={path}
+                  color={style.color}
+                  level={style.level}
+                  border={style.outline}
+                />
+              );
+            })}
             {rect && <ZoomRect {...rect} />}
             {workSchedules && (
               <WorkScheduleLayer

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getStdExceptionType.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getStdExceptionType.ts
@@ -1,0 +1,33 @@
+import type { CurveStyleExceptionType } from 'modules/simulationResult/types';
+import {
+  findExceptionWithOccurrenceId,
+  isPacedTrainWithDetails,
+} from 'modules/trainSchedule/helpers/pacedTrain';
+import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
+import type { TrainId } from 'reducers/osrdconf/types';
+import {
+  isOccurrenceId,
+  extractPacedTrainIdFromOccurrenceId,
+  extractEditoastIdFromPacedTrainId,
+} from 'utils/trainId';
+
+/**
+ * Returns the exception type the STD classifier cares about for a given
+ * train. A `start_time` change is the only one that affects the curve in
+ * this chart; the TOD will have its own helper for `path_and_schedule`.
+ */
+const getStdExceptionType = (
+  trainSchedulesWithDetailsById: Map<number, TrainScheduleWithDetails>,
+  trainId: TrainId
+): CurveStyleExceptionType | undefined => {
+  if (!isOccurrenceId(trainId)) return undefined;
+  const trainScheduleId = extractEditoastIdFromPacedTrainId(
+    extractPacedTrainIdFromOccurrenceId(trainId)
+  );
+  const trainSchedule = trainSchedulesWithDetailsById.get(trainScheduleId);
+  if (!trainSchedule || !isPacedTrainWithDetails(trainSchedule)) return undefined;
+  const exception = findExceptionWithOccurrenceId(trainSchedule.paced.exceptions, trainId);
+  return exception?.start_time ? 'start_time' : undefined;
+};
+
+export default getStdExceptionType;

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  DEFAULT_TRAIN_PATH_COLORS,
+  REST_BACKGROUND_COLOR,
+} from 'applications/operationalStudies/consts';
+
+import getCurveStyle, { INVALID_OUTLINE } from '../getCurveStyle';
+
+const colors = DEFAULT_TRAIN_PATH_COLORS;
+
+describe('getCurveStyle', () => {
+  describe('none', () => {
+    it('should return the normal color with full opacity', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: true });
+      expect(style.color).toBe(colors.normal);
+      expect(style.opacity).toBe(1);
+      expect(style.outline).toBeUndefined();
+    });
+
+    it('should label with the normal color, a regular font and a white background', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: true });
+      expect(style.label).toEqual({
+        color: colors.normal,
+        fontWeight: 400,
+        background: { color: REST_BACKGROUND_COLOR, opacity: 0.9 },
+      });
+    });
+
+    it('should add the invalid outline when the train is not simulated', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: false });
+      expect(style.outline).toEqual(INVALID_OUTLINE);
+    });
+
+    it('should not add the invalid outline when isSimulated is undefined', () => {
+      const style = getCurveStyle('none', { colors });
+      expect(style.outline).toBeUndefined();
+    });
+  });
+});

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -67,4 +67,31 @@ describe('getCurveStyle', () => {
       expect(style.outline).toEqual(INVALID_OUTLINE);
     });
   });
+
+  describe('passiveSecondary', () => {
+    it('should return the normal color with a thin background-colored outline', () => {
+      const style = getCurveStyle('passiveSecondary', { colors, isSimulated: true });
+      expect(style.color).toBe(colors.normal);
+      expect(style.opacity).toBe(1);
+      expect(style.outline).toEqual({
+        offset: 0,
+        width: 2,
+        color: colors.background,
+      });
+    });
+
+    it('should label with the hovered color and a normal-colored border on the background', () => {
+      const style = getCurveStyle('passiveSecondary', { colors, isSimulated: true });
+      expect(style.label).toEqual({
+        color: colors.hovered,
+        background: { color: colors.background, border: colors.normal },
+        fontWeight: 400,
+      });
+    });
+
+    it('should replace the outline with the invalid one when the train is not simulated', () => {
+      const style = getCurveStyle('passiveSecondary', { colors, isSimulated: false });
+      expect(style.outline).toEqual(INVALID_OUTLINE);
+    });
+  });
 });

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -70,6 +70,34 @@ describe('getCurveStyle', () => {
     });
   });
 
+  describe('passivePrimary', () => {
+    it('should return the category color with a background-colored outline', () => {
+      const style = getCurveStyle('passivePrimary', { colors, isSimulated: true });
+      expect(style.color).toBe(colors.normal);
+      expect(style.level).toBeUndefined();
+      expect(style.opacity).toBe(1);
+      expect(style.outline).toEqual({
+        offset: 0,
+        width: 3,
+        color: colors.background,
+      });
+    });
+
+    it('should label like active: hovered color, bold, with a normal-colored border', () => {
+      const style = getCurveStyle('passivePrimary', { colors, isSimulated: true });
+      expect(style.label).toEqual({
+        color: colors.hovered,
+        background: { color: colors.background, border: colors.normal },
+        fontWeight: 600,
+      });
+    });
+
+    it('should replace the outline with the invalid one when the train is not simulated', () => {
+      const style = getCurveStyle('passivePrimary', { colors, isSimulated: false });
+      expect(style.outline).toEqual(INVALID_OUTLINE);
+    });
+  });
+
   describe('passiveSecondary', () => {
     it('should return the normal color with a thin background-colored outline', () => {
       const style = getCurveStyle('passiveSecondary', { colors, isSimulated: true });

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -188,4 +188,43 @@ describe('getCurveStyle', () => {
       });
     });
   });
+
+  describe('hover modifier', () => {
+    it('should switch a none-state curve to the hovered tint at level 3', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: true }, { hovered: true });
+      expect(style.color).toBe(colors.hovered);
+      expect(style.level).toBe(3);
+      expect(style.opacity).toBe(1);
+      expect(style.outline).toBeUndefined();
+      expect(style.label).toEqual({
+        color: colors.hovered,
+        background: { color: colors.background },
+        fontWeight: 400,
+      });
+    });
+
+    it('should add the invalid outline when a hovered none-state train is not simulated', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: false }, { hovered: true });
+      expect(style.outline).toEqual(INVALID_OUTLINE);
+    });
+
+    it.each(['active', 'passivePrimary', 'passiveSecondary', 'drag'] as const)(
+      'should not change anything when hovering a %s curve',
+      (state) => {
+        const base = getCurveStyle(state, { colors, isSimulated: true });
+        const hovered = getCurveStyle(state, { colors, isSimulated: true }, { hovered: true });
+        expect(hovered).toEqual(base);
+      }
+    );
+
+    it('should win over outOfSelection on a none-state curve', () => {
+      const fromHover = getCurveStyle(
+        'none',
+        { colors, isSimulated: true },
+        { hovered: true, outOfSelection: true }
+      );
+      const onlyHover = getCurveStyle('none', { colors, isSimulated: true }, { hovered: true });
+      expect(fromHover).toEqual(onlyHover);
+    });
+  });
 });

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -119,4 +119,45 @@ describe('getCurveStyle', () => {
       });
     });
   });
+
+  describe('out of selection', () => {
+    it('should use the background tint for the curve and the label', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: true }, { outOfSelection: true });
+      expect(style.color).toBe(colors.background);
+      expect(style.label).toEqual({
+        color: colors.background,
+        fontWeight: 400,
+        background: { color: REST_BACKGROUND_COLOR, opacity: 0.9 },
+      });
+    });
+
+    it('should have no outline', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: false }, { outOfSelection: true });
+      expect(style.outline).toBeUndefined();
+    });
+
+    it('should ignore the state when out of selection', () => {
+      const fromActive = getCurveStyle(
+        'active',
+        { colors, isSimulated: true },
+        { outOfSelection: true }
+      );
+      const fromNone = getCurveStyle(
+        'none',
+        { colors, isSimulated: true },
+        { outOfSelection: true }
+      );
+      expect(fromActive).toEqual(fromNone);
+    });
+
+    it('should leave the base style untouched when not out of selection', () => {
+      const style = getCurveStyle('none', { colors, isSimulated: true }, { outOfSelection: false });
+      expect(style.color).toBe(colors.normal);
+      expect(style.label).toEqual({
+        color: colors.normal,
+        fontWeight: 400,
+        background: { color: REST_BACKGROUND_COLOR, opacity: 0.9 },
+      });
+    });
+  });
 });

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 
 import {
   DEFAULT_TRAIN_PATH_COLORS,
+  DRAGGED_CURVE_COLOR,
+  DRAGGED_CURVE_OUTLINE_COLOR,
   REST_BACKGROUND_COLOR,
   SELECTED_CURVE_COLOR,
   SELECTED_CURVE_OUTLINE_COLOR,
@@ -92,6 +94,29 @@ describe('getCurveStyle', () => {
     it('should replace the outline with the invalid one when the train is not simulated', () => {
       const style = getCurveStyle('passiveSecondary', { colors, isSimulated: false });
       expect(style.outline).toEqual(INVALID_OUTLINE);
+    });
+  });
+
+  describe('drag', () => {
+    it('should return the dark navy color at level 1 with the yellow halo outline', () => {
+      const style = getCurveStyle('drag', { colors, isSimulated: true });
+      expect(style.color).toBe(DRAGGED_CURVE_COLOR);
+      expect(style.level).toBe(1);
+      expect(style.opacity).toBe(1);
+      expect(style.outline).toEqual({
+        offset: 0,
+        width: 1.5,
+        color: DRAGGED_CURVE_OUTLINE_COLOR,
+      });
+    });
+
+    it('should keep the active selection label', () => {
+      const style = getCurveStyle('drag', { colors, isSimulated: true });
+      expect(style.label).toEqual({
+        color: colors.normal,
+        background: { color: colors.background },
+        fontWeight: 600,
+      });
     });
   });
 });

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_TRAIN_PATH_COLORS,
   REST_BACKGROUND_COLOR,
+  SELECTED_CURVE_COLOR,
+  SELECTED_CURVE_OUTLINE_COLOR,
 } from 'applications/operationalStudies/consts';
 
 import getCurveStyle, { INVALID_OUTLINE } from '../getCurveStyle';
@@ -35,6 +37,34 @@ describe('getCurveStyle', () => {
     it('should not add the invalid outline when isSimulated is undefined', () => {
       const style = getCurveStyle('none', { colors });
       expect(style.outline).toBeUndefined();
+    });
+  });
+
+  describe('active', () => {
+    it('should return the active blue color with the active outline', () => {
+      const style = getCurveStyle('active', { colors, isSimulated: true });
+      expect(style.color).toBe(SELECTED_CURVE_COLOR);
+      expect(style.level).toBeUndefined();
+      expect(style.opacity).toBe(1);
+      expect(style.outline).toEqual({
+        offset: 0,
+        width: 3,
+        color: SELECTED_CURVE_OUTLINE_COLOR,
+      });
+    });
+
+    it('should label with the hovered color, bold, with a normal-colored border', () => {
+      const style = getCurveStyle('active', { colors, isSimulated: true });
+      expect(style.label).toEqual({
+        color: colors.hovered,
+        background: { color: colors.background, border: colors.normal },
+        fontWeight: 600,
+      });
+    });
+
+    it('should replace the active outline with the invalid one when the train is not simulated', () => {
+      const style = getCurveStyle('active', { colors, isSimulated: false });
+      expect(style.outline).toEqual(INVALID_OUTLINE);
     });
   });
 });

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveVisualState.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveVisualState.spec.ts
@@ -31,7 +31,7 @@ describe('getCurveVisualState', () => {
               selection: { id: PACED_1, by: 'timetable' },
             })
           )
-        ).toBe('passivePrimary');
+        ).toEqual({ state: 'passivePrimary', hovered: false });
       }
     );
 
@@ -46,7 +46,7 @@ describe('getCurveVisualState', () => {
               selection: { id: PACED_1_OCC_2, by: 'timetable' },
             })
           )
-        ).toBe('passivePrimary');
+        ).toEqual({ state: 'passivePrimary', hovered: false });
       }
     );
 
@@ -61,7 +61,7 @@ describe('getCurveVisualState', () => {
               selection: { id: PACED_1_OCC_2, by: 'timetable' },
             })
           )
-        ).toBe('passiveSecondary');
+        ).toEqual({ state: 'passiveSecondary', hovered: false });
       }
     );
 
@@ -76,7 +76,7 @@ describe('getCurveVisualState', () => {
               selection: { id: PACED_1, by: 'timetable' },
             })
           )
-        ).toBe('passivePrimary');
+        ).toEqual({ state: 'passivePrimary', hovered: false });
       }
     );
 
@@ -91,7 +91,7 @@ describe('getCurveVisualState', () => {
               selection: { id: PACED_1, by: 'timetable' },
             })
           )
-        ).toBe('passiveSecondary');
+        ).toEqual({ state: 'passiveSecondary', hovered: false });
       }
     );
 
@@ -106,7 +106,7 @@ describe('getCurveVisualState', () => {
               selection: { id: PACED_1, by: 'timetable' },
             })
           )
-        ).toBe('none');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
   });
@@ -125,7 +125,7 @@ describe('getCurveVisualState', () => {
             selection: { id: PACED_1, by: 'std' },
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('B.1 bis - unique train, train is the selected one on tod, it should return passivePrimary', () => {
@@ -137,7 +137,7 @@ describe('getCurveVisualState', () => {
             selection: { id: PACED_1, by: 'std' },
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('B.2 - compliant, train without start_time exception on std, it should return active', () => {
@@ -150,7 +150,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('B.2 bis - compliant, train without start_time exception on tod, it should return passivePrimary', () => {
@@ -163,7 +163,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('B.2 ter - compliant, train with start_time exception on std, it should return passiveSecondary', () => {
@@ -176,7 +176,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('B.2 quater - compliant, train with start_time exception on tod, it should return passiveSecondary', () => {
@@ -189,7 +189,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('B.3 - single, last clicked occurrence on std, it should return active', () => {
@@ -202,7 +202,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('B.3 bis - single, last clicked occurrence on tod, it should return passivePrimary', () => {
@@ -215,7 +215,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('B.3 ter - single, other occurrence of same paced on std, it should return passiveSecondary', () => {
@@ -228,7 +228,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('B.3 quater - single, other occurrence of same paced on tod, it should return none', () => {
@@ -241,7 +241,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('none');
+      ).toEqual({ state: 'none', hovered: false });
     });
 
     it('B.4 - single, self with start_time exception on std, it should return active', () => {
@@ -254,7 +254,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('B.4 bis - single, self with start_time exception on tod, it should return passivePrimary', () => {
@@ -267,7 +267,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('B.4 ter - single, other occurrence of same paced on std, it should return passiveSecondary', () => {
@@ -280,7 +280,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('B.4 quater - single, other occurrence of same paced on tod, it should return none', () => {
@@ -293,7 +293,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('none');
+      ).toEqual({ state: 'none', hovered: false });
     });
 
     it('B.5 - all, any occurrence of same paced on std, it should return active', () => {
@@ -306,7 +306,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'all',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('B.5 - all also applies to an occurrence with a start_time exception on std, it should return active', () => {
@@ -319,7 +319,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'all',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('B.5 bis - all, any occurrence of same paced on tod, it should return passivePrimary', () => {
@@ -332,7 +332,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'all',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('B.5 bis - all also applies to an occurrence with a path_and_schedule exception on tod, it should return passivePrimary', () => {
@@ -345,7 +345,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'all',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     // Defensive cases for single mode (not produced by the current dispatch,
@@ -361,7 +361,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('single mode with a selection from another paced train, it should return none', () => {
@@ -374,7 +374,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('none');
+      ).toEqual({ state: 'none', hovered: false });
     });
   });
 
@@ -391,7 +391,7 @@ describe('getCurveVisualState', () => {
             selection: { id: PACED_1, by: 'tod' },
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('C.1 bis - unique train, train is the selected one on std, it should return passivePrimary', () => {
@@ -403,7 +403,7 @@ describe('getCurveVisualState', () => {
             selection: { id: PACED_1, by: 'tod' },
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('C.2 - compliant, train without path_and_schedule exception on tod, it should return active', () => {
@@ -416,7 +416,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('C.2 bis - compliant, train without path_and_schedule exception on std, it should return passivePrimary', () => {
@@ -429,7 +429,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('C.2 ter - compliant, train with path_and_schedule exception on tod, it should return passiveSecondary', () => {
@@ -442,7 +442,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('C.2 quater - compliant, train with path_and_schedule exception on std, it should return passiveSecondary', () => {
@@ -455,7 +455,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('C.3 - single, last clicked occurrence on tod, it should return active', () => {
@@ -468,7 +468,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('C.3 bis - single, last clicked occurrence on std, it should return passivePrimary', () => {
@@ -481,7 +481,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('C.3 ter - single, other occurrence of same paced on tod, it should return passiveSecondary', () => {
@@ -494,7 +494,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('C.3 quater - single, other occurrence of same paced on std, it should return none', () => {
@@ -507,7 +507,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('none');
+      ).toEqual({ state: 'none', hovered: false });
     });
 
     it('C.4 - single, self with path_and_schedule exception on tod, it should return active', () => {
@@ -520,7 +520,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('C.4 bis - single, self with path_and_schedule exception on std, it should return passivePrimary', () => {
@@ -533,7 +533,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
 
     it('C.4 ter - single, other occurrence of same paced on tod, it should return passiveSecondary', () => {
@@ -546,7 +546,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('passiveSecondary');
+      ).toEqual({ state: 'passiveSecondary', hovered: false });
     });
 
     it('C.4 quater - single, other occurrence of same paced on std, it should return none', () => {
@@ -559,7 +559,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'single',
           })
         )
-      ).toBe('none');
+      ).toEqual({ state: 'none', hovered: false });
     });
 
     it('C.5 - all, any occurrence of same paced on tod, it should return active', () => {
@@ -572,7 +572,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'all',
           })
         )
-      ).toBe('active');
+      ).toEqual({ state: 'active', hovered: false });
     });
 
     it('C.5 bis - all, any occurrence of same paced on std, it should return passivePrimary', () => {
@@ -585,7 +585,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'all',
           })
         )
-      ).toBe('passivePrimary');
+      ).toEqual({ state: 'passivePrimary', hovered: false });
     });
   });
 
@@ -601,7 +601,7 @@ describe('getCurveVisualState', () => {
               selection: undefined,
             })
           )
-        ).toBe('none');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
@@ -616,7 +616,7 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1, from: 'timetable' },
             })
           )
-        ).toBe('hover');
+        ).toEqual({ state: 'none', hovered: true });
       }
     );
 
@@ -631,12 +631,12 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1, from: 'timetable' },
             })
           )
-        ).toBe('none');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
     it.each(['std', 'tod'] as const)(
-      'D.3 - hover on an occurrence from train list propagates to siblings on %s, it should return hover',
+      'D.3 - hover on an occurrence from train list, sibling on %s does not receive the hover',
       (chart) => {
         expect(
           getCurveVisualState(
@@ -646,12 +646,12 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1_OCC_2, from: 'timetable' },
             })
           )
-        ).toBe('hover');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
     it.each(['std', 'tod'] as const)(
-      'D.4 - hover from std on no-exception train propagates to siblings without start_time exception on %s, it should return hover',
+      'D.4 - hover from std on no-exception train, sibling without start_time exception on %s does not receive the hover',
       (chart) => {
         expect(
           getCurveVisualState(
@@ -661,7 +661,7 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1_OCC_2, from: 'std' },
             })
           )
-        ).toBe('hover');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
@@ -676,7 +676,7 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1_OCC_2, from: 'std' },
             })
           )
-        ).toBe('none');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
@@ -695,7 +695,7 @@ describe('getCurveVisualState', () => {
               },
             })
           )
-        ).toBe('hover');
+        ).toEqual({ state: 'none', hovered: true });
       }
     );
 
@@ -714,12 +714,12 @@ describe('getCurveVisualState', () => {
               },
             })
           )
-        ).toBe('none');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
     it.each(['std', 'tod'] as const)(
-      'D.6 - hover from tod on no-exception train propagates to siblings without path_and_schedule exception on %s, it should return hover',
+      'D.6 - hover from tod on no-exception train, sibling without path_and_schedule exception on %s does not receive the hover',
       (chart) => {
         expect(
           getCurveVisualState(
@@ -729,7 +729,7 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1_OCC_2, from: 'tod' },
             })
           )
-        ).toBe('hover');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
@@ -744,7 +744,7 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1_OCC_2, from: 'tod' },
             })
           )
-        ).toBe('none');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
@@ -763,7 +763,7 @@ describe('getCurveVisualState', () => {
               },
             })
           )
-        ).toBe('hover');
+        ).toEqual({ state: 'none', hovered: true });
       }
     );
 
@@ -782,7 +782,7 @@ describe('getCurveVisualState', () => {
               },
             })
           )
-        ).toBe('none');
+        ).toEqual({ state: 'none', hovered: false });
       }
     );
 
@@ -790,7 +790,7 @@ describe('getCurveVisualState', () => {
       { chart: 'std', by: 'std' },
       { chart: 'tod', by: 'tod' },
     ] as const)(
-      'D.8 - hover on an already active curve on $chart, it should stay active',
+      'D.8 - hover on an already active curve on $chart, it should stay active with hovered true',
       ({ chart, by }) => {
         expect(
           getCurveVisualState(
@@ -801,7 +801,7 @@ describe('getCurveVisualState', () => {
               hover: { trainId: PACED_1_OCC_2, from: by },
             })
           )
-        ).toBe('active');
+        ).toEqual({ state: 'active', hovered: true });
       }
     );
   });
@@ -821,7 +821,7 @@ describe('getCurveVisualState', () => {
               train: { id: PACED_1, isDragging: true },
             })
           )
-        ).toBe('drag');
+        ).toEqual({ state: 'drag', hovered: false });
       }
     );
 
@@ -834,7 +834,7 @@ describe('getCurveVisualState', () => {
             selection: { id: PACED_1, by: 'std' },
           })
         )
-      ).toBe('drag');
+      ).toEqual({ state: 'drag', hovered: false });
     });
 
     it('E.4 - drag should win over a hover', () => {
@@ -846,7 +846,7 @@ describe('getCurveVisualState', () => {
             hover: { trainId: PACED_1, from: 'std' },
           })
         )
-      ).toBe('drag');
+      ).toEqual({ state: 'drag', hovered: false });
     });
   });
 });

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveVisualState.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveVisualState.spec.ts
@@ -179,7 +179,7 @@ describe('getCurveVisualState', () => {
       ).toBe('passiveSecondary');
     });
 
-    it('B.2 quater - compliant, train with start_time exception on tod, it should return none', () => {
+    it('B.2 quater - compliant, train with start_time exception on tod, it should return passiveSecondary', () => {
       expect(
         getCurveVisualState(
           buildInput({
@@ -189,7 +189,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('none');
+      ).toBe('passiveSecondary');
     });
 
     it('B.3 - single, last clicked occurrence on std, it should return active', () => {
@@ -445,7 +445,7 @@ describe('getCurveVisualState', () => {
       ).toBe('passiveSecondary');
     });
 
-    it('C.2 quater - compliant, train with path_and_schedule exception on std, it should return none', () => {
+    it('C.2 quater - compliant, train with path_and_schedule exception on std, it should return passiveSecondary', () => {
       expect(
         getCurveVisualState(
           buildInput({
@@ -455,7 +455,7 @@ describe('getCurveVisualState', () => {
             panelMode: 'compliant',
           })
         )
-      ).toBe('none');
+      ).toBe('passiveSecondary');
     });
 
     it('C.3 - single, last clicked occurrence on tod, it should return active', () => {

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -1,6 +1,8 @@
 import type { CurveOutline, CurveStyle } from '@osrd-project/ui-charts';
 
 import {
+  DRAGGED_CURVE_COLOR,
+  DRAGGED_CURVE_OUTLINE_COLOR,
   REST_BACKGROUND_COLOR,
   SELECTED_CURVE_COLOR,
   SELECTED_CURVE_OUTLINE_COLOR,
@@ -67,6 +69,18 @@ const getCurveStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyl
     },
   };
 
+  const dragStyle: CurveStyle = {
+    color: DRAGGED_CURVE_COLOR,
+    opacity: 1,
+    level: 1,
+    outline: { offset: 0, width: 1.5, color: DRAGGED_CURVE_OUTLINE_COLOR },
+    label: {
+      color: colors.normal,
+      background: { color: colors.background },
+      fontWeight: FONT_WEIGHT_BOLD,
+    },
+  };
+
   switch (state) {
     case 'none':
       return noneStyle;
@@ -74,6 +88,8 @@ const getCurveStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyl
       return activeStyle;
     case 'passiveSecondary':
       return passiveSecondaryStyle;
+    case 'drag':
+      return dragStyle;
     default:
       // Other states are implemented in following commits.
       return { color: colors.normal, opacity: 1 };

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -1,0 +1,47 @@
+import type { CurveOutline, CurveStyle } from '@osrd-project/ui-charts';
+
+import { REST_BACKGROUND_COLOR } from 'applications/operationalStudies/consts';
+import type { CategoryColors } from 'applications/operationalStudies/types';
+import type { CurveVisualState } from 'modules/simulationResult/types';
+
+export const INVALID_OUTLINE: CurveOutline = {
+  offset: 4,
+  color: 'transparent',
+  backgroundColor: 'rgba(0, 0, 0, 0.05)',
+};
+
+const FONT_WEIGHT_REGULAR = 400;
+const RESTING_LABEL_BACKGROUND: NonNullable<CurveStyle['label']>['background'] = {
+  color: REST_BACKGROUND_COLOR,
+  opacity: 0.9,
+};
+
+type TrainForStyle = {
+  colors: CategoryColors;
+  isSimulated?: boolean;
+};
+
+const getCurveStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle => {
+  const { colors, isSimulated } = train;
+
+  const noneStyle: CurveStyle = {
+    color: colors.normal,
+    opacity: 1,
+    label: {
+      color: colors.normal,
+      fontWeight: FONT_WEIGHT_REGULAR,
+      background: RESTING_LABEL_BACKGROUND,
+    },
+    ...(isSimulated === false && { outline: INVALID_OUTLINE }),
+  };
+
+  switch (state) {
+    case 'none':
+      return noneStyle;
+    default:
+      // Other states are implemented in following commits.
+      return { color: colors.normal, opacity: 1 };
+  }
+};
+
+export default getCurveStyle;

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -34,7 +34,18 @@ type StyleOptions = {
    * its label fade out so the selection stands out.
    */
   outOfSelection?: boolean;
+  /**
+   * The train is directly under the cursor. Hover takes priority over
+   * `outOfSelection` (the curve "comes back" while hovered).
+   */
+  hovered?: boolean;
 };
+
+const hoveredLabel = (colors: CategoryColors): NonNullable<CurveStyle['label']> => ({
+  color: colors.hovered,
+  background: { color: colors.background },
+  fontWeight: FONT_WEIGHT_REGULAR,
+});
 
 const getBaseStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle => {
   const { colors, isSimulated } = train;
@@ -125,16 +136,35 @@ const getBaseStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle
   }
 };
 
+const getHoveredStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle => {
+  const { colors, isSimulated } = train;
+  // 'none' hovered is a full visual switch to the category hovered tint.
+  if (state === 'none') {
+    return {
+      color: colors.hovered,
+      opacity: 1,
+      level: 3,
+      label: hoveredLabel(colors),
+      ...(isSimulated === false && { outline: INVALID_OUTLINE }),
+    };
+  }
+  // 'active', 'passivePrimary', 'passiveSecondary' and 'drag' do not change on
+  // hover: the user is already focused on (or interacting with) this curve.
+  return getBaseStyle(state, train);
+};
+
 /**
  * Maps a curve visual state to its style primitives.
  *
- * `outOfSelection` is a transverse modifier applied on top of the state.
+ * `outOfSelection` and `hovered` are transverse modifiers applied on top of
+ * the state. When `hovered` is set it wins over `outOfSelection`.
  */
 const getCurveStyle = (
   state: CurveVisualState,
   train: TrainForStyle,
-  { outOfSelection = false }: StyleOptions = {}
+  { outOfSelection = false, hovered = false }: StyleOptions = {}
 ): CurveStyle => {
+  if (hovered) return getHoveredStyle(state, train);
   if (outOfSelection) {
     const { colors } = train;
     return {

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -65,6 +65,21 @@ const getBaseStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle
     },
   };
 
+  // Passive primary: the curve belongs to the active selection but the click
+  // happened elsewhere (mirror chart, or timetable). It keeps the category
+  // color so it doesn't take the spotlight away from the actual click target.
+  const passivePrimaryStyle: CurveStyle = {
+    color: colors.normal,
+    opacity: 1,
+    outline:
+      isSimulated === true ? { offset: 0, width: 3, color: colors.background } : INVALID_OUTLINE,
+    label: {
+      color: colors.hovered,
+      background: { color: colors.background, border: colors.normal },
+      fontWeight: FONT_WEIGHT_BOLD,
+    },
+  };
+
   const passiveSecondaryStyle: CurveStyle = {
     color: colors.normal,
     opacity: 1,
@@ -94,13 +109,19 @@ const getBaseStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle
       return noneStyle;
     case 'active':
       return activeStyle;
+    case 'passivePrimary':
+      return passivePrimaryStyle;
     case 'passiveSecondary':
       return passiveSecondaryStyle;
     case 'drag':
       return dragStyle;
-    default:
-      // Other states are implemented in following commits.
-      return { color: colors.normal, opacity: 1 };
+    default: {
+      // Exhaustiveness check: TS fails to compile if a state is added to the
+      // union without a case here.
+      // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
+      const _exhaustive: never = state;
+      throw new Error(`Unhandled curve visual state: ${_exhaustive}`);
+    }
   }
 };
 

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -1,6 +1,10 @@
 import type { CurveOutline, CurveStyle } from '@osrd-project/ui-charts';
 
-import { REST_BACKGROUND_COLOR } from 'applications/operationalStudies/consts';
+import {
+  REST_BACKGROUND_COLOR,
+  SELECTED_CURVE_COLOR,
+  SELECTED_CURVE_OUTLINE_COLOR,
+} from 'applications/operationalStudies/consts';
 import type { CategoryColors } from 'applications/operationalStudies/types';
 import type { CurveVisualState } from 'modules/simulationResult/types';
 
@@ -11,6 +15,7 @@ export const INVALID_OUTLINE: CurveOutline = {
 };
 
 const FONT_WEIGHT_REGULAR = 400;
+const FONT_WEIGHT_BOLD = 600;
 const RESTING_LABEL_BACKGROUND: NonNullable<CurveStyle['label']>['background'] = {
   color: REST_BACKGROUND_COLOR,
   opacity: 0.9,
@@ -35,9 +40,26 @@ const getCurveStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyl
     ...(isSimulated === false && { outline: INVALID_OUTLINE }),
   };
 
+  // Active selection on the chart that received the click: blue curve and halo.
+  const activeStyle: CurveStyle = {
+    color: SELECTED_CURVE_COLOR,
+    opacity: 1,
+    outline:
+      isSimulated === true
+        ? { offset: 0, width: 3, color: SELECTED_CURVE_OUTLINE_COLOR }
+        : INVALID_OUTLINE,
+    label: {
+      color: colors.hovered,
+      background: { color: colors.background, border: colors.normal },
+      fontWeight: FONT_WEIGHT_BOLD,
+    },
+  };
+
   switch (state) {
     case 'none':
       return noneStyle;
+    case 'active':
+      return activeStyle;
     default:
       // Other states are implemented in following commits.
       return { color: colors.normal, opacity: 1 };

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -28,7 +28,15 @@ type TrainForStyle = {
   isSimulated?: boolean;
 };
 
-const getCurveStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle => {
+type StyleOptions = {
+  /**
+   * Active selection is open and the train is not part of it. The curve and
+   * its label fade out so the selection stands out.
+   */
+  outOfSelection?: boolean;
+};
+
+const getBaseStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle => {
   const { colors, isSimulated } = train;
 
   const noneStyle: CurveStyle = {
@@ -94,6 +102,31 @@ const getCurveStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyl
       // Other states are implemented in following commits.
       return { color: colors.normal, opacity: 1 };
   }
+};
+
+/**
+ * Maps a curve visual state to its style primitives.
+ *
+ * `outOfSelection` is a transverse modifier applied on top of the state.
+ */
+const getCurveStyle = (
+  state: CurveVisualState,
+  train: TrainForStyle,
+  { outOfSelection = false }: StyleOptions = {}
+): CurveStyle => {
+  if (outOfSelection) {
+    const { colors } = train;
+    return {
+      color: colors.background,
+      opacity: 1,
+      label: {
+        color: colors.background,
+        fontWeight: FONT_WEIGHT_REGULAR,
+        background: RESTING_LABEL_BACKGROUND,
+      },
+    };
+  }
+  return getBaseStyle(state, train);
 };
 
 export default getCurveStyle;

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -55,11 +55,25 @@ const getCurveStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyl
     },
   };
 
+  const passiveSecondaryStyle: CurveStyle = {
+    color: colors.normal,
+    opacity: 1,
+    outline:
+      isSimulated === true ? { offset: 0, width: 2, color: colors.background } : INVALID_OUTLINE,
+    label: {
+      color: colors.hovered,
+      background: { color: colors.background, border: colors.normal },
+      fontWeight: FONT_WEIGHT_REGULAR,
+    },
+  };
+
   switch (state) {
     case 'none':
       return noneStyle;
     case 'active':
       return activeStyle;
+    case 'passiveSecondary':
+      return passiveSecondaryStyle;
     default:
       // Other states are implemented in following commits.
       return { color: colors.normal, opacity: 1 };

--- a/front/src/modules/simulationResult/helpers/getCurveVisualState.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveVisualState.ts
@@ -57,15 +57,13 @@ const getChartSelectionState = (
   if (panelMode === 'single') return chart === primaryChart ? 'passiveSecondary' : 'none';
 
   // 'compliant' (B.2, C.2): occurrences with the relevant exception get
-  // passiveSecondary on the primary chart and none on the other one, the rest
-  // gets the same as self.
+  // passiveSecondary on both charts (they stay visible as family context on
+  // the mirror, per the design planches), the rest gets the same as self.
   if (panelMode === 'compliant') {
     // The exception type relevant for this mode, derived from the selection source.
     const relevantException: CurveStyleExceptionType =
       selection.by === 'std' ? 'start_time' : 'path_and_schedule';
-    if (train.exceptionType === relevantException) {
-      return chart === primaryChart ? 'passiveSecondary' : 'none';
-    }
+    if (train.exceptionType === relevantException) return 'passiveSecondary';
     return chart === primaryChart ? 'active' : 'passivePrimary';
   }
 

--- a/front/src/modules/simulationResult/helpers/getCurveVisualState.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveVisualState.ts
@@ -8,6 +8,7 @@
 import type {
   CurveStyleExceptionType,
   CurveStyleInput,
+  CurveVisualClassification,
   CurveVisualState,
 } from 'modules/simulationResult/types';
 import type { TrainId } from 'reducers/osrdconf/types';
@@ -70,50 +71,15 @@ const getChartSelectionState = (
   return 'none';
 };
 
-/**
- * Returns the hover state for this train, or `undefined` when the hover
- * does not apply to this train. The caller function uses hover as a layer
- * on top of the selection state: `undefined` means "keep the selection
- * state", a returned state means "override it".
- */
-const getHoverState = (
-  train: TrainInput,
-  hover: NonNullable<CurveStyleInput['hover']>
-): CurveVisualState | undefined => {
-  // Self always gets hover (D.2, D.5, D.7, plus the hovered itself in D.3/D.4/D.6).
-  if (train.id === hover.trainId) return 'hover';
-
-  // Trains outside the hovered's paced family never get hover.
-  if (!samePacedTrain(train.id, hover.trainId)) return undefined;
-
-  // Hover from the train list (D.2, D.3):
-  // - hovered is a unique train (PacedTrainId): only self gets hover (D.2, handled above).
-  // - hovered is an occurrence (OccurrenceId): every occurrence of the paced gets hover (D.3).
-  if (hover.from === 'timetable') {
-    return isOccurrenceId(hover.trainId) ? 'hover' : undefined;
-  }
-
-  // Hover from a chart (STD or TOD): the relevant exception type follows the source.
-  const relevantException: CurveStyleExceptionType =
-    hover.from === 'std' ? 'start_time' : 'path_and_schedule';
-
-  // Hovered itself has the relevant exception (D.5, D.7): only self gets hover.
-  if (hover.exceptionType === relevantException) return undefined;
-
-  // Hovered has no relevant exception (D.4, D.6): propagate to paced siblings that
-  // also have no relevant exception.
-  return train.exceptionType === relevantException ? undefined : 'hover';
-};
-
 const getCurveVisualState = ({
   chart,
   train,
   selection,
   panelMode,
   hover,
-}: CurveStyleInput): CurveVisualState => {
+}: CurveStyleInput): CurveVisualClassification => {
   // E.4: a dragged train always gets 'drag', regardless of selection or hover.
-  if (train.isDragging) return 'drag';
+  if (train.isDragging) return { state: 'drag', hovered: false };
 
   let state: CurveVisualState = 'none';
   if (selection) {
@@ -123,13 +89,12 @@ const getCurveVisualState = ({
         : getChartSelectionState(chart, train, selection, panelMode);
   }
 
-  // D.8: an already active curve stays active even when hovered.
-  if (hover && state !== 'active') {
-    const hoverState = getHoverState(train, hover);
-    if (hoverState) return hoverState;
-  }
+  // The hover effect is only applied to the train directly under the cursor.
+  // The matrix used to propagate it to paced siblings (D.3/D.4/D.6), but the
+  // design planches show that only the directly hovered train changes visually.
+  const hovered = !!hover && train.id === hover.trainId;
 
-  return state;
+  return { state, hovered };
 };
 
 export default getCurveVisualState;

--- a/front/src/modules/simulationResult/helpers/getPathStyleV2.ts
+++ b/front/src/modules/simulationResult/helpers/getPathStyleV2.ts
@@ -1,0 +1,22 @@
+import type { CategoryColors } from 'applications/operationalStudies/types';
+import type { CurveStyleInput } from 'modules/simulationResult/types';
+
+import getCurveStyle from './getCurveStyle';
+import getCurveVisualState from './getCurveVisualState';
+
+// TODO: Drop getPathStyle when TOD style is implemented, and rename this fucntion to getCurveStyle
+const getPathStyleV2 = (
+  input: CurveStyleInput,
+  train: { colors: CategoryColors; isSimulated?: boolean }
+) => {
+  const { state, hovered } = getCurveVisualState(input);
+
+  // When the selection comes from the timetable, the other trains stay visible
+  // (the goal is to preserve the overall context). Chart-driven selections fade
+  // the rest out to put the focus on the click target.
+  const outOfSelection =
+    state === 'none' && !!input.selection && input.selection.by !== 'timetable';
+  return getCurveStyle(state, train, { hovered, outOfSelection });
+};
+
+export default getPathStyleV2;

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -130,16 +130,20 @@ export type DraggingState = {
 };
 
 /**
- * The six visual states a curve can take in STD/TOD charts.
- * - 1 none, 2 hover, 3 active, 4 passivePrimary, 5 passiveSecondary, 6 drag.
+ * The five visual states a curve can take in STD/TOD charts. Hover is not
+ * part of this union: it is a transverse modifier carried alongside the
+ * state (see [[CurveVisualClassification]]).
  */
-export type CurveVisualState =
-  | 'none'
-  | 'hover'
-  | 'active'
-  | 'passivePrimary'
-  | 'passiveSecondary'
-  | 'drag';
+export type CurveVisualState = 'none' | 'active' | 'passivePrimary' | 'passiveSecondary' | 'drag';
+
+/**
+ * Output of the curve visual state classifier: the base state and a
+ * transverse `hovered` flag set only for the train directly under the cursor.
+ */
+export type CurveVisualClassification = {
+  state: CurveVisualState;
+  hovered: boolean;
+};
 
 /**
  * Exception types that influence the curve visual state. The values match

--- a/front/ui/ui-charts/src/common/index.ts
+++ b/front/ui/ui-charts/src/common/index.ts
@@ -5,6 +5,7 @@ export { usePicking, useDraw } from './hooks/useCanvas';
 export { getCrispLineCoordinate } from './helpers/time';
 
 export type {
+  CurveOutline,
   CurveStyle,
   HoveredItem,
   DrawingFunction,

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -49,8 +49,6 @@ export type CurveStyle = {
   label?: {
     border?: { color: string; width: number };
     fontWeight?: number;
-    background: { color: string; opacity?: number };
-    color: string;
   };
 };
 

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -47,7 +47,8 @@ export type CurveStyle = {
   level?: PathLevel;
   outline?: CurveOutline;
   label?: {
-    border?: { color: string; width: number };
+    background?: { color: string; opacity?: number; border?: string };
+    color?: string;
     fontWeight?: number;
   };
 };

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -24,6 +24,17 @@ export type RGBAColor = [number, number, number, number];
 export type PickingLayerType = (typeof PICKING_LAYERS)[number];
 export type LayerType = (typeof LAYERS)[number];
 
+export type CurveOutline = {
+  /** Offset compared to the curve */
+  offset: number;
+  /** Color of the outline */
+  color: string;
+  /** Thickness of the outline */
+  width?: number;
+  /** Won't be used most of the time, color will be used */
+  backgroundColor?: string;
+};
+
 /**
  * Visual style of a curve, computed by the shared curve-style helper
  * and used by STD (PathLayer) and TOD (OccupancyBlockLayer).
@@ -34,16 +45,7 @@ export type CurveStyle = {
   color: string;
   opacity: number;
   level?: PathLevel;
-  outline?: {
-    /** Offset compared to the curve */
-    offset: number;
-    /** Color of the outline */
-    color: string;
-    /** Thickness of the outline */
-    width?: number;
-    /** Won't be used most of the time, color will be used */
-    backgroundColor?: string;
-  };
+  outline?: CurveOutline;
   label?: {
     border?: { color: string; width: number };
     fontWeight?: number;

--- a/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -6,6 +6,7 @@ import { hexToRgb, indexToColor } from '../../common/helpers/colors';
 import { getCrispLineCoordinate } from '../../common/helpers/time';
 import { useDraw, usePicking } from '../../common/hooks/useCanvas';
 import type {
+  CurveStyle,
   DrawingFunction,
   PickingDrawingFunction,
   PickingElement,
@@ -92,12 +93,8 @@ export type PathLayerProps = {
   color: string;
   pickingTolerance?: number;
   level?: PathLevel;
-  border?: {
-    offset: number;
-    color: string;
-    width?: number;
-    backgroundColor?: string;
-  };
+  border?: CurveStyle['outline'];
+  label?: CurveStyle['label'];
 };
 
 /**
@@ -112,6 +109,7 @@ export const PathLayer = ({
   level = DEFAULT_LEVEL,
   pickingTolerance = DEFAULT_PICKING_TOLERANCE,
   border,
+  label,
 }: PathLayerProps) => {
   /**
    * This function returns the list of points to join to draw the path. As it can be discontinuous,
@@ -296,20 +294,24 @@ export const PathLayer = ({
         background,
         fontSize,
         fontFamily,
+        fontWeight = 400,
         padding = TEXT_PADDING,
         alpha = 0.75,
+        borderColor,
       }: {
         textColor: string;
         background: string;
         fontSize?: number;
         fontFamily?: string;
+        fontWeight?: number;
         padding?: number;
         alpha?: number;
+        borderColor?: string;
       }
     ) => {
       ctx.save();
 
-      ctx.font = `${fontSize}px ${fontFamily}`;
+      ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
 
       const measure = ctx.measureText(text);
       const left = measure.actualBoundingBoxLeft;
@@ -326,7 +328,20 @@ export const PathLayer = ({
       // BACKGROUND
       ctx.globalAlpha = alpha;
       ctx.fillStyle = background;
-      ctx.fillRect(rx, ry, w, h);
+      ctx.beginPath();
+      ctx.roundRect(rx, ry, w, h, 3);
+      ctx.fill();
+
+      // BORDER
+      if (borderColor) {
+        ctx.save();
+        ctx.globalAlpha = 1;
+        ctx.strokeStyle = borderColor;
+        ctx.lineWidth = 1;
+        ctx.roundRect(rx, ry, w, h, 3);
+        ctx.stroke();
+        ctx.restore();
+      }
 
       // TEXT
       ctx.globalAlpha = 1;
@@ -354,12 +369,12 @@ export const PathLayer = ({
           pathsStyles: { fontSize, fontFamily },
         },
       }: SpaceTimeChartContextType,
-      label: string,
+      text: string,
       labelColor: string,
       points: Point[],
       pathLength: number
     ) => {
-      if (!label) return;
+      if (!text) return;
 
       const firstPointOnScreenIndex = points.findIndex(({ x, y }) =>
         !swapAxis
@@ -405,22 +420,25 @@ export const PathLayer = ({
       ctx.textAlign = 'start';
 
       const padding = 2;
-      const measure = ctx.measureText(label);
+      const measure = ctx.measureText(text);
       const w = measure.width + 2 * padding;
 
       const dx = w < pathLength ? 5 : (pathLength - w) / 2; // Progressively center the label if the path is shorter than the label
-      const dy = angle >= 0 ? -5 : 15;
+      const dy = angle >= 0 ? -7 : 17;
 
-      drawLabelWithBackground(ctx, label, dx, dy, {
+      drawLabelWithBackground(ctx, text, dx, dy, {
         fontSize,
         fontFamily,
-        textColor: labelColor,
-        background,
+        fontWeight: label?.fontWeight,
+        textColor: label?.color ?? labelColor,
+        background: label?.background?.color ?? background,
+        alpha: label?.background?.opacity,
+        borderColor: label?.background?.border,
         padding,
       });
       ctx.restore();
     },
-    [drawLabelWithBackground]
+    [drawLabelWithBackground, label]
   );
 
   const computePathLength = useCallback(
@@ -525,14 +543,17 @@ export const PathLayer = ({
         drawLabelWithBackground(ctx, path.label, x, labelY, {
           fontFamily,
           fontSize,
-          textColor: color,
-          background,
+          fontWeight: label?.fontWeight,
+          textColor: label?.color ?? color,
+          background: label?.background?.color ?? background,
+          alpha: label?.background?.opacity,
+          borderColor: label?.background?.border,
         });
       }
 
       ctx.restore();
     },
-    [level, color, drawLabelWithBackground, path.label]
+    [level, color, drawLabelWithBackground, path.label, label]
   );
 
   const drawAll = useCallback<DrawingFunction<SpaceTimeChartContextType>>(

--- a/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -51,26 +51,33 @@ type PathStyle = {
   endWidth: number;
   dashArray?: number[];
   opacity?: number;
-  lineCap?: CanvasLineCap;
+  lineCap: CanvasLineCap;
 };
 
-export type PathLevel = 1 | 2 | 3 | 4;
+export type PathLevel = 1 | 2 | 3 | 4 | 5;
 const STYLES: Record<PathLevel, PathStyle> = {
   1: {
-    width: 1.5,
-    endWidth: 1.5,
+    width: 0.5,
+    endWidth: 0.5,
+    lineCap: 'round',
   },
   2: {
     width: 1,
     endWidth: 1,
+    lineCap: 'round',
   },
   3: {
+    width: 1.5,
+    endWidth: 1.5,
+    lineCap: 'round',
+  },
+  4: {
     width: 1,
     endWidth: 1,
     dashArray: [5, 5],
     lineCap: 'square',
   },
-  4: {
+  5: {
     width: 1.5,
     endWidth: 1,
     dashArray: [0, 4],
@@ -551,7 +558,7 @@ export const PathLayer = ({
       ctx.lineWidth = style.width;
       ctx.setLineDash(style.dashArray || []);
       ctx.globalAlpha = style.opacity || 1;
-      ctx.lineCap = style.lineCap || 'square';
+      ctx.lineCap = style.lineCap;
       const lines = getPathLines(stcContext);
       lines.forEach((points) => {
         ctx.beginPath();

--- a/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { flatten, inRange, last } from 'lodash';
+import { flatten, inRange } from 'lodash';
 
 import { hexToRgb, indexToColor } from '../../common/helpers/colors';
 import { getCrispLineCoordinate } from '../../common/helpers/time';
@@ -14,12 +14,11 @@ import type {
 import { SpaceTimeChartCanvasContext } from '../lib/context';
 import {
   type DataPoint,
-  DEFAULT_PATH_END,
   type OperationalPoint,
   type PathData,
   type SpaceTimeChartContextType,
 } from '../lib/types';
-import { drawAliasedDisc, drawAliasedLine, drawPathExtremity } from '../utils/canvas';
+import { drawAliasedDisc, drawAliasedLine } from '../utils/canvas';
 import { getPathDirection, getSpacePixels } from '../utils/paths';
 import { getSpaceBreakpoints } from '../utils/scales';
 
@@ -417,40 +416,6 @@ export const PathLayer = ({
     [drawLabelWithBackground]
   );
 
-  /**
-   * This function draws the extremities of the path.
-   */
-  const drawExtremities = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
-    (ctx, { getTimePixel, getSpacePixel, swapAxis = false }) => {
-      if (!path.points.length) return;
-
-      const from = path.points[0];
-      const fromEnd = path.fromEnd || DEFAULT_PATH_END;
-      const to = last(path.points) as DataPoint;
-      const toEnd = path.toEnd || DEFAULT_PATH_END;
-
-      drawPathExtremity(
-        ctx,
-        getTimePixel(from.time),
-        getSpacePixel(from.position),
-        swapAxis,
-        'from',
-        getPathDirection(path, 0),
-        fromEnd
-      );
-      drawPathExtremity(
-        ctx,
-        getTimePixel(to.time),
-        getSpacePixel(to.position),
-        swapAxis,
-        'to',
-        getPathDirection(path, path.points.length - 1, true),
-        toEnd
-      );
-    },
-    [path]
-  );
-
   const computePathLength = useCallback(
     (operationalPoints: OperationalPoint[], lines: Point[][]) => {
       let totalLength = 0;
@@ -600,11 +565,6 @@ export const PathLayer = ({
         ctx.stroke();
       });
 
-      // Draw extremities:
-      ctx.setLineDash([]);
-      ctx.lineWidth = style.endWidth;
-      drawExtremities(ctx, stcContext);
-
       // Draw label:
       if (!stcContext.hidePathsLabels) {
         const pathLength = computePathLength(stcContext.operationalPoints, lines);
@@ -622,7 +582,6 @@ export const PathLayer = ({
       drawPauses,
       level,
       getPathLines,
-      drawExtremities,
       drawSinglePoint,
       computePathLength,
       drawLabel,

--- a/front/ui/ui-charts/src/spaceTimeChart/lib/consts.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/lib/consts.ts
@@ -19,7 +19,7 @@ export const OCCUPANCY_WARNING = '#FFEABF';
 
 // Fonts:
 export const FONT_SIZE = 10;
-export const FONT = 'IBM Plex Sans, sans-serif';
+export const FONT = 'IBM Plex Mono, monospace';
 
 export const DEFAULT_THEME: SpaceTimeChartTheme = {
   background: 'white',

--- a/front/ui/ui-charts/src/spaceTimeChart/utils/canvas.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/utils/canvas.ts
@@ -1,7 +1,7 @@
 import { clamp } from 'lodash';
 
 import type { Point, RGBAColor } from '../../common/types';
-import type { SpaceTimeChartContextType, Direction, PathEnd, RGBColor } from '../lib/types';
+import type { SpaceTimeChartContextType, RGBColor } from '../lib/types';
 
 /**
  * This function draws a thick lines from "from" to "to" on the given ImageData, with no
@@ -279,86 +279,6 @@ export function drawAliasedRect(
       imageData.data[index + 2] = b;
       imageData.data[index + 3] = 255;
     }
-  }
-}
-
-/**
- * This function draws a "stop" path extremity.
- * That handles a path that stops or starts exactly in an operational points included in the line
- * represented in the chart.
- */
-const STOP_END_SIZE = 6;
-export function drawPathStopExtremity(
-  ctx: CanvasRenderingContext2D,
-  timePixel: number,
-  spacePixel: number,
-  swapAxis: boolean
-): void {
-  ctx.beginPath();
-  if (!swapAxis) {
-    ctx.moveTo(timePixel, spacePixel - STOP_END_SIZE / 2);
-    ctx.lineTo(timePixel, spacePixel + STOP_END_SIZE / 2);
-  } else {
-    ctx.moveTo(spacePixel - STOP_END_SIZE / 2, timePixel);
-    ctx.lineTo(spacePixel + STOP_END_SIZE / 2, timePixel);
-  }
-  ctx.stroke();
-}
-
-/**
- * This function draws an "out" path extremity.
- * That handles a path that leaves or joins the line represented in the chart.
- */
-const OUT_END_SIZE = 12;
-export function drawPathOutExtremity(
-  ctx: CanvasRenderingContext2D,
-  timePixel: number,
-  spacePixel: number,
-  swapAxis: boolean,
-  extremityType: 'from' | 'to',
-  pathDirection: Direction
-): void {
-  let horizontalSign = extremityType === 'from' ? -1 : 1;
-  let verticalSign = (pathDirection === 'backward' ? -1 : 1) * horizontalSign;
-  let controlX = timePixel + 4 * horizontalSign;
-  let controlY = spacePixel + (OUT_END_SIZE - 2) * verticalSign;
-  let x = timePixel;
-  let y = spacePixel;
-  if (swapAxis) {
-    [horizontalSign, verticalSign] = [verticalSign, horizontalSign];
-    [controlX, controlY] = [controlY, controlX];
-    [x, y] = [y, x];
-  }
-
-  ctx.beginPath();
-  ctx.moveTo(x, y);
-  ctx.bezierCurveTo(
-    controlX,
-    controlY,
-    controlX,
-    controlY,
-    x + OUT_END_SIZE * horizontalSign,
-    y + OUT_END_SIZE * verticalSign
-  );
-  ctx.stroke();
-}
-
-/**
- * This function draws a path extremity.
- */
-export function drawPathExtremity(
-  ctx: CanvasRenderingContext2D,
-  timePixel: number,
-  spacePixel: number,
-  swapAxis: boolean,
-  extremityType: 'from' | 'to',
-  pathDirection: Direction,
-  pathEnd: PathEnd
-): void {
-  if (pathEnd === 'out') {
-    drawPathOutExtremity(ctx, timePixel, spacePixel, swapAxis, extremityType, pathDirection);
-  } else {
-    drawPathStopExtremity(ctx, timePixel, spacePixel, swapAxis);
   }
 }
 


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/17052
_See commits_

## Description
A shared helper turns each curve visual state into a style the charts can render: color, outline, label, level.
Wired into the STD chart in place of the old `getPathStyle`. Hover is treated as a modifier on top of the base state.

## Context: what was done before

PR [#16770](https://github.com/OpenRailAssociation/osrd/pull/16770) (closes #16585) introduced `getCurveVisualState`: a pure classifier that turns the selection / hover / drag context into one of the visual states (`none`, `active`, `passivePrimary`, `passiveSecondary`, `drag`). It knows *which* state a curve is in, but not how it should look. This PR is the next step.

## What this PR does

**Part 1: Map each state to a style** (`getCurveStyle`):
- One commit per visual state (`none`, `active`, `passivePrimary`, `passiveSecondary`, `drag`).
- Hover is applied as a modifier on top of the base state.
- Curves out of the active selection fade.
- Labels and outlines follow the Sketch mockups.

**Part 2: Wire the new style into the STD chart**:
- Replace the old `getPathStyle` by `getPathStyleV2` in the STD wrapper.
- Handle the selection source (`std` / `tod` / `timetable`) to pick the right exception type for compliance.
- Adjust `ui-charts` (line cap, label rendering, curve thickness) to match the new look.

The two first commits (`keep exception siblings visible on the mirror chart`, `ui-charts: adapt label type in CurveStyle`) are small adjustments that make the wiring easier and do not belong to the main flow.

## How to test

Open a study with at least one paced train projected and one unique train. Hover, select and drag curves both from the train list and from the tod itself, then check that each state matches what the Sketch mockups show:

- [Selection from the train list](https://www.sketch.com/s/183fcd09-8341-47c0-9c8e-15f29c0c4437/f/477E2ED6-2AD6-4C90-8505-9E4F919252B0#Inspect)
- [Selection from the STD chart](https://www.sketch.com/s/50744654-4631-4fae-8e7c-7eb22dfadc1a/p/B3B26243-D873-4148-9198-FB48EF301327/canvas#Inspect)

## Out of scope

- Wiring the new helper into the TOD chart. The helper is already chart-agnostic, the TOD side is a follow-up ticket.
- Connecting the panel selection mode to the style. The helper already takes a `panelMode` field, but it is hardcoded to `compliant` here. The panel wiring PR brings the real value.
