### PR TITLE
Refactor osm2railjson

### DIFF
--- a/editoast/osm_to_railjson/src/generate_routes.rs
+++ b/editoast/osm_to_railjson/src/generate_routes.rs
@@ -6,11 +6,15 @@
 
 use std::collections::HashMap;
 
+use itertools::Itertools;
+use schemas::infra::BufferStop;
+use schemas::infra::Detector;
 use schemas::infra::Direction;
 use schemas::infra::Endpoint;
-use schemas::infra::RailJson;
 use schemas::infra::Route;
+use schemas::infra::Switch;
 use schemas::infra::TrackEndpoint;
+use schemas::infra::TrackSection;
 use schemas::infra::Waypoint;
 use schemas::infra::builtin_node_types_list;
 use schemas::primitives::Identifier;
@@ -58,23 +62,30 @@ struct Graph {
 
 impl Graph {
     /* Part 2: build the graph from track sections, switches, buffers and detectors */
-    fn load(&mut self, railjson: &RailJson) {
-        self.edges_from_track_sections(railjson);
-        self.edges_from_switches(railjson);
+    fn load(
+        &mut self,
+        track_sections: &[TrackSection],
+        detectors: &[Detector],
+        buffer_stops: &[BufferStop],
+        switches: &[Switch],
+    ) {
+        self.edges_from_track_sections(track_sections, detectors, buffer_stops);
+        self.edges_from_switches(switches);
     }
 
-    fn edges_from_track_sections(&mut self, railjson: &RailJson) {
+    fn edges_from_track_sections(
+        &mut self,
+        track_sections: &[TrackSection],
+        detectors: &[Detector],
+        buffer_stops: &[BufferStop],
+    ) {
         // We need to split handle separately the signals that are forward
-        let mut detectors = HashMap::<_, Vec<_>>::new();
+        let detectors_by_track = detectors
+            .iter()
+            .map(|detector| (&detector.track, detector))
+            .into_group_map();
 
-        for detector in &railjson.detectors {
-            detectors
-                .entry(detector.track.clone())
-                .or_default()
-                .push(detector.clone());
-        }
-
-        for (track, detectors) in &detectors {
+        for (track, detectors) in &detectors_by_track {
             // When going from start to end
             // We only consider the last detector (closest to end) that is on the same track
             // All the other can be considered as block defining
@@ -103,7 +114,7 @@ impl Graph {
             self.add_directed_edge(d.clone(), v, EdgeType::FromDetector(Direction::StopToStart));
         }
 
-        for buffer in &railjson.buffer_stops {
+        for buffer in buffer_stops {
             let b = Node::BufferStop(buffer.id.clone());
             if buffer.position < 0.1 {
                 let u = Node::from_track_endpoint(&buffer.track, Endpoint::Begin);
@@ -114,18 +125,18 @@ impl Graph {
             }
         }
 
-        for track in &railjson.track_sections {
+        for track in track_sections {
             // We only consider tracks that have no detector for the given direction on them as we split them
             let u = Node::from_track_endpoint(&track.id, Endpoint::Begin);
             let v = Node::from_track_endpoint(&track.id, Endpoint::End);
-            if !detectors.contains_key(&track.id) {
+            if !detectors_by_track.contains_key(&track.id) {
                 self.add_symmetrical_edge(v.clone(), u.clone(), EdgeType::Track);
             }
         }
     }
 
-    fn edges_from_switches(&mut self, railjson: &RailJson) {
-        for switch in &railjson.switches {
+    fn edges_from_switches(&mut self, switches: &[Switch]) {
+        for switch in switches {
             let builtin_node_types = builtin_node_types_list();
             let switch_type = builtin_node_types
                 .iter()
@@ -281,17 +292,20 @@ impl Graph {
     }
 }
 
-pub fn routes(railjson: &RailJson) -> Vec<Route> {
+pub fn routes(
+    track_sections: &[TrackSection],
+    detectors: &[Detector],
+    buffer_stops: &[BufferStop],
+    switches: &[Switch],
+) -> Vec<Route> {
     let mut graph = Graph::default();
-    graph.load(railjson);
+    graph.load(track_sections, detectors, buffer_stops, switches);
 
-    let from_buffers = railjson
-        .buffer_stops
+    let from_buffers = buffer_stops
         .iter()
         .flat_map(|b| graph.one_to_all_routes(Node::BufferStop(b.id.clone())));
 
-    let from_detectors = railjson
-        .detectors
+    let from_detectors = detectors
         .iter()
         .flat_map(|d| graph.one_to_all_routes(Node::Detector(d.id.clone())));
 
@@ -303,6 +317,7 @@ mod tests {
     use super::*;
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
+    use schemas::infra::RailJson;
     use schemas::infra::TrackSection;
 
     fn min_infra() -> RailJson {
@@ -341,7 +356,13 @@ mod tests {
     #[test]
     fn build_graph() {
         let mut g = super::Graph::default();
-        g.load(&min_infra());
+        let railjson = min_infra();
+        g.load(
+            &railjson.track_sections,
+            &railjson.detectors,
+            &railjson.buffer_stops,
+            &railjson.switches,
+        );
         let begin = super::Node::BufferStop("buffer_begin".into());
         let end = super::Node::BufferStop("buffer_end".into());
         let detector = super::Node::Detector("detector".into());
@@ -387,7 +408,13 @@ mod tests {
     #[test]
     /* --s-- one track, one detector, two buffers */
     fn minimal_routes() {
-        let routes = super::routes(&min_infra());
+        let railjson = min_infra();
+        let routes = super::routes(
+            &railjson.track_sections,
+            &railjson.detectors,
+            &railjson.buffer_stops,
+            &railjson.switches,
+        );
         assert_eq!(4, routes.len());
     }
 
@@ -399,7 +426,12 @@ mod tests {
     fn generate_routes() {
         let railjson =
             crate::osm_to_railjson::parse_osm("src/tests/routes.osm.pbf".into(), false).unwrap();
-        let routes = super::routes(&railjson);
+        let routes = super::routes(
+            &railjson.track_sections,
+            &railjson.detectors,
+            &railjson.buffer_stops,
+            &railjson.switches,
+        );
         assert_eq!(6, routes.len());
         let routes_with_switches_count = routes
             .iter()

--- a/editoast/osm_to_railjson/src/generate_signals.rs
+++ b/editoast/osm_to_railjson/src/generate_signals.rs
@@ -18,12 +18,13 @@ use std::collections::HashSet;
 use schemas::infra::Direction;
 use schemas::infra::Endpoint;
 use schemas::infra::LogicalSignal;
-use schemas::infra::RailJson;
 use schemas::infra::Side;
 use schemas::infra::Signal;
 use schemas::infra::SignalExtensions;
 use schemas::infra::SignalSncfExtension;
 use schemas::infra::Speed;
+use schemas::infra::SpeedSection;
+use schemas::infra::Switch;
 use schemas::infra::TrackEndpoint;
 use schemas::infra::TrackSection;
 use schemas::primitives::Identifier;
@@ -103,11 +104,10 @@ impl<'a> Track<'a> {
     /// Returns the new `track_endpoint` at the end of the track.
     fn push_track_section(
         &mut self,
-        railjson: &'a RailJson,
+        track_sections: &'a [TrackSection],
         track_endpoint: &TrackEndpoint,
     ) -> TrackEndpoint {
-        let track_section = railjson
-            .track_sections
+        let track_section = track_sections
             .iter()
             .find(|ts| ts.id == track_endpoint.track)
             .unwrap();
@@ -306,13 +306,17 @@ impl<'a> Track<'a> {
     }
 }
 
-fn create_tracks<'a>(railjson: &'a RailJson) -> Vec<Track<'a>> {
+fn create_tracks<'a>(
+    track_sections: &'a [TrackSection],
+    switches: &'a [Switch],
+    speed_sections: &'a [SpeedSection],
+) -> Vec<Track<'a>> {
     // Map of track endpoints connected by link switches.
     let mut link_switches: HashMap<&TrackEndpoint, &TrackEndpoint> = HashMap::new();
     // Set of track endpoints that are connected to intersection.
     let mut endpoints_linked_to_intersection: HashSet<&TrackEndpoint> = HashSet::new();
 
-    for switch in &railjson.switches {
+    for switch in switches {
         if switch.switch_type == Identifier::from("link") {
             let (endpoint_0, endpoint_1) = switch
                 .ports
@@ -329,7 +333,7 @@ fn create_tracks<'a>(railjson: &'a RailJson) -> Vec<Track<'a>> {
     // List of track endpoints not linked to a link switch.
     // Meaning they are the boundary of a track.
     let mut track_boundaries = Vec::new();
-    for track_section in &railjson.track_sections {
+    for track_section in track_sections {
         for endpoint in [Endpoint::Begin, Endpoint::End] {
             let track_endpoint = TrackEndpoint {
                 endpoint,
@@ -353,10 +357,10 @@ fn create_tracks<'a>(railjson: &'a RailJson) -> Vec<Track<'a>> {
             highest_speed_limit: None,
         };
 
-        endpoint = track.push_track_section(railjson, &endpoint);
+        endpoint = track.push_track_section(track_sections, &endpoint);
         // Follow the track sections and link switches until there are no more link switches.
         while let Some(linked_endpoint) = link_switches.get(&endpoint) {
-            endpoint = track.push_track_section(railjson, linked_endpoint);
+            endpoint = track.push_track_section(track_sections, linked_endpoint);
         }
 
         // Remove the endpoint from the track boundaries, so that we don't start a track from it.
@@ -368,7 +372,7 @@ fn create_tracks<'a>(railjson: &'a RailJson) -> Vec<Track<'a>> {
             .track_sections
             .iter()
             .filter_map(|(track_section, _)| {
-                railjson.speed_sections.iter().find(|speed_section| {
+                speed_sections.iter().find(|speed_section| {
                     speed_section
                         .track_ranges
                         .iter()
@@ -447,14 +451,15 @@ fn new_signal(
     }
 }
 
-/// Override the signals and detectors and generate them from the track sections and switches.
-pub fn generate_signals(railjson: &mut RailJson) {
-    let tracks = create_tracks(railjson);
+/// Generate signals from the track sections, switches and speed sections.
+pub fn generate_signals(
+    track_sections: &[TrackSection],
+    switches: &[Switch],
+    speed_sections: &[SpeedSection],
+) -> Vec<Signal> {
+    let tracks = create_tracks(track_sections, switches, speed_sections);
 
-    let signals = create_signals(&tracks);
-
-    railjson.detectors = signals.iter().map(crate::utils::detector).collect();
-    railjson.signals = signals;
+    create_signals(&tracks)
 }
 
 #[cfg(test)]
@@ -468,9 +473,9 @@ mod tests {
 
     #[test]
     fn generate_signals_switches() {
-        let mut railjson =
+        let railjson =
             crate::osm_to_railjson::parse_osm("src/tests/switches.osm.pbf".into(), true).unwrap();
-        super::generate_signals(&mut railjson);
+
         assert_eq!(railjson.signals.len(), 382);
         assert_eq!(railjson.detectors.len(), 382);
     }
@@ -503,10 +508,9 @@ mod tests {
         #[case] expected_position: f64,
         #[case] expected_direction: Direction,
     ) {
-        let mut railjson =
+        let railjson =
             crate::osm_to_railjson::parse_osm("src/tests/intersection.osm.pbf".into(), true)
                 .unwrap();
-        super::generate_signals(&mut railjson);
 
         assert!(signal_exists(
             &railjson,
@@ -518,10 +522,10 @@ mod tests {
 
     #[test]
     fn generate_signals_intersection_nf() {
-        let mut railjson =
+        let railjson =
             crate::osm_to_railjson::parse_osm("src/tests/intersection.osm.pbf".into(), true)
                 .unwrap();
-        super::generate_signals(&mut railjson);
+
         assert_eq!(railjson.signals.len(), 8);
 
         assert!(railjson.signals.iter().all(|signal| {
@@ -549,9 +553,8 @@ mod tests {
         #[case] expected_position: f64,
         #[case] expected_direction: Direction,
     ) {
-        let mut railjson =
+        let railjson =
             crate::osm_to_railjson::parse_osm("src/tests/tvm_signal.osm.pbf".into(), true).unwrap();
-        super::generate_signals(&mut railjson);
 
         assert!(signal_exists(
             &railjson,

--- a/editoast/osm_to_railjson/src/osm_to_railjson.rs
+++ b/editoast/osm_to_railjson/src/osm_to_railjson.rs
@@ -2,19 +2,13 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
 
-use schemas::infra::TrackSectionExtensions;
-use schemas::infra::TrackSectionSncfExtension;
-use schemas::infra::TrackSectionSourceExtension;
-use schemas::primitives::NonBlankString;
 use tracing::debug;
-use tracing::error;
 use tracing::info;
 
 use super::utils::*;
 use crate::generate_routes;
 use crate::generate_signals;
 use schemas::infra::RailJson;
-use schemas::infra::TrackSection;
 
 use itertools::Itertools as _;
 
@@ -31,6 +25,27 @@ pub fn osm_to_railjson(
         railjson_out.display()
     );
     let railjson = parse_osm(osm_pbf_in, generate_signals)?;
+
+    info!("Writing RailJson to {} with:", railjson_out.display());
+    info!(
+        "  - {} operational points",
+        railjson.operational_points.len()
+    );
+    info!("  - {} routes", railjson.routes.len());
+    info!(
+        "  - {} extended switch types",
+        railjson.extended_switch_types.len()
+    );
+    info!("  - {} switches", railjson.switches.len());
+    info!("  - {} track sections", railjson.track_sections.len());
+    info!("  - {} speed sections", railjson.speed_sections.len());
+    info!("  - {} neutral sections", railjson.neutral_sections.len());
+    info!("  - {} electrifications", railjson.electrifications.len());
+    info!("  - {} signals", railjson.signals.len());
+    info!("  - {} buffer stops", railjson.buffer_stops.len());
+    info!("  - {} detectors", railjson.detectors.len());
+    info!("  - {} level crossings", railjson.level_crossings.len());
+
     let file = std::fs::File::create(railjson_out)?;
     serde_json::to_writer(file, &railjson)?;
     Ok(())
@@ -62,124 +77,47 @@ pub fn parse_osm(
         .read(&osm_pbf_in)?;
     info!("🗺️ We have {} nodes and {} edges", nodes.len(), edges.len());
 
-    let rail_edges = edges
-        .iter()
+    let edges = edges
+        .into_iter()
         .filter(|e| e.properties.train == osm4routing::TrainAccessibility::Allowed)
         .filter(|e| e.source != e.target)
         .collect_vec();
 
     let mut adjacencies = HashMap::<osm4routing::NodeId, NodeAdjacencies>::new();
-    for edge in rail_edges.clone() {
+    for edge in &edges {
         adjacencies.entry(edge.source).or_default().edges.push(edge);
         adjacencies.entry(edge.target).or_default().edges.push(edge);
     }
-
-    let track_sections: Vec<TrackSection> = rail_edges
-        .iter()
-        .map(|e| {
-            let geo = geos::geojson::Geometry::new(geos::geojson::Value::LineString(
-                e.geometry.iter().map(|c| vec![c.x, c.y]).collect(),
-            ));
-            TrackSection {
-                id: e.id.as_str().into(),
-                length: e.length(),
-                geo: geo.clone(),
-                extensions: TrackSectionExtensions {
-                    sncf: Some(TrackSectionSncfExtension {
-                        line_code: 0,
-                        line_name: e
-                            .tags
-                            .get("name")
-                            .map(NonBlankString::from)
-                            .unwrap_or(NonBlankString::from("??")),
-                        track_name: e
-                            .tags
-                            .get("railway:track_ref")
-                            .map(NonBlankString::from)
-                            .unwrap_or(NonBlankString::from("??")),
-                        track_number: 0,
-                    }),
-                    source: Some(TrackSectionSourceExtension {
-                        name: "OpenStreetMap".into(),
-                        id: "osm".into(),
-                    }),
-                },
-                ..Default::default()
-            }
-        })
-        .collect();
-
     let nodes_tracks = NodeToTrack::from_edges(&edges);
+
+    let track_sections = track_sections(&edges);
+    let (switches, buffer_stops) = switches_and_buffer_stops(&mut adjacencies);
+    let speed_sections = edges.iter().clone().flat_map(speed_sections).collect_vec();
+    let electrifications = edges.iter().clone().flat_map(electrifications).collect();
+    let operational_points = operational_points(&osm_pbf_in, &nodes_tracks, &track_sections);
     let signals = if generate_signals {
-        vec![]
+        generate_signals::generate_signals(&track_sections, &switches, &speed_sections)
     } else {
         signals(&osm_pbf_in, &nodes_tracks, &adjacencies)
     };
-    let mut railjson = RailJson {
-        extended_switch_types: vec![],
-        detectors: signals.iter().map(detector).collect(),
-        signals,
-        speed_sections: rail_edges
-            .iter()
-            .copied()
-            .flat_map(speed_sections)
-            .collect(),
-        electrifications: rail_edges
-            .iter()
-            .copied()
-            .flat_map(electrifications)
-            .collect(),
-        operational_points: operational_points(&osm_pbf_in, &nodes_tracks, &track_sections),
-        track_sections,
-        ..Default::default()
-    };
+    let detectors = signals.iter().map(detector).collect_vec();
 
-    for (node, mut adj) in adjacencies {
-        for e1 in &adj.edges {
-            for e2 in &adj.edges {
-                if e1.id < e2.id
-                    && let Some(branch) = try_into_branch(node, e1, e2)
-                {
-                    adj.branches.push(branch);
-                }
-            }
-        }
-
-        let id = node.0;
-        let edges_count = adj.edges.len();
-        let branches_count = adj.branches.len();
-        match (edges_count, branches_count) {
-            (0, _) => error!("node {id} without edge"),
-            (1, 0) => railjson
-                .buffer_stops
-                .push(edge_to_buffer(&node, adj.edges[0], 0)),
-            (2, 0) => {
-                // This can happens when data is truncated (e.g. cropped to a region, or the output track is a service track)
-                railjson
-                    .buffer_stops
-                    .push(edge_to_buffer(&node, adj.edges[0], 0));
-                railjson
-                    .buffer_stops
-                    .push(edge_to_buffer(&node, adj.edges[1], 1));
-            }
-            (2, 1) => railjson.switches.push(link_switch(node, &adj.branches)),
-            (3, 2) => railjson.switches.push(point_switch(node, &adj.branches)),
-            (4, 2) => railjson.switches.push(cross_switch(node, &adj.branches)),
-            (4, 4) => railjson
-                .switches
-                .push(double_slip_switch(node, &adj.branches)),
-            _ => debug!("node {id} with {edges_count} edges and {branches_count} branches"),
-        }
-    }
-    if generate_signals {
-        debug!("Start generating signals");
-        generate_signals::generate_signals(&mut railjson);
-        debug!("Done, got {} signals", railjson.signals.len());
-    }
     debug!("Start generating routes");
-    railjson.routes = generate_routes::routes(&railjson);
-    debug!("Done, got {} routes", railjson.routes.len());
-    Ok(railjson)
+    let routes = generate_routes::routes(&track_sections, &detectors, &buffer_stops, &switches);
+    debug!("Done, got {} routes", routes.len());
+
+    Ok(RailJson {
+        detectors,
+        signals,
+        speed_sections,
+        electrifications,
+        operational_points,
+        track_sections,
+        switches,
+        buffer_stops,
+        routes,
+        ..Default::default()
+    })
 }
 
 #[cfg(test)]

--- a/editoast/osm_to_railjson/src/utils.rs
+++ b/editoast/osm_to_railjson/src/utils.rs
@@ -26,12 +26,16 @@ use schemas::infra::SpeedSection;
 use schemas::infra::Switch;
 use schemas::infra::TrackEndpoint;
 use schemas::infra::TrackSection;
+use schemas::infra::TrackSectionExtensions;
+use schemas::infra::TrackSectionSncfExtension;
+use schemas::infra::TrackSectionSourceExtension;
 use schemas::primitives::Identifier;
 use schemas::primitives::NonBlankString;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
+use tracing::debug;
 use tracing::error;
 use tracing::warn;
 use uuid::Uuid;
@@ -72,7 +76,7 @@ type Branch = (TrackEndpoint, TrackEndpoint);
 
 /// Tries to convert two edges into a branch
 /// Will return None if the angle between the two edges isn’t right
-pub fn try_into_branch(center: osm4routing::NodeId, e1: &Edge, e2: &Edge) -> Option<Branch> {
+fn try_into_branch(center: osm4routing::NodeId, e1: &Edge, e2: &Edge) -> Option<Branch> {
     let center_coord = if e1.source == center {
         e1.geometry[0]
     } else {
@@ -104,12 +108,12 @@ fn track_section(n: NodeId, edge: &Edge) -> TrackEndpoint {
 // That’s where buffer stops, and switches happen
 // To do that, we count how many edges are adjacent to that node and how many branches go through that node
 #[derive(Default)]
-pub struct NodeAdjacencies<'a> {
+pub(crate) struct NodeAdjacencies<'a> {
     pub edges: Vec<&'a Edge>,
     pub branches: Vec<Branch>,
 }
 
-pub fn link_switch(node: NodeId, branches: &[Branch]) -> Switch {
+fn link_switch(node: NodeId, branches: &[Branch]) -> Switch {
     let mut ports = HashMap::new();
     ports.insert("A".into(), branches[0].0.clone());
     ports.insert("B".into(), branches[0].1.clone());
@@ -122,7 +126,7 @@ pub fn link_switch(node: NodeId, branches: &[Branch]) -> Switch {
     }
 }
 
-pub fn point_switch(node: NodeId, branches: &[Branch]) -> Switch {
+fn point_switch(node: NodeId, branches: &[Branch]) -> Switch {
     let mut endpoint_count = HashMap::<&TrackEndpoint, u64>::new();
     for (src, dst) in branches {
         *endpoint_count.entry(src).or_default() += 1;
@@ -145,7 +149,7 @@ pub fn point_switch(node: NodeId, branches: &[Branch]) -> Switch {
     }
 }
 
-pub fn cross_switch(node: NodeId, branches: &[Branch]) -> Switch {
+fn cross_switch(node: NodeId, branches: &[Branch]) -> Switch {
     let mut ports = HashMap::new();
     ports.insert("A1".into(), branches[0].0.clone());
     ports.insert("B1".into(), branches[0].1.clone());
@@ -165,7 +169,7 @@ fn different_branches(a: &Branch, b: &Branch) -> bool {
     a.0 != b.0 && a.0 != b.1 && a.1 != b.0 && a.1 != b.1
 }
 
-pub fn double_slip_switch(node: NodeId, branches: &[Branch]) -> Switch {
+fn double_slip_switch(node: NodeId, branches: &[Branch]) -> Switch {
     let (north1, south1) = &branches[0];
     let (north2, south2) = branches
         .iter()
@@ -188,7 +192,7 @@ pub fn double_slip_switch(node: NodeId, branches: &[Branch]) -> Switch {
 }
 
 // Computes the angle between the segments [oa] and [ob]
-pub fn angle(o: Coord, a: Coord, b: Coord) -> f64 {
+fn angle(o: Coord, a: Coord, b: Coord) -> f64 {
     ((a.y - o.y).atan2(a.x - o.x).to_degrees() - (b.y - o.y).atan2(b.x - o.x).to_degrees()).abs()
 }
 
@@ -212,12 +216,12 @@ fn main_signal(node: &osm4routing::osmpbfreader::OsmObj) -> bool {
 
 /// When reading OpenStreetMap data, we sometimes need to match a Node to a Track and position
 /// This struct maps the nodes to the Edges (a Way from OpenStreetMap that might have been split)
-pub struct NodeToTrack<'a> {
+pub(crate) struct NodeToTrack<'a> {
     nodes_edges: HashMap<NodeId, Vec<&'a Edge>>,
 }
 
 impl<'a> NodeToTrack<'a> {
-    pub fn from_edges(edges: &'a Vec<Edge>) -> Self {
+    pub fn from_edges(edges: &'a [Edge]) -> Self {
         let mut nodes_edges = HashMap::<NodeId, Vec<&Edge>>::new();
         for edge in edges {
             for node in &edge.nodes {
@@ -251,7 +255,7 @@ impl<'a> NodeToTrack<'a> {
     }
 }
 
-pub fn signals(
+pub(crate) fn signals(
     osm_pbf_in: &std::path::PathBuf,
     nodes_to_tracks: &NodeToTrack,
     adjacencies: &HashMap<osm4routing::NodeId, NodeAdjacencies>,
@@ -298,7 +302,7 @@ pub fn signals(
         .collect()
 }
 
-pub fn speed_sections(edge: &Edge) -> Vec<SpeedSection> {
+pub(crate) fn speed_sections(edge: &Edge) -> Vec<SpeedSection> {
     let speeds = match (
         edge.tags.get("maxspeed"),
         edge.tags.get("maxspeed:forward"),
@@ -400,7 +404,7 @@ fn sncf_extensions(node: &Node) -> SignalSncfExtension {
 }
 
 /// Builds a detector that is located on the same position as the signal
-pub fn detector(signal: &Signal) -> Detector {
+pub(crate) fn detector(signal: &Signal) -> Detector {
     Detector {
         id: signal.id.clone(),
         track: signal.track.clone(),
@@ -409,7 +413,7 @@ pub fn detector(signal: &Signal) -> Detector {
     }
 }
 
-pub fn edge_to_buffer(node: &NodeId, edge: &Edge, count: i64) -> BufferStop {
+fn edge_to_buffer(node: &NodeId, edge: &Edge, count: i64) -> BufferStop {
     BufferStop {
         id: format!("buffer-{}-{count}", node.0).into(),
         track: edge.id.clone().into(),
@@ -422,7 +426,7 @@ pub fn edge_to_buffer(node: &NodeId, edge: &Edge, count: i64) -> BufferStop {
     }
 }
 
-pub fn electrifications(edge: &Edge) -> Option<Electrification> {
+pub(crate) fn electrifications(edge: &Edge) -> Option<Electrification> {
     // TODO: handle multiple overlapping electrifications
     // Specific infrastructures can support multiple electrifications (e.g. "voltage"="600;1500;3000;15000;25000").
     // Short term solution : pick the first one, i.g. "600;1500;3000;15000;25000" -> "600V"
@@ -486,7 +490,7 @@ fn local_track_name_fallback(
         .unwrap_or(NonBlankString::from(Uuid::new_v4().to_string()))
 }
 
-pub fn operational_points(
+pub(crate) fn operational_points(
     osm_pbf_in: &std::path::PathBuf,
     nodes_to_tracks: &NodeToTrack,
     track_sections: &[TrackSection],
@@ -596,6 +600,80 @@ fn identifier(
             name: format!("op_{}", uic).into(),
             uic,
         }))
+}
+
+pub(crate) fn track_sections(edges: &[Edge]) -> Vec<TrackSection> {
+    edges
+        .iter()
+        .map(|e| {
+            let geo = geos::geojson::Geometry::new(geos::geojson::Value::LineString(
+                e.geometry.iter().map(|c| vec![c.x, c.y]).collect(),
+            ));
+            TrackSection {
+                id: e.id.as_str().into(),
+                length: e.length(),
+                geo: geo.clone(),
+                extensions: TrackSectionExtensions {
+                    sncf: Some(TrackSectionSncfExtension {
+                        line_code: 0,
+                        line_name: e
+                            .tags
+                            .get("name")
+                            .map(NonBlankString::from)
+                            .unwrap_or(NonBlankString::from("??")),
+                        track_name: e
+                            .tags
+                            .get("railway:track_ref")
+                            .map(NonBlankString::from)
+                            .unwrap_or(NonBlankString::from("??")),
+                        track_number: 0,
+                    }),
+                    source: Some(TrackSectionSourceExtension {
+                        name: "OpenStreetMap".into(),
+                        id: "osm".into(),
+                    }),
+                },
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn switches_and_buffer_stops(
+    adjacencies: &mut HashMap<osm4routing::NodeId, NodeAdjacencies<'_>>,
+) -> (Vec<Switch>, Vec<BufferStop>) {
+    let mut switches = Vec::new();
+    let mut buffer_stops = Vec::new();
+    for (node, adj) in adjacencies {
+        for e1 in &adj.edges {
+            for e2 in &adj.edges {
+                if e1.id < e2.id
+                    && let Some(branch) = try_into_branch(*node, e1, e2)
+                {
+                    adj.branches.push(branch);
+                }
+            }
+        }
+
+        let id = node.0;
+        let edges_count = adj.edges.len();
+        let branches_count = adj.branches.len();
+        match (edges_count, branches_count) {
+            (0, _) => error!("node {id} without edge"),
+            (1, 0) => buffer_stops.push(edge_to_buffer(node, adj.edges[0], 0)),
+            (2, 0) => {
+                // This can happens when data is truncated (e.g. cropped to a region, or the output track is a service track)
+                buffer_stops.push(edge_to_buffer(node, adj.edges[0], 0));
+                buffer_stops.push(edge_to_buffer(node, adj.edges[1], 1));
+            }
+            (2, 1) => switches.push(link_switch(*node, &adj.branches)),
+            (3, 2) => switches.push(point_switch(*node, &adj.branches)),
+            (4, 2) => switches.push(cross_switch(*node, &adj.branches)),
+            (4, 4) => switches.push(double_slip_switch(*node, &adj.branches)),
+            _ => debug!("node {id} with {edges_count} edges and {branches_count} branches"),
+        }
+    }
+    (switches, buffer_stops)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The goal of this PR is to restructure the code in a more sensible way. The refactoring of the more "low level" code will come in a future PR.

(By railjson parts I refer to the vecs of objects in the railjson)

Before:
- some raijson parts had their creation code in a top level function
- create some railjson parts
- create the raijson as mutable
- modify the railjson with the rest of its parts

Now:
- all the raijson part have their creation code in their own function
- create all the raijson part
- create the railjson only at the end