### PR TITLE
editoast: fix validate_consist_max_speed

### DIFF
--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -394,7 +394,7 @@ impl ConsistConfiguration {
                 .and_then(|t| t.max_speed)
                 .unwrap_or(quantities::Velocity::new::<meter_per_second>(f64::INFINITY)),
         );
-        let consist_max_speed = consist_max_speed.floor::<meter_per_second>();
+        let consist_max_speed = consist_max_speed.ceil::<meter_per_second>();
 
         if let Some(request_max_speed) = self.max_speed
             && (request_max_speed < quantities::Velocity::new::<meter_per_second>(0.0)


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/issues/16979.

Method validates approximatively that the consist's max speed isn't higher than the max_speed of the traction_engine/towed_rs. We should use ceil here, not floor.

Ceiling to the first decimal was considered, but dropped (this decision is open to challenge if needed) due to:
- users are selecting max_speed in tens of km/h, so we don't need such precision. Especially since this was just a quick check to make sure errors are picked up (like inputting 1000km/h for a train).
- it would add a dependency to a new crate, math. Or we'd need to do uom::ceil(max_speed*10)/10, which is quite ugly.