### PR TITLE
editoast: make fix_local_track_name_format down migration runnable

### DIFF
--- a/editoast/migrations/2026-05-22-161500-0000_fix_local_track_name_format/down.sql
+++ b/editoast/migrations/2026-05-22-161500-0000_fix_local_track_name_format/down.sql
@@ -1,2 +1,5 @@
 -- Irreversible data correction migration.
 -- It normalizes malformed JSON values in-place.
+-- Add a noop so the migration can still be reversed
+-- since it won't cause any breaking change.
+SELECT 1;


### PR DESCRIPTION
Make `2026-05-22-161500-0000_fix_local_track_name_format` migration revertable by adding a noop.

Data is not recoverable but we can still run the down migration since there are no breaking changes. This allows previous migration to be reverted.

@emersion unfortunately we can't use `NULL;`:

```
Rolling back migration 2026-05-22-161500-0000_fix_local_track_name_format
2026-06-03T14:36:01.535273Z ERROR diesel::database: Failed to execute query query="-- Irreversible data correction migration.\n-- It normalizes malformed JSON values in-place.\n-- Add a noop so the migration can still be reversed \n-- since it won't cause any breaking change.\nNULL;" err=DatabaseError(Unknown, "syntax error at or near \"NULL\"")
Failed to run migrations: Failed to run 2026-05-22-161500-0000_fix_local_track_name_format with: syntax error at or near "NULL"
```

From my understanding it's only usable in PL/SQL (IF THEN...).