### PR TITLE
Reorder and rename scenario page boards

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -1,12 +1,13 @@
 {
   "boardFullNames": {
+    "chronogram": "Level Crossings",
     "sdd": "Speed Distance Diagram",
     "std": "Space Time Diagram"
   },
   "boards": {
-    "chronogram": "Chronogram",
+    "chronogram": "Crossings",
     "conflicts": "Conflicts",
-    "macro": "Macro",
+    "macro": "Network Graph",
     "map": "Map",
     "sdd": "SDD",
     "std": "STD",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -1,12 +1,13 @@
 {
   "boardFullNames": {
+    "chronogram": "Passages à niveau",
     "sdd": "Graphique Espace Vitesse",
     "std": "Graphique Espace Temps"
   },
   "boards": {
-    "chronogram": "Chronogramme",
+    "chronogram": "PNs",
     "conflicts": "Conflits",
-    "macro": "Macro",
+    "macro": "Réticulaire",
     "map": "Carte",
     "sdd": "GEV",
     "std": "GET",

--- a/front/src/applications/operationalStudies/views/Scenario/ScenarioView.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/ScenarioView.tsx
@@ -12,11 +12,10 @@ const Scenario = () => {
 
   const { activeBoards, toggleBoard } = usePersistScenarioHeader(scenario?.id, [
     'trains',
-    'map',
     'std',
-    'sdd',
     'tables',
-    'chronogram',
+    'sdd',
+    'map',
   ]);
 
   if (!scenario || !sandboxId) return null;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -13,6 +13,7 @@ import { Loader } from 'common/Loaders';
 import Conflicts from 'modules/conflict/components/Conflicts';
 import useConflictsFilter from 'modules/conflict/hooks/useConflictsFilter';
 import ScenarioLoaderMessage from 'modules/scenario/components/ScenarioLoaderMessage';
+import ChronogramWrapper from 'modules/simulationResult/components/Chronogram/ChronogramWrapper';
 import { setFailure } from 'reducers/main';
 import type { TrainScheduleToEditData } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
@@ -37,6 +38,8 @@ type ScenarioContentProps = {
 
 const MACRO_EDITOR_HEIGHT = 776; // px
 const MACRO_MIN_HEIGHT = 500;
+const CHRONOGRAM_INITIAL_HEIGHT = 492;
+const CHRONOGRAM_MIN_HEIGHT = 398;
 
 const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) => {
   const { t, i18n } = useTranslation('operational-studies');
@@ -51,6 +54,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
   const [collapsedTimetableEdit, setCollapsedTimetableEdit] = useState(false);
   const [trainScheduleToEditData, setTrainScheduleToEditData] = useState<TrainScheduleToEditData>();
   const [macroBoardHeight, setMacroBoardHeight] = useState<number>(MACRO_EDITOR_HEIGHT);
+  const [chronogramHeight, setChronogramHeight] = useState<number>(CHRONOGRAM_INITIAL_HEIGHT);
 
   const {
     trainSchedulesWithDetails,
@@ -135,7 +139,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
     [updateTrainScheduleDepartureTime, refreshNge]
   );
 
-  const simulationResultBoards = ['map', 'tables', 'std', 'sdd', 'chronogram'] as Board[];
+  const simulationResultBoards = ['std', 'tables', 'sdd', 'map'] as Board[];
   const isBoardSimulationResultsActive = simulationResultBoards.some((board) =>
     activeBoards.has(board)
   );
@@ -218,6 +222,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
               <ScenarioLoaderMessage />
             )}
           <div className="scenario-results">
+            {/* STD / TABLES / SDD / MAP */}
             {isInfraLoaded && isBoardSimulationResultsActive && (
               <SimulationResults
                 scenarioData={{ name: scenario.name, infraName: scenario.infra_name }}
@@ -234,9 +239,10 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
                 setIsScrollingToTimeStopsTable={setIsScrollingToTimeStopsTable}
               />
             )}
+            {/* MACRO */}
             {activeBoards.has('macro') && (
               <BoardWrapper
-                name="MACRO"
+                name={t('boards.macro')}
                 resizable={{
                   height: macroBoardHeight,
                   setHeight: setMacroBoardHeight,
@@ -263,8 +269,30 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
                 </div>
               </BoardWrapper>
             )}
+            {/* CHRONOGRAM */}
+            {isInfraLoaded && trainSchedulesWithDetails.length > 0 && (
+              <BoardWrapper
+                hidden={!activeBoards.has('chronogram')}
+                name={t('boards.chronogram')}
+                resizable={{
+                  height: chronogramHeight,
+                  setHeight: setChronogramHeight,
+                  minHeight: CHRONOGRAM_MIN_HEIGHT,
+                }}
+                withFooter
+              >
+                <div data-testid="chronogram" className="simulation-chronogram">
+                  <ChronogramWrapper
+                    timetableId={timetableId}
+                    trainSchedulesWithDetails={trainSchedulesWithDetails}
+                    chronogramHeight={chronogramHeight}
+                  />
+                </div>
+              </BoardWrapper>
+            )}
           </div>
         </div>
+        {/* CONFLICTS */}
         <div
           className="right-column"
           data-testid="conflicts-list"

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -17,12 +17,12 @@ import InfraLoadingState from './InfraLoadingState';
 
 const BOARDS: Board[] = [
   'trains',
+  'std',
+  'tables',
+  'sdd',
   'map',
   'macro',
-  'std',
-  'sdd',
   'chronogram',
-  'tables',
   'conflicts',
 ];
 
@@ -147,7 +147,9 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
                     toggleBoard(board);
                   }}
                   title={
-                    board === 'sdd' || board === 'std' ? t(`boardFullNames.${board}`) : undefined
+                    board === 'sdd' || board === 'std' || board === 'chronogram'
+                      ? t(`boardFullNames.${board}`)
+                      : undefined
                   }
                 >
                   {t(`boards.${board}`)}

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -10,7 +10,6 @@ import useSimulationResults from 'applications/operationalStudies/hooks/useSimul
 import type { Board } from 'applications/operationalStudies/types';
 import { type Conflict, type TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 import SimulationWarpedMap from 'common/Map/WarpedMap/SimulationWarpedMap';
-import ChronogramWrapper from 'modules/simulationResult/components/Chronogram/ChronogramWrapper';
 import createHandleTrainDrag from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag';
 import SpaceTimeChartWrapper, {
   MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT,
@@ -42,11 +41,10 @@ import BoardWrapper from '../BoardWrapper';
 import SimulationResultsExport from './SimulationResultsExport';
 import SimulationResultsMap from './SimulationResultsMap';
 
+// TODO: SimulationResults should be dropped and boards embedded directly inside ScenarioContent (see comments in #17091)
 export const HIDDEN_CHART_TOP_HEIGHT = 23;
 const SDD_INITIAL_HEIGHT = 460;
 const SDD_MIN_HEIGHT = 400;
-const CHRONOGRAM_INITIAL_HEIGHT = 492;
-const CHRONOGRAM_MIN_HEIGHT = 398;
 
 type SimulationResultsProps = {
   scenarioData: { name: string; infraName: string };
@@ -108,8 +106,6 @@ const SimulationResults = ({
     : undefined;
 
   const [SDDHeight, setSDDHeight] = useState(SDD_INITIAL_HEIGHT);
-
-  const [chronogramHeight, setChronogramHeight] = useState(CHRONOGRAM_INITIAL_HEIGHT);
 
   const [mapCanvas, setMapCanvas] = useState<string>();
 
@@ -303,6 +299,73 @@ const SimulationResults = ({
         </BoardWrapper>
       )}
 
+      {/* TIME STOPS TABLE */}
+      {simulationResults && (
+        <BoardWrapper
+          ref={timeStopsTableRef}
+          hidden={!activeBoards.has('tables')}
+          name={simulationResults.train.train_name}
+          items={[
+            {
+              title: displayOnlyPathSteps
+                ? t('simulationResults.displayWaypoints')
+                : t('simulationResults.hideWaypoints'),
+              icon: <Eye />,
+              onClick: () => {
+                dispatch(toggleDisplayOnlyPathSteps());
+              },
+            },
+          ]}
+          customHeader={
+            <TrainHeader
+              train={simulationResults.train}
+              trainSchedulesWithDetails={trainSchedulesWithDetails}
+              upsertTrainSchedules={upsertTrainSchedules}
+              setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
+              setTrainScheduleToEditData={setTrainScheduleToEditData}
+            />
+          }
+          customFooter={
+            simulationResults?.isValid && (
+              <div className="time-stop-outputs">
+                {/* SIMULATION EXPORT BUTTONS */}
+                <SimulationResultsExport
+                  path={simulationResults.path}
+                  scenarioData={scenarioData}
+                  train={simulationResults.train}
+                  simulation={simulationResults.simulation}
+                  pathProperties={simulationResults.pathProperties}
+                  rollingStock={simulationResults.rollingStock}
+                  mapCanvas={mapCanvas}
+                />
+              </div>
+            )
+          }
+          footerClass={'times-stops-table-footer'}
+          withFooter
+        >
+          <div data-testid="time-stop-outputs" className="time-stop-outputs">
+            <TimeStopsTableWrapper
+              infraId={infraId}
+              selectedTrain={simulationResults?.train}
+              trainSchedulesWithDetails={trainSchedulesWithDetails}
+              upsertTrainSchedules={upsertTrainSchedules}
+              isSimulationDataLoading={isSimulationDataLoading}
+              operationalPointsOnPath={simulationResults.pathProperties?.operationalPoints}
+              voltages={simulationResults.pathProperties?.voltages}
+              rollingStock={simulationResults.rollingStock}
+              {...(simulationResults?.isValid &&
+                simulationSummary?.isValid && {
+                  isValid: true,
+                  simulatedTrain: simulationResults.simulation.final_output,
+                  simulatedPathItemTimes: simulationSummary.pathItemTimes,
+                  simulatedPathItemRespect: simulationSummary.pathItemRespect,
+                })}
+            />
+          </div>
+        </BoardWrapper>
+      )}
+
       {/* SIMULATION : SPEED SPACE CHART */}
       {activeBoards.has('sdd') && (
         <BoardWrapper
@@ -342,97 +405,6 @@ const SimulationResults = ({
           />
         </div>
       </BoardWrapper>
-
-      {simulationResults && (
-        <>
-          {/* CHRONOGRAMME */}
-          {trainSchedulesWithDetails.length > 0 && (
-            <BoardWrapper
-              hidden={!activeBoards.has('chronogram')}
-              name={t('boards.chronogram')}
-              resizable={{
-                height: chronogramHeight,
-                setHeight: setChronogramHeight,
-                minHeight: CHRONOGRAM_MIN_HEIGHT,
-              }}
-              withFooter
-            >
-              <div data-testid="chronogram" className="simulation-chronogram">
-                <ChronogramWrapper
-                  timetableId={timetableId}
-                  trainSchedulesWithDetails={trainSchedulesWithDetails}
-                  chronogramHeight={chronogramHeight}
-                />
-              </div>
-            </BoardWrapper>
-          )}
-
-          {/* TIME STOPS TABLE */}
-          <BoardWrapper
-            ref={timeStopsTableRef}
-            hidden={!activeBoards.has('tables')}
-            name={simulationResults.train.train_name}
-            items={[
-              {
-                title: displayOnlyPathSteps
-                  ? t('simulationResults.displayWaypoints')
-                  : t('simulationResults.hideWaypoints'),
-                icon: <Eye />,
-                onClick: () => {
-                  dispatch(toggleDisplayOnlyPathSteps());
-                },
-              },
-            ]}
-            customHeader={
-              <TrainHeader
-                train={simulationResults.train}
-                trainSchedulesWithDetails={trainSchedulesWithDetails}
-                upsertTrainSchedules={upsertTrainSchedules}
-                setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
-                setTrainScheduleToEditData={setTrainScheduleToEditData}
-              />
-            }
-            customFooter={
-              simulationResults?.isValid && (
-                <div className="time-stop-outputs">
-                  {/* SIMULATION EXPORT BUTTONS */}
-                  <SimulationResultsExport
-                    path={simulationResults.path}
-                    scenarioData={scenarioData}
-                    train={simulationResults.train}
-                    simulation={simulationResults.simulation}
-                    pathProperties={simulationResults.pathProperties}
-                    rollingStock={simulationResults.rollingStock}
-                    mapCanvas={mapCanvas}
-                  />
-                </div>
-              )
-            }
-            footerClass={'times-stops-table-footer'}
-            withFooter
-          >
-            <div data-testid="time-stop-outputs" className="time-stop-outputs">
-              <TimeStopsTableWrapper
-                infraId={infraId}
-                selectedTrain={simulationResults?.train}
-                trainSchedulesWithDetails={trainSchedulesWithDetails}
-                upsertTrainSchedules={upsertTrainSchedules}
-                isSimulationDataLoading={isSimulationDataLoading}
-                operationalPointsOnPath={simulationResults.pathProperties?.operationalPoints}
-                voltages={simulationResults.pathProperties?.voltages}
-                rollingStock={simulationResults.rollingStock}
-                {...(simulationResults?.isValid &&
-                  simulationSummary?.isValid && {
-                    isValid: true,
-                    simulatedTrain: simulationResults.simulation.final_output,
-                    simulatedPathItemTimes: simulationSummary.pathItemTimes,
-                    simulatedPathItemRespect: simulationSummary.pathItemRespect,
-                  })}
-              />
-            </div>
-          </BoardWrapper>
-        </>
-      )}
     </div>
   );
 };

--- a/front/tests/pages/operational-studies/simulation-results-page.ts
+++ b/front/tests/pages/operational-studies/simulation-results-page.ts
@@ -17,7 +17,6 @@ class OpSimulationResultPage extends ScenarioPage {
   private readonly timeStopsOutputs: Locator;
   private readonly macroEditor: Locator;
   private readonly conflictsList: Locator;
-  private readonly chronogram: Locator;
   private readonly noDataSpan: Locator;
 
   constructor(page: Page) {
@@ -36,7 +35,6 @@ class OpSimulationResultPage extends ScenarioPage {
     this.simulationMap = page.getByTestId('simulation-map');
     this.timeStopsOutputs = page.getByTestId('time-stop-outputs');
     this.macroEditor = page.getByTestId('macro-editor');
-    this.chronogram = page.getByTestId('chronogram');
     this.noDataSpan = page.getByTestId('no-data-sdd');
   }
 
@@ -55,7 +53,6 @@ class OpSimulationResultPage extends ScenarioPage {
       expect(this.spaceTimeChart).toBeVisible(),
       expect(this.simulationMap).toBeVisible(),
       expect(this.timesStopsDataSheet).toBeVisible(),
-      expect(this.chronogram).toBeVisible(),
     ]);
   }
 
@@ -67,7 +64,6 @@ class OpSimulationResultPage extends ScenarioPage {
       expect(this.speedSpaceChart).toBeVisible(),
       expect(this.noDataSpan).toBeVisible(),
       expect(this.simulationMap).toBeVisible(),
-      expect(this.chronogram).toBeVisible(),
     ]);
   }
 
@@ -106,10 +102,6 @@ class OpSimulationResultPage extends ScenarioPage {
     await toggleByState(this.sddButton, this.speedSpaceChart, isVisible);
   }
 
-  async setChronogramVisible(isVisible = true) {
-    await toggleByState(this.chronogramButton, this.chronogram, isVisible);
-  }
-
   async setMapVisible(isVisible = true) {
     await toggleByState(this.simulationMapButton, this.simulationMap, isVisible);
   }
@@ -127,7 +119,6 @@ class OpSimulationResultPage extends ScenarioPage {
     await this.setMapVisible();
     await this.setSddVisible();
     await this.setTableOutputVisible();
-    await this.setChronogramVisible();
     await this.setMacroVisible();
     await this.waitForLoaderToDisappear({ timeout: 15_000 });
   }
@@ -136,7 +127,6 @@ class OpSimulationResultPage extends ScenarioPage {
     await this.setStdVisible();
     await this.setMapVisible();
     await this.setSddVisible();
-    await this.setChronogramVisible();
     await this.setTrainListVisible();
   }
 }


### PR DESCRIPTION
- Rename the "Chronogramme" board to "PNs"/ "Crossings"
- Rename the "Macro" board to "Réticulaire"/"Network Graph"
- Reorder header buttons: Trains, GET, Tableaux, GEV, Carte, Réticulaire, PNs, Conflits
- Reorder central column boards: GET, Tableau, GEV, Carte, Réticulaire, PNs
- PNs board is now disabled by default

> [!NOTE]
> The central column order requires Network Graph before chronogram. Network Graph (macro/NGE) was already rendered in `ScenarioContent`, after `SimulationResults`. Chronogram was rendered inside `SimulationResults`. To get the right order, the chronogram was moved out of `SimulationResults` into `ScenarioContent`, after the macro block.

close : https://github.com/osrd-project/osrd-confidential/issues/1608

