### PR TITLE
front: remove eslint-plugin-react to replace it by native lints

### DIFF
--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -120,7 +120,6 @@
     "no-confusing-void-expression": "off",
     "no-constructor-return": "off",
     "no-continue": "off",
-    "no-deprecated": "off",
     "no-did-mount-set-state": "off",
     "no-did-update-set-state": "off",
     "no-duplicate-hooks": "off",
@@ -434,7 +433,6 @@
       }
     ],
     "react-js/no-deprecated": "error",
-    "react-js/prop-types": "error",
     "react-hooks-js/component-hook-factories": "error",
     "react-hooks-js/config": "error",
     "react-hooks-js/error-boundaries": "error",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "import", "react", "vitest", "jsx-a11y"],
+  "plugins": ["eslint", "import", "jsx-a11y", "react", "typescript", "vitest"],
   "categories": {
     "correctness": "error",
     "suspicious": "error",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -17,10 +17,6 @@
       "specifier": "eslint-plugin-react-hooks"
     },
     {
-      "name": "react-js",
-      "specifier": "eslint-plugin-react"
-    },
-    {
       "name": "import-js",
       "specifier": "eslint-plugin-import"
     }
@@ -432,7 +428,6 @@
         ]
       }
     ],
-    "react-js/no-deprecated": "error",
     "react-hooks-js/component-hook-factories": "error",
     "react-hooks-js/config": "error",
     "react-hooks-js/error-boundaries": "error",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -117,7 +117,6 @@
         "@vitejs/plugin-react": "^6.0.2",
         "ansi-to-html": "^0.7.2",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "glob": "^13.0.6",
         "happy-dom": "^20.9.0",
@@ -8791,25 +8790,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.findlast": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
       "dev": true,
@@ -8862,21 +8842,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.tosorted": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
@@ -10869,32 +10834,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-iterator-helpers": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.0.3",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.6",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.4",
-        "safe-array-concat": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -11170,37 +11109,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.37.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.9",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
-      }
-    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
@@ -11219,30 +11127,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-storybook": {
@@ -11411,6 +11295,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12883,22 +12768,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/iterator.prototype": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/jay-peg": {
       "version": "1.1.1",
       "license": "MIT",
@@ -13121,20 +12990,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jsx-ast-utils": {
-      "version": "3.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flat": "^1.3.1",
-        "object.assign": "^4.1.4",
-        "object.values": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/kdbush": {
@@ -14816,20 +14671,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
@@ -18644,41 +18485,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.matchall": {
-      "version": "4.0.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "regexp.prototype.flags": "^1.5.3",
-        "set-function-name": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.repeat": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "dev": true,
@@ -21022,7 +20828,6 @@
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.5.0",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-storybook": "^10.4.1",
         "oxfmt": "^0.51.0",

--- a/front/package.json
+++ b/front/package.json
@@ -117,7 +117,6 @@
     "@vitejs/plugin-react": "^6.0.2",
     "ansi-to-html": "^0.7.2",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "glob": "^13.0.6",
     "happy-dom": "^20.9.0",

--- a/front/src/applications/editor/tools/rangeEdition/components/EyeToggle.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components/EyeToggle.tsx
@@ -2,7 +2,7 @@ import { Eye, EyeClosed } from '@osrd-project/ui-icons';
 
 type EyeToggleProps = {
   checked: boolean;
-  onClick: React.FormEventHandler<HTMLDivElement>;
+  onClick: React.MouseEventHandler<HTMLDivElement>;
 };
 
 function EyeToggle({ checked, onClick }: EyeToggleProps) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/PowerRestrictionsSelector/helpers/__tests__/formatPowerRestrictions.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/PowerRestrictionsSelector/helpers/__tests__/formatPowerRestrictions.spec.ts
@@ -90,7 +90,7 @@ describe('formatPowerRestrictions', () => {
   it('should throw an error if a pathStep is not found', () => {
     expect(() =>
       formatPowerRestrictions(powerRestrictions, [], customRanges, changePoints, pathLength)
-    ).toThrowError('Impossible to locate the path step a while formatting the power restrictions');
+    ).toThrow('Impossible to locate the path step a while formatting the power restrictions');
   });
 
   it('should throw an error if a pathStep has no positionOnPath', () => {
@@ -102,6 +102,6 @@ describe('formatPowerRestrictions', () => {
         changePoints,
         pathLength
       )
-    ).toThrowError('Impossible to locate a path step while formatting the power restrictions');
+    ).toThrow('Impossible to locate a path step while formatting the power restrictions');
   });
 });

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
@@ -130,7 +130,7 @@ const RollingStockEditorForm = ({
     }
   };
 
