### PR TITLE
front: adds read-only intermediate waypoints panel

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -424,6 +424,16 @@
       "cancelMapSelection": "Cancel",
       "focusLocationOnMap": "Focus the map on this operational point",
       "frameAll": "Center on all path steps on map",
+      "intermediateWaypointsPanel": {
+        "collapseGroup": "Collapse intermediate points",
+        "expandGroup": "Expand intermediate points",
+        "hide": "Hide",
+        "hideLabel": "Hide intermediate OPs",
+        "idleMessage": "Complete the itinerary to display its intermediate OPs.",
+        "noWaypoint": "No intermediate OPs to display, the itinerary isn't valid.",
+        "panelTitle": "Intermediate points",
+        "showLabel": "Display all intermediate OPs"
+      },
       "invalidOP": "Non recognized point: ",
       "moveLocationOnMap": "Move location on the map",
       "movePointOnMap": "Move this waypoint using the map",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -424,6 +424,16 @@
       "cancelMapSelection": "Annuler",
       "focusLocationOnMap": "Centrer la carte sur ce point remarquable",
       "frameAll": "Centrer sur tous les points de passage sur la carte",
+      "intermediateWaypointsPanel": {
+        "collapseGroup": "Replier les points intermédiaires",
+        "expandGroup": "Déplier les points intermédiaires",
+        "hide": "Masquer",
+        "hideLabel": "Masquer les PR intermédiaires",
+        "idleMessage": "Complétez l'itinéraire pour afficher ses PR intermédiaires.",
+        "noWaypoint": "Aucun point intermédiaire à afficher, le chemin n'est pas valide.",
+        "panelTitle": "Points intermédiaires",
+        "showLabel": "Afficher tous les PR intermédiaires"
+      },
       "invalidOP": "Point non reconnu : ",
       "moveLocationOnMap": "Déplacer le point remarquable sur la carte",
       "movePointOnMap": "Déplacez ce point en utilisant la carte",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import type { ItineraryPathProperties } from 'applications/operationalStudies/types';
