### PR TITLE
 front: stdcm: display consist changes on stop only in results table 

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -129,7 +129,7 @@ const StdcmResultsTable = ({
                       {displayedRollingStock ?? '='}
                     </td>
                   </tr>
-                  {consistChanges && (
+                  {consistChanges && step.duration !== null && (
                     <tr>
                       <td className="index">
                         <Container />

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -111,19 +111,13 @@ const StdcmResultsTable = ({
                       {isLastStep || step.duration !== null ? step.time : ''}
                     </td>
                     <td className="stop">
-                      <div
-                        className={
-                          step.duration !== null && !isLastStep
-                            ? 'stop-with-duration ml-n2'
-                            : 'stop'
-                        }
-                      >
-                        {isNotExtremity || !isRequestedPathStep
-                          ? step.duration !== null
-                            ? getStopDurationTime(step.duration)
-                            : step.time
-                          : ''}
-                      </div>
+                      {isNotExtremity && (
+                        <div
+                          className={step.duration !== null ? 'stop-with-duration ml-n2' : 'stop'}
+                        >
+                          {step.duration !== null ? getStopDurationTime(step.duration) : step.time}
+                        </div>
+                      )}
                     </td>
                     <td className="stop">
                       {isFirstStep || step.duration !== null ? step.stopEndTime : ''}


### PR DESCRIPTION
Close #17022

Also a small code simplification for the stop duration.

After: 
<img width="1025" height="632" alt="image" src="https://github.com/user-attachments/assets/cae45e4d-8066-4480-865b-e931e386c72e" />
Before:
<img width="1037" height="783" alt="image" src="https://github.com/user-attachments/assets/1e511ab1-20d7-4e68-ace9-9b22fbf417d7" />
