### PR TITLE
front: hide clear button in track combobox when no track selected

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
@@ -27,8 +27,6 @@ import {
 } from './ComboBoxCustomList/ListElementComponent';
 import { computePathStepCoordinates, isOpRefMetadata } from './utils';
 
-const EMPTY_OPTION = { label: '', id: '' };
-
 type PathStepProps = {
   pathStep: PathStepV2;
   setPathSteps?: React.Dispatch<React.SetStateAction<PathStepV2[]>>;
@@ -188,7 +186,7 @@ const PathStepItem = ({
     // No track should be selected if the path step is invalid or has no secondary code
     // or is a step added by map click
     if (!isOpRefMetadata(pathStepMetadata) || !pathStepMetadata.trackName) {
-      return EMPTY_OPTION;
+      return undefined;
     }
 
     return (


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/17066

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenRailAssociation/codesmith/osrd/pr/17067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783154965&installation_id=137912551&pr_number=17067&repository=OpenRailAssociation%2Fosrd&return_to=https%3A%2F%2Fgithub.com%2FOpenRailAssociation%2Fosrd%2Fpull%2F17067&signature=d7b8ff4c7c2a2a68e902f2ca9f0ecc5ece19990d8eb425b2c38955689d666321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->