### PR TITLE
gateway: oidc: fix extra claims that can be not string type

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "openidconnect",
  "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "url",
 ]
@@ -622,6 +623,12 @@ name = "base64"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -2122,15 +2129,16 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openidconnect"
 version = "4.0.1"
-source = "git+https://github.com/osrd-project/openidconnect-rs.git?branch=disable-profile#c7a31f10d34f654df336017b03b394ea1c06b55d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
  "hmac",
  "http 1.3.1",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "oauth2",
  "p256",
@@ -2575,7 +2583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -53,7 +53,7 @@ regex = "1.12.3"
 # actix_auth
 actix-web-httpauth = "0.8"
 
-openidconnect = { git = "https://github.com/osrd-project/openidconnect-rs.git", branch = "disable-profile" }
+openidconnect = "4.0.1"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }

--- a/gateway/actix_auth/Cargo.toml
+++ b/gateway/actix_auth/Cargo.toml
@@ -16,6 +16,7 @@ dyn-clone.workspace = true
 futures-util.workspace = true
 log.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 
 # oidc

--- a/gateway/actix_auth/src/providers/oidc.rs
+++ b/gateway/actix_auth/src/providers/oidc.rs
@@ -18,6 +18,7 @@ use openidconnect::{
 };
 use openidconnect::{EndpointMaybeSet, EndpointNotSet, EndpointSet, HttpClientError};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 
 use super::{
@@ -38,7 +39,7 @@ pub struct OidcConfig {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct AllAdditionalClaims(HashMap<String, String>);
+pub struct AllAdditionalClaims(HashMap<String, Value>);
 
 impl AdditionalClaims for AllAdditionalClaims {}
 
@@ -289,9 +290,12 @@ impl SessionProvider for OidcProvider {
                     .0
                     .get(identity_claim_field)
                     .cloned()
-                    .ok_or_else(|| {
-                        CallbackError::IdentityFieldNotFoundInClaims(identity_claim_field.clone())
-                    })?
+                    .ok_or(CallbackError::IdentityFieldNotFoundInClaims(
+                        identity_claim_field.clone(),
+                    ))?
+                    .as_str()
+                    .ok_or(CallbackError::IdentityFieldIsNotString)?
+                    .to_string()
             } else {
                 claims.subject().to_string()
             };
@@ -416,6 +420,8 @@ pub enum CallbackError {
     InvalidAmr,
     #[error("identity_claim_field not found: '{0}'")]
     IdentityFieldNotFoundInClaims(String),
+    #[error("identity_claim_field is not a string")]
+    IdentityFieldIsNotString,
 }
 
 impl actix_web::ResponseError for CallbackError {
@@ -431,6 +437,24 @@ impl actix_web::ResponseError for CallbackError {
             CallbackError::InvalidAcr => StatusCode::BAD_REQUEST,
             CallbackError::InvalidAmr => StatusCode::BAD_REQUEST,
             CallbackError::IdentityFieldNotFoundInClaims(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            CallbackError::IdentityFieldIsNotString => StatusCode::INTERNAL_SERVER_ERROR,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FullTokenResponse;
+    #[test]
+    fn oidc_token_response_fails() {
+        // Mocked jwt generated with a random private key
+        let jwt = "eyJ0eXAiOiJKV1QiLCJraWQiOiJlU1g5UDdnYzgxSUlqQWsvbW5YZFJPYkVsblE9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJtb2NrZWQiLCJhbXIiOlsicGFzc3dvcmQiXSwiaXNzIjoiaHR0cHM6Ly9tb2NrZWQ6NDQzL29wZW5hbS9vYXV0aDIvcmVhbG1zL3Jvb3QvcmVhbG1zL1NTTzIiLCJ0b2tlbk5hbWUiOiJpZF90b2tlbiIsInR5cGUiOiJJIiwibG9naW4iOiJtb2NrZWQiLCJ1aWRfdW5pZmllIjoibW9ja2VkIiwiYWNyIjoiZGVmYXVsdCIsInVpZCI6IlhYMDAwMCIsInVwZGF0ZWRfYXQiOjAsImF6cCI6Ik9TUkQiLCJhdXRoX3RpbWUiOjE3ODAzOTI4NzksImV4cCI6MTc4MDQwNzI3OSwiaWF0IjoxNzgwMzkyODc5LCJlbWFpbCI6Im1vY2tlZEBvc3JkLmZyIiwicHJvZmlsIjpbIk9TUkQtMSIsIk9TUi0yIl0sImdpdmVuX25hbWUiOiJTbWl0aCIsIm5vbmNlIjoiSm9JaWVuMVp3bWNhcDBfX1hCR3RUQSIsImF1ZCI6Ik9TUkQiLCJjX2hhc2giOiJXXzg5QktmLXNoNFV1Y0p0bkFiTm5nIiwibmFtZSI6IlNtaXRoIENob28iLCJyZWFsbSI6Ii9TU08yIiwidG9rZW5UeXBlIjoiSldUVG9rZW4iLCJmYW1pbHlfbmFtZSI6IkNob28iLCJlbnRpdHkiOiJYWDAwWFgifQ.mEhiJvXNmQdxJwrcisSDWH66aBBwHuQFgbEDAORrwG1jtxKZxc_lsVWh8DihAsOFFJcp4p0pfiedlC_eRi60q-FsBIxxqOWT6e3H8sFGCVmKbd3Tu3OxEE7aWEWLaHaA3x7wtnlmu-eF_0mCwrH_1DaghUJ9NbAM2RyHK5o2NPRUK7FXWS7vMF-jqLz3G0_7M3Gb1-_e3I4E1QwUiVGBClZvF64RQNr5pjq7pl6cpfUE2A2H64l21_rxgzvF4WIUXbpE1d3LIgi7eDDpwXroGIH3-w97H_ExQF3YJHAErMdCf72Il0VugANSmtVPdLQfEaA3VXiIsotLsU-m9bMVLQ";
+
+        let raw_token_response = format!(
+            r#"{{"access_token":"dummy-access-token","token_type":"Bearer","id_token":"{jwt}"}}"#
+        );
+
+        serde_json::from_str::<FullTokenResponse>(&raw_token_response)
+            .expect("should be able to parse");
     }
 }


### PR DESCRIPTION
With the integration of the `identity_claim_field` we introduced a bug. We expected all extra claims to be strings, which might not be the case. The issue does not come from the prod identity provider :facepalm: 
![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWdydXlqcWMwbGx1eTJ0OHg1c2U0emh2c3U4aGRvZWFwcnZzMmM4byZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Ra1bmpxpsppNC/giphy.gif)

This PR contains:
1. Revert: https://github.com/OpenRailAssociation/osrd/pull/16978/changes
2. Fix the extra claims type

Once merged, we can delete our `openidconnect-rs` fork.


