### PR TITLE
editoast, front: change TimeWindow time_begin from datetime to ms offset

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1926,8 +1926,8 @@ paths:
                           type: string
                           example: PT5M
                         time_begin:
-                          type: string
-                          format: date-time
+                          type: integer
+                          format: int64
                     - type: object
                       required:
                       - direction
@@ -4517,8 +4517,8 @@ paths:
                               type: string
                               example: PT5M
                             time_begin:
-                              type: string
-                              format: date-time
+                              type: integer
+                              format: int64
   /train_schedules/{id}:
     get:
       tags:

--- a/editoast/schemas/src/primitives/time_window.rs
+++ b/editoast/schemas/src/primitives/time_window.rs
@@ -1,13 +1,14 @@
 use super::PositiveDuration;
-use chrono::DateTime;
-use chrono::Utc;
+use common::units::quantities::Offset;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct TimeWindow {
-    pub time_begin: DateTime<Utc>,
+    #[serde(with = "common::units::millisecond::i64")]
+    #[schema(value_type = i64)]
+    pub time_begin: Offset,
     #[schema(value_type = chrono::Duration, example = "PT5M")]
     pub duration: PositiveDuration,
 }

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -16,10 +16,9 @@ use editoast_models::train_schedule::OccurrenceId;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
-use chrono::DateTime;
 use chrono::Duration;
-use chrono::Utc;
 use common::units::millisecond;
+use common::units::quantities::Offset;
 use core_client::pathfinding::TrackRange;
 use core_client::simulation::ReportTrain;
 use database::DbConnection;
@@ -208,10 +207,7 @@ pub(in crate::views) async fn occupancy(
                 occurrence_id,
                 simulation,
                 pathfinding,
-                DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(
-                    train_schedule.start_time,
-                ))
-                .unwrap(),
+                train_schedule.start_time,
                 rolling_stock_length,
             ) {
                 level_crossing_occupancies.push(occupancy);
@@ -248,7 +244,7 @@ fn find_level_crossing_occupancy(
     occurrence_id: &OccurrenceId,
     simulation: &simulation::Response,
     pathfinding: &PathfindingResult,
-    start_time: DateTime<Utc>,
+    start_time: Offset,
     rolling_stock_length: &u64,
 ) -> Option<LevelCrossingOccupancy> {
     // Check simulation results
@@ -313,7 +309,7 @@ fn find_occupancy_time_window(
     level_crossing: &LevelCrossing,
     lc_position: &u64,
     matched_track_offset: &TrackOffset,
-    start_time: DateTime<Utc>,
+    start_time: Offset,
     rolling_stock_length: &u64,
 ) -> Option<TimeWindow> {
     let pedal_position =
@@ -332,7 +328,7 @@ fn find_occupancy_time_window(
     let leaving_time = interpolate_arrival_time(lc_end_position, report_train);
 
     Some(TimeWindow {
-        time_begin: start_time + Duration::milliseconds(arrival_time),
+        time_begin: start_time + millisecond::i64::new(arrival_time),
         duration: Duration::milliseconds(leaving_time - arrival_time)
             .try_into()
             .expect("leaving_time should be greater than arrival_time"),
@@ -620,9 +616,7 @@ mod tests {
         assert_eq!(occupancy.direction, Direction::StartToStop);
         assert_eq!(
             occupancy.time_window.time_begin,
-            DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(train.start_time))
-                .unwrap()
-                + Duration::milliseconds(10)
+            train.start_time + millisecond::i64::new(10)
         );
         assert_eq!(occupancy.time_window.duration.num_milliseconds(), 55);
     }

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -1,6 +1,3 @@
-use chrono::DateTime;
-use chrono::Duration;
-use chrono::Utc;
 use common::units::millisecond;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::simulation::ReportTrain;
@@ -238,11 +235,7 @@ fn find_track_occupancy_for_operational_point_with_context<'a>(
             train_schedule,
         ),
         time_window: TimeWindow {
-            time_begin: DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(
-                train_schedule.start_time,
-            ))
-            .unwrap()
-                + Duration::milliseconds(arrival_time),
+            time_begin: train_schedule.start_time + millisecond::i64::new(arrival_time),
             duration: stop_duration,
         },
     }]
@@ -253,6 +246,7 @@ pub mod tests {
     use crate::error::InternalError;
     use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
+    use chrono::Duration;
     use common::units::millisecond;
     use core_client::pathfinding::PathfindingNotFound;
     use core_client::pathfinding::TrackRange;
@@ -466,8 +460,7 @@ pub mod tests {
 
             assert_eq!(
                 *time_begin,
-                DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(start_time)).unwrap()
-                    + Duration::milliseconds(expected_time as i64)
+                start_time + millisecond::i64::new(expected_time as i64)
             );
             assert_eq!(
                 *duration,
@@ -577,8 +570,7 @@ pub mod tests {
         );
         assert_eq!(
             results[0].time_window.time_begin,
-            DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(start_time)).unwrap()
-                + Duration::minutes(5)
+            start_time + millisecond::i64::new(300_000)
         );
     }
 }

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -10,9 +10,6 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
-use chrono::DateTime;
-use chrono::Duration;
-use chrono::Utc;
 use common::units::millisecond;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
