### PR TITLE
editoast: fix valkey compression using core-task

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -603,13 +603,13 @@ dependencies = [
  "arcstr",
  "deadpool-redis",
  "futures 0.3.32",
- "lz4_flex",
  "rand 0.10.1",
  "redis-test",
  "serde",
  "serde_json",
  "tracing",
  "url",
+ "zstd",
 ]
 
 [[package]]
@@ -912,6 +912,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uom",
+ "zstd",
 ]
 
 [[package]]
@@ -2908,15 +2909,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lz4_flex"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
-dependencies = [
- "twox-hash",
-]
 
 [[package]]
 name = "matchers"
@@ -5322,12 +5314,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typeid"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -151,6 +151,7 @@ utoipa = { git = "https://github.com/leovalais/utoipa.git", branch = "enum-varia
   "uuid",
 ] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
+zstd = "0.13.3"
 
 [dependencies]
 anyhow = "1.0"

--- a/editoast/cache/Cargo.toml
+++ b/editoast/cache/Cargo.toml
@@ -11,12 +11,10 @@ mock = ["redis-test"]
 arcstr.workspace = true
 deadpool-redis.workspace = true
 futures.workspace = true
-lz4_flex = { version = "0.13.1", default-features = false, features = [
-  "frame",
-] }
 rand.workspace = true
 redis-test = { version = "1.0.3", optional = true } # /!\ latest version's 'redis' dependency may not compatible with deadpool-redis re-export
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 url.workspace = true
+zstd.workspace = true

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -154,47 +154,7 @@ impl Connection {
         &mut self,
         key: K,
     ) -> Result<Option<T>, RedisError> {
-        let value: Option<String> = self.get(key).await?;
-        match value {
-            Some(v) => match serde_json::from_str(&v) {
-                Ok(value) => Ok(value),
-                Err(e) => {
-                    tracing::warn!(
-                        "the cached value is not a valid JSON for type '{}': {e}",
-                        std::any::type_name::<T>()
-                    );
-                    Ok(None)
-                }
-            },
-            None => Ok(None),
-        }
-    }
-
-    /// Get a list of deserializable value from valkey
-    #[tracing::instrument(name = "cache:json_get_bulk", skip(self), err)]
-    pub async fn json_get_bulk<T: DeserializeOwned, K: Debug + ToRedisArgs + Send + Sync>(
-        &mut self,
-        keys: &[K],
-    ) -> Result<impl Iterator<Item = Option<T>>, RedisError> {
-        let values: Vec<Option<String>> = if !keys.is_empty() {
-            self.mget(keys).await?
-        } else {
-            // Avoid mget to fail if keys is empty
-            vec![]
-        };
-        let cached_values = values.into_iter().map(|value| {
-            value.and_then(|v| match serde_json::from_str(&v) {
-                Ok(value) => Some(value),
-                Err(e) => {
-                    tracing::warn!(
-                        "the cached value is not a valid JSON for type '{}': {e}",
-                        std::any::type_name::<T>()
-                    );
-                    None
-                }
-            })
-        });
-        Ok(cached_values)
+        Ok(self.json_get_bulk(&[key]).await?.next().unwrap())
     }
 
     /// Set a serializable value to valkey with expiry time
@@ -204,18 +164,7 @@ impl Connection {
         key: K,
         value: &T,
     ) -> Result<(), RedisError> {
-        let str_value = match serde_json::to_string(value) {
-            Ok(value) => value,
-            Err(e) => {
-                tracing::warn!(
-                    "failed to serialize value to JSON for type '{}': {e}",
-                    std::any::type_name::<T>()
-                );
-                return Ok(());
-            }
-        };
-        self.set::<_, _, ()>(key, str_value).await?;
-        Ok(())
+        self.json_set_bulk(&[(key, value)]).await
     }
 
     /// Set a list of serializable values to valkey
