### PR TITLE
front: add backwards compat for old start_time format

### DIFF
--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -44,7 +44,8 @@ export type PacedTrainResponseWithPaced = PacedTrainWithPaced & {
   id: number;
 };
 
-export type PacedTrainFromJson = Omit<TrainSchedule, 'category'> & {
+export type PacedTrainFromJson = Omit<TrainSchedule, 'start_time' | 'category'> & {
+  start_time: string | number;
   category?: TrainCategory | string | null;
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/helpers/generatePayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/helpers/generatePayloads.ts
@@ -102,6 +102,10 @@ export function generateTrainPayloads(
 
     trainSchedules.push({
       ...trainScheduleBase,
+      start_time:
+        typeof pacedTrain.start_time === 'string'
+          ? new Date(pacedTrain.start_time).getTime()
+          : pacedTrain.start_time,
       category: checkCategory(pacedTrain.category, allowedSubCategories),
       labels: buildLabels(pacedTrain.labels, pacedTrain.category, allowedSubCategories),
       paced: paced


### PR DESCRIPTION
Commit 49adf19a77fa ("editoast, front: change train_schedule start_time from datetime to ms offset") has made a breaking change to our JSON import/export format. Add a small conversion step so that our users' JSON files can still be imported.