@@ -1668,11 +1665,8 @@ fn find_track_occupancy_unknown_operational_point(
                             } else {
                                 schedule_item.arrival?.num_milliseconds()
                             };
-                            let time_begin = DateTime::<Utc>::from_timestamp_millis(
-                                millisecond::i64::from(train_schedule.start_time),
-                            )
-                            .unwrap()
-                                + Duration::milliseconds(arrival_time);
+                            let time_begin =
+                                train_schedule.start_time + millisecond::i64::new(arrival_time);
                             Some(TimeWindow {
                                 time_begin,
                                 duration,
@@ -1681,10 +1675,7 @@ fn find_track_occupancy_unknown_operational_point(
                         // No schedule item for the first path item: use start_time directly.
                         .or_else(|| {
                             is_first_path_item.then_some(TimeWindow {
-                                time_begin: DateTime::<Utc>::from_timestamp_millis(
-                                    millisecond::i64::from(train_schedule.start_time),
-                                )
-                                .unwrap(),
+                                time_begin: train_schedule.start_time,
                                 duration: Default::default(),
                             })
                         })?;
@@ -1790,10 +1781,8 @@ mod tests {
     use std::collections::HashMap;
 
     use axum::http::StatusCode;
-    use chrono::DateTime;
     use chrono::Duration;
     use chrono::TimeDelta;
-    use chrono::Utc;
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::InvalidPathItem;
     use core_client::pathfinding::PathfindingInputError;
@@ -3396,10 +3385,7 @@ mod tests {
         );
 
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0].1.time_window.time_begin,
-            DateTime::<Utc>::from_timestamp_millis(millisecond::i64::from(start_time)).unwrap()
-        );
+        assert_eq!(result[0].1.time_window.time_begin, start_time);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2064,7 +2064,7 @@ export type PostLevelCrossingOccupancyApiResponse =
         }
     ) & {
       duration: string;
-      time_begin: string;
+      time_begin: number;
     } & {
       direction: Direction;
     })[];
@@ -2726,7 +2726,7 @@ export type PostTrainSchedulesTrackOccupancyApiResponse =
         }
     ) & {
       duration: string;
-      time_begin: string;
+      time_begin: number;
     })[];
   }[];
 export type PostTrainSchedulesTrackOccupancyApiArg = {

--- a/front/src/modules/simulationResult/components/Chronogram/buildOccupancyBlocks.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/buildOccupancyBlocks.ts
@@ -5,7 +5,7 @@ import type {
   LevelCrossing,
   PostLevelCrossingOccupancyApiResponse,
 } from 'common/api/osrdEditoastApi';
-import { addDurationToDate, Duration } from 'utils/duration';
+import { Duration } from 'utils/duration';
 
 const MIN_GAP_BETWEEN_OCCUPANCIES_MS = 15_000; // 15 seconds
 
@@ -20,11 +20,8 @@ function computeOccupanciesBlocks(
 ): LevelCrossingOccupancies {
   const sortedOccupancies = occupancies
     .map((occupancy) => ({
-      startTime: new Date(occupancy.time_begin).getTime(),
-      endTime: addDurationToDate(
-        new Date(occupancy.time_begin),
-        Duration.parse(occupancy.duration)
-      ).getTime(),
+      startTime: occupancy.time_begin,
+      endTime: occupancy.time_begin + Duration.parse(occupancy.duration).ms,
       trainNames: [trainNameById.get(occupancy.train_schedule_id) ?? ''],
     }))
     .sort((a, b) => a.startTime - b.startTime);

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones.ts
@@ -61,7 +61,7 @@ export function getMovableOccupancyZone(
   exception?: PacedTrainException
 ): MovableOccupancyZone {
   const trainStartTime = departureTime.getTime();
-  const occupationStartTime = +new Date(occupation.time_begin);
+  const occupationStartTime = occupation.time_begin;
   const occupationEndTime = occupationStartTime + Duration.parse(occupation.duration).ms;
   const timeToPosition = getTimeToPosition(spaceTimeCurves);
 


### PR DESCRIPTION
This PR improves consistency following the migration of the `train_schedule` `start_time` to an offset.