-  const submit = (e: React.FormEvent<HTMLFormElement>, data: RollingStockParametersValues) => {
+  const submit = (e: React.SubmitEvent<HTMLFormElement>, data: RollingStockParametersValues) => {
     e.preventDefault();
     let error: undefined | { name: string; message: string };
     if (!data.name) {

--- a/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
@@ -1,4 +1,4 @@
-import { type LegacyRef, type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, type RefAttributes, useEffect, useRef, useState } from 'react';
 
 import TetherComponent from 'react-tether';
 
@@ -55,7 +55,7 @@ const DropdownSNCF = ({
         className="over-modal dropdown"
         attachment="top right"
         targetAttachment="bottom right"
-        renderTarget={(ref: LegacyRef<HTMLButtonElement>) => (
+        renderTarget={(ref: RefAttributes<HTMLButtonElement>['ref']) => (
           <button
             data-testid="dropdown-sncf"
             ref={ref}
@@ -72,7 +72,7 @@ const DropdownSNCF = ({
             )}
           </button>
         )}
-        renderElement={(ref: LegacyRef<HTMLDivElement>) =>
+        renderElement={(ref: RefAttributes<HTMLDivElement>['ref']) =>
           isDropdownShown && (
             <div ref={ref}>
               <div

--- a/front/src/common/BootstrapSNCF/InputSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/InputSNCF.tsx
@@ -44,7 +44,7 @@ export type InputSNCFProps = {
   condensed?: boolean;
   textRight?: boolean;
   disabled?: boolean;
-  ref?: React.MutableRefObject<HTMLInputElement>;
+  ref?: React.RefObject<HTMLInputElement>;
 };
 
 const InputSNCF = ({

--- a/front/src/common/IntervalsDataViz/data.ts
+++ b/front/src/common/IntervalsDataViz/data.ts
@@ -614,7 +614,7 @@ export function cropForDatavizViewbox(
 export function cropOperationPointsForDatavizViewbox(
   operationalPoints: Array<OperationalPoint>,
   currentViewBox: [number, number] | null,
-  wrapper: React.MutableRefObject<HTMLDivElement | null>,
+  wrapper: React.RefObject<HTMLDivElement | null>,
   fullLength: number
 ): Array<OperationalPoint & { positionInPx: number }> {
   if (wrapper.current !== null && fullLength > 0) {

--- a/front/src/common/Map/BaseMap.tsx
+++ b/front/src/common/Map/BaseMap.tsx
@@ -1,4 +1,4 @@
-import { type MutableRefObject, type PropsWithChildren, useEffect, useState } from 'react';
+import { type RefObject, type PropsWithChildren, useEffect, useState } from 'react';
 
 import type { Geometry } from 'geojson';
 import type { MapLayerMouseEvent, MapLibreEvent } from 'maplibre-gl';
@@ -24,7 +24,7 @@ import { CUSTOM_ATTRIBUTION } from './const';
 type MapProps = {
   mapSettings: MapSettings;
   mapId: string;
-  mapRef: MutableRefObject<MapRef | null>;
+  mapRef: RefObject<MapRef | null>;
   interactiveLayerIds: string[];
   infraId?: number;
   updatePartialViewPort: (newPartialViewPort: Partial<Viewport>) => void;

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -34,7 +34,7 @@ function generateRandomString(length: number): string {
  */
 export function generateCodeNumber(): string {
   const currentDate = new Date();
-  const year = currentDate.getFullYear().toString().substr(-2);
+  const year = currentDate.getFullYear().toString().slice(-2);
   const month = (currentDate.getMonth() + 1).toString().padStart(2, '0');
   const randomPart1 = generateRandomString(3);
   const randomPart2 = generateRandomString(3);

--- a/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
@@ -18,7 +18,7 @@ type RollingStockCardProps = {
   isOpen: boolean;
   isOnEditMode?: boolean;
   noCardSelected: boolean;
-  ref2scroll?: React.MutableRefObject<HTMLDivElement | null>;
+  ref2scroll?: React.RefObject<HTMLDivElement | null>;
   rollingStock: LightRollingStockWithLiveries;
   setOpenedRollingStockCardId: (openCardId: number | undefined) => void;
   onSelectRollingStock?: (rollingStock: LightRollingStockWithLiveries, comfort: Comfort) => void;

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useMemo, type MutableRefObject } from 'react';
+import React, { useState, useEffect, useContext, useMemo, type RefObject } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -13,7 +13,7 @@ import { RollingStockCard } from '../RollingStockCard';
 
 type RollingStockModal = {
   rollingStockId: number | undefined;
-  ref2scroll: MutableRefObject<HTMLDivElement | null>;
+  ref2scroll: RefObject<HTMLDivElement | null>;
   onSelectRollingStock: (rollingStock: LightRollingStockWithLiveries, comfort: Comfort) => void;
 };
 

--- a/front/src/utils/hooks/useInputChange.ts
+++ b/front/src/utils/hooks/useInputChange.ts
@@ -2,7 +2,7 @@ import { isEqual } from 'lodash';
 
 const useInputChange =
   <T>(
-    initialValuesRef: React.MutableRefObject<T | null>,
+    initialValuesRef: React.RefObject<T | null>,
     setCurrent: React.Dispatch<React.SetStateAction<T>>,
     setHasChanges: React.Dispatch<React.SetStateAction<boolean>>
   ) =>

--- a/front/ui/base/package.json
+++ b/front/ui/base/package.json
@@ -14,7 +14,6 @@
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.5.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-storybook": "^10.4.1",
     "oxfmt": "^0.51.0",

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
@@ -38,6 +38,7 @@ const ScreenshotButton = () => {
     >
       <button
         onClick={() =>
+          // oxlint-disable-next-line typescript/no-deprecated -- False flag, as only the last argument is deprecated
           captureCanvases().then((blob) => FileSaver.saveAs(blob, 'space-time-chart.png'))
         }
       >

--- a/front/ui/ui-core/src/components/DatePicker/__tests__/useCalendarPicker.spec.ts
+++ b/front/ui/ui-core/src/components/DatePicker/__tests__/useCalendarPicker.spec.ts
@@ -58,7 +58,7 @@ describe('useCalendarPicker', () => {
             selectedSlot: { start: new Date(2024, february, 2), end: new Date(2024, february, 1) },
           })
         )
-      ).toThrowError();
+      ).toThrow();
     });
 
     it('should throw an error if selectableSlot is not valid', () => {
@@ -67,7 +67,7 @@ describe('useCalendarPicker', () => {
         end: new Date(2024, february, 1),
       };
 
-      expect(() => renderHook(() => useCalendarPicker({ selectableSlot }))).toThrowError();
+      expect(() => renderHook(() => useCalendarPicker({ selectableSlot }))).toThrow();
     });
 
     it('should throw an error if selectedSlot is not within selectableSlot', () => {
@@ -77,9 +77,7 @@ describe('useCalendarPicker', () => {
         end: new Date(2024, february, 4),
       };
 
-      expect(() =>
-        renderHook(() => useCalendarPicker({ selectedSlot, selectableSlot }))
-      ).toThrowError();
+      expect(() => renderHook(() => useCalendarPicker({ selectedSlot, selectableSlot }))).toThrow();
     });
 
     it('should throw an error when initialDate is not a valid date', () => {
@@ -89,9 +87,7 @@ describe('useCalendarPicker', () => {
         end: new Date(2024, february, 4),
       };
 
-      expect(() =>
-        renderHook(() => useCalendarPicker({ initialDate, selectableSlot }))
-      ).toThrowError();
+      expect(() => renderHook(() => useCalendarPicker({ initialDate, selectableSlot }))).toThrow();
     });
   });
 

--- a/front/ui/ui-core/src/components/DatePicker/__tests__/useDatePicker.spec.ts
+++ b/front/ui/ui-core/src/components/DatePicker/__tests__/useDatePicker.spec.ts
@@ -206,7 +206,7 @@ describe('useDatePicker', () => {
         });
 
         expect(result.current.inputValue).toBe('01/01/24 - ');
-        expect(onDayChange).not.toBeCalled();
+        expect(onDayChange).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
It just happen that `react-js/no-deprecated` and `react-js/prop-types` will never be implemented as-is by oxlint, because they are deemed redundant or better served by other lint rules:

> 🚫 `react/no-deprecated`: No need to implement, already implemented by `typescript/no-deprecated` via tsgolint.
> 🚫 `react/prop-types`: PropTypes are ignored in React 19, and TypeScript + the no-unsafe-xxx rules already catches unsafe props in most cases.

This makes sense to me, so let's switch to `typescript/no-deprectated`. Enabling it back raises some errors, so the relevant commit fixes them. And because those lints are removed, this pull request remove the `eslint-plugin-react` package from our `package.json`.

As it's a freebie, I also re-enable the `eslint` core plugin as it's part of the default plugin list from `oxlint`; it's the only one that we can enable without causing errors (the two other we don't enable, `oxc` and `unicorn`, raise _a lot_ of lint errors, so it's better to create another PR for each of them).