### PR TITLE
editoast, core, front: use ms offset instead of datetime in conflicts

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -173,7 +173,7 @@ class TimetableDownloader(
                         SpacingRequirement.fromRJSWithAddedTime(
                             rjsRequirement,
                             infra,
-                            trainRequirementById.startTime.durationSinceEpoch(),
+                            trainRequirementById.startTime.seconds,
                         )
                     val set = zoneUses.computeIfAbsent(requirement.zone) { TreeRangeSet.create() }
                     set.add(Range.closedOpen(requirement.beginTime, requirement.endTime))

--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -203,7 +203,7 @@ class JSONTimetableReader(val jsonTimetablePath: String) : TimetableProvider {
                     SpacingRequirement.fromRJSWithAddedTime(
                         rjsSpacingReq,
                         infra,
-                        train.startTime.durationSinceEpoch(),
+                        train.startTime.seconds,
                     )
                 val set = zoneUses.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
                 set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))

--- a/core/src/main/kotlin/fr/sncf/osrd/api/RequirementsParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/RequirementsParser.kt
@@ -11,8 +11,6 @@ import fr.sncf.osrd.utils.units.TimeDelta
 import fr.sncf.osrd.utils.units.seconds
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
-import java.time.Duration.between
-import java.time.ZonedDateTime
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -22,11 +20,11 @@ val requirementsParserLogger: Logger = LoggerFactory.getLogger("RequirementsPars
 fun parseTrainsRequirements(
     infra: RawInfra,
     trainsRequirements: Map<String, TrainRequirementsRequest>,
-    startTime: ZonedDateTime,
+    referenceTime: TimeDelta,
 ): List<Requirements> {
     val res = mutableListOf<Requirements>()
     for ((id, trainRequirements) in trainsRequirements) {
-        val delta = TimeDelta(between(startTime, trainRequirements.startTime).toMillis())
+        val delta = trainRequirements.startTime - referenceTime
         val spacingRequirements =
             parseSpacingRequirements(infra, trainRequirements.spacingRequirements, delta)
         val routingRequirements =
@@ -95,9 +93,9 @@ fun parseRoutingRequirements(
 fun parseWorkSchedulesRequest(
     infra: RawSignalingInfra,
     workSchedulesRequest: WorkSchedulesRequest,
-    startTime: ZonedDateTime,
+    referenceTime: TimeDelta,
 ): Collection<Requirements> {
-    val delta = TimeDelta(between(startTime, workSchedulesRequest.startTime).toMillis())
+    val delta = workSchedulesRequest.startTime - referenceTime
     return convertWorkScheduleMap(infra, workSchedulesRequest.workScheduleRequirements, delta)
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
@@ -15,8 +15,8 @@ import fr.sncf.osrd.conflicts.Conflict
 import fr.sncf.osrd.conflicts.Requirements
 import fr.sncf.osrd.conflicts.detectConflicts
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
-import java.time.Duration
-import java.time.ZonedDateTime
+import fr.sncf.osrd.utils.units.TimeDelta
+import fr.sncf.osrd.utils.units.seconds
 
 class ConflictDetectionEndpoint(private val infraManager: InfraProvider) : Take {
     override fun act(req: Request, ctx: Take.QueueContext?): Response {
@@ -58,21 +58,21 @@ class ConflictDetectionEndpoint(private val infraManager: InfraProvider) : Take 
 private fun makeConflictDetectionResponse(
     infra: RawSignalingInfra,
     conflicts: Collection<Conflict>,
-    startTime: ZonedDateTime,
+    referenceTime: TimeDelta,
 ): ConflictDetectionResponse {
     return ConflictDetectionResponse(
         conflicts.map {
             ConflictResponse(
                 it.trainIds,
                 it.workScheduleIds,
-                startTime.plus(Duration.ofMillis((it.startTime * 1000).toLong())),
-                startTime.plus(Duration.ofMillis((it.endTime * 1000).toLong())),
+                referenceTime + it.startTime.seconds,
+                (it.endTime - it.startTime).seconds,
                 it.conflictType,
                 it.requirements.map { requirement ->
                     ConflictRequirement(
                         infra.getZoneName(requirement.zone),
-                        startTime.plus(Duration.ofMillis((requirement.startTime * 1000).toLong())),
-                        startTime.plus(Duration.ofMillis((requirement.endTime * 1000).toLong())),
+                        referenceTime + requirement.startTime.seconds,
+                        (requirement.endTime - requirement.startTime).seconds,
                     )
                 },
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionRequest.kt
@@ -8,7 +8,7 @@ import fr.sncf.osrd.api.RJSRoutingRequirement
 import fr.sncf.osrd.api.RJSSpacingRequirement
 import fr.sncf.osrd.api.WorkSchedule
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
-import java.time.ZonedDateTime
+import fr.sncf.osrd.utils.units.TimeDelta
 
 class ConflictDetectionRequest(
     /** Infra ID. */
@@ -28,10 +28,15 @@ class ConflictDetectionRequest(
 /** Describes the requirements needed for a given train to run without any delay. */
 open class TrainRequirementsRequest(
     /**
-     * Start time for the given train. Acts as a reference point for all time values in the spacing
-     * and routing requirements for this train (values expressed as time delta).
+     * Start time for the given train: elapsed ms since an implicit 'request base time'.
+     * `start_time` acts as a reference point for all time values in the spacing and routing
+     * requirements for this train (values expressed as time delta).
+     *
+     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
+     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
+     * the timetable start for hourly timetables.
      */
-    @Json(name = "start_time") val startTime: ZonedDateTime,
+    @Json(name = "start_time") val startTime: TimeDelta,
     /**
      * Spacing requirements for the given train (i.e. which zones need to be free in which time
      * ranges).
@@ -49,7 +54,16 @@ open class TrainRequirementsRequest(
 class TrainRequirementsById(
     @Json(name = "train_id") val trainId: String,
     @Json(name = "train_name") val trainName: String?,
-    @Json(name = "start_time") startTime: ZonedDateTime,
+    /**
+     * Start time for the given train: elapsed ms since an implicit 'request base time'.
+     * `start_time` acts as a reference point for all time values in the spacing and routing
+     * requirements for this train (values expressed as time delta).
+     *
+     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
+     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
+     * the timetable start for hourly timetables.
+     */
+    @Json(name = "start_time") startTime: TimeDelta,
     @Json(name = "spacing_requirements") spacingRequirements: Collection<RJSSpacingRequirement>,
     @Json(name = "routing_requirements") routingRequirements: Collection<RJSRoutingRequirement>,
 ) : TrainRequirementsRequest(startTime, spacingRequirements, routingRequirements)
@@ -57,10 +71,15 @@ class TrainRequirementsById(
 /** Describes the set of work schedules in the given timetable. */
 class WorkSchedulesRequest(
     /**
-     * Reference time for other time values in the work schedule requirements (expressed as time
-     * deltas).
+     * Start time for the work schedules: elapsed ms since the implicit 'request base time'.
+     * `start_time` acts as a reference point for all time values in the work schedule requirements
+     * (values expressed as time delta).
+     *
+     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
+     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
+     * the timetable start for hourly timetables.
      */
-    @Json(name = "start_time") val startTime: ZonedDateTime,
+    @Json(name = "start_time") val startTime: TimeDelta,
     /** Map of work schedule id -> work schedule data. */
     @Json(name = "work_schedule_requirements")
     val workScheduleRequirements: Map<String, WorkSchedule>,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionResponse.kt
@@ -6,7 +6,8 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.conflicts.ConflictType
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
-import java.time.ZonedDateTime
+import fr.sncf.osrd.utils.units.Duration
+import fr.sncf.osrd.utils.units.TimeDelta
 
 class ConflictDetectionResponse(
     /**
@@ -27,10 +28,18 @@ class ConflictResponse(
     @Json(name = "train_ids") val trainIds: Collection<String>,
     /** List of work schedule IDs for this given conflict, if any. */
     @Json(name = "work_schedule_ids") val workScheduleIds: Collection<String>,
-    /** Start of the conflict time range. This is the *union* of all the conflicting time ranges. */
-    @Json(name = "start_time") val startTime: ZonedDateTime,
-    /** End of the conflict time range. See `start_time`. */
-    @Json(name = "end_time") val endTime: ZonedDateTime,
+    /**
+     * Start of the conflict time range: elapsed ms since the implicit 'request base time'.
+     *
+     * This is the *union* of all the conflicting time ranges.
+     *
+     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
+     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
+     * the timetable start for hourly timetables.
+     */
+    @Json(name = "start_time") val startTime: TimeDelta,
+    /** Duration of the conflict. */
+    @Json(name = "duration") val duration: Duration,
     /** One of "Spacing" or "Routing" depending on the kind of conflicting resource. */
     @Json(name = "conflict_type") val conflictType: ConflictType,
     /** List of all conflicting requirements. Can't be empty. */
@@ -47,10 +56,20 @@ class ConflictResponse(
 class ConflictRequirement(
     /** Zone name, as returned from `ZoneInfra.getZoneName` */
     @Json(name = "zone") val zone: String,
-    /** Start of the time range (earliest start time for any zone use) */
-    @Json(name = "start_time") val startTime: ZonedDateTime,
-    /** End of the time range (latest end time for any zone use) */
-    @Json(name = "end_time") val endTime: ZonedDateTime,
+    /**
+     * Start of the time range (earliest start time for any zone use in this conflict): elapsed ms
+     * since the implicit 'request base time'.
+     *
+     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
+     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
+     * the timetable start for hourly timetables.
+     */
+    @Json(name = "start_time") val startTime: TimeDelta,
+    /**
+     * Duration of the time range (difference between the latest end time and the earliest
+     * start_time for any zone use in this conflict).
+     */
+    @Json(name = "duration") val duration: Duration,
 )
 
 val conflictResponseAdapter: JsonAdapter<ConflictDetectionResponse> =

--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -1,5 +1,4 @@
-use chrono::DateTime;
-use chrono::Utc;
+use common::units::quantities::Offset;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -27,7 +26,16 @@ pub struct ConflictDetectionRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrainRequirements {
-    pub start_time: DateTime<Utc>,
+    /// Start time for the given train: elapsed ms since an implicit 'request base time'.
+    /// `start_time` acts as a reference point for all time values in the spacing and routing
+    /// requirements for this train (values expressed as time delta).
+    ///
+    /// The implicit 'request base time' is the same over the whole request
+    /// (`trains_requirements` and `work_schedules`) and response.
+    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    /// timetables.
+    #[serde(with = "common::units::millisecond::i64")]
+    pub start_time: Offset,
     pub spacing_requirements: Vec<SpacingRequirement>,
     pub routing_requirements: Vec<RoutingRequirement>,
 }
@@ -39,14 +47,33 @@ pub struct TrainRequirementsById {
     pub train_id: String,
     /// ID that can be used to find the train in tools other than OSRD. Used in debug traces.
     pub train_name: String,
-    pub start_time: DateTime<Utc>,
+    /// Start time for the given train: elapsed ms since an implicit 'request base time'.
+    /// `start_time` acts as a reference point for all time values in the spacing and routing
+    /// requirements for this train (values expressed as an offset).
+    ///
+    /// The implicit 'request base time' is the same over the whole request
+    /// (`trains_requirements` and `work_schedules`) and response.
+    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    /// timetables.
+    #[serde(with = "common::units::millisecond::i64")]
+    #[schema(value_type = i64)]
+    pub start_time: Offset,
     pub spacing_requirements: Vec<SpacingRequirement>,
     pub routing_requirements: Vec<RoutingRequirement>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct WorkSchedulesRequest {
-    pub start_time: DateTime<Utc>,
+    /// Start time for the work schedules: elapsed ms since the implicit 'request base time'.
+    /// `start_time` acts as a reference point for all time values in the work schedule
+    /// requirements (values expressed as an offset).
+    ///
+    /// The implicit 'request base time' is the same over the whole request
+    /// (`trains_requirements` and `work_schedules`) and response.
+    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    /// timetables.
+    #[serde(with = "common::units::millisecond::i64")]
+    pub start_time: Offset,
     pub work_schedule_requirements: HashMap<String, WorkSchedule>,
 }
 
@@ -62,10 +89,17 @@ pub struct Conflict {
     pub train_ids: Vec<Uuid>,
     /// List of work schedule ids involved in the conflict
     pub work_schedule_ids: Vec<String>,
-    /// Datetime of the start of the conflict
-    pub start_time: DateTime<Utc>,
-    /// Datetime of the end of the conflict
-    pub end_time: DateTime<Utc>,
+    /// Start of the conflict time range: elapsed ms since the implicit 'request base time'.
+    /// This is the *union* of all the conflicting time ranges.
+    ///
+    /// The implicit 'request base time' is the same over the whole request
+    /// (`trains_requirements` and `work_schedules`) and response.
+    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    /// timetables.
+    #[serde(with = "common::units::millisecond::i64")]
+    pub start_time: Offset,
+    /// Duration of the conflict in ms.
+    pub duration: u64,
     /// Type of the conflict
     pub conflict_type: ConflictType,
     /// List of requirements causing the conflict
@@ -74,14 +108,24 @@ pub struct Conflict {
 
 /// Unmet requirement causing a conflict.
 ///
-/// The start and end time describe the conflicting time span (not the full
+/// The start time and duration describe the conflicting time span (not the full
 /// requirement's time span).
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
 #[schema(as = CoreConflictRequirement)]
 pub struct ConflictRequirement {
     pub zone: String,
-    pub start_time: DateTime<Utc>,
-    pub end_time: DateTime<Utc>,
+    /// Start of the time range during which the zone is contested: elapsed ms since the implicit
+    /// 'request base time'. Earliest start time for any zone use.
+    ///
+    /// The implicit 'request base time' is the same over the whole request
+    /// (`trains_requirements` and `work_schedules`) and response.
+    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    /// timetables.
+    #[serde(with = "common::units::millisecond::i64")]
+    #[schema(value_type = i64)]
+    pub start_time: Offset,
+    /// Duration of the time range in ms (difference between the latest end time and the earliest start_time for any zone use in this conflict).
+    pub duration: u64,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq)]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5153,26 +5153,34 @@ components:
       - train_ids
       - work_schedule_ids
       - start_time
-      - end_time
+      - duration
       - conflict_type
       - requirements
       properties:
         conflict_type:
           $ref: '#/components/schemas/CoreConflictType'
           description: Type of the conflict
-        end_time:
-          type: string
-          format: date-time
-          description: Datetime of the end of the conflict
+        duration:
+          type: integer
+          format: int64
+          description: Duration of the conflict in ms.
+          minimum: 0
         requirements:
           type: array
           items:
             $ref: '#/components/schemas/CoreConflictRequirement'
           description: List of requirements causing the conflict
         start_time:
-          type: string
-          format: date-time
-          description: Datetime of the start of the conflict
+          type: integer
+          format: int64
+          description: |-
+            Start of the conflict time range: elapsed ms since an implicit 'request base time'.
+            This is the *union* of all the conflicting time ranges.
+
+            The implicit 'request base time' is the same as the train schedules' `start_time`
+            frame in this timetable.
+            Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+            timetables.
         train_ids:
           type: array
           items:
@@ -5330,19 +5338,29 @@ components:
       description: |-
         Unmet requirement causing a conflict.
 
-        The start and end time describe the conflicting time span (not the full
+        The start time and duration describe the conflicting time span (not the full
         requirement's time span).
       required:
       - zone
       - start_time
-      - end_time
+      - duration
       properties:
-        end_time:
-          type: string
-          format: date-time
+        duration:
+          type: integer
+          format: int64
+          description: Duration of the time range in ms (difference between the latest end time and the earliest start_time for any zone use in this conflict).
+          minimum: 0
         start_time:
-          type: string
-          format: date-time
+          type: integer
+          format: int64
+          description: |-
+            Start of the time range during which the zone is contested: elapsed ms since the implicit
+            'request base time'. Earliest start time for any zone use.
+
+            The implicit 'request base time' is the same over the whole request
+            (`trains_requirements` and `work_schedules`) and response.
+            Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+            timetables.
         zone:
           type: string
     CoreConflictType:
@@ -5982,8 +6000,17 @@ components:
           items:
             $ref: '#/components/schemas/CoreSpacingRequirement'
         start_time:
-          type: string
-          format: date-time
+          type: integer
+          format: int64
+          description: |-
+            Start time for the given train: elapsed ms since an implicit 'request base time'.
+            `start_time` acts as a reference point for all time values in the spacing and routing
+            requirements for this train (values expressed as an offset).
+
+            The implicit 'request base time' is the same over the whole request
+            (`trains_requirements` and `work_schedules`) and response.
+            Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+            timetables.
         train_id:
           type: string
         train_name:

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -20,12 +20,10 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use chrono::DateTime;
-use chrono::Utc;
-use common::units::millisecond;
 use common::units::quantities::Acceleration;
 use common::units::quantities::Length;
 use common::units::quantities::Mass;
+use common::units::quantities::Offset;
 use common::units::quantities::Velocity;
 use core_client::AsCoreRequest;
 use core_client::conflict_detection::Conflict as CoreConflict;
@@ -262,10 +260,18 @@ pub struct Conflict {
     train_ids: Vec<OccurrenceId>,
     /// List of work schedule ids involved in the conflict
     pub work_schedule_ids: Vec<i64>,
-    /// Datetime of the start of the conflict
-    pub start_time: DateTime<Utc>,
-    /// Datetime of the end of the conflict
-    pub end_time: DateTime<Utc>,
+    /// Start of the conflict time range: elapsed ms since an implicit 'request base time'.
+    /// This is the *union* of all the conflicting time ranges.
+    ///
+    /// The implicit 'request base time' is the same as the train schedules' `start_time`
+    /// frame in this timetable.
+    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    /// timetables.
+    #[serde(with = "common::units::millisecond::i64")]
+    #[schema(value_type = i64)]
+    pub start_time: Offset,
+    /// Duration of the conflict in ms.
+    pub duration: u64,
     /// Type of the conflict
     pub conflict_type: ConflictType,
     /// List of requirements causing the conflict
@@ -304,7 +310,7 @@ impl Conflict {
             train_ids,
             work_schedule_ids,
             start_time: conflict.start_time,
-            end_time: conflict.end_time,
+            duration: conflict.duration,
             conflict_type: conflict.conflict_type,
             requirements: conflict.requirements,
         })
@@ -417,10 +423,7 @@ pub(in crate::views) async fn conflicts(
             Some((
                 train_id,
                 TrainRequirements {
-                    start_time: DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(
-                        train_schedule.start_time(),
-                    ))
-                    .unwrap(),
+                    start_time: train_schedule.start_time(),
                     spacing_requirements: simulation.final_output.spacing_requirements.clone(),
                     routing_requirements: simulation.final_output.routing_requirements.clone(),
                 },
@@ -582,9 +585,7 @@ pub(in crate::views) async fn requirements(
     .into_iter()
     .map(|(sim, _)| Arc::unwrap_or_clone(sim));
 
-    let start_times = occurrences.iter().map(|ts| {
-        DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(ts.start_time())).unwrap()
-    });
+    let start_times = occurrences.iter().map(|ts| ts.start_time());
     let train_names = occurrences.iter().map(|ts| ts.train_name.clone());
     let results = build_trains_requirements(
         occurrence_ids.into_iter(),
@@ -599,7 +600,7 @@ pub(in crate::views) async fn requirements(
 
 fn build_trains_requirements(
     train_ids: impl Iterator<Item = OccurrenceId>,
-    start_times: impl Iterator<Item = DateTime<Utc>>,
+    start_times: impl Iterator<Item = Offset>,
     simulations: impl Iterator<Item = simulation::Response>,
     train_names: impl Iterator<Item = String>,
 ) -> impl Iterator<Item = TrainRequirementsById> {
@@ -1120,12 +1121,12 @@ mod tests {
 
     use axum::http::StatusCode;
     use chrono::Duration;
-    use chrono::NaiveDate;
     use common::units;
     use core_client::simulation::RoutingRequirement;
     use core_client::simulation::RoutingZoneRequirement;
     use core_client::simulation::SpacingRequirement;
     use pretty_assertions::assert_eq;
+    use schemas::fixtures::ms_since_epoch;
     use schemas::fixtures::simple_rolling_stock;
     use schemas::fixtures::towed_rolling_stock;
 
@@ -1209,7 +1210,7 @@ mod tests {
 
         let train_schedule_t1_1 = simple_paced_train_base();
         let mut train_schedule_t1_2 = simple_paced_train_base();
-        train_schedule_t1_2.train_occurrence.start_time += millisecond::i64::new(12_000_000);
+        train_schedule_t1_2.train_occurrence.start_time += units::millisecond::i64::new(12_000_000);
         train_schedule_t1_2.paced.as_mut().unwrap().time_window =
             Duration::minutes(120).try_into().unwrap();
         train_schedule_t1_2.paced.as_mut().unwrap().interval =
@@ -1251,7 +1252,7 @@ mod tests {
         let (timetable2, train_schedule_set2) =
             create_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
         let mut train_schedule_t2_1 = simple_paced_train_base();
-        train_schedule_t2_1.train_occurrence.start_time += millisecond::i64::new(12_000_000);
+        train_schedule_t2_1.train_occurrence.start_time += units::millisecond::i64::new(12_000_000);
         train_schedule_t2_1.paced.as_mut().unwrap().time_window =
             Duration::minutes(120).try_into().unwrap();
         train_schedule_t2_1.paced.as_mut().unwrap().interval =
@@ -1326,11 +1327,7 @@ mod tests {
         // Given
         let infra = Infra::default();
         let ts_id = 13;
-        let ts_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
-            .unwrap()
-            .and_hms_opt(8, 0, 0)
-            .unwrap()
-            .and_utc();
+        let ts_start_time = ms_since_epoch("2025-01-01T08:00:00Z");
 
         let spacing_requirement = SpacingRequirement {
             zone: "ZONE_1".to_string(),
@@ -1353,12 +1350,8 @@ mod tests {
             }],
         };
         let paced_train_id = 42;
-        let paced_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
-            .unwrap()
-            .and_hms_opt(9, 0, 0)
-            .unwrap()
-            .and_utc();
-        let paced_interval = Duration::try_hours(1).unwrap();
+        let paced_start_time = ms_since_epoch("2025-01-01T09:00:00Z");
+        let paced_interval = units::second::new(3600.0);
 
         let train_ids = vec![
             OccurrenceId::new_base(paced_train_id, 0),

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4676,19 +4676,33 @@ export type TimetableResult = {
 };
 export type CoreConflictType = 'Spacing' | 'Routing';
 export type CoreConflictRequirement = {
-  end_time: string;
-  start_time: string;
+  /** Duration of the time range in ms (difference between the latest end time and the earliest start_time for any zone use in this conflict). */
+  duration: number;
+  /** Start of the time range during which the zone is contested: elapsed ms since the implicit
+    'request base time'. Earliest start time for any zone use.
+    
+    The implicit 'request base time' is the same over the whole request
+    (`trains_requirements` and `work_schedules`) and response.
+    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    timetables. */
+  start_time: number;
   zone: string;
 };
 export type Conflict = {
   /** Type of the conflict */
   conflict_type: CoreConflictType;
-  /** Datetime of the end of the conflict */
-  end_time: string;
+  /** Duration of the conflict in ms. */
+  duration: number;
   /** List of requirements causing the conflict */
   requirements: CoreConflictRequirement[];
-  /** Datetime of the start of the conflict */
-  start_time: string;
+  /** Start of the conflict time range: elapsed ms since an implicit 'request base time'.
+    This is the *union* of all the conflicting time ranges.
+    
+    The implicit 'request base time' is the same as the train schedules' `start_time`
+    frame in this timetable.
+    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    timetables. */
+  start_time: number;
   /** List of trains involved in the conflict. */
   train_ids: (
     | {
@@ -4714,7 +4728,15 @@ export type Conflict = {
 export type CoreTrainRequirementsById = {
   routing_requirements: CoreRoutingRequirement[];
   spacing_requirements: CoreSpacingRequirement[];
-  start_time: string;
+  /** Start time for the given train: elapsed ms since an implicit 'request base time'.
+    `start_time` acts as a reference point for all time values in the spacing and routing
+    requirements for this train (values expressed as an offset).
+    
+    The implicit 'request base time' is the same over the whole request
+    (`trains_requirements` and `work_schedules`) and response.
+    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    timetables. */
+  start_time: number;
   train_id: string;
   /** ID that can be used to find the train in tools other than OSRD. Used in debug traces. */
   train_name: string;

--- a/front/src/modules/conflict/__tests__/sampleData.ts
+++ b/front/src/modules/conflict/__tests__/sampleData.ts
@@ -40,8 +40,8 @@ export const pacedTrain = ({
 
 export const conflictBase = (partial: Partial<Conflict> = {}): Conflict => ({
   conflict_type: 'Spacing',
-  end_time: '',
-  start_time: '',
+  duration: 0,
+  start_time: 0,
   requirements: [],
   train_ids: [],
   work_schedule_ids: [],

--- a/front/src/modules/conflict/components/ConflictCard.tsx
+++ b/front/src/modules/conflict/components/ConflictCard.tsx
@@ -43,7 +43,9 @@ const ConflictCard = ({ conflict }: { conflict: ConflictWithTrainNames }) => {
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main' });
   const dateTimeLocale = useDateTimeLocale();
   const start_time = new Date(conflict.start_time).toLocaleTimeString(dateTimeLocale);
-  const end_time = new Date(conflict.end_time).toLocaleTimeString(dateTimeLocale);
+  const end_time = new Date(conflict.start_time + conflict.duration).toLocaleTimeString(
+    dateTimeLocale
+  );
   const start_date = new Date(conflict.start_time).toLocaleDateString(dateTimeLocale);
   const totalTrains = conflict.trainsData.length;
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
@@ -62,8 +62,8 @@ const useProjectedConflicts = (
       }
 
       return reqs.map((req) => ({
-        timeStart: +new Date(req.start_time),
-        timeEnd: +new Date(req.end_time),
+        timeStart: req.start_time,
+        timeEnd: req.start_time + req.duration,
         spaceStart: boundaries[index],
         spaceEnd: boundaries[index + 1],
       }));

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -144,12 +144,24 @@ class CoreConflictRequirement(BaseModel):
     """
     Unmet requirement causing a conflict.
 
-    The start and end time describe the conflicting time span (not the full
+    The start time and duration describe the conflicting time span (not the full
     requirement's time span).
     """
 
-    end_time: AwareDatetime
-    start_time: AwareDatetime
+    duration: Annotated[int, Field(ge=0)]
+    """
+    Duration of the time range in ms (difference between the latest end time and the earliest start_time for any zone use in this conflict).
+    """
+    start_time: int
+    """
+    Start of the time range during which the zone is contested: elapsed ms since the implicit
+    'request base time'. Earliest start time for any zone use.
+
+    The implicit 'request base time' is the same over the whole request
+    (`trains_requirements` and `work_schedules`) and response.
+    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    timetables.
+    """
     zone: str
 
 
@@ -4120,17 +4132,23 @@ class Conflict(BaseModel):
     """
     Type of the conflict
     """
-    end_time: AwareDatetime
+    duration: Annotated[int, Field(ge=0)]
     """
-    Datetime of the end of the conflict
+    Duration of the conflict in ms.
     """
     requirements: list[CoreConflictRequirement]
     """
     List of requirements causing the conflict
     """
-    start_time: AwareDatetime
+    start_time: int
     """
-    Datetime of the start of the conflict
+    Start of the conflict time range: elapsed ms since an implicit 'request base time'.
+    This is the *union* of all the conflicting time ranges.
+
+    The implicit 'request base time' is the same as the train schedules' `start_time`
+    frame in this timetable.
+    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    timetables.
     """
     train_ids: list[OccurrenceIdBase | OccurrenceIdModified | OccurrenceIdCreated]
     """
@@ -4259,7 +4277,17 @@ class CoreTrainPath(BaseModel):
 class CoreTrainRequirementsById(BaseModel):
     routing_requirements: list[CoreRoutingRequirement]
     spacing_requirements: list[CoreSpacingRequirement]
-    start_time: AwareDatetime
+    start_time: int
+    """
+    Start time for the given train: elapsed ms since an implicit 'request base time'.
+    `start_time` acts as a reference point for all time values in the spacing and routing
+    requirements for this train (values expressed as an offset).
+
+    The implicit 'request base time' is the same over the whole request
+    (`trains_requirements` and `work_schedules`) and response.
+    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    timetables.
+    """
     train_id: str
     train_name: str
     """


### PR DESCRIPTION
Conflicts will be used on hourly timetables which are not related to a specific date. In that case, using a datetime doesn't make sense.

- Adapt `TrainRequirementsById`, `WorkScheduleRequest`, `Conflict` and `ConflictRequirement` `start_time` to use an offset in ms
- Adapt `Conflict` and `ConflictRequirement` `end_time` to use a duration in ms instead
- Rename `startTime` to `referenceTime` in requirements parsing and response making to avoid confusion in core
- Adapt core and frontend accordingly