### PR TITLE
front: remove unused updatetrainschedule helper

### DIFF
--- a/front/src/modules/trainSchedule/helpers/updateTrainScheduleHelpers.ts
+++ b/front/src/modules/trainSchedule/helpers/updateTrainScheduleHelpers.ts
@@ -45,18 +45,6 @@ export async function createPacedTrains(
   ).unwrap();
   return newPacedTrains;
 }
-export async function updateTrainSchedule(
-  dispatch: AppDispatch,
-  id: number,
-  trainSchedule: TrainSchedule
-) {
-  await dispatch(
-    osrdEditoastApi.endpoints.putTrainSchedulesById.initiate({
-      id,
-      trainSchedule,
-    })
-  ).unwrap();
-}
 
 async function updatePacedTrain(dispatch: AppDispatch, id: number, trainSchedule: TrainSchedule) {
   if (trainSchedule.paced?.exceptions && trainSchedule.paced.exceptions.length > 0) {
@@ -64,7 +52,12 @@ async function updatePacedTrain(dispatch: AppDispatch, id: number, trainSchedule
       'updatePacedTrain: exceptions should not be included in the paced field. Use exception endpoints instead.'
     );
   }
-  await updateTrainSchedule(dispatch, id, trainSchedule);
+  await dispatch(
+    osrdEditoastApi.endpoints.putTrainSchedulesById.initiate({
+      id,
+      trainSchedule,
+    })
+  ).unwrap();
 }
 
 export async function createExceptions(


### PR DESCRIPTION
Remove unused `updateTrainSchedule` function and inline the API call directly in `updatePacedTrain`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenRailAssociation/codesmith/osrd/pr/17065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783153456&installation_id=137912551&pr_number=17065&repository=OpenRailAssociation%2Fosrd&return_to=https%3A%2F%2Fgithub.com%2FOpenRailAssociation%2Fosrd%2Fpull%2F17065&signature=8fef5277372ea08d237a224993d6be631c154fb034302c79888f43ae4c1c4afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->