### PR TITLE
front: enable eqeqeq lint

### DIFF
--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -64,7 +64,6 @@
     "default-case-last": "off",
     "default-param-last": "off",
     "dot-notation": "off",
-    "eqeqeq": "off",
     "eslint/require-await": "off",
     "exhaustive-deps": "off",
     "exports-last": "off",

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -133,7 +133,7 @@ const IntervalEditorComponent = (
     closeModal();
     setData(fixedData);
     setSelected((old) => (old !== null && fixedData[old] ? old : null));
-    setHovered((old) => (old != null && fixedData[old.index] ? old : null));
+    setHovered((old) => (old !== null && fixedData[old.index] ? old : null));
   }, [fixedData]);
 
   /**

--- a/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
+++ b/front/src/applications/operationalStudies/hooks/useEtcsBrakingCurves.ts
@@ -43,10 +43,10 @@ const formatEtcsCurves = (etcsBrakingCurves: CoreEtcsBrakingCurvesResponse): Etc
     [EtcsBrakingType.STOP]: stops.map(toBrakingCurve),
     [EtcsBrakingType.SLOWDOWN]: slowdowns.map(toBrakingCurve),
     [EtcsBrakingType.SPACING]: conflicts
-      .filter((conflict) => conflict.conflict_type == 'Spacing')
+      .filter((conflict) => conflict.conflict_type === 'Spacing')
       .map(toBrakingCurve),
     [EtcsBrakingType.ROUTING]: conflicts
-      .filter((conflict) => conflict.conflict_type == 'Routing')
+      .filter((conflict) => conflict.conflict_type === 'Routing')
       .map(toBrakingCurve),
   };
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
@@ -175,7 +175,7 @@ export const relabelDuplicateTrigrams = (nodes: NodeDto[]): NodeDto[] => {
 
   return nodes.map((node) => {
     const trigramIds = trigramsToIds.get(node.betriebspunktName)!;
-    if (trigramIds.length == 1) return node;
+    if (trigramIds.length === 1) return node;
     const idIndex = trigramIds.findIndex((id) => id === node.id);
     const newTrigram = `${node.betriebspunktName}-${idIndex + 1}`;
     return {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalMap.tsx
@@ -359,7 +359,7 @@ const ItineraryModalMap = ({
             let coordinates: Position | undefined;
             if (pathProperties?.operational_points) {
               // If there is a pathfinding, we use it to get the simulated coordinates
-              if (pathStepMetadata.type == 'trackOffset') {
+              if (pathStepMetadata.type === 'trackOffset') {
                 coordinates = pathStepMetadata.coordinates;
               } else {
                 const matchedOp = pathProperties.operational_points.find((op) =>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/utils.ts
@@ -30,7 +30,7 @@ export const computePathStepCoordinates = (pathStepMetadata: PathStepMetadata) =
 export const buildOpRef = (op: OperationalPoint): OperationalPointReference => {
   const ch = op.extensions?.sncf?.ch;
   const uic = op.extensions?.identifier?.uic;
-  if (uic != null)
+  if (uic !== undefined)
     return {
       type: 'uic',
       uic,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -187,7 +187,9 @@ const PacedTrainItem = ({
 
   const deleteAllExceptions = async () => {
     // TODO_EXCEPTION: remove filter when using TrainScheduleException type
-    const allIds = pacedTrain.paced.exceptions.filter((e) => e.id != null).map((e) => e.id!);
+    const allIds = pacedTrain.paced.exceptions
+      .filter((e) => typeof e.id === 'number')
+      .map((e) => e.id!);
 
     if (allIds.length > 0) {
       await deleteExceptions(dispatch, allIds);

--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -198,11 +198,11 @@ const SendToRailwayManagerModal = ({
       },
       {
         label: t('modal.maxSpeed'),
-        value: consist.maxSpeed != null ? `${consist.maxSpeed} km/h` : '-',
+        value: typeof consist.maxSpeed === 'number' ? `${consist.maxSpeed} km/h` : '-',
       },
       {
         label: t('modal.totalLength'),
-        value: consist.totalLength != null ? `${consist.totalLength} m` : '-',
+        value: typeof consist.totalLength === 'number' ? `${consist.totalLength} m` : '-',
       },
       { label: t('modal.gauge'), value: consist.loadingGauge ?? '-' },
     ],

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmFeedback.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmFeedback.tsx
@@ -15,9 +15,9 @@ const StdcmFeedback = () => {
   if (
     !consist ||
     !consist.tractionEngine ||
-    consist.totalLength == null ||
-    consist.totalMass == null ||
-    consist.maxSpeed == null
+    typeof consist.totalLength !== 'number' ||
+    typeof consist.totalMass !== 'number' ||
+    typeof consist.maxSpeed !== 'number'
   )
     return null;
 

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -115,7 +115,7 @@ const TypeAndPath = ({ setDisplayTypeAndPath, isInNewModal = false }: TypeAndPat
         const filteredResults = results.filter((result) => {
           const searchResult = result as SearchResultItemOperationalPoint;
           // We need to ensure the name is not null since we sort the results depending on it.
-          return searchResult.name != null && MAIN_OP_CH_CODES.includes(searchResult.ch);
+          return searchResult.name && MAIN_OP_CH_CODES.includes(searchResult.ch);
         });
         setSearchResults(filteredResults as SearchResultItemOperationalPoint[]);
       })

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
@@ -139,8 +139,8 @@ export function buildSplitPoints(
               position: operationalPointPosition,
               onClick: handleWaypointClick,
             }}
-            waypointRef={waypointId == activeWaypointId ? activeWaypointRef : undefined}
-            isActive={waypointId == activeWaypointId}
+            waypointRef={waypointId === activeWaypointId ? activeWaypointRef : undefined}
+            isActive={waypointId === activeWaypointId}
             isMenuActive={false}
           />
         </TrackOccupancyManchette>

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/sortTracks.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/sortTracks.ts
@@ -12,8 +12,8 @@ export function extractFirstNumber(s: string): number | null {
 // then alphabetically), followed by named tracks without numbers,
 // unnamed tracks, and finally '[ ]'.
 export function compareTracksByName(a: Track, b: Track): number {
-  const na = a.name != null ? extractFirstNumber(a.name) : null;
-  const nb = b.name != null ? extractFirstNumber(b.name) : null;
+  const na = a.name ? extractFirstNumber(a.name) : null;
+  const nb = b.name ? extractFirstNumber(b.name) : null;
   if (na !== null && nb !== null) return na - nb || a.name!.localeCompare(b.name!);
   if (na !== null) return -1;
   if (nb !== null) return 1;

--- a/front/src/modules/timesStops/MarginCell.tsx
+++ b/front/src/modules/timesStops/MarginCell.tsx
@@ -94,7 +94,7 @@ const MarginCellEditable = ({
 
   const inputRef = useRef<HTMLInputElement>(null);
   const skipCommitOnBlurRef = useRef(false);
-  const isEmpty: boolean = raw == null;
+  const isEmpty: boolean = raw === null;
 
   useEffect(() => {
     setUnit(initialValue?.unit ?? MarginUnit.percent);

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -169,7 +169,7 @@ export const adjustFollowingWaypointsForMidnight = (
       item,
       pathIndex: selectedTrain.path.findIndex((step) => step.id === item.at),
     }))
-    .filter(({ item, pathIndex }) => item.arrival != null && pathIndex > editedPathIndex)
+    .filter(({ item, pathIndex }) => item.arrival && pathIndex > editedPathIndex)
     .toArray();
 
   let lastOffset = Duration.subtractDate(newValue, startTime);

--- a/front/src/modules/trainSchedule/helpers/pacedTrain.ts
+++ b/front/src/modules/trainSchedule/helpers/pacedTrain.ts
@@ -228,16 +228,18 @@ export const getOccurrenceTrainName = (
  * Return true if the exception has at least one change group defined (excluding disabled).
  */
 export const hasChangeGroups = (exception: SimulatedException): boolean =>
