### PR TITLE
editoast: use realistic values for rolling resistance in the tests

### DIFF
--- a/editoast/schemas/src/fixtures.rs
+++ b/editoast/schemas/src/fixtures.rs
@@ -35,11 +35,9 @@ pub fn simple_rolling_stock() -> RollingStock {
         railjson_version: "12".to_string(),
         rolling_resistance: RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)²
-            // We should use more realistic values and fix the tests
-            A: units::newton::new(1.0),
-            B: units::kilogram_per_second::new(0.01),
-            C: units::kilogram_per_meter::new(0.0005),
+            A: units::newton::new(1000.0),
+            B: units::kilogram_per_second::new(40.0),
+            C: units::kilogram_per_meter::new(2.0),
         },
         length: units::meter::new(140.0),
         mass: units::kilogram::new(15000.0),
@@ -60,11 +58,9 @@ pub fn towed_rolling_stock() -> TowedRollingStock {
         inertia_coefficient: 1.05,
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
-            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)²
-            // We should use more realistic values and fix the tests
-            A: units::meter_per_second_squared::new(1.0),
-            B: units::hertz::new(0.01),
-            C: units::per_meter::new(0.0002),
+            A: units::meter_per_second_squared::new(0.01),
+            B: units::hertz::new(0.0002),
+            C: units::per_meter::new(2e-5),
         },
         const_gamma: units::meter_per_second_squared::new(0.5),
         max_speed: Some(units::meter_per_second::new(35.0)),

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1621,9 +1621,9 @@ mod tests {
             physics_consist.compute_rolling_resistance(),
             RollingResistance {
                 rolling_resistance_type: "davis".to_string(),
-                A: units::newton::new(35001.0),
-                B: units::kilogram_per_second::new(350.01),
-                C: units::kilogram_per_meter::new(7.0005),
+                A: units::newton::new(1350.0),
+                B: units::kilogram_per_second::new(47.0),
+                C: units::kilogram_per_meter::new(2.7),
             }
         );
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -749,9 +749,9 @@ mod tests {
         rolling_stock.startup_acceleration = units::meter_per_second_squared::new(0.04);
         rolling_stock.rolling_resistance = RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            A: units::newton::new(1.0),
-            B: units::kilogram_per_second::new(0.01),
-            C: units::kilogram_per_meter::new(0.0005),
+            A: units::newton::new(1000.0),
+            B: units::kilogram_per_second::new(40.0),
+            C: units::kilogram_per_meter::new(2.0),
         };
 
         let towed_rolling_stock = towed_rolling_stock();

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -778,9 +778,9 @@ mod tests {
             physics_consist.rolling_resistance,
             RollingResistance {
                 rolling_resistance_type: "davis".to_string(),
-                A: units::newton::new(100001.0),
-                B: units::kilogram_per_second::new(1000.01),
-                C: units::kilogram_per_meter::new(20.0005),
+                A: units::newton::new(2000.0),
+                B: units::kilogram_per_second::new(60.0),
+                C: units::kilogram_per_meter::new(4.0),
             }
         );
     }


### PR DESCRIPTION
Set realistic values for rolling resistance in the fixtures and tests. Adjusted the tests to these new values.

For the RollingResistance values, I took inspiration from the rolling stock values found on demo.osrd.fr

For the RollingResistancePerWeight values, I approximately converted the previous values according to the units given in the TODO comment