### PR TITLE
core, editoast: pathfinding, simulation, stdcm: refacto api backtrack field

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
@@ -225,7 +225,6 @@ class BenchSTDCM : CliCommand {
                             parseMarginValue(request.margin),
                             Pathfinding.TIMEOUT,
                             temporarySpeedLimitManager,
-                            allowedTrackSections,
                             STDCMGraph.SearchMetadata(
                                 request.startTime,
                                 requirements.metadata,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
@@ -25,7 +25,7 @@ class PathfindingBlockSuccess(
 
     /** Offsets of the waypoints given as input */
     @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
-    @Json(name = "backtrack_positions") val backtrackPositions: List<Offset<PhysicsPath>>,
+    @Json(name = "backtrack_path_items") val backtrackPathItems: List<Int>,
 ) : PathfindingBlockResponse {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -34,13 +34,13 @@ class PathfindingBlockSuccess(
         if (path != other.path) return false
         if (length != other.length) return false
         if (pathItemPositions != other.pathItemPositions) return false
-        if (backtrackPositions != other.backtrackPositions) return false
+        if (backtrackPathItems != other.backtrackPathItems) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(path, length, pathItemPositions, backtrackPositions)
+        return Objects.hash(path, length, pathItemPositions, backtrackPathItems)
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -236,8 +236,8 @@ private fun buildNoPathFoundException(
 
 data class ProcessedPathfindingResponse(
     val path: TrainPath,
-    val targetOffsets: List<Offset<PhysicsPath>>,
-    val backtrackingOffsets: List<Offset<PhysicsPath>>,
+    val waypointOffsets: List<Offset<PhysicsPath>>,
+    val backtrackIndexes: List<Int>,
 )
 
 private fun processPathfindingResponse(
@@ -247,8 +247,9 @@ private fun processPathfindingResponse(
     val trainPath = explorer.buildFullPath(infra.rawInfra, infra.blockInfra)
     val seenSteps = explorer.getStepTracker().getSeenSteps().toList()
     val stepOffsets = seenSteps.map { it.travelledPathOffset }
-    val backtrackingOffsets = seenSteps.filter { it.isBacktracking }.map { it.travelledPathOffset }
-    return ProcessedPathfindingResponse(trainPath, stepOffsets, backtrackingOffsets)
+    val backtrackIndexes =
+        seenSteps.mapIndexedNotNull { index, step -> if (step.isBacktracking) index else null }
+    return ProcessedPathfindingResponse(trainPath, stepOffsets, backtrackIndexes)
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -17,8 +17,8 @@ fun runPathfindingPostProcessing(
         runPathfindingBlockPostProcessing(
             infra,
             rawPath.path,
-            rawPath.targetOffsets,
-            rawPath.backtrackingOffsets,
+            rawPath.waypointOffsets,
+            rawPath.backtrackIndexes,
         )
     validatePathfindingResponse(infra, initialRequest, res)
     return res
@@ -27,14 +27,14 @@ fun runPathfindingPostProcessing(
 fun runPathfindingBlockPostProcessing(
     infra: FullInfra,
     trainPath: TrainPath,
-    waypointOffsets: List<Offset<PhysicsPath>>,
-    backtrackingOffsets: List<Offset<PhysicsPath>>,
+    pathItemPositions: List<Offset<PhysicsPath>>,
+    backtrackPathItems: List<Int>,
 ): PathfindingBlockSuccess {
     return PathfindingBlockSuccess(
         trainPath.toJsonTrainPath(infra.rawInfra, infra.blockInfra),
         trainPath.getLength(),
-        waypointOffsets,
-        backtrackingOffsets,
+        pathItemPositions,
+        backtrackPathItems,
     )
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
@@ -33,12 +33,14 @@ class SimulationRequest(
     @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
     @Json(name = "electrical_profile_set_id") val electricalProfileSetId: String?,
     @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
-    @Json(name = "backtrack_positions") val backtrackPositions: List<Offset<PhysicsPath>>,
+    @Json(name = "backtrack_path_items") val backtrackPathItems: List<Int>,
 ) {
     init {
-        backtrackPositions.forEach { position ->
-            require(pathItemPositions.contains(position))
-            require(schedule.first { it.pathOffset == position }.stopFor != null)
+        backtrackPathItems.forEach { pathItemIndex ->
+            require(pathItemIndex > 0 && pathItemIndex < pathItemPositions.size - 1)
+            require(
+                schedule.first { it.pathOffset == pathItemPositions[pathItemIndex] }.stopFor != null
+            )
         }
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -207,7 +207,7 @@ class STDCMEndpoint(
                     infra,
                     path.trainPath,
                     path.waypointOffsets,
-                    path.backtrackingOffsets,
+                    path.backtrackIndexes,
                 )
 
             val simulationResponse =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -191,7 +191,6 @@ class STDCMEndpoint(
                     parseMarginValue(request.margin),
                     Pathfinding.TIMEOUT,
                     temporarySpeedLimitManager,
-                    allowedTrackSections,
                     STDCMGraph.SearchMetadata(request.startTime, requirements.metadata, s3Context),
                     failureExplainer = failureExplainer,
                     callback,
@@ -364,25 +363,6 @@ class STDCMEndpoint(
                 )
             }
         }
-    }
-
-    /** Build the electrical profiles from the path */
-    private fun buildSTDCMElectricalProfiles(
-        path: STDCMResult,
-        rollingStock: RollingStock,
-        comfort: Comfort,
-    ): RangeValues<ElectricalProfileValue> {
-        val electrificationMap =
-            path.trainPath.getElectrificationMap(
-                rollingStock.basePowerClass,
-                offsetRangeMapOf(),
-                rollingStock.powerRestrictions,
-                false,
-            )
-        val curvesAndConditions = rollingStock.mapTractiveEffortCurves(electrificationMap, comfort)
-        val electrificationRanges =
-            ElectrificationRange.from(curvesAndConditions.conditions, electrificationMap)
-        return makeElectricalProfiles(electrificationRanges)
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -22,6 +22,6 @@ data class STDCMResult(
     val departureTime: Double,
     val stopResults: List<TrainStop>,
     val waypointOffsets: List<Offset<PhysicsPath>>,
-    val backtrackingOffsets: List<Offset<PhysicsPath>>,
+    val backtrackIndexes: List<Int>,
     val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -7,7 +7,6 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.TrackSectionId
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
@@ -59,7 +58,6 @@ fun findPath(
     standardAllowance: AllowanceValue?,
     pathfindingTimeout: Double,
     temporarySpeedLimitManager: TemporarySpeedLimitManager,
-    allowedTrackSections: Set<TrackSectionId>? = null,
     searchMetadata: STDCMGraph.SearchMetadata? = null,
     failureExplainer: FailureExplainer? = null,
     progressCallback: ProgressCallback? = null,
@@ -78,7 +76,6 @@ fun findPath(
             standardAllowance,
             pathfindingTimeout,
             temporarySpeedLimitManager,
-            allowedTrackSections,
             searchMetadata,
             failureExplainer,
             progressCallback,
@@ -99,10 +96,9 @@ class STDCMPathfinding(
     tag: String?,
     standardAllowance: AllowanceValue?,
     private val pathfindingTimeout: Double = Pathfinding.TIMEOUT,
-    private val temporarySpeedLimitManager: TemporarySpeedLimitManager,
-    private val allowedTrackSections: Set<TrackSectionId>?,
-    private val searchMetadata: STDCMGraph.SearchMetadata?,
-    private val failureExplainer: FailureExplainer?,
+    temporarySpeedLimitManager: TemporarySpeedLimitManager,
+    searchMetadata: STDCMGraph.SearchMetadata?,
+    failureExplainer: FailureExplainer?,
     private val progressCallback: ProgressCallback? = null,
 ) {
 
@@ -150,8 +146,6 @@ class STDCMPathfinding(
                     comfort,
                     maxRunTime,
                     blockAvailability,
-                    graph.tag,
-                    temporarySpeedLimitManager,
                 ) ?: return null
         val travelTime = res.envelope.totalTime
         val stopTime = res.stopResults.sumOf { it.duration }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -7,7 +7,6 @@ import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
-import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
@@ -41,8 +40,6 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         comfort: Comfort?,
         maxRunTime: Double,
         blockAvailability: BlockAvailabilityInterface,
-        trainTag: String?,
-        temporarySpeedLimitManager: TemporarySpeedLimitManager,
     ): STDCMResult? {
         val edges = path.edges
         val lastExplorer = edges.last().infraExplorer

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -90,7 +90,9 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 // after the redesign of simulation data models
                 makePathStops(stops, trainPath),
                 seenSteps.map { it.travelledPathOffset },
-                seenSteps.filter { it.isBacktracking }.map { it.travelledPathOffset },
+                seenSteps.mapIndexedNotNull { index, step ->
+                    if (step.isBacktracking) index else null
+                },
                 withAllowance.engineeringAllowanceRanges,
             )
         return if (res.envelope.totalTime > maxRunTime) {

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -128,8 +128,9 @@ pub struct PathfindingResultSuccess {
     /// The path offset in mm of each path item given as input of the pathfinding
     /// The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
     pub path_item_positions: Vec<u64>,
-    /// The path offset in mm of each position where the train backtracks
-    pub backtrack_positions: Option<Vec<u64>>,
+    /// The indexes of the path items where the train backtracks
+    // TODO: Remove Option once front is fully connected
+    pub backtrack_path_items: Option<Vec<usize>>,
 }
 
 // Enum for input-related errors

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -280,10 +280,11 @@ pub struct Request {
     pub options: TrainScheduleOptions,
     pub physics_consist: PhysicsConsist,
     pub electrical_profile_set_id: Option<i64>,
-    /// The path offset in mm of each path item given as input of the pathfinding
+    /// The path offsets in mm of each path item given as input of the pathfinding
     pub path_item_positions: Vec<u64>,
-    /// The path offset in mm of each position where the train backtracks
-    pub backtrack_positions: Option<Vec<u64>>,
+    /// The indexes of the path items where the train backtracks
+    // TODO: Remove Option once front is fully connected
+    pub backtrack_path_items: Option<Vec<usize>>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -342,7 +342,7 @@ pub(crate) mod test_data {
                 },
                 length: id as u64,
                 path_item_positions: (1..=positions_count).collect(),
-                backtrack_positions: Some(vec![]),
+                backtrack_path_items: Some(vec![]),
             },
         );
         let mut path = serde_json::to_value(response).unwrap();

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -19,7 +19,7 @@ pub(super) fn build_request(
     core_client::pathfinding::PathfindingResultSuccess {
         path,
         path_item_positions,
-        backtrack_positions,
+        backtrack_path_items,
         ..
     }: core_client::pathfinding::PathfindingResultSuccess,
 ) -> Result<core_client::simulation::Request, ()> {
@@ -117,7 +117,7 @@ pub(super) fn build_request(
         physics_consist: sim_consist.0.clone(),
         path,
         path_item_positions,
-        backtrack_positions,
+        backtrack_path_items,
     })
 }
 
@@ -172,7 +172,7 @@ mod tests {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         };
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
@@ -253,7 +253,7 @@ mod tests {
             physics_consist: sim_consist.0,
             path,
             path_item_positions,
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         };
 
         assert_eq!(request, expected);
@@ -272,7 +272,7 @@ mod tests {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         };
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
@@ -399,7 +399,7 @@ mod tests {
             physics_consist: sim_consist.0,
             path,
             path_item_positions,
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         };
 
         assert_eq!(request, expected);
@@ -419,7 +419,7 @@ mod tests {
             path,
             length: 100,
             path_item_positions: path_positions,
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         };
 
         let core_env = CoreEnv::new_mock(MockingClient::new());

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5643,15 +5643,14 @@ components:
       - length
       - path_item_positions
       properties:
-        backtrack_positions:
+        backtrack_path_items:
           type:
           - array
           - 'null'
           items:
             type: integer
-            format: int64
             minimum: 0
-          description: The path offset in mm of each position where the train backtracks
+          description: The indexes of the path items where the train backtracks
         length:
           type: integer
           format: int64

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -443,7 +443,7 @@ mod tests {
             },
             length: 14450000,
             path_item_positions: vec![0, 14450000],
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         }
     }
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -562,7 +562,7 @@ pub mod tests {
             },
             length,
             path_item_positions: vec![],
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         })
     }
 

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -775,7 +775,7 @@ fn build_simulation_request<T: TrainScheduleLike>(
         physics_consist,
         electrical_profile_set_id,
         path_item_positions: path_item_positions.to_vec(),
-        backtrack_positions: Some(vec![]),
+        backtrack_path_items: Some(vec![]),
     }
 }
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -722,7 +722,7 @@ mod tests {
             },
             length: 1,
             path_item_positions: vec![0, 10],
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         }
     }
 

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -311,7 +311,7 @@ pub mod tests {
             },
             length: 100,
             path_item_positions,
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         })
     }
 

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -2670,7 +2670,7 @@ mod tests {
                     "track_section_ranges": [],
                 },
                 "path_item_positions": [],
-                "backtrack_positions": [],
+                "backtrack_path_items": [],
                 "length": 1,
                 "status": "success"
             }))
