### PR TITLE
editoast: authz: return can_revoke privileges in infra_privileges

### DIFF
--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -151,6 +151,7 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
                 can_share_write,
                 can_delete,
                 can_share_ownership,
+                can_revoke,
             ) = openfga
                 .checks((
                     User::role().check(&Role::Admin, &user),
@@ -160,6 +161,7 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
                     Infra::can_share_write().check(&user, &infra),
                     Infra::can_delete().check(&user, &infra),
                     Infra::can_share_ownership().check(&user, &infra),
+                    Infra::can_revoke().check(&user, &infra),
                 ))
                 .await?;
             let mut privileges = HashSet::new();
@@ -171,6 +173,7 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
             privileges.extend(
                 (admin || can_share_ownership).then_some(InfraPrivilege::CanShareOwnership),
             );
+            privileges.extend((admin || can_revoke).then_some(InfraPrivilege::CanRevoke));
             Ok(privileges)
         }
         .boxed()
@@ -464,6 +467,7 @@ mod tests {
                 InfraPrivilege::CanShareWrite,
                 InfraPrivilege::CanDelete,
                 InfraPrivilege::CanShareOwnership,
+                InfraPrivilege::CanRevoke,
             ])
         );
     }

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -886,6 +886,7 @@ mod tests {
                 StandardPrivilege::CanShareWrite,
                 StandardPrivilege::CanDelete,
                 StandardPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRevoke,
             ])
         );
         assert_eq!(
@@ -962,7 +963,8 @@ mod tests {
                 StandardPrivilege::CanWrite,
                 StandardPrivilege::CanShareWrite,
                 StandardPrivilege::CanDelete,
-                StandardPrivilege::CanShareOwnership
+                StandardPrivilege::CanShareOwnership,
+                StandardPrivilege::CanRevoke,
             ])
         );
         assert!(!privileges.contains_key(&infra_unused));


### PR DESCRIPTION
Small hotfix, that privilege was not retrieved from openfga in `authz::v2::infra_privileges`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenRailAssociation/codesmith/osrd/pr/17070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783159215&installation_id=137912551&pr_number=17070&repository=OpenRailAssociation%2Fosrd&return_to=https%3A%2F%2Fgithub.com%2FOpenRailAssociation%2Fosrd%2Fpull%2F17070&signature=3663942d8c2c547ac47c661355ec1c1c41925613d07e4ec5ad74a24412cdb48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->