### PR TITLE
front: stdcm: preserve edited consist values

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -129,7 +129,7 @@ const StdcmResultsTable = ({
                       {isFirstStep || step.duration !== null ? step.stopEndTime : ''}
                     </td>
                     <td className={cx('weight', { 'muted-text': !isFirstStep })}>
-                      {displayedMass ? `${Math.floor(displayedMass)}t` : '='}
+                      {displayedMass ? `${displayedMass}t` : '='}
                     </td>
                     <td className={cx('ref', { 'muted-text': !isFirstStep })}>
                       {displayedRollingStock ?? '='}

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmSimulationReportSheet.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmSimulationReportSheet.tsx
@@ -94,7 +94,7 @@ const StdcmSimulationReportSheet = ({
         {
           rollingStockName: rollingStock.name,
           mass: consist.totalMass ?? kgToT(rollingStock.mass),
-          length: rollingStock.length,
+          length: consist.totalLength ?? rollingStock.length,
         },
         t
       ),

--- a/front/src/applications/stdcm/utils/simulationOutputUtils.ts
+++ b/front/src/applications/stdcm/utils/simulationOutputUtils.ts
@@ -138,7 +138,7 @@ export const formatStdcmDataForSimulationTable = (
       startTime,
       ...(isFirst
         ? {
-            weight: `${Math.floor(consist.mass)} t`,
+            weight: `${consist.mass} t`,
             length: `${consist.length} m`,
             referenceEngine: consist.rollingStockName,
           }


### PR DESCRIPTION
## What

Fix inconsistencies in STDCM consist value display.

- Preserve edited consist mass values in result tables instead of flooring them.
- Preserve edited consist mass values in simulation report tables.
- Use edited consist length values in the simulation report timetable instead of the rolling stock default length.

## Why

When consist values are modified from their defaults, STDCM displays inconsistent values between the timetable and the simulation report.

This change ensures that edited consist values are displayed consistently throughout STDCM.

Closes #17024 