-  exception.constraint_distribution != null ||
-  exception.initial_speed != null ||
-  exception.labels != null ||
-  exception.options != null ||
-  exception.path_and_schedule != null ||
-  exception.rolling_stock != null ||
-  exception.rolling_stock_category != null ||
-  exception.speed_limit_tag != null ||
-  exception.start_time != null ||
-  exception.train_name != null;
+  Boolean(
+    exception.constraint_distribution ||
+    exception.initial_speed ||
+    exception.labels ||
+    exception.options ||
+    exception.path_and_schedule ||
+    exception.rolling_stock ||
+    exception.rolling_stock_category ||
+    exception.speed_limit_tag ||
+    exception.start_time ||
+    exception.train_name
+  );
 
 /**
  * Return true if the exception has at least one change group defined OR is disabled.

--- a/front/src/utils/hooks/useAuth.ts
+++ b/front/src/utils/hooks/useAuth.ts
@@ -50,7 +50,7 @@ function useAuth() {
     let impersonated = userToImpersonate
       ? (await fetchFullUser({ body: { ids: [userToImpersonate.id], identities: [] } })).data?.[0]
       : undefined;
-    if (impersonated && impersonated.identities.length == 0) {
+    if (impersonated && impersonated.identities.length === 0) {
       impersonated = undefined;
     }
     dispatch(setImpersonatedUser(impersonated));

--- a/front/ui/storybook/stories/ui-charts/speedSpaceChart/utils.ts
+++ b/front/ui/storybook/stories/ui-charts/speedSpaceChart/utils.ts
@@ -35,7 +35,7 @@ const formatMrsp = (mrsp: Simulation['mrsp']) => {
     boundaries: boundaries.map(convertMmToKM),
     values: values.map((speed, index) => ({
       speed: convertMsToKmh(speed),
-      isTemporary: (index + 1) % 4 == 0,
+      isTemporary: (index + 1) % 4 === 0,
     })),
   };
 };

--- a/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
+++ b/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
@@ -70,7 +70,7 @@ const TimeGraduations = () => {
         ctx.stroke();
       });
 
-      if (!swapAxis && isHover && mouseX != null && !isNaN(mouseX)) {
+      if (!swapAxis && isHover && !isNaN(mouseX)) {
         const crispX = getCrispLineCoordinate(mouseX, 1);
         const timeValue = getTime(crispX);
         const timeLabel = new Date(timeValue).toLocaleTimeString();

--- a/front/ui/ui-charts/src/manchette/utils/helpers.ts
+++ b/front/ui/ui-charts/src/manchette/utils/helpers.ts
@@ -180,4 +180,4 @@ export const getScales = (
 export const isInteractiveWaypoint = (
   item: InteractiveWaypoint | ReactNode
 ): item is InteractiveWaypoint =>
-  item != null && typeof item === 'object' && 'id' in item && 'position' in item;
+  item !== null && typeof item === 'object' && 'id' in item && 'position' in item;

--- a/front/ui/ui-charts/src/spaceTimeChart/utils/canvas.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/utils/canvas.ts
@@ -236,7 +236,7 @@ export function drawAliasedQuadrilateral(
 
         // Invert the equation: x(y) = (y - c) / m
         // Look only for points that are on the left of the line, so for a given y, x < (y - c) / m
-        if (pointA.y > y != pointB.y > y && x < (y - c) / m) {
+        if (pointA.y > y !== pointB.y > y && x < (y - c) / m) {
           isInside = !isInside;
         }
       }

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/InteractionButtons.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/InteractionButtons.tsx
@@ -22,7 +22,7 @@ const InteractionButtons = ({
     <button
       type="button"
       className={cx('reset-button', {
-        'reset-button-disabled': store.ratioX == 1 && store.leftOffset == 0,
+        'reset-button-disabled': store.ratioX === 1 && store.leftOffset === 0,
       })}
       onClick={reset}
       data-testid={testIdPrefix ? `${testIdPrefix}-reset` : undefined}

--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/speedLimits.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/speedLimits.ts
@@ -33,7 +33,7 @@ export const drawSpeedLimits = ({ ctx, width, height, store }: DrawFunctionParam
   for (let i = 0; i < mrsp.values.length; i++) {
     const { speed, isTemporary } = mrsp.values[i];
 
-    const isLastValue = i == mrsp.values.length - 1;
+    const isLastValue = i === mrsp.values.length - 1;
     const currentBoundary = isLastValue ? maxPosition : mrsp.boundaries[i];
     const currentBoundaryX = positionToPosX(currentBoundary, maxPosition, width, ratioX);
 


### PR DESCRIPTION
This one is part of the recommended lints, so dropping it from our config file enables it.

There are a few cases to look out for when comparing with `== null`, because this check returns true when the value is null or undefined:

- Some checks were unnecessary because values were never `null` nor `undefined`
- Some checks can be turned into `===` because the value is not `null | undefined`, it's just one or the other
- Some checks need to explicitly check for `typeof value === 'number'`, because zero is falsish
- Other checks can be turned into `Boolean(value)` (e.g. when checking for `ObjectType | null | undefined`)