+import DotsLoader from 'common/DotsLoader';
+import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
+import type { SuggestedOP } from 'modules/trainSchedule/types';
+import type { PathStepV2 } from 'reducers/osrdconf/types';
+
+import { groupOperationalPoints } from './utils';
+import WaypointGroup from './WaypointGroup';
+
+type IntermediateWaypointsPanelProps = {
+  pathSteps: PathStepV2[];
+  pathProperties: ItineraryPathProperties | undefined;
+  status: 'idle' | 'loading' | 'error' | 'success';
+  onHide: () => void;
+};
+
+const IntermediateWaypointsPanel = ({
+  pathSteps,
+  pathProperties,
+  status,
+  onHide,
+}: IntermediateWaypointsPanelProps) => {
+  const { t } = useTranslation('operational-studies', {
+    keyPrefix: 'manageTrainSchedule.itineraryModal.intermediateWaypointsPanel',
+  });
+
+  const suggestedOps: SuggestedOP[] = useMemo(() => {
+    if (!pathProperties?.operational_points || !pathProperties.geometry) return [];
+    return formatSuggestedOperationalPoints(
+      pathProperties.operational_points,
+      pathProperties.geometry,
+      pathProperties.length
+    );
+  }, [pathProperties]);
+
+  const groups = useMemo(
+    () => groupOperationalPoints(suggestedOps, pathSteps),
+    [suggestedOps, pathSteps]
+  );
+
+  return (
+    <aside
+      className="intermediate-waypoints-panel"
+      aria-label={t('panelTitle')}
+      data-testid="intermediate-waypoints-panel"
+    >
+      {status === 'loading' ? (
+        <div className="intermediate-waypoints-panel__loader">
+          <DotsLoader />
+        </div>
+      ) : status === 'success' ? (
+        <div className="intermediate-waypoints-panel__list">
+          {groups.map((group) => (
+            <WaypointGroup key={group.requestedStep.id} group={group} />
+          ))}
+        </div>
+      ) : (
+        <div className="intermediate-waypoints-panel__empty">
+          <p className="intermediate-waypoints-panel__empty-message">
+            {t(status === 'idle' ? 'idleMessage' : 'noWaypoint')}
+          </p>
+          <button
+            type="button"
+            className="intermediate-waypoints-panel__empty-hide"
+            onClick={onHide}
+          >
+            {t('hide')}
+          </button>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default IntermediateWaypointsPanel;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+import { ChevronDown, ChevronUp } from '@osrd-project/ui-icons';
+import { useTranslation } from 'react-i18next';
+
+import type { WaypointGroup as WaypointGroupType } from './types';
+import WaypointRow from './WaypointRow';
+
+type WaypointGroupProps = {
+  group: WaypointGroupType;
+  defaultExpanded?: boolean;
+};
+
+const WaypointGroup = ({ group, defaultExpanded = true }: WaypointGroupProps) => {
+  const { t } = useTranslation('operational-studies', {
+    keyPrefix: 'manageTrainSchedule.itineraryModal.intermediateWaypointsPanel',
+  });
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const hasIntermediates = group.intermediates.length > 0;
+
+  return (
+    <div className="intermediate-waypoints-panel__group">
+      <div className="intermediate-waypoints-panel__group-header">
+        {hasIntermediates ? (
+          <button
+            type="button"
+            className="intermediate-waypoints-panel__group-toggle"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            aria-label={expanded ? t('collapseGroup') : t('expandGroup')}
+          >
+            {expanded ? <ChevronUp /> : <ChevronDown />}
+          </button>
+        ) : (
+          <span className="intermediate-waypoints-panel__group-toggle" aria-hidden />
+        )}
+        <WaypointRow op={group.requestedOp} isRequested />
+      </div>
+      {expanded && hasIntermediates && (
+        <ul className="intermediate-waypoints-panel__group-body">
+          {group.intermediates.map((op) => (
+            <li key={op.opId ?? `${op.track}-${op.offsetOnTrack}-${op.positionOnPath}`}>
+              <WaypointRow op={op} isRequested={false} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default WaypointGroup;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointRow.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointRow.tsx
@@ -1,0 +1,52 @@
+import { Dot, Plus } from '@osrd-project/ui-icons';
+import cx from 'classnames';
+
+import { isStation } from 'modules/pathfinding/utils';
+import type { SuggestedOP } from 'modules/trainSchedule/types';
+
+type WaypointRowProps = {
+  /**
+   * The operational point this row displays, or undefined for a requested step
+   * that matches no OP along the path (for instance a map-click waypoint)
+   * which renders as a placeholder row:
+   */
+  op: SuggestedOP | undefined;
+  isRequested: boolean;
+};
+
+const WaypointRow = ({ op, isRequested }: WaypointRowProps) => {
+  const station = !!op && isStation(op.ch ?? '');
+
+  return (
+    <div
+      className={cx('intermediate-waypoints-panel__row', {
+        'intermediate-waypoints-panel__row--requested': isRequested,
+      })}
+      data-testid="intermediate-waypoint-row"
+    >
+      <span className="intermediate-waypoints-panel__row-name">{op?.name ?? '-'}</span>
+      <span className="intermediate-waypoints-panel__row-station-icon" aria-hidden>
+        {/* TODO: Replace this with the train-station icon from ui-icons once it's been added */}
+        {station && <i className="icons-itinerary-train-station" />}
+      </span>
+      <span className="intermediate-waypoints-panel__row-ch">{op?.ch ?? ''}</span>
+      {isRequested ? (
+        <span className="intermediate-waypoints-panel__row-status" aria-hidden>
+          <Dot variant="fill" />
+        </span>
+      ) : (
+        // TODO: Implement the logic behind this button, and enable it
+        <button
+          type="button"
+          className="intermediate-waypoints-panel__row-add"
+          aria-hidden
+          disabled
+        >
+          <Plus />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default WaypointRow;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/__tests__/utils.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+
+import type { SuggestedOP } from 'modules/trainSchedule/types';
+import type { PathStepV2 } from 'reducers/osrdconf/types';
+
+import { groupOperationalPoints } from '../utils';
+
+const makeStep = (id: string, uic: number, ch = 'BV'): PathStepV2 => ({
+  id,
+  location: {
+    type: 'operational_point_part_reference',
+    operational_point: { type: 'uic', uic, secondary_code: ch },
+  },
+  arrival: null,
+  stopFor: null,
+  theoreticalMargin: null,
+  receptionSignal: null,
+});
+
+const makeOp = (id: string, uic: number, ch = 'BV', positionOnPath = 0): SuggestedOP => ({
+  opId: id,
+  pathStepId: undefined,
+  name: `op-${id}`,
+  uic,
+  ch,
+  offsetOnTrack: 0,
+  track: 'track-1',
+  positionOnPath,
+});
+
+describe('groupOperationalPoints', () => {
+  it('puts intermediate OPs between two requested steps in the first group', () => {
+    const steps = [makeStep('s1', 1), makeStep('s2', 2)];
+    const ops = [
+      makeOp('o1', 1, 'BV', 0),
+      makeOp('o2', 99, 'BV', 100),
+      makeOp('o3', 98, 'BV', 200),
+      makeOp('o4', 2, 'BV', 300),
+    ];
+
+    const groups = groupOperationalPoints(ops, steps);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].requestedStep.id).toBe('s1');
+    expect(groups[0].requestedOp?.opId).toBe('o1');
+    expect(groups[0].intermediates.map((o) => o.opId)).toEqual(['o2', 'o3']);
+    expect(groups[1].requestedStep.id).toBe('s2');
+    expect(groups[1].requestedOp?.opId).toBe('o4');
+    expect(groups[1].intermediates).toEqual([]);
+  });
+
+  it('handles two adjacent requested steps with no intermediates between them', () => {
+    const steps = [makeStep('s1', 1), makeStep('s2', 2), makeStep('s3', 3)];
+    const ops = [
+      makeOp('o1', 1, 'BV', 0),
+      makeOp('o2', 2, 'BV', 100),
+      makeOp('oMid', 99, 'BV', 150),
+      makeOp('o3', 3, 'BV', 200),
+    ];
+
+    const groups = groupOperationalPoints(ops, steps);
+
+    expect(groups[0].intermediates).toEqual([]);
+    expect(groups[1].intermediates.map((o) => o.opId)).toEqual(['oMid']);
+    expect(groups[2].intermediates).toEqual([]);
+  });
+
+  it('returns an empty array when there are no valid/located steps', () => {
+    const emptyStep: PathStepV2 = {
+      id: 's1',
+      location: null,
+      arrival: null,
+      stopFor: null,
+      theoreticalMargin: null,
+      receptionSignal: null,
+    };
+    expect(groupOperationalPoints([makeOp('o1', 1)], [emptyStep])).toEqual([]);
+  });
+
+  it('does not stall when a middle requested step matches no OP', () => {
+    // Simulate a map-click waypoint that no returned OP matches:
+    const trackOffsetStep: PathStepV2 = {
+      id: 's2',
+      location: { type: 'track_offset', track: 'xxx', offset: 50 },
+      arrival: null,
+      stopFor: null,
+      theoreticalMargin: null,
+      receptionSignal: null,
+    };
+    const steps = [makeStep('s1', 1), trackOffsetStep, makeStep('s3', 3)];
+    const ops = [
+      makeOp('o1', 1, 'BV', 0),
+      makeOp('oMid', 99, 'BV', 100),
+      makeOp('o3', 3, 'BV', 200),
+    ];
+
+    const groups = groupOperationalPoints(ops, steps);
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0].requestedOp?.opId).toBe('o1');
+    expect(groups[0].intermediates.map((o) => o.opId)).toEqual(['oMid']);
+    expect(groups[1].requestedStep.id).toBe('s2');
+    expect(groups[1].requestedOp).toBeUndefined();
+    expect(groups[1].intermediates).toEqual([]);
+    expect(groups[2].requestedStep.id).toBe('s3');
+    expect(groups[2].requestedOp?.opId).toBe('o3');
+  });
+});

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/types.ts
@@ -1,0 +1,8 @@
+import type { SuggestedOP } from 'modules/trainSchedule/types';
+import type { PathStepV2 } from 'reducers/osrdconf/types';
+
+export type WaypointGroup = {
+  requestedStep: PathStepV2;
+  requestedOp: SuggestedOP | undefined;
+  intermediates: SuggestedOP[];
+};

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
@@ -1,0 +1,50 @@
+import { matchPathStepAndOp } from 'modules/pathfinding/utils';
+import type { SuggestedOP } from 'modules/trainSchedule/types';
+import type { PathStepV2 } from 'reducers/osrdconf/types';
+
+import type { WaypointGroup } from './types';
+
+/**
+ * Groups operational points along the computed path under the requested step
+ * that precedes each one. Each group is a requested step followed by the
+ * intermediate OPs that fall between it and the next requested step.
+ *
+ * A requested step may have no matching OP (for instance a map-click waypoint
+ * that does not coincide with an operational point along the path). Such a
+ * step keeps an undefined `requestedOp` and does not block the grouping of the
+ * steps after it.
+ */
+export function groupOperationalPoints(
+  operationalPoints: SuggestedOP[],
+  pathSteps: PathStepV2[]
+): WaypointGroup[] {
+  const validSteps = pathSteps.filter(
+    (step): step is PathStepV2 & { location: NonNullable<PathStepV2['location']> } =>
+      step.location !== null
+  );
+
+  if (validSteps.length === 0) return [];
+
+  const groups: WaypointGroup[] = validSteps.map((step) => ({
+    requestedStep: step,
+    requestedOp: undefined,
+    intermediates: [],
+  }));
+
+  let currentGroupIndex = -1;
+
+  operationalPoints.forEach((op) => {
+    const matchedIndex = validSteps.findIndex(
+      (step, index) => index > currentGroupIndex && matchPathStepAndOp(step.location, op)
+    );
+
+    if (matchedIndex !== -1) {
+      currentGroupIndex = matchedIndex;
+      groups[currentGroupIndex].requestedOp = op;
+    } else if (currentGroupIndex >= 0) {
+      groups[currentGroupIndex].intermediates.push(op);
+    }
+  });
+
+  return groups;
+}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
-import { ArrowSwitch, FrameAll, Plus } from '@osrd-project/ui-icons';
+import { ArrowSwitch, Fold, FrameAll, Plus, Unfold } from '@osrd-project/ui-icons';
 import bbox from '@turf/bbox';
 import cx from 'classnames';
 import type { Position } from 'geojson';
@@ -52,6 +52,7 @@ import useMapTrackSelection from '../hooks/useMapTrackSelection';
 import type { FeatureInfoClick } from '../types';
 import type { OperationalPointSuggestion } from './ComboBoxCustomList/ListElementComponent';
 import { usePathStepsMetadata } from './hooks/usePathStepsMetadata';
+import IntermediateWaypointsPanel from './IntermediateWaypointsPanel/IntermediateWaypointsPanel';
 import ItineraryModalFormHeader from './ItineraryModalFormHeader';
 import ItineraryModalMap from './ItineraryModalMap';
 import PathStepItem from './PathStepItem';
@@ -117,6 +118,12 @@ const ItineraryModal = ({
   const [customTracksByOpKey, setCustomTracksByOpKey] = useState<
     Map<string, { trackId: string; trackName: string }[]>
   >(new Map());
+  const [waypointsPanelOpen, setWaypointsPanelOpen] = useState(false);
+  const toggleWaypointsPanelLabel = t(
+    waypointsPanelOpen
+      ? 'intermediateWaypointsPanel.hideLabel'
+      : 'intermediateWaypointsPanel.showLabel'
+  );
 
   const closeModal = () => {
     modalRef.current?.close();
@@ -269,6 +276,31 @@ const ItineraryModal = ({
     workerStatus === 'READY' && locatedStepsCount >= 2 && !hasInvalidPathStep
       ? pathProperties
       : undefined;
+
+  const waypointsPanelStatus = useMemo<'idle' | 'loading' | 'error' | 'success'>(() => {
+    if (pathfindingError) return 'error';
+    if (displayedPathProperties) return 'success';
+
+    // No path properties yet: distinguish "pathfinding is on its way" (loading)
+    // from "the itinerary isn't set up enough to trigger it" (idle).
+    const isPathfindingPending =
+      workerStatus === 'READY' &&
+      locatedStepsCount >= 2 &&
+      !hasInvalidPathStep &&
+      !!modalFormState.rollingStockId;
+    return isPathfindingPending ? 'loading' : 'idle';
+  }, [
+    workerStatus,
+    locatedStepsCount,
+    hasInvalidPathStep,
+    modalFormState.rollingStockId,
+    pathfindingError,
+    displayedPathProperties,
+  ]);
+
+  const canOpenWaypointsPanel =
+    waypointsPanelStatus === 'success' || waypointsPanelStatus === 'loading';
+  const waypointsPanelButtonDisabled = !waypointsPanelOpen && !canOpenWaypointsPanel;
 
   const markEditing = (stepId: string) => {
     editingStepIdRef.current = stepId;
@@ -627,15 +659,15 @@ const ItineraryModal = ({
               'with-invalid-step': hasInvalidPathStepDisplay || invalidTrackSteps.length > 0,
             })}
           >
-            <button
-              data-testid="reverse-itinerary-button"
-              className="reverse-itinerary-button"
-              type="button"
-              onClick={reverseItinerary}
-            >
-              <ArrowSwitch />
-            </button>
             <div className="itinerary-icons">
+              <button
+                data-testid="reverse-itinerary-button"
+                className="reverse-itinerary-button"
+                type="button"
+                onClick={reverseItinerary}
+              >
+                <ArrowSwitch />
+              </button>
               <button className="frame-all" onClick={frameAllPathSteps}>
                 <FrameAll title={t('frameAll')} aria-label={t('frameAll')} />
               </button>
@@ -803,6 +835,20 @@ const ItineraryModal = ({
                 </>
               );
             })}
+            <button
+              data-testid="show-intermediate-waypoints-button"
+              className="show-intermediate-waypoints-button"
+              type="button"
+              onClick={() => setWaypointsPanelOpen((v) => !v)}
+              disabled={waypointsPanelButtonDisabled}
+              aria-expanded={waypointsPanelOpen}
+              aria-label={toggleWaypointsPanelLabel}
+            >
+              {waypointsPanelOpen ? <Fold /> : <Unfold />}
+              <span className="show-intermediate-waypoints-button__label" aria-hidden>
+                {toggleWaypointsPanelLabel}
+              </span>
+            </button>
           </div>
         </div>
         <div className="itinerary-modal-form-footer">
@@ -816,6 +862,16 @@ const ItineraryModal = ({
           <Button label={t('next')} variant="Primary" size="medium" onClick={submitItinerary} />
         </div>
       </div>
+      {waypointsPanelOpen && (
+        <div className="itinerary-modal-waypoints-panel-wrapper">
+          <IntermediateWaypointsPanel
+            pathSteps={pathSteps}
+            pathProperties={displayedPathProperties}
+            status={waypointsPanelStatus}
+            onHide={() => setWaypointsPanelOpen(false)}
+          />
+        </div>
+      )}
       <div
         className={cx('itinerary-modal-map', {
           'map-selection-active': mapSelectionStepId !== null,

--- a/front/src/styles/scss/_variables.scss
+++ b/front/src/styles/scss/_variables.scss
@@ -76,6 +76,7 @@ $colors: (
   'primary40': #3c8aff,
   'primary50': #256afa,
   'primary60': #1844ef,
+  'primary70': #201ede,
   'primary80': #1f0f96,
   'primary90': #180f47,
   'selection20': #fff2b3,

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -162,8 +162,8 @@
         border-radius: 8px;
         margin-top: 12px;
         margin-inline: 8px;
-        padding-top: 16px;
-        padding-bottom: 46px;
+        padding-top: 8px;
+        padding-bottom: 8px;
 
         &.with-invalid-step {
           border: 8px solid var(--black10);
@@ -224,20 +224,21 @@
             display: block !important;
           }
         }
-        .reverse-itinerary-button {
-          position: absolute;
-          padding: 8px;
-          transform: rotate(90deg);
-          top: 0;
-          left: 8px;
-          color: var(--grey30);
-        }
-
         .itinerary-icons {
           display: flex;
-          justify-content: end;
+          justify-content: space-between;
           align-items: center;
-          padding-inline: 16px;
+          padding-inline: 8px 16px;
+
+          .reverse-itinerary-button {
+            padding: 8px;
+            color: var(--grey30);
+            transform: rotate(90deg);
+
+            span {
+              display: flex;
+            }
+          }
 
           .frame-all span {
             display: flex;
@@ -247,6 +248,41 @@
             &:hover {
               color: var(--black100);
             }
+          }
+        }
+
+        .show-intermediate-waypoints-button {
+          margin-left: 8px;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 5px 8px;
+          border-radius: 8px;
+          color: var(--grey30);
+
+          &:disabled {
+            cursor: not-allowed;
+            opacity: 0.4;
+          }
+
+          &__label {
+            color: var(--grey80);
+            font-size: 0.875rem;
+            display: none;
+          }
+
+          &[aria-expanded='true'],
+          &:hover:not(:disabled) {
+            padding-right: 12px;
+
+            .show-intermediate-waypoints-button__label {
+              display: inline;
+            }
+          }
+
+          &:hover:not(:disabled) {
+            background-color: var(--black5);
+            color: var(--primary70);
           }
         }
 
@@ -512,6 +548,156 @@
       padding-inline: 34px;
       margin-top: var(--footer-box-shadow-height);
       box-shadow: 0 calc(-1 * var(--footer-box-shadow-height)) 0 0 var(--black10);
+    }
+  }
+
+  .itinerary-modal-waypoints-panel-wrapper {
+    width: 420px;
+    flex-shrink: 0;
+    border-left: 1px solid var(--grey30);
+  }
+
+  .intermediate-waypoints-panel {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    background: var(--ambientB5);
+    font-size: 1rem;
+
+    $groupHeaderPaddingLeft: 8px;
+    $groupHeaderGap: 16px;
+    $groupToggleWidth: 20px;
+    $rowGap: 23px;
+    $emptyStateGap: 27px;
+
+    &__loader,
+    &__empty {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      text-align: center;
+      gap: $emptyStateGap;
+    }
+
+    &__empty-message {
+      max-width: 240px;
+      color: var(--info60);
+      margin: 0;
+    }
+
+    &__empty-hide {
+      margin: 0;
+      border: none;
+      background: none;
+      color: var(--primary60);
+
+      &:hover {
+        color: var(--primary80);
+      }
+    }
+
+    &__list {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+    }
+
+    &__group-header {
+      display: flex;
+      align-items: center;
+      gap: $groupHeaderGap;
+      padding-left: $groupHeaderPaddingLeft;
+      margin-top: 1px;
+      background: var(--ambientB15);
+      border-bottom: 1px solid var(--grey20);
+    }
+
+    &__group-toggle {
+      flex-shrink: 0;
+      width: $groupToggleWidth;
+      height: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      border: none;
+      background: none;
+      color: var(--grey80);
+    }
+
+    &__group-body {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      // Texts from rows inside the group body should align on the left exactly
+      // with the group header text:
+      li {
+        margin-left: calc(
+          #{$groupHeaderPaddingLeft} + #{$groupToggleWidth} + #{$groupHeaderGap} / 2
+        );
+        padding-left: calc(#{$groupHeaderGap} / 2);
+        border-bottom: 1px solid var(--grey20);
+      }
+    }
+
+    &__row {
+      flex-grow: 1;
+      display: flex;
+      align-items: center;
+      min-width: 0;
+      height: 36px;
+      padding-right: 10px;
+      color: var(--grey80);
+      gap: $rowGap;
+
+      &--requested {
+        font-weight: 600;
+      }
+    }
+
+    &__row-name {
+      flex-grow: 1;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      & + * {
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
+    }
+
+    &__row-station-icon,
+    &__row-status,
+    &__row-add {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    &__row-station-icon {
+      width: 16px;
+      color: var(--grey40);
+    }
+
+    &__row-ch {
+      min-width: 20px;
+      text-align: right;
+    }
+
+    &__row-status {
+      color: var(--grey20);
+    }
+
+    &__row-add {
+      color: var(--grey20);
+      // TODO:
+      // Restore visible style for that button
+      // color: var(--primary60);
     }
   }
 


### PR DESCRIPTION
This PR implements #16946.

Details:
- Adds new WaypointGroup type, to represent the collapsible groups of waypoints in the upcoming intermediate waypoints panel
- Adds groupOperationalPoints, that, given suggested OPs and path steps, returns the waypoint groups to display
- Adds unit tests covering these cases
- Adds the read-only IntermediateWaypointsPanel, with its WaypointGroup and WaypointRow components, to list the OPs found along the path
- Wires a toggle button into the itinerary modal, deriving the panel status from displayedPathProperties so it stays in sync with the map