### PR TITLE
editoast: adapt endpoints with timetable type parameter

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4100,7 +4100,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TrainScheduleSetForm'
+              $ref: '#/components/schemas/TrainScheduleSetUpdateForm'
         required: true
       responses:
         '200':
@@ -15993,6 +15993,7 @@ components:
       required:
       - description
       - published
+      - timetable_type
       properties:
         catalog_entry_id:
           type:
@@ -16007,6 +16008,8 @@ components:
           - 'null'
         published:
           type: boolean
+        timetable_type:
+          $ref: '#/components/schemas/TimetableType'
     TrainScheduleSetResponse:
       allOf:
       - $ref: '#/components/schemas/TrainScheduleSet'
@@ -16018,6 +16021,25 @@ components:
             type: integer
             format: int64
             minimum: 0
+    TrainScheduleSetUpdateForm:
+      type: object
+      required:
+      - description
+      - published
+      properties:
+        catalog_entry_id:
+          type:
+          - integer
+          - 'null'
+          format: int64
+        description:
+          type: string
+        name:
+          type:
+          - string
+          - 'null'
+        published:
+          type: boolean
     TrainScheduleSimulationSummaryResult:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4030,6 +4030,11 @@ paths:
         required: false
         schema:
           type: boolean
+      - name: timetable_type
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/TimetableType'
       responses:
         '200':
           description: list of train schedule sets

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -13472,6 +13472,7 @@ components:
         - train_schedules_count
         - project
         - study
+        - timetable_type
         properties:
           infra_name:
             type: string
@@ -13479,6 +13480,8 @@ components:
             $ref: '#/components/schemas/Project'
           study:
             $ref: '#/components/schemas/Study'
+          timetable_type:
+            $ref: '#/components/schemas/TimetableType'
           train_schedules_count:
             type: integer
             format: int64
@@ -13489,9 +13492,12 @@ components:
         required:
         - infra_name
         - train_schedules_count
+        - timetable_type
         properties:
           infra_name:
             type: string
+          timetable_type:
+            $ref: '#/components/schemas/TimetableType'
           train_schedules_count:
             type: integer
             format: int64

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3278,6 +3278,12 @@ paths:
       tags:
       - timetable
       summary: Create a timetable
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimetableForm'
+        required: true
       responses:
         '201':
           description: Timetable with train schedule ids
@@ -15479,6 +15485,13 @@ components:
             within the target document where the operation is performed.
         value:
           description: Value to test against.
+    TimetableForm:
+      type: object
+      required:
+      - timetable_type
+      properties:
+        timetable_type:
+          $ref: '#/components/schemas/TimetableType'
     TimetableResult:
       type: object
       description: Creation result for a Timetable

--- a/editoast/src/views/operational_studies/hierarchy/scenario.rs
+++ b/editoast/src/views/operational_studies/hierarchy/scenario.rs
@@ -121,17 +121,25 @@ pub struct ScenarioWithDetails {
     pub scenario: Scenario,
     pub infra_name: String,
     pub train_schedules_count: i64,
+    pub timetable_type: schemas::timetable_type::TimetableType,
 }
 
 impl ScenarioWithDetails {
     pub async fn from_scenario(
         scenario: Scenario,
         conn: &mut DbConnection,
-    ) -> Result<Self, database::DatabaseError> {
+    ) -> Result<Self, ScenarioError> {
+        let timetable = Timetable::retrieve_or_fail(conn.clone(), scenario.timetable_id, || {
+            ScenarioError::TimetableNotFound {
+                timetable_id: scenario.timetable_id,
+            }
+        })
+        .await?;
         Ok(Self {
             infra_name: scenario.infra_name(conn).await?,
             train_schedules_count: scenario.train_schedules_count(conn).await?,
             scenario,
+            timetable_type: timetable.timetable_type.0,
         })
     }
 }
@@ -144,6 +152,7 @@ pub struct ScenarioResponse {
     pub train_schedules_count: i64,
     pub project: Project,
     pub study: Study,
+    pub timetable_type: schemas::timetable_type::TimetableType,
 }
 
 impl ScenarioResponse {
@@ -158,6 +167,7 @@ impl ScenarioResponse {
             train_schedules_count: scenarios_with_details.train_schedules_count,
             project,
             study,
+            timetable_type: scenarios_with_details.timetable_type,
         }
     }
 }
