### PR TITLE
plug selection panel modes

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel.tsx
@@ -2,7 +2,7 @@ import { OccurrenceAll, OccurrenceCompliant, OccurrenceSingle } from '@osrd-proj
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-type PanelSelectionMode = 'compliant' | 'all' | 'single';
+export type PanelSelectionMode = 'compliant' | 'all' | 'single';
 
 type CurveSelectionSidePanelProps = {
   position: number;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 
 export type PanelSelectionMode = 'compliant' | 'all' | 'single';
 
+export const PANEL_SELECTION_MODES: PanelSelectionMode[] = ['compliant', 'all', 'single'];
+
 type CurveSelectionSidePanelProps = {
   position: number;
   panelSelectionMode: PanelSelectionMode;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -30,14 +30,19 @@ import { type PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEdi
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { configureHandlePan } from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan';
 import type {
+  CurveStyleExceptionType,
   PathOperationalPoint,
   TrainSpaceTimeData,
   WaypointsPanelData,
   DraggingState,
 } from 'modules/simulationResult/types';
-import { isPacedTrainWithDetails } from 'modules/trainSchedule/helpers/pacedTrain';
+import {
+  findExceptionWithOccurrenceId,
+  getFirstActiveOccurrenceId,
+  isPacedTrainWithDetails,
+} from 'modules/trainSchedule/helpers/pacedTrain';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
-import type { TrainId } from 'reducers/osrdconf/types';
+import type { OccurrenceId, TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrain } from 'reducers/simulationResults';
 import {
   getHoveredTrainId,
@@ -51,6 +56,7 @@ import {
   formatPacedTrainIdToIndexedOccurrenceId,
   isOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
+  extractPacedTrainIdFromTrainId,
   extractOccurrenceIndexFromOccurrenceId,
   extractExceptionIdFromOccurrenceId,
   isAddedExceptionId,
@@ -59,9 +65,10 @@ import {
 import { mapBy } from 'utils/types';
 
 import { buildSplitPoints } from './buildSplitPoints';
-import CurveSelectionSidePanel from './CurveSelectionSidePanel';
+import CurveSelectionSidePanel, { type PanelSelectionMode } from './CurveSelectionSidePanel';
 import cutSpaceTimeCurves from './helpers/cutSpaceTimeCurves';
 import formatSpaceTimeCurves from './helpers/formatSpaceTimeCurves';
+import getPanelOccurrenceCounts from './helpers/getPanelOccurrenceCounts';
 import getPathStyle from './helpers/getPathStyle';
 import makeProjectedTrains from './helpers/makeProjectedTrains';
 import { getOccupancyBlocks } from './helpers/utils';
@@ -153,6 +160,9 @@ const SpaceTimeChartWrapper = ({
 
   const [hoveredItem, setHoveredItem] = useState<null | HoveredItem>(null);
   const [draggingState, setDraggingState] = useState<DraggingState>();
+
+  const [panelSelectionMode, setPanelSelectionMode] = useState<PanelSelectionMode>('compliant');
+  const [lastClickedOccurrenceId, setLastClickedOccurrenceId] = useState<OccurrenceId>();
 
   const translations = { linearMode: t('main.linearMode') };
 
@@ -364,6 +374,41 @@ const SpaceTimeChartWrapper = ({
     [setHoveredItem]
   );
 
+  const selectedPacedTrainId = selectedTrainId
+    ? extractPacedTrainIdFromTrainId(selectedTrainId)
+    : undefined;
+
+  const selectedTrain = selectedPacedTrainId
+    ? trainSchedulesWithDetailsById.get(extractEditoastIdFromPacedTrainId(selectedPacedTrainId))
+    : undefined;
+
+  const panelExceptionType: CurveStyleExceptionType =
+    selectedTrainBy === 'tod' ? 'path_and_schedule' : 'start_time';
+
+  const panelCounts =
+    selectedTrain && isPacedTrainWithDetails(selectedTrain) && selectedTrainBy !== 'timetable'
+      ? getPanelOccurrenceCounts(selectedTrain.paced, panelExceptionType)
+      : undefined;
+  const showCurvePanel = !!panelCounts;
+
+  const handlePanelModeChange = (mode: PanelSelectionMode) => {
+    setPanelSelectionMode(mode);
+    if (mode === 'single') {
+      const singleId =
+        lastClickedOccurrenceId ??
+        (selectedTrain && isPacedTrainWithDetails(selectedTrain) && selectedPacedTrainId
+          ? getFirstActiveOccurrenceId(selectedTrain, selectedPacedTrainId)
+          : undefined);
+      if (singleId) {
+        dispatch(updateSelectedTrain({ id: singleId, by: 'std' }));
+      }
+      return;
+    }
+    if (selectedPacedTrainId) {
+      dispatch(updateSelectedTrain({ id: selectedPacedTrainId, by: 'std' }));
+    }
+  };
+
   const handleClick: SpaceTimeChartProps['onClick'] = () => {
     if (
       !draggingState &&
@@ -386,6 +431,18 @@ const SpaceTimeChartWrapper = ({
         isTrainId(clickedTrainId) &&
         (selectedTrainId !== clickedTrainId || selectedTrainBy !== 'std')
       ) {
+        if (isOccurrenceId(clickedTrainId)) {
+          setLastClickedOccurrenceId(clickedTrainId);
+          const trainScheduleId = extractEditoastIdFromPacedTrainId(
+            extractPacedTrainIdFromOccurrenceId(clickedTrainId)
+          );
+          const trainSchedule = trainSchedulesWithDetailsById.get(trainScheduleId);
+          const exception =
+            trainSchedule && isPacedTrainWithDetails(trainSchedule)
+              ? findExceptionWithOccurrenceId(trainSchedule.paced.exceptions, clickedTrainId)
+              : undefined;
+          setPanelSelectionMode(exception?.start_time ? 'single' : 'compliant');
+        }
         onTrainClick(clickedTrainId);
       }
     }
@@ -463,6 +520,9 @@ const SpaceTimeChartWrapper = ({
               <PathLayer
                 key={`${path.id}-${path.points[0]?.position}`}
                 path={path}
+                // TODO: forward `panelSelectionMode` to getPathStyle when the
+                // curve-style mapping ticket needs it to pick which occurrences
+                // are highlighted in blue.
                 {...getPathStyle(
                   hoveredItem,
                   path,
@@ -493,13 +553,12 @@ const SpaceTimeChartWrapper = ({
               </>
             )}
           </SpaceTimeChart>
-          {/*TODO : update onModeChange and counts when implementing compliant/all/single modes*/}
-          {selectedTrainBy && selectedTrainBy !== 'timetable' && (
+          {showCurvePanel && (
             <CurveSelectionSidePanel
               position={height / 2}
-              panelSelectionMode="compliant"
-              onModeChange={() => {}}
-              counts={{ compliant: 3, all: 6 }}
+              panelSelectionMode={panelSelectionMode}
+              onModeChange={handlePanelModeChange}
+              counts={panelCounts}
             />
           )}
         </div>

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -65,7 +65,10 @@ import {
 import { mapBy } from 'utils/types';
 
 import { buildSplitPoints } from './buildSplitPoints';
-import CurveSelectionSidePanel, { type PanelSelectionMode } from './CurveSelectionSidePanel';
+import CurveSelectionSidePanel, {
+  PANEL_SELECTION_MODES,
+  type PanelSelectionMode,
+} from './CurveSelectionSidePanel';
 import cutSpaceTimeCurves from './helpers/cutSpaceTimeCurves';
 import formatSpaceTimeCurves from './helpers/formatSpaceTimeCurves';
 import getPanelOccurrenceCounts from './helpers/getPanelOccurrenceCounts';
@@ -155,6 +158,7 @@ const SpaceTimeChartWrapper = ({
   const isSimulationEnabled = useSelector(getIsSimulationEnabled);
   const { id: selectedTrainId, by: selectedTrainBy } = useSelector(getSelectedTrain) || {};
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
   const activeWaypointRef = useRef<HTMLDivElement>(null);
 
@@ -448,14 +452,47 @@ const SpaceTimeChartWrapper = ({
     }
   };
 
+  const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
+    if (e.code === 'KeyS') {
+      if (!selectedPacedTrainId) return;
+      e.preventDefault();
+      const currentIndex = PANEL_SELECTION_MODES.indexOf(panelSelectionMode);
+      const nextMode = PANEL_SELECTION_MODES[(currentIndex + 1) % PANEL_SELECTION_MODES.length];
+      handlePanelModeChange(nextMode);
+      return;
+    }
+    if (e.key === 'Escape' && selectedTrainId && selectedTrainBy !== 'timetable') {
+      e.preventDefault();
+      dispatch(updateSelectedTrain({ id: selectedTrainId, by: 'timetable' }));
+      if (showCurvePanel) setPanelSelectionMode('compliant');
+    }
+  };
+
+  const handleCloseSettingsPanel = () => {
+    setShowSettingsPanel(false);
+    wrapperRef.current?.focus();
+  };
+
+  const handleSetWaypointsPanelIsOpen = (open: boolean) => {
+    setWaypointsPanelIsOpen?.(open);
+    if (!open) wrapperRef.current?.focus();
+  };
+
   return (
-    <div data-testid="manchette-space-time-chart" className="ui-manchette-space-time-chart-wrapper">
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      data-testid="manchette-space-time-chart"
+      className="ui-manchette-space-time-chart-wrapper"
+      ref={wrapperRef}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+    >
       {waypointsPanelData &&
         waypointsPanelIsOpen &&
         createPortal(
           <WaypointsPanel
             waypointsPanelIsOpen={waypointsPanelIsOpen}
-            setWaypointsPanelIsOpen={setWaypointsPanelIsOpen}
+            setWaypointsPanelIsOpen={handleSetWaypointsPanelIsOpen}
             waypoints={operationalPoints}
             waypointsPanelData={waypointsPanelData}
             hideOffsets={pathfindingHasFailed}
@@ -498,7 +535,7 @@ const SpaceTimeChartWrapper = ({
             <SettingsPanel
               settings={settings}
               onChange={setSettings}
-              onClose={() => setShowSettingsPanel(false)}
+              onClose={handleCloseSettingsPanel}
               isTrainScheduleValid={isTrainScheduleValid}
             />
           )}

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/getPanelOccurrenceCounts.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/getPanelOccurrenceCounts.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+
+import type { CurveStyleExceptionType } from 'modules/simulationResult/types';
+import type { SimulatedException } from 'modules/trainSchedule/types';
+import { Duration } from 'utils/duration';
+
+import getPanelOccurrenceCounts from '../getPanelOccurrenceCounts';
+
+const exception = (
+  partial: { key: string } & Partial<Record<keyof SimulatedException, unknown>>
+): SimulatedException => partial as SimulatedException;
+
+const paced = (exceptions: SimulatedException[] = []) => ({
+  timeWindow: new Duration({ hours: 1 }),
+  interval: new Duration({ minutes: 10 }),
+  exceptions,
+});
+
+const STD: CurveStyleExceptionType = 'start_time';
+const TOD: CurveStyleExceptionType = 'path_and_schedule';
+
+describe('getPanelOccurrenceCounts', () => {
+  it('should count all indexed occurrences as compliant when there are no exceptions', () => {
+    expect(getPanelOccurrenceCounts(paced(), STD)).toEqual({ compliant: 6, all: 6 });
+  });
+
+  it.each([
+    { label: 'on the STD', exceptionType: STD, field: 'start_time' as const },
+    { label: 'on the TOD', exceptionType: TOD, field: 'path_and_schedule' as const },
+  ])(
+    'should subtract a $label non-compliant override from the compliant count',
+    ({ exceptionType, field }) => {
+      const result = getPanelOccurrenceCounts(
+        paced([exception({ key: 'e1', occurrence_index: 2, [field]: { value: 1000 } })]),
+        exceptionType
+      );
+      expect(result).toEqual({ compliant: 5, all: 6 });
+    }
+  );
+
+  it('should remove a disabled indexed occurrence from both counts', () => {
+    const result = getPanelOccurrenceCounts(
+      paced([exception({ key: 'e1', occurrence_index: 1, disabled: true })]),
+      STD
+    );
+    expect(result).toEqual({ compliant: 5, all: 5 });
+  });
+
+  it('should add an active added exception to the total but not to compliant on the STD', () => {
+    const result = getPanelOccurrenceCounts(
+      paced([exception({ key: 'e1', start_time: { value: 5000 } })]),
+      STD
+    );
+    expect(result).toEqual({ compliant: 6, all: 7 });
+  });
+
+  it('should count an added exception as compliant on the TOD when it does not override path_and_schedule', () => {
+    const result = getPanelOccurrenceCounts(
+      paced([exception({ key: 'e1', start_time: { value: 5000 } })]),
+      TOD
+    );
+    expect(result).toEqual({ compliant: 7, all: 7 });
+  });
+
+  it('should ignore an indexed exception that does not override the relevant field', () => {
+    const result = getPanelOccurrenceCounts(
+      paced([exception({ key: 'e1', occurrence_index: 1, path_and_schedule: { value: 'foo' } })]),
+      STD
+    );
+    expect(result).toEqual({ compliant: 6, all: 6 });
+  });
+
+  it('should handle a mix of exception types', () => {
+    const result = getPanelOccurrenceCounts(
+      paced([
+        exception({ key: 'e1', occurrence_index: 0, disabled: true }),
+        exception({ key: 'e2', occurrence_index: 2, start_time: { value: 1000 } }),
+        exception({ key: 'e3', start_time: { value: 5000 } }),
+      ]),
+      STD
+    );
+    expect(result).toEqual({ compliant: 4, all: 6 });
+  });
+});

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPanelOccurrenceCounts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPanelOccurrenceCounts.ts
@@ -1,0 +1,39 @@
+import { getOccurrencesNb } from 'modules/trainSchedule/helpers/pacedTrain';
+import type { PacedDetails } from 'modules/trainSchedule/types';
+
+import type { CurveStyleExceptionType } from '../../../types';
+
+/**
+ * For the curve selection panel:
+ * - `all` = every active occurrence of the paced train
+ * - `compliant` = occurrences that still match the paced pattern on the chart's
+ *   relevant field (`start_time` for the STD, `path_and_schedule` for the TOD)
+ */
+const getPanelOccurrenceCounts = (
+  paced: PacedDetails,
+  exceptionType: CurveStyleExceptionType
+): { compliant: number; all: number } => {
+  let active = getOccurrencesNb({
+    timeWindow: paced.timeWindow,
+    interval: paced.interval,
+  });
+  let nonCompliant = 0;
+
+  for (const exception of paced.exceptions) {
+    // A disabled indexed exception hides that occurrence entirely.
+    if (exception.occurrence_index !== undefined && exception.disabled) {
+      active -= 1;
+      continue;
+    }
+    // An added exception introduces a new active occurrence on top of the pattern.
+    if (exception.occurrence_index === undefined) {
+      active += 1;
+    }
+    // Any active exception that overrides the chart's relevant field is non-compliant.
+    if (exception[exceptionType]) nonCompliant += 1;
+  }
+
+  return { compliant: active - nonCompliant, all: active };
+};
+
+export default getPanelOccurrenceCounts;

--- a/front/src/modules/trainSchedule/helpers/__tests__/pacedTrain.spec.ts
+++ b/front/src/modules/trainSchedule/helpers/__tests__/pacedTrain.spec.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
 import type { TrainSchedule, PacedTrainException } from 'common/api/osrdEditoastApi';
-import type { SimulatedException, SimulationSummary } from 'modules/trainSchedule/types';
+import type {
+  PacedTrainWithPacedWithDetails,
+  SimulatedException,
+  SimulationSummary,
+} from 'modules/trainSchedule/types';
+import type { PacedTrainId } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import {
   formatEditoastIdToPacedTrainId,
@@ -11,6 +16,7 @@ import {
 
 import {
   extractOccurrenceDetailsFromPacedTrain,
+  getFirstActiveOccurrenceId,
   getOccurrencesNb,
   getOccurrencesWorstStatus,
   isOccurrencePresentInPacedTrain,
@@ -415,5 +421,100 @@ describe('isOccurrencePresentInPacedTrain', () => {
         trainSchedule
       )
     ).toEqual(false);
+  });
+});
+
+describe('getFirstActiveOccurrenceId', () => {
+  const PACED_ID = 'paced_1' as PacedTrainId;
+  const PACED_START_MS = new Date('2026-01-01T08:00:00Z').getTime();
+  const INTERVAL_MS = 10 * 60 * 1000;
+
+  const exception = (
+    partial: { key: string } & Partial<Record<keyof SimulatedException, unknown>>
+  ): SimulatedException => partial as SimulatedException;
+
+  const schedule = (exceptions: SimulatedException[] = []) =>
+    ({
+      startTime: new Date(PACED_START_MS),
+      paced: {
+        timeWindow: new Duration({ hours: 1 }),
+        interval: new Duration({ minutes: 10 }),
+        exceptions,
+      },
+    }) as unknown as PacedTrainWithPacedWithDetails;
+
+  it('should return the first slot when there are no exceptions', () => {
+    expect(getFirstActiveOccurrenceId(schedule(), PACED_ID)).toBe('indexedoccurrence_1_0');
+  });
+
+  it('should skip a disabled slot and return the next one', () => {
+    const result = getFirstActiveOccurrenceId(
+      schedule([exception({ key: 'e1', occurrence_index: 0, disabled: true })]),
+      PACED_ID
+    );
+    expect(result).toBe('indexedoccurrence_1_1');
+  });
+
+  it('should skip multiple consecutive disabled slots', () => {
+    const result = getFirstActiveOccurrenceId(
+      schedule([
+        exception({ key: 'e1', occurrence_index: 0, disabled: true }),
+        exception({ key: 'e2', occurrence_index: 1, disabled: true }),
+        exception({ key: 'e3', occurrence_index: 2, disabled: true }),
+      ]),
+      PACED_ID
+    );
+    expect(result).toBe('indexedoccurrence_1_3');
+  });
+
+  it('should pick the indexed slot whose start_time override makes it earliest', () => {
+    const result = getFirstActiveOccurrenceId(
+      schedule([
+        // Slot 2 is moved before slot 0 by its start_time override
+        exception({
+          key: 'e1',
+          occurrence_index: 2,
+          start_time: { value: PACED_START_MS - INTERVAL_MS },
+        }),
+      ]),
+      PACED_ID
+    );
+    expect(result).toBe('indexedoccurrence_1_2');
+  });
+
+  it('should pick an added exception when it is earlier than the first indexed slot', () => {
+    const result = getFirstActiveOccurrenceId(
+      schedule([
+        exception({
+          key: 'e1',
+          id: 42,
+          start_time: { value: PACED_START_MS - INTERVAL_MS },
+        }),
+      ]),
+      PACED_ID
+    );
+    expect(result).toBe('exception_1_42');
+  });
+
+  it('should keep the indexed slot when an added exception comes after it', () => {
+    const result = getFirstActiveOccurrenceId(
+      schedule([
+        exception({
+          key: 'e1',
+          id: 42,
+          start_time: { value: PACED_START_MS + 5 * INTERVAL_MS },
+        }),
+      ]),
+      PACED_ID
+    );
+    expect(result).toBe('indexedoccurrence_1_0');
+  });
+
+  it('should return undefined when every slot is disabled and no added exception exists', () => {
+    const exceptions: SimulatedException[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      exceptions.push(exception({ key: `e${i}`, occurrence_index: i, disabled: true }));
+    }
+    expect(getFirstActiveOccurrenceId(schedule(exceptions), PACED_ID)).toBeUndefined();
   });
 });

--- a/front/src/modules/trainSchedule/helpers/pacedTrain.ts
+++ b/front/src/modules/trainSchedule/helpers/pacedTrain.ts
@@ -286,3 +286,44 @@ export const isOccurrencePresentInPacedTrain = (
 
   return occurrenceIndex >= 0 && occurrenceIndex < getOccurrencesNb(paced);
 };
+
+/**
+ * Returns the id of the earliest active occurrence of the paced train. An
+ * occurrence is considered active when it is not disabled by an exception.
+ * Both indexed slots (with or without `start_time` override) and added
+ * exceptions are taken into account. Used as a fallback when no occurrence
+ * has been clicked yet but the panel switches to `single` mode.
+ */
+export const getFirstActiveOccurrenceId = (
+  trainSchedule: PacedTrainWithPacedWithDetails,
+  pacedTrainId: PacedTrainId
+): OccurrenceId | undefined => {
+  const { paced } = trainSchedule;
+  const startTimeMs = trainSchedule.startTime.getTime();
+  const intervalMs = paced.interval.ms;
+
+  let bestId: OccurrenceId | undefined;
+  let bestTimeMs = Infinity;
+
+  const slotCount = getOccurrencesNb(paced);
+  for (let i = 0; i < slotCount; i += 1) {
+    const indexedException = paced.exceptions.find((e) => e.occurrence_index === i);
+    if (indexedException?.disabled) continue;
+    const timeMs = indexedException?.start_time?.value ?? startTimeMs + i * intervalMs;
+    if (timeMs < bestTimeMs) {
+      bestTimeMs = timeMs;
+      bestId = formatPacedTrainIdToIndexedOccurrenceId(pacedTrainId, i);
+    }
+  }
+
+  for (const exception of paced.exceptions) {
+    if (exception.occurrence_index !== undefined || !exception.start_time || !exception.id)
+      continue;
+    if (exception.start_time.value < bestTimeMs) {
+      bestTimeMs = exception.start_time.value;
+      bestId = formatPacedTrainIdToExceptionId(pacedTrainId, exception.id);
+    }
+  }
+
+  return bestId;
+};

--- a/front/src/modules/trainSchedule/types.ts
+++ b/front/src/modules/trainSchedule/types.ts
@@ -103,6 +103,8 @@ export type PacedTrainWithPacedWithDetails = TrainScheduleWithSummaries & {
   };
 };
 
+export type PacedDetails = PacedTrainWithPacedWithDetails['paced'];
+
 export type TrainScheduleWithDetails = PacedTrainWithDetails;
 
 export type ExceptionChangeGroups = Omit<


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/16583

The 3-button selection panel now works: clicking a button updates the mode and selects the matching train (PacedTrainId for `compliant`/`all`, the last clicked OccurrenceId for `single`). Counts come from the active paced train.
Adds two shortcuts on the chart: `s` cycles the panel modes, `Esc` goes back to the timetable selection. Focus returns to the chart when the settings panel or waypoints menu closes.


## Out of scope

- Curves do not yet turn blue based on the panel mode. The panel state and the selected train are correct, but the visual highlight on the curves is the job of the curve-style work in [#17006](https://github.com/OpenRailAssociation/osrd/pull/17006). Once that PR lands, the link is a one-line change.
- Clicking a curve on the TOD does not update the panel or the selection. Only clicks on the STD are handled in this PR. The mirror behavior from the TOD will be done in a follow-up ticket.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenRailAssociation/codesmith/osrd/pr/17074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783168646&installation_id=137912551&pr_number=17074&repository=OpenRailAssociation%2Fosrd&return_to=https%3A%2F%2Fgithub.com%2FOpenRailAssociation%2Fosrd%2Fpull%2F17074&signature=7766c96fe224fe9de71c332905c897dea563ac5573fdc2a85a7ca38e33965104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->