@@ -2704,7 +2704,7 @@ mod tests {
                     track_section_ranges: vec![],
                 },
                 path_item_positions: vec![],
-                backtrack_positions: Some(vec![]),
+                backtrack_path_items: Some(vec![]),
                 length: 1
             })
         )
@@ -2788,7 +2788,7 @@ mod tests {
                     "track_section_ranges": [],
                 },
                 "path_item_positions": [],
-                "backtrack_positions": [],
+                "backtrack_path_items": [],
                 "length": 1,
                 "status": "success"
             }))
@@ -2841,7 +2841,7 @@ mod tests {
                     track_section_ranges: vec![],
                 },
                 path_item_positions: vec![],
-                backtrack_positions: Some(vec![]),
+                backtrack_path_items: Some(vec![]),
                 length: 1
             })
         )
@@ -2985,7 +2985,7 @@ mod tests {
             },
             length: 14450000,
             path_item_positions: vec![0, 14450000],
-            backtrack_positions: Some(vec![]),
+            backtrack_path_items: Some(vec![]),
         }
     }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3661,8 +3661,8 @@ export type CoreTrainPath = {
   track_section_ranges: CoreTrackRange[];
 };
 export type CorePathfindingResultSuccess = {
-  /** The path offset in mm of each position where the train backtracks */
-  backtrack_positions?: number[] | null;
+  /** The indexes of the path items where the train backtracks */
+  backtrack_path_items?: number[] | null;
   /** Length of the path in mm */
   length: number;
   /** Full description of the path data */

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -199,7 +199,7 @@ class PathfindingNotFoundNotFoundInTracks(BaseModel):
     error_type: Literal["not_found_in_tracks"]
 
 
-class BacktrackPosition(RootModel[int]):
+class BacktrackPathItem(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
@@ -5427,9 +5427,9 @@ class CorePathfindingResultSuccess(BaseModel):
     A successful pathfinding result. This is also used for STDCM response.
     """
 
-    backtrack_positions: list[BacktrackPosition] | None = None
+    backtrack_path_items: list[BacktrackPathItem] | None = None
     """
-    The path offset in mm of each position where the train backtracks
+    The indexes of the path items where the train backtracks
     """
     length: Annotated[int, Field(ge=0)]
     """

--- a/tests/tests/path.py
+++ b/tests/tests/path.py
@@ -11,4 +11,4 @@ class Path:
     path: Dict[str, List]
     length: int
     path_item_positions: Iterable[Any]
-    backtrack_positions: Iterable[Any]
+    backtrack_path_items: Iterable[int]

--- a/tests/tests/test_pathfinding.py
+++ b/tests/tests/test_pathfinding.py
@@ -154,7 +154,7 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
         },
         "length": 45548966,
         "path_item_positions": [0, 45548966],
-        "backtrack_positions": [],
+        "backtrack_path_items": [],
     }
 )
 


### PR DESCRIPTION
It was kinda weird to have backtrack positions be offsets since they are already contained in pathItemPositions. Change the field to a list of indexes of path items instead.
See https://github.com/osrd-project/osrd-confidential/issues/325.