@@ -176,7 +186,6 @@ pub(in crate::views) async fn create(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Json(data): Json<ScenarioCreateForm>,
 ) -> Result<impl IntoResponse> {
-    let timetable_id = data.timetable_id;
     let infra_id = data.infra_id;
     let study_id = data.study_id;
     let scenario_cs = data.into_changeset();
@@ -185,11 +194,6 @@ pub(in crate::views) async fn create(
         db_pool.get().await?,
         study_id,
         async move |mut conn, study, _project| {
-            Timetable::exists_or_fail(&mut conn, timetable_id, || {
-                ScenarioError::TimetableNotFound { timetable_id }
-            })
-            .await?;
-
             Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
                 infra_id,
             })

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -125,21 +125,36 @@ pub struct TimetableIdParam {
     pub id: i64,
 }
 
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct TimetableForm {
+    timetable_type: schemas::timetable_type::TimetableType,
+}
+
+impl TimetableForm {
+    pub fn into_changeset(self) -> Changeset<Timetable> {
+        Timetable::changeset().timetable_type(editoast_models::timetable_type::TimetableType(
+            self.timetable_type,
+        ))
+    }
+}
+
 /// Create a timetable
 #[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     post, path = "",
     tag = "timetable",
+    request_body = TimetableForm,
     responses(
         (status = 201, description = "Timetable with train schedule ids", body = TimetableResult),
     ),
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    Json(timetable_form): Json<TimetableForm>,
 ) -> Result<impl IntoResponse> {
     let conn = &mut db_pool.get().await?;
 
-    let timetable = Timetable::changeset().create(conn).await?;
+    let timetable = timetable_form.into_changeset().create(conn).await?;
     let response: TimetableResult = timetable.into();
 
     Ok((StatusCode::CREATED, Json(response)))
@@ -1167,6 +1182,9 @@ mod tests {
 
         let created_timetable: TimetableResult = app
             .post("/timetable")
+            .json(&TimetableForm {
+                timetable_type: schemas::timetable_type::TimetableType::Hourly,
+            })
             .await
             .assert_status(StatusCode::CREATED)
             .json();

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -740,7 +740,10 @@ mod tests {
             .expect("Failed to create train schedule set")
     }
 
-    async fn create_train_schedule_with_timetable_type(conn: &mut DbConnection, timetable_type: editoast_models::timetable_type::TimetableType) -> TrainScheduleSet {
+    async fn create_train_schedule_set_with_timetable_type(
+        conn: &mut DbConnection,
+        timetable_type: editoast_models::timetable_type::TimetableType,
+    ) -> TrainScheduleSet {
         let catalog_entry = create_catalog_entry(conn).await;
         TrainScheduleSet::changeset()
             .catalog_entry_id(Some(catalog_entry.id))
@@ -753,15 +756,18 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_train_schedule_sets() {
+    async fn get_train_schedule_sets_with_timetable_type() {
         let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let train_schedule_set_1 =
             create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
-        let train_schedule_set_2 =
-            create_train_schedule_with_timetable_type(&mut db_pool.get().await.unwrap(), editoast_models::timetable_type::TimetableType(
-                schemas::timetable_type::TimetableType::Hourly
-            )).await;
+        let train_schedule_set_2 = create_train_schedule_set_with_timetable_type(
+            &mut db_pool.get().await.unwrap(),
+            editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly,
+            ),
+        )
+        .await;
         let response: Vec<TrainScheduleSetResponse> = app
             .get("/train_schedule_sets?timetable_type=HOURLY")
             .await
@@ -792,7 +798,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_train_schedule_sets_with_timetable_type() {
+    async fn get_train_schedule_sets() {
         let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let train_schedule_set_1 =

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -113,6 +113,7 @@ pub(in crate::views) async fn post(
 pub(in crate::views) struct TrainScheduleSetQueryParams {
     catalog_entry_id: Option<i64>,
     published: Option<bool>,
+    timetable_type: Option<schemas::timetable_type::TimetableType>,
 }
 
 #[editoast_derive::route(authz::Role::OperationalStudies)]
@@ -158,6 +159,7 @@ pub(in crate::views) async fn get(
     Query(TrainScheduleSetQueryParams {
         catalog_entry_id,
         published,
+        timetable_type,
     }): Query<TrainScheduleSetQueryParams>,
 ) -> Result<Json<Vec<TrainScheduleSetResponse>>> {
     let conn = &mut db_pool.get().await?;
@@ -171,6 +173,14 @@ pub(in crate::views) async fn get(
 
     if let Some(published) = published {
         settings = settings.filter(move || TrainScheduleSet::PUBLISHED.eq(published));
+    }
+
+    if let Some(timetable_type) = timetable_type {
+        settings = settings.filter(move || {
+            TrainScheduleSet::TIMETABLE_TYPE.eq(editoast_models::timetable_type::TimetableType(
+                timetable_type,
+            ))
+        });
     }
 
     let train_schedule_sets = TrainScheduleSet::list(conn, settings).await?;
@@ -730,8 +740,59 @@ mod tests {
             .expect("Failed to create train schedule set")
     }
 
+    async fn create_train_schedule_with_timetable_type(conn: &mut DbConnection, timetable_type: editoast_models::timetable_type::TimetableType) -> TrainScheduleSet {
+        let catalog_entry = create_catalog_entry(conn).await;
+        TrainScheduleSet::changeset()
+            .catalog_entry_id(Some(catalog_entry.id))
+            .name(Some("test".to_string()))
+            .description(String::default())
+            .timetable_type(timetable_type)
+            .create(conn)
+            .await
+            .expect("Failed to create train schedule set")
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_train_schedule_sets() {
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+        let train_schedule_set_1 =
+            create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
+        let train_schedule_set_2 =
+            create_train_schedule_with_timetable_type(&mut db_pool.get().await.unwrap(), editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Hourly
+            )).await;
+        let response: Vec<TrainScheduleSetResponse> = app
+            .get("/train_schedule_sets?timetable_type=HOURLY")
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(response.len(), 1);
+        assert_eq!(
+            response,
+            vec![TrainScheduleSetResponse {
+                train_schedule_set: train_schedule_set_2,
+                train_schedule_count: 0,
+            }]
+        );
+
+        let response: Vec<TrainScheduleSetResponse> = app
+            .get("/train_schedule_sets?timetable_type=CALENDAR")
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(response.len(), 1);
+        assert_eq!(
+            response,
+            vec![TrainScheduleSetResponse {
+                train_schedule_set: train_schedule_set_1.clone(),
+                train_schedule_count: 0,
+            }]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_train_schedule_sets_with_timetable_type() {
         let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let train_schedule_set_1 =

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -60,6 +60,7 @@ pub(in crate::views) struct TrainScheduleSetForm {
     name: Option<String>,
     description: String,
     published: bool,
+    timetable_type: schemas::timetable_type::TimetableType,
 }
 
 impl TrainScheduleSetForm {
@@ -69,6 +70,9 @@ impl TrainScheduleSetForm {
             .name(self.name)
             .description(self.description)
             .published(self.published)
+            .timetable_type(editoast_models::timetable_type::TimetableType(
+                self.timetable_type,
+            ))
     }
 }
 
@@ -89,10 +93,10 @@ pub(in crate::views) struct TrainScheduleSetIdParam {
 )]
 pub(in crate::views) async fn post(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Json(train_schedule_set_create_form): Json<TrainScheduleSetForm>,
+    Json(train_schedule_set_form): Json<TrainScheduleSetForm>,
 ) -> Result<impl IntoResponse> {
     let conn = &mut db_pool.get().await?;
-    let changeset = train_schedule_set_create_form.into_changeset();
+    let changeset = train_schedule_set_form.into_changeset();
     let train_schedule_set = changeset.create(conn).await?;
 
     Ok((
@@ -182,12 +186,29 @@ pub(in crate::views) async fn get(
     Ok(Json(results))
 }
 
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(in crate::views) struct TrainScheduleSetUpdateForm {
+    catalog_entry_id: Option<i64>,
+    name: Option<String>,
+    description: String,
+    published: bool,
+}
+
+impl TrainScheduleSetUpdateForm {
+    pub fn into_changeset(self) -> Changeset<TrainScheduleSet> {
+        TrainScheduleSet::changeset()
+            .catalog_entry_id(self.catalog_entry_id)
+            .name(self.name)
+            .description(self.description)
+            .published(self.published)
+    }
+}
 #[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     put, path = "",
     tag = "train_schedule_set",
     params(TrainScheduleSetIdParam),
-    request_body = TrainScheduleSetForm,
+    request_body = TrainScheduleSetUpdateForm,
     responses(
         (status = 200, description = "Train schedule set", body = TrainScheduleSetResponse),
         (status = 404, description = "Train schedule set not found"),
@@ -198,7 +219,7 @@ pub(in crate::views) async fn put(
     Path(TrainScheduleSetIdParam {
         id: train_schedule_set_id,
     }): Path<TrainScheduleSetIdParam>,
-    Json(train_schedule_set_form): Json<TrainScheduleSetForm>,
+    Json(train_schedule_set_form): Json<TrainScheduleSetUpdateForm>,
 ) -> Result<Json<TrainScheduleSetResponse>> {
     let conn = &mut db_pool.get().await?;
     let changeset = train_schedule_set_form.into_changeset();
@@ -332,6 +353,7 @@ mod tests {
     use crate::views::timetable::train_schedule::TrainScheduleResponse;
     use crate::views::train_schedule_set::TrainScheduleSetForm;
     use crate::views::train_schedule_set::TrainScheduleSetResponse;
+    use crate::views::train_schedule_set::TrainScheduleSetUpdateForm;
     use chrono::Duration;
     use common::units::second;
     use database::DbConnection;
@@ -569,6 +591,7 @@ mod tests {
             name: Some("test".to_string()),
             description: String::default(),
             published: false,
+            timetable_type: schemas::timetable_type::TimetableType::Calendar,
         };
         let response: TrainScheduleSetResponse = app
             .post("/train_schedule_sets")
@@ -606,6 +629,7 @@ mod tests {
             name: Some("test".to_string()),
             description: String::default(),
             published: false,
+            timetable_type: schemas::timetable_type::TimetableType::Calendar,
         };
         let response: TrainScheduleSetResponse = app
             .post("/train_schedule_sets")
@@ -620,7 +644,9 @@ mod tests {
             name: Some("test".to_string()),
             description: String::default(),
             published: false,
-            timetable_type: Default::default(),
+            timetable_type: editoast_models::timetable_type::TimetableType(
+                schemas::timetable_type::TimetableType::Calendar,
+            ),
         };
 
         assert_eq!(
@@ -780,7 +806,7 @@ mod tests {
         let db_pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
         let train_schedule_set_id = train_schedule_set.id;
-        let train_schedule_set_form = TrainScheduleSetForm {
+        let train_schedule_set_form = TrainScheduleSetUpdateForm {
             catalog_entry_id: None,
             name: Some("test_updated".to_string()),
             description: "test description".to_string(),
@@ -802,7 +828,9 @@ mod tests {
                     name: Some("test_updated".to_string()),
                     description: "test description".to_string(),
                     published: false,
-                    timetable_type: Default::default(),
+                    timetable_type: editoast_models::timetable_type::TimetableType(
+                        schemas::timetable_type::TimetableType::Calendar
+                    ),
                 },
                 train_schedule_count: 0
             }
@@ -817,7 +845,7 @@ mod tests {
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
         let train_schedule_set_id = train_schedule_set.id;
-        let train_schedule_set_form = TrainScheduleSetForm {
+        let train_schedule_set_form = TrainScheduleSetUpdateForm {
             catalog_entry_id: Some(catalog_entry.id),
             name: Some("test_updated".to_string()),
             description: "test description".to_string(),

--- a/front/src/applications/operationalStudies/hooks/__tests__/useScenario.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useScenario.spec.ts
@@ -124,7 +124,12 @@ describe('useScenario', () => {
 
     await waitFor(() => expect(result.current.sandboxId).toBe(999));
     expect(mocks.postTrainScheduleSets).toHaveBeenCalledWith({
-      trainScheduleSetForm: { name: null, description: '', published: false },
+      trainScheduleSetForm: {
+        name: null,
+        description: '',
+        published: false,
+        timetable_type: 'CALENDAR',
+      },
     });
     expect(mocks.linkTrainScheduleSets).toHaveBeenCalledWith({
       id: mockScenario.timetable_id,

--- a/front/src/applications/operationalStudies/hooks/useScenario.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenario.ts
@@ -74,6 +74,7 @@ const useScenario = () => {
           name: null, // sandbox never has a name
           description: '',
           published: false,
+          timetable_type: 'CALENDAR',
         },
       }).unwrap();
 

--- a/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
@@ -157,7 +157,7 @@ export default function useScenarioTrainScheduleSet(
 
       await updateTrainScheduleSetMutation({
         id: trainScheduleSet.id,
-        trainScheduleSetForm: {
+        trainScheduleSetUpdateForm: {
           ...trainScheduleSetData,
           catalog_entry_id: catalogEntryId,
         },
@@ -296,6 +296,7 @@ export default function useScenarioTrainScheduleSet(
               catalog_entry_id: item.trainScheduleSet.catalog_entry_id,
               published: false,
               description: item.trainScheduleSet.description,
+              timetable_type: 'CALENDAR',
             },
           }).unwrap();
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1293,6 +1293,7 @@ const injectedRtkApi = api
           params: {
             catalog_entry_id: queryArg.catalogEntryId,
             published: queryArg.published,
+            timetable_type: queryArg.timetableType,
           },
         }),
         providesTags: ['train_schedule_set'],
@@ -2625,6 +2626,7 @@ export type GetTrainScheduleSetsApiResponse =
 export type GetTrainScheduleSetsApiArg = {
   catalogEntryId?: number;
   published?: boolean;
+  timetableType?: TimetableType;
 };
 export type PostTrainScheduleSetsApiResponse =
   /** status 201 Train schedule set */ TrainScheduleSetResponse;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1322,7 +1322,7 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: `/train_schedule_sets/${queryArg.id}`,
           method: 'PUT',
-          body: queryArg.trainScheduleSetForm,
+          body: queryArg.trainScheduleSetUpdateForm,
         }),
         invalidatesTags: ['train_schedule_set'],
       }),
@@ -2642,7 +2642,7 @@ export type PutTrainScheduleSetsByIdApiResponse =
 export type PutTrainScheduleSetsByIdApiArg = {
   /** A train schedule set ID */
   id: number;
-  trainScheduleSetForm: TrainScheduleSetForm;
+  trainScheduleSetUpdateForm: TrainScheduleSetUpdateForm;
 };
 export type DeleteTrainScheduleSetsByIdApiResponse = unknown;
 export type DeleteTrainScheduleSetsByIdApiArg = {
@@ -5010,6 +5010,13 @@ export type TrainScheduleSetResponse = TrainScheduleSet & {
   train_schedule_count: number;
 };
 export type TrainScheduleSetForm = {
+  catalog_entry_id?: number | null;
+  description: string;
+  name?: string | null;
+  published: boolean;
+  timetable_type: TimetableType;
+};
+export type TrainScheduleSetUpdateForm = {
   catalog_entry_id?: number | null;
   description: string;
   name?: string | null;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4200,8 +4200,10 @@ export type Scenario = {
   tags: Tags;
   timetable_id: number;
 };
+export type TimetableType = 'CALENDAR' | 'HOURLY';
 export type ScenarioWithDetails = Scenario & {
   infra_name: string;
+  timetable_type: TimetableType;
   train_schedules_count: number;
 };
 export type ScenarioCreateForm = {
@@ -4234,6 +4236,7 @@ export type ScenarioResponse = Scenario & {
   infra_name: string;
   project: Project;
   study: Study;
+  timetable_type: TimetableType;
   train_schedules_count: number;
 };
 export type ScenarioPatchForm = {
@@ -4668,7 +4671,6 @@ export type SubCategory = {
 export type SubCategoryPage = PaginationStats & {
   results: SubCategory[];
 };
-export type TimetableType = 'CALENDAR' | 'HOURLY';
 export type TimetableResult = {
   timetable_id: number;
   timetable_type: TimetableType;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1077,7 +1077,11 @@ const injectedRtkApi = api
         invalidatesTags: ['temporary_speed_limits'],
       }),
       postTimetable: build.mutation<PostTimetableApiResponse, PostTimetableApiArg>({
-        query: () => ({ url: `/timetable`, method: 'POST' }),
+        query: (queryArg) => ({
+          url: `/timetable`,
+          method: 'POST',
+          body: queryArg.timetableForm,
+        }),
         invalidatesTags: ['timetable'],
       }),
       deleteTimetableById: build.mutation<
@@ -2423,7 +2427,9 @@ export type PostTemporarySpeedLimitGroupApiArg = {
 };
 export type PostTimetableApiResponse =
   /** status 201 Timetable with train schedule ids */ TimetableResult;
-export type PostTimetableApiArg = void;
+export type PostTimetableApiArg = {
+  timetableForm: TimetableForm;
+};
 export type DeleteTimetableByIdApiResponse = unknown;
 export type DeleteTimetableByIdApiArg = {
   /** A timetable ID */
@@ -4663,6 +4669,9 @@ export type SubCategoryPage = PaginationStats & {
 export type TimetableType = 'CALENDAR' | 'HOURLY';
 export type TimetableResult = {
   timetable_id: number;
+  timetable_type: TimetableType;
+};
+export type TimetableForm = {
   timetable_type: TimetableType;
 };
 export type CoreConflictType = 'Spacing' | 'Routing';

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -160,7 +160,11 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
             published: false,
           },
         }).unwrap();
-        const timetable = await postTimetable().unwrap();
+        const timetable = await postTimetable({
+          timetableForm: {
+            timetable_type: 'CALENDAR',
+          },
+        }).unwrap();
         await linkTrainScheduleSetToTimetable({
           id: timetable.timetable_id,
           body: { train_schedule_set_ids: [sandbox.id] },

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -13,6 +13,7 @@ import {
   osrdEditoastApi,
   type ScenarioPatchForm,
   type ScenarioWithDetails,
+  type TimetableType,
 } from 'common/api/osrdEditoastApi';
 import ChipsSNCF from 'common/BootstrapSNCF/ChipsSNCF';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
@@ -152,18 +153,18 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
       setDisplayErrors(true);
     } else if (projectId && studyId && currentScenario && currentScenario.name) {
       try {
+        const timetableType: TimetableType = 'CALENDAR';
         // Creating a scenario requires to: create a sandbox, a timetable, link both and finally create the scenario
         const sandbox = await postTrainScheduleSets({
           trainScheduleSetForm: {
             name: null, // sandbox never has a name
             description: '',
             published: false,
+            timetable_type: timetableType,
           },
         }).unwrap();
         const timetable = await postTimetable({
-          timetableForm: {
-            timetable_type: 'CALENDAR',
-          },
+          timetableForm: { timetable_type: timetableType },
         }).unwrap();
         await linkTrainScheduleSetToTimetable({
           id: timetable.timetable_id,

--- a/front/tests/utils/scenario.ts
+++ b/front/tests/utils/scenario.ts
@@ -45,7 +45,9 @@ export default async function createScenario(
   const study: Study = studyId ? ({ id: studyId } as Study) : await getStudy(project.id);
 
   // Create a new timetable result
-  const timetableResult: TimetableResult = await postApiRequest(`/api/timetable`);
+  const timetableResult: TimetableResult = await postApiRequest(`/api/timetable`, {
+    timetable_type: 'CALENDAR',
+  });
 
   // Create the sandbox
   const trainScheduleSet: TrainScheduleSet = await postApiRequest(`/api/train_schedule_sets`, {
@@ -53,6 +55,7 @@ export default async function createScenario(
     description: '',
     catalog_entry_id: null,
     published: false,
+    timetable_type: 'CALENDAR',
   });
 
   // Link the timetable with the sandbox

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -3865,10 +3865,18 @@ class TrainScheduleSetForm(BaseModel):
     description: str
     name: str | None = None
     published: bool
+    timetable_type: TimetableType
 
 
 class TrainScheduleSetResponse(TrainScheduleSet):
     train_schedule_count: Annotated[int, Field(ge=0)]
+
+
+class TrainScheduleSetUpdateForm(BaseModel):
+    catalog_entry_id: int | None = None
+    description: str
+    name: str | None = None
+    published: bool
 
 
 class Version(BaseModel):

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -5121,6 +5121,7 @@ class ScenarioPatchForm(BaseModel):
 
 class ScenarioWithDetails(Scenario):
     infra_name: str
+    timetable_type: TimetableType
     train_schedules_count: int
 
 
@@ -5965,6 +5966,7 @@ class ScenarioResponse(Scenario):
     infra_name: str
     project: Project
     study: Study
+    timetable_type: TimetableType
     train_schedules_count: int
 
 

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -5339,6 +5339,10 @@ class SwitchExtensions(BaseModel):
     sncf: SwitchSncfExtension | None = None
 
 
+class TimetableForm(BaseModel):
+    timetable_type: TimetableType
+
+
 class TimetableResult(BaseModel):
     """
     Creation result for a Timetable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -514,7 +514,7 @@ def west_to_south_east_simulations(
 
 @pytest.fixture
 def timetable_id(session: Session) -> int:
-    r = session.post(f"{EDITOAST_URL}timetable/")
+    r = session.post(f"{EDITOAST_URL}timetable/", json={"timetable_type": "CALENDAR"})
     if not r.ok:
         raise RuntimeError(f"Error creating timetable {r.status_code}: {r.content}")
     return r.json()["timetable_id"]
@@ -529,6 +529,7 @@ def train_schedule_set_id(session: Session, timetable_id: int) -> int:
             "catalog_entry": None,
             "description": "",
             "published": False,
+            "timetable_type": "CALENDAR",
         },
     )
     r.raise_for_status()

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -126,7 +126,9 @@ def get_infra(editoast_url: str, infra_name: str, session: Session) -> int:
 
 def create_scenario(editoast_url: str, infra_id: int, session: Session) -> Scenario:
     # Create the timetable
-    r = _post_with_timeout(session, editoast_url + "/timetable/", json={})
+    r = _post_with_timeout(
+        session, editoast_url + "/timetable/", json={"timetable_type": "CALENDAR"}
+    )
     timetable_id = r.json()["timetable_id"]
     r = _post_with_timeout(
         session,
@@ -136,6 +138,7 @@ def create_scenario(editoast_url: str, infra_id: int, session: Session) -> Scena
             "name": None,
             "published": False,
             "description": "",
+            "timetable_type": "CALENDAR",
         },
     )
     train_schedule_set_id = r.json()["id"]

--- a/tests/tests/test_scenario.py
+++ b/tests/tests/test_scenario.py
@@ -53,6 +53,7 @@ class _ScenarioResponse:
     last_modification: str
     tags: list[str]
     infra_name: str
+    timetable_type: str
     project: _Project
     study: _Study
 

--- a/tests/tests/utils/timetable.py
+++ b/tests/tests/utils/timetable.py
@@ -26,7 +26,7 @@ def create_scenario(
     session: Session,
 ) -> tuple[int, int, int]:
     # Create the timetable
-    r = session.post(editoast_url + "/timetable/")
+    r = session.post(editoast_url + "/timetable/", json={"timetable_type": "CALENDAR"})
     if r.status_code // 100 != 2:
         err = f"Error creating timetable {r.status_code}: {r.content}"
         raise RuntimeError(err)
@@ -39,6 +39,7 @@ def create_scenario(
             "name": None,
             "published": False,
             "description": "",
+            "timetable_type": "CALENDAR",
         },
     )
     if r.status_code // 100 != 2:


### PR DESCRIPTION
fix #16503
fix #16518
fix #16517
fix #16514

This PR adapts several endpoints to the timetable_type parameter

- [x] GET /scenarios
- [x] POST and GET /train_schedule_sets
- [x] POST /timetables
- [ ] osrd_data adaption