@@ -228,43 +177,12 @@ impl Connection {
         if items.is_empty() {
             return Ok(());
         }
-        let serialized_items = items
-            .iter()
-            .filter_map(|(key, value)| match serde_json::to_string(value) {
-                Ok(str_value) => Some((key, str_value)),
-                Err(e) => {
-                    tracing::warn!(
-                        "failed to serialize value to JSON for type '{}': {e}",
-                        std::any::type_name::<T>()
-                    );
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        if !serialized_items.is_empty() {
-            self.mset::<_, _, ()>(&serialized_items).await?;
-        }
-        Ok(())
-    }
-
-    /// Set a list of compressed serializable values to valkey
-    #[tracing::instrument(name = "cache:compressed_set_bulk", skip(self, items), err)]
-    pub async fn compressed_set_bulk<K: Debug + ToRedisArgs + Send + Sync, T: Serialize>(
-        &mut self,
-        items: &[(K, T)],
-    ) -> Result<(), RedisError> {
-        // Avoid mset to fail if keys is empty
-        if items.is_empty() {
-            return Ok(());
-        }
 
         let compressed_items = span!(Level::INFO, "Compressing data").in_scope(|| {
             items
                 .iter()
                 .filter_map(|(key, value)| {
-                    // Create a LZ4 encoder.
-                    let mut encoder = lz4_flex::frame::FrameEncoder::new(Vec::new());
+                    let mut encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
                     // Serialize the `value` into JSON format and write it to the encoder (which compresses it).
                     if let Err(e) = serde_json::to_writer(&mut encoder, value) {
                         tracing::warn!(
@@ -297,9 +215,9 @@ impl Connection {
         Ok(())
     }
 
-    /// Retrieves a list of compressed serialized values from Valkey, decompresses them, and deserializes the result.
-    #[tracing::instrument(name = "cache:compressed_get_bulk", skip(self), err)]
-    pub async fn compressed_get_bulk<K: Debug + ToRedisArgs + Send + Sync, T: DeserializeOwned>(
+    /// Get a list of deserializable value from valkey
+    #[tracing::instrument(name = "cache:json_get_bulk", skip(self), err)]
+    pub async fn json_get_bulk<T: DeserializeOwned, K: Debug + ToRedisArgs + Send + Sync>(
         &mut self,
         keys: &[K],
     ) -> Result<impl Iterator<Item = Option<T>>, RedisError> {
@@ -321,7 +239,8 @@ impl Connection {
                 .into_iter()
                 .map(|value| {
                     value.and_then(|compressed_data| {
-                        let mut decoder = lz4_flex::frame::FrameDecoder::new(&compressed_data[..]);
+                        let mut decoder = zstd::Decoder::new(&compressed_data[..]).unwrap();
+
                         match serde_json::from_reader(&mut decoder) {
                             Ok(deserialized) => Some(deserialized),
                             Err(e) => {

--- a/editoast/core_task/Cargo.toml
+++ b/editoast/core_task/Cargo.toml
@@ -29,3 +29,4 @@ core_client = { workspace = true }
 http.workspace = true
 pretty_assertions.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
+zstd.workspace = true

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -489,11 +489,13 @@ mod tests {
     use deadpool_redis::redis;
     use http::StatusCode;
 
+    use crate::compress_json;
     use crate::mock_mget;
 
     use super::test_data::*;
     use super::*;
 
+    // TODO: Adapt this test so we mock `json_get_bulk` instead of `MGET` and avoid dealing with compressed values in the test.
     #[tokio::test]
     async fn pathfinding_env() {
         common::setup_tracing_for_test();
@@ -509,9 +511,14 @@ mod tests {
 
         let vk = cache::Client::new_mock(
             vec![
-                mock_mget(vec![(pfenv.key(1), Some(path(1))), (pfenv.key(2), None)]),
+                mock_mget(vec![
+                    (pfenv.key(1), Some(compress_json(&path(1)))),
+                    (pfenv.key(2), None),
+                ]),
                 cache::MockCmd::new(
-                    redis::cmd("SET").arg(pfenv.key(2)).arg(path(2).to_string()),
+                    redis::cmd("MSET")
+                        .arg(pfenv.key(2))
+                        .arg(compress_json(&path(2))),
                     Ok(redis::Value::Nil),
                 ),
             ],

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -502,11 +502,13 @@ mod tests {
     use http::StatusCode;
     use pretty_assertions::assert_eq;
 
+    use crate::compress_json;
     use crate::mock_mget;
 
     use super::test_data::*;
     use super::*;
 
+    // TODO: Adapt this test so we mock `json_get_bulk` instead of `MGET` and avoid dealing with compressed values in the test.
     #[tokio::test]
     async fn simulation_env_into_stream() {
         common::setup_tracing_for_test();
@@ -527,17 +529,26 @@ mod tests {
         let vk = cache::Client::new_mock(
             vec![
                 mock_mget(vec![
-                    (simenv.pathfinding_env.key(1), Some(path(1, 4))),
-                    (simenv.pathfinding_env.key(2), Some(path(2, 4))),
+                    (
+                        simenv.pathfinding_env.key(1),
+                        Some(compress_json(&path(1, 4))),
+                    ),
+                    (
+                        simenv.pathfinding_env.key(2),
+                        Some(compress_json(&path(2, 4))),
+                    ),
                 ]),
                 mock_mget(vec![
-                    (simenv.cache_key(1), Some(simulation_success(1))),
+                    (
+                        simenv.cache_key(1),
+                        Some(compress_json(&simulation_success(1))),
+                    ),
                     (simenv.cache_key(2), None),
                 ]),
                 cache::MockCmd::new(
-                    redis::cmd("SET")
+                    redis::cmd("MSET")
                         .arg(simenv.cache_key(2))
-                        .arg(simulation_success(2).to_string()),
+                        .arg(compress_json(&simulation_success(2))),
                     Ok(redis::Value::Nil),
                 ),
             ],

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -214,20 +214,14 @@ where
          */
 
         let (cache_write_tx, mut cache_write_rx) =
-            tokio::sync::mpsc::unbounded_channel::<(String, String)>();
+            tokio::sync::mpsc::unbounded_channel::<(String, serde_json::Value)>();
         {
             let vkconn = vkconn.clone();
             // 'write_cache' task, writes input key-value pairs to cache, logging errors
             tokio::spawn(
                 async move {
-                    use deadpool_redis::redis::AsyncCommands as _;
-                    while let Some((key, serialized_value)) = cache_write_rx.recv().await {
-                        if let Err(e) = vkconn
-                            .lock()
-                            .await
-                            .set::<_, _, ()>(key.clone(), serialized_value)
-                            .await
-                        {
+                    while let Some((key, value)) = cache_write_rx.recv().await {
+                        if let Err(e) = vkconn.lock().await.json_set(key.clone(), &value).await {
                             tracing::error!(?e, key, "task stream: cache write failure")
                         }
                     }
@@ -325,12 +319,12 @@ where
                             match input.compute(ctx.clone()).await {
                                 Ok(value) => {
                                     #[cfg(not(test))]
-                                    let serialized = serde_json::to_string(&value).unwrap();
+                                    let serialized = serde_json::to_value(&value).unwrap();
                                     #[cfg(test)]
                                     let serialized = {
                                         let mut serialized = serde_json::to_value(&value).unwrap();
                                         serialized.sort_all_objects();
-                                        serialized.to_string()
+                                        serialized
                                     };
                                     cache_write_tx.send((cache_key, serialized)).ok();
                                     results_tx
@@ -356,8 +350,15 @@ where
 }
 
 #[cfg(test)]
+fn compress_json<T: Serialize>(value: &T) -> Vec<u8> {
+    let mut encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
+    serde_json::to_writer(&mut encoder, value).unwrap();
+    encoder.finish().unwrap()
+}
+
+#[cfg(test)]
 /// Builds an `MGET` mocked command with sorted keys and ordered JSON keys for determinism
-fn mock_mget(mut values: Vec<(String, Option<serde_json::Value>)>) -> cache::MockCmd {
+fn mock_mget(mut values: Vec<(String, Option<Vec<u8>>)>) -> cache::MockCmd {
     values.sort_by_key(|(k, _)| k.clone());
     let (keys, values): (Vec<_>, Vec<_>) = values.into_iter().unzip();
     cache::MockCmd::new(
@@ -366,10 +367,7 @@ fn mock_mget(mut values: Vec<(String, Option<serde_json::Value>)>) -> cache::Moc
             values
                 .into_iter()
                 .map(|v| match v {
-                    Some(mut v) => {
-                        v.sort_all_objects();
-                        deadpool_redis::redis::Value::SimpleString(v.to_string())
-                    }
+                    Some(v) => deadpool_redis::redis::Value::BulkString(v),
                     None => deadpool_redis::redis::Value::Nil,
                 })
                 .collect(),

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -297,7 +297,7 @@ async fn pathfinding_blocks_batch(
 
     // Try to retrieve the result from Valkey
     let pathfinding_cached_results: Vec<Option<Arc<PathfindingResult>>> = valkey_conn
-        .compressed_get_bulk(&hashes)
+        .json_get_bulk(&hashes)
         .await?
         .map(|result| result.map(Arc::new))
         .collect();
@@ -380,7 +380,7 @@ async fn pathfinding_blocks_batch(
     }
 
     debug!(nb_cached = to_cache.len(), "Caching pathfinding response");
-    valkey_conn.compressed_set_bulk(&to_cache).await?;
+    valkey_conn.json_set_bulk(&to_cache).await?;
 
     Ok(pathfinding_results)
 }

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -548,7 +548,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     );
     let cached_simulation_hash = to_sim.keys().collect::<Vec<_>>();
     let cached_results: Vec<Option<Arc<simulation::Response>>> = valkey_conn
-        .compressed_get_bulk(&cached_simulation_hash)
+        .json_get_bulk(&cached_simulation_hash)
         .await?
         .map(|simulation| simulation.map(Arc::new))
         .collect();
@@ -600,7 +600,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     }
 
     // Cache the simulation response
-    valkey_conn.compressed_set_bulk(&to_cache).await?;
+    valkey_conn.json_set_bulk(&to_cache).await?;
 
     // Return the response
     Ok(simulation_results


### PR DESCRIPTION
With the new core-task model, we disabled (unintentionally) compression. Which produce timeouts and 500 in production.

What is done here:
- Remove `json_set` and `json_get` without compressions. All utilities functions are now using compression
- Moving from lz4 to zstd (see benchmark)
- Fix core-task to use the utilities function instead of pushing non-compressed payloads.


### Benchmarch

Running a `simulation_summary` endpoint on ~100 trains with a flushed cache.
- 152 elements are in the cache

| Algo | Endpoint time (miss cache) | Size in valkey (MB) |
| --  | -- | -- |
| lz4 | ~5.4s | 2.47 |
| zstd | ~5.4s | 1.16 |
