### PR TITLE
chart: fix typo (camelCase) in editoast deployment

### DIFF
--- a/chart/templates/editoast/deployment.yaml
+++ b/chart/templates/editoast/deployment.yaml
@@ -114,7 +114,7 @@ spec:
             {{- toYaml .Values.services.editoast.resources | nindent 12 }}
 
       {{- if .Values.services.editoast.service_account_name }}
-      service_account_name: {{ .Values.services.editoast.service_account_name }}
+      serviceAccountName: {{ .Values.services.editoast.service_account_name }}
       {{- end}}
 
       {{- if .Values.services.editoast.permanent_storage_size }}

--- a/chart/templates/stateful_editoast/deployment.yaml
+++ b/chart/templates/stateful_editoast/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             {{- toYaml .Values.services.statefulEditoast.resources | nindent 12 }}
 
       {{- if .Values.services.editoast.service_account_name }}
-          service_account_name: {{ .Values.services.editoast.service_account_name }}
+          serviceAccountName: {{ .Values.services.editoast.service_account_name }}
       {{- end}}
 
       {{- if .Values.services.editoast.permanent_storage_size }}


### PR DESCRIPTION
I went a bit too fast copy pasting the core configuration forgetting there was preprocessing in osrdyne for core. This PR fixes it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenRailAssociation/codesmith/osrd/pr/17076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783169735&installation_id=137912551&pr_number=17076&repository=OpenRailAssociation%2Fosrd&return_to=https%3A%2F%2Fgithub.com%2FOpenRailAssociation%2Fosrd%2Fpull%2F17076&signature=b3367ac5a18d04a0be2f08fc0c04e77f5689e1c6d7518be386e6f831959fc2b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->