### PR TITLE
front: also count warnings based on rows that aren't visible

### DIFF
--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -86,7 +86,7 @@ const TimeStopsTableWrapper = ({
   const preEditPathItemTimesRef = useRef<typeof simulatedPathItemTimes>(undefined);
   const isTrainSimulationPendingRef = useRef(false);
 
-  const { rows, stableIsValid } = useTimesStopsTableData(
+  const { rows, stableIsValid, allRows } = useTimesStopsTableData(
     infraId,
     isValid,
     isSimulationDataLoading,
@@ -123,9 +123,6 @@ const TimeStopsTableWrapper = ({
     setPinnedState(null);
   }
 
-  // The single source of truth for what the table displays. Any derived data fed to
-  // TimesStopsTable (warnings, styling, etc.) should be computed from optimisticRows,
-  // not from selectedTrain, to stay in sync with the displayed values during edits.
   const optimisticRows = useMemo(() => {
     let copyRows: TimesStopsRowNew[] = rows;
     if (optimisticEdits) {
@@ -149,13 +146,13 @@ const TimeStopsTableWrapper = ({
   const { blocks: powerRestrictionBlocks, warningCount: powerRestrictionWarningCount } = useMemo(
     () =>
       computePowerRestrictionWarnings({
-        rows: optimisticRows,
+        rows: allRows,
         path: selectedTrain.path,
         operationalPointsOnPath,
         voltages,
         rollingStock,
       }),
-    [optimisticRows, voltages, selectedTrain.path, operationalPointsOnPath, rollingStock]
+    [allRows, voltages, selectedTrain.path, operationalPointsOnPath, rollingStock]
   );
 
   const {

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -177,7 +177,7 @@ const useTimesStopsTableData = (
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'],
   simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'],
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints']
-): { rows: TimesStopsRowNew[]; stableIsValid: boolean } => {
+): { allRows: TimesStopsRowNew[]; rows: TimesStopsRowNew[]; stableIsValid: boolean } => {
   const { t } = useTranslation('operational-studies');
   const { getTrackSectionsByIds } = useScenarioContext();
   const displayOnlyPathSteps = useSelector(getDisplayOnlyPathSteps);
@@ -436,7 +436,7 @@ const useTimesStopsTableData = (
     [allRows, displayOnlyPathSteps]
   );
 
-  return { rows: filteredRows, stableIsValid };
+  return { allRows, rows: filteredRows, stableIsValid };
 };
 
 export default useTimesStopsTableData;


### PR DESCRIPTION
fix #16639

Count power restriction warnings also based on rows that aren't visible to the user.

Co-Authored by @hhirtz 