### PR TITLE
editoast, front: add geographical position in `path_properties` endpoint response

### DIFF
--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -1,3 +1,4 @@
+use common::geometry::GeoJsonPoint;
 use geos::geojson::Geometry;
 use schemas::infra::OperationalPointExtensions;
 use schemas::infra::OperationalPointPart;
@@ -33,7 +34,7 @@ pub struct PathPropertiesResponse {
     /// Geometry of the path
     pub geometry: Geometry,
     /// Operational points along the path
-    pub operational_points: Vec<OperationalPointOnPath>,
+    pub operational_points: Vec<OperationalPointOnPathInfo>,
     /// Zones along the path
     pub zones: PropertyZoneValues,
 }
@@ -90,11 +91,18 @@ pub enum PropertyElectrificationValue {
     NonElectrified,
 }
 
-/// Operational point along a path.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[schema(as = CoreOperationalPointOnPath)]
-#[derive(PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 pub struct OperationalPointOnPath {
+    #[serde(flatten)]
+    pub info: OperationalPointOnPathInfo,
+    #[schema(value_type = Option<GeoJsonPoint>)]
+    pub geo: Option<geos::geojson::Geometry>,
+}
+
+/// Operational point along a path.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+#[schema(as = CoreOperationalPointOnPath)]
+pub struct OperationalPointOnPathInfo {
     /// Id of the operational point
     #[schema(inline)]
     pub id: Identifier,
@@ -110,9 +118,9 @@ pub struct OperationalPointOnPath {
     pub weight: Option<u8>,
 }
 
-impl OperationalPointOnPath {
+impl OperationalPointOnPathInfo {
     pub fn new_test(id: &str, ci: i64, trigram: &str) -> Self {
-        OperationalPointOnPath {
+        OperationalPointOnPathInfo {
             id: Identifier(id.into()),
             part: OperationalPointPart {
                 track: Identifier("T1".to_string()),

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11604,6 +11604,15 @@ components:
           format: int32
           minimum: 0
       additionalProperties: false
+    OperationalPointOnPath:
+      allOf:
+      - $ref: '#/components/schemas/CoreOperationalPointOnPath'
+      - type: object
+        properties:
+          geo:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/GeoJsonPoint'
     OperationalPointPart:
       type: object
       required:
@@ -12106,7 +12115,7 @@ components:
         operational_points:
           type: array
           items:
-            $ref: '#/components/schemas/CoreOperationalPointOnPath'
+            $ref: '#/components/schemas/OperationalPointOnPath'
           description: Operational points along the path
         slopes:
           oneOf:

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -742,7 +742,7 @@ pub(in crate::views) async fn match_operational_points(
     }))
 }
 
-fn compute_operational_point_geo(
+pub fn compute_operational_point_geo(
     points: &[geos::geojson::Geometry],
 ) -> Option<geos::geojson::Geometry> {
     if points.is_empty() {

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -12,11 +12,13 @@ use axum::extract::Path;
 use axum::extract::State;
 use common::geometry::GeoJsonLineString;
 use core_client::path_properties::OperationalPointOnPath;
+use core_client::path_properties::OperationalPointOnPathInfo;
 use core_client::path_properties::PathPropertiesRequest;
 use core_client::path_properties::PropertyElectrificationValues;
 use core_client::path_properties::PropertyValuesF64;
 use core_client::path_properties::PropertyZoneValues;
 use core_client::pathfinding::TrackRange;
+use database::DbConnection;
 use geos::geojson::Geometry;
 use serde::Deserialize;
 use serde::Serialize;
@@ -26,7 +28,9 @@ use utoipa::ToSchema;
 
 use crate::AppState;
 use crate::error::Result;
+use crate::generated_data::operational_point::OperationalPointLayer;
 use crate::views::AuthenticationExt;
+use crate::views::infra::compute_operational_point_geo;
 use crate::views::path::retrieve_infra_version;
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Hash)]
@@ -57,17 +61,32 @@ pub(in crate::views) struct PathProperties {
     zones: PropertyZoneValues,
 }
 
-impl From<core_client::path_properties::PathPropertiesResponse> for PathProperties {
-    fn from(response: core_client::path_properties::PathPropertiesResponse) -> Self {
-        PathProperties {
-            slopes: response.slopes,
-            curves: response.curves,
-            electrifications: response.electrifications,
-            geometry: response.geometry,
-            operational_points: response.operational_points,
-            zones: response.zones,
-        }
+fn build_operational_point_on_path(
+    opop_info: &OperationalPointOnPathInfo,
+    geo_points: Option<&Vec<Geometry>>,
+) -> OperationalPointOnPath {
+    OperationalPointOnPath {
+        info: opop_info.clone(),
+        geo: geo_points.and_then(|points| compute_operational_point_geo(points)),
     }
+}
+
+/// Add geographical position to `OperationalPointOnPathInfo`
+async fn populate_opop_geo(
+    conn: &mut DbConnection,
+    infra_id: i64,
+    operational_points_on_path: &[OperationalPointOnPathInfo],
+) -> Result<Vec<OperationalPointOnPath>> {
+    let opop_ids: Vec<_> = operational_points_on_path
+        .iter()
+        .map(|opop_info| opop_info.id.as_str())
+        .collect();
+    let geo_points = OperationalPointLayer::get(conn, infra_id, &opop_ids).await?;
+
+    Ok(operational_points_on_path
+        .iter()
+        .map(|opop| build_operational_point_on_path(opop, geo_points.get(opop.id.as_str())))
+        .collect())
 }
 
 /// Compute path properties
@@ -116,14 +135,26 @@ pub(in crate::views) async fn post(
     .run(Arc::new(tokio::sync::Mutex::new(vkconn)), core_client)
     .await?;
 
-    Ok(Json(PathProperties::from(path_properties)))
+    Ok(Json(PathProperties {
+        slopes: path_properties.slopes,
+        curves: path_properties.curves,
+        electrifications: path_properties.electrifications,
+        geometry: path_properties.geometry,
+        operational_points: populate_opop_geo(
+            conn,
+            infra_id,
+            path_properties.operational_points.as_slice(),
+        )
+        .await?,
+        zones: path_properties.zones,
+    }))
 }
 
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
     use core_client::mocking::MockingClient;
-    use core_client::path_properties::OperationalPointOnPath;
+    use core_client::path_properties::OperationalPointOnPathInfo;
     use core_client::path_properties::PropertyElectrificationValue;
     use core_client::path_properties::PropertyElectrificationValues;
     use core_client::path_properties::PropertyValuesF64;
@@ -148,7 +179,7 @@ mod tests {
             geometry: geos::geojson::Geometry::new(geos::geojson::Value::LineString(vec![vec![
                 0.0, 0.0,
             ]])),
-            operational_points: vec![OperationalPointOnPath::new_test("1", 0, "1")],
+            operational_points: vec![OperationalPointOnPathInfo::new_test("1", 0, "1")],
             zones: PropertyZoneValues::new(vec![0, 1], vec!["Zone 1".into()]),
         }
     }
@@ -187,8 +218,13 @@ mod tests {
             path_properties_response.electrifications
         );
         assert_eq!(response.geometry, path_properties_response.geometry);
+        let operational_points_info: Vec<_> = response
+            .operational_points
+            .iter()
+            .map(|op| op.info.clone())
+            .collect();
         assert_eq!(
-            response.operational_points,
+            operational_points_info,
             path_properties_response.operational_points
         );
     }
@@ -216,8 +252,13 @@ mod tests {
             path_properties_response.electrifications
         );
         assert_eq!(response.geometry, path_properties_response.geometry);
+        let operational_points_info: Vec<_> = response
+            .operational_points
+            .iter()
+            .map(|op| op.info.clone())
+            .collect();
         assert_eq!(
-            response.operational_points,
+            operational_points_info,
             path_properties_response.operational_points
         );
     }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3564,6 +3564,9 @@ export type CoreOperationalPointOnPath = {
   /** Importance of the operational point */
   weight: number | null;
 };
+export type OperationalPointOnPath = CoreOperationalPointOnPath & {
+  geo?: null | GeoJsonPoint;
+};
 export type PathProperties = {
   /** Curves along the path */
   curves: {
@@ -3596,7 +3599,7 @@ export type PathProperties = {
   /** Geometry of the path */
   geometry: GeoJsonLineString;
   /** Operational points along the path */
-  operational_points: CoreOperationalPointOnPath[];
+  operational_points: OperationalPointOnPath[];
   /** Slopes along the path */
   slopes: {
     /** List of `n` boundaries of the ranges.


### PR DESCRIPTION
## Context

Ref: [#15437]

## Goal

Add a field `geo?: null | GeoJsonPoint` in the `path_properties` endpoint response.

## Criteria of acceptance

Behavior of `path_properties` endpoint does not change