### PR TITLE
Change GET default projection to operationalPoint Projection

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SettingsPanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SettingsPanel.tsx
@@ -60,12 +60,12 @@ const SettingsPanel = ({
           disabled={!isTrainScheduleValid || !isSimulationEnabled}
           options={[
             {
-              label: t('timeSpaceChartSettings.trackProjection'),
-              value: 'trackProjection',
-            },
-            {
               label: t('timeSpaceChartSettings.operationalPointProjection'),
               value: 'operationalPointProjection',
+            },
+            {
+              label: t('timeSpaceChartSettings.trackProjection'),
+              value: 'trackProjection',
             },
           ]}
         />

--- a/front/src/reducers/simulationResults/index.ts
+++ b/front/src/reducers/simulationResults/index.ts
@@ -14,7 +14,7 @@ export const simulationResultsInitialState: SimulationResultsState = {
   selectedTrain: undefined,
   hoveredTrainId: undefined,
   trainIdUsedForProjection: undefined,
-  projectionType: 'trackProjection',
+  projectionType: 'operationalPointProjection',
   displayOnlyPathSteps: false,
   isSimulationEnabled: true,
 };

--- a/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/001-get-manchette.spec.ts
@@ -139,14 +139,13 @@ test.describe('Space Time Diagram / Manchette', { tag: ['@op', '@manchette', '@s
         await getManchetteComponent.verifyVisibleWaypointsCount(
           STD_MANCHETTE.initialVisibleWaypoints
         );
-        await getManchetteComponent.hideWaypoint(STD_MANCHETTE.normalWaypointIndex);
-        // After hiding the normal waypoint the requested point is displayed instead
+        await getManchetteComponent.hideWaypoint(STD_MANCHETTE.firstHiddenWaypointIndex);
         await getManchetteComponent.verifyVisibleWaypointsCount(
-          STD_MANCHETTE.initialVisibleWaypoints
+          STD_MANCHETTE.visibleAfterHidingFirstWaypoint
         );
-        await getManchetteComponent.hideWaypoint(STD_MANCHETTE.requestedWaypointIndex, true);
+        await getManchetteComponent.hideWaypoint(STD_MANCHETTE.secondHiddenWaypointIndex, false);
         await getManchetteComponent.verifyVisibleWaypointsCount(
-          STD_MANCHETTE.visibleAfterHidingRequested
+          STD_MANCHETTE.visibleAfterHidingSecondWaypoint
         );
         await getManchetteComponent.openManchettePanel();
         await getManchetteComponent.verifyWaypointsCheckedState(

--- a/front/tests/pages/operational-studies/std-manchette.ts
+++ b/front/tests/pages/operational-studies/std-manchette.ts
@@ -1,5 +1,5 @@
 import { readJsonFile } from '../../utils/file-utils';
-import { requestedPoint, type Waypoint } from '../../utils/manchette';
+import type { Waypoint } from '../../utils/manchette';
 import type { TimetableFilterTranslations } from '../../utils/types';
 const frScenarioTranslations: TimetableFilterTranslations = readJsonFile<{
   main: TimetableFilterTranslations;
@@ -9,7 +9,6 @@ export const requestedDestination = frScenarioTranslations.requestedDestination;
 export const expectedWaypointsPanelDataForUniqueTrain: Record<string, Partial<Waypoint>> = {
   North_East_station: { secondaryCode: 'BV', offset: '0.0', checked: true },
   Mid_East_station: { secondaryCode: 'BV', offset: '19.55', checked: true },
-  [requestedPoint('2')]: { offset: '22.47', checked: true },
   Mid_West_station: { secondaryCode: 'BV', offset: '34.0', checked: true },
   North_West_station: { secondaryCode: 'BC', offset: '47.55', checked: true },
 };
@@ -17,17 +16,15 @@ export const expectedWaypointsPanelDataForUniqueTrain: Record<string, Partial<Wa
 export const expectedWaypointsPanelDataForPacedTrain: Record<string, Partial<Waypoint>> = {
   North_East_station: { secondaryCode: 'BV', offset: '0.0', checked: true },
   Mid_East_station: { secondaryCode: 'BV', offset: '19.55', checked: true },
-  [requestedPoint('1')]: { offset: '22.47', checked: true },
   Mid_West_station: { secondaryCode: 'BV', offset: '34.0', checked: true },
   North_West_station: { secondaryCode: 'BV', offset: '47.60', checked: true },
-  [requestedDestination]: { offset: '47.65', checked: true },
 };
 
 export const expectedWaypointsListDataForPacedTrain: Record<string, Partial<Waypoint>> = {
   North_East_station: { secondaryCode: 'BV', offset: '0' },
-  [requestedPoint('1')]: { offset: '22.5' },
+  Mid_East_station: { secondaryCode: 'BV', offset: '19.6' },
   Mid_West_station: { secondaryCode: 'BV', offset: '34' },
-  [requestedDestination]: { offset: '47.7' },
+  North_West_station: { secondaryCode: 'BV', offset: '47.6' },
 };
 
 export const expectedWaypointsListDataForUniqueTrain: Record<string, Partial<Waypoint>> = {
@@ -37,17 +34,18 @@ export const expectedWaypointsListDataForUniqueTrain: Record<string, Partial<Way
   North_West_station: { secondaryCode: 'BC', offset: '47.6' },
 };
 
-export const WAYPOINT_CHECKBOX_STATE = { checked: 3, total: 5 };
+export const WAYPOINT_CHECKBOX_STATE = { checked: 2, total: 4 };
 export const STD_MANCHETTE = {
   occupancyWaypointIndex: 1,
-  requestedWaypointIndex: 2,
-  normalWaypointIndex: 3,
+  firstHiddenWaypointIndex: 3,
+  secondHiddenWaypointIndex: 2,
 
   initialVisibleWaypoints: 4,
-  visibleAfterHidingRequested: 3,
+  visibleAfterHidingFirstWaypoint: 3,
+  visibleAfterHidingSecondWaypoint: 2,
 
   waypointPanel: {
-    expectedChecked: 3,
-    expectedTotal: 5,
+    expectedChecked: 2,
+    expectedTotal: 4,
   },
 };


### PR DESCRIPTION
close https://github.com/osrd-project/osrd-confidential/issues/1610

> [!NOTE]  
> Now that `operationalPointProjection` is the default projection, the manchette e2e expectations had to be updated because this scenario no longer produces the same visible waypoint sequence as before.
The test now verifies the actual waypoint visibility sequence observed when successive waypoints are hidden.