### PR TITLE
front: add simple selectors fields to header

### DIFF
--- a/front/src/modules/rollingStock/hooks/useCategoryOptions.ts
+++ b/front/src/modules/rollingStock/hooks/useCategoryOptions.ts
@@ -1,9 +1,18 @@
 import { useTranslation } from 'react-i18next';
 
+import type { TrainCategory } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import { TrainMainCategoryDict } from 'modules/rollingStock/consts';
 
 import type { CategoryOptionWithId } from '../types';
+
+export function categoryOptionId(category: TrainCategory): string {
+  if ('main_category' in category) {
+    return `main:${category.main_category}`;
+  } else {
+    return `sub:${category.sub_category_code}`;
+  }
+}
 
 /**
  * Custom hook to generate category options for a dropdown or selection component.
@@ -20,7 +29,7 @@ export default function useCategoryOptions(withPlaceholder = true) {
   const validMainCategories = Array.from(Object.values(TrainMainCategoryDict));
 
   const mainCategoryOptions: CategoryOptionWithId[] = validMainCategories.map((mainCategory) => ({
-    id: `main:${mainCategory}`,
+    id: categoryOptionId({ main_category: mainCategory }),
     label: t(`rollingStock.categoriesOptions.${mainCategory}`),
     category: { main_category: mainCategory },
   }));
@@ -29,7 +38,7 @@ export default function useCategoryOptions(withPlaceholder = true) {
     const matchedSubCategories = subCategories.filter((sub) => sub.main_category === mainCategory);
 
     return matchedSubCategories.map((sub) => ({
-      id: `sub:${sub.code}`,
+      id: categoryOptionId({ sub_category_code: sub.code }),
       label: sub.name,
       category: { sub_category_code: sub.code },
       color: sub.color,

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -5,8 +5,12 @@ import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
+import type { TrainCategory } from 'common/api/osrdEditoastApi';
 import type { Comfort, ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
+import useCategoryOptions, {
+  categoryOptionId,
+} from 'modules/rollingStock/hooks/useCategoryOptions';
 import type { Train } from 'reducers/osrdconf/types';
 import { useDateTimeLocale } from 'utils/date';
 import { usePrevious } from 'utils/hooks/state';
@@ -15,7 +19,6 @@ import { isOccurrenceId } from 'utils/trainId';
 import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 import {
-  getCategoryName,
   getServiceInterval,
   getServiceWindow,
   getShortDepartureDate,
@@ -33,6 +36,7 @@ type TrainFieldsState = {
   speed_limit_tag: string | null;
   constraint_distribution: ConstraintDistribution;
   comfort: Comfort | null;
+  category: TrainCategory | null;
 };
 
 function getFieldsFromTrain(train: Train): TrainFieldsState {
@@ -41,11 +45,17 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     speed_limit_tag: train.speed_limit_tag ?? null,
     constraint_distribution: train.constraint_distribution,
     comfort: train.comfort ?? null,
+    category: train.category ?? null,
   };
 }
 
 function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
-  return { ...train, ...fields, comfort: fields.comfort === null ? undefined : fields.comfort };
+  return {
+    ...train,
+    ...fields,
+    comfort: fields.comfort === null ? undefined : fields.comfort,
+    category: fields.category === null ? undefined : fields.category,
+  };
 }
 
 function registerChange<K extends keyof TrainFieldsState>(
@@ -86,6 +96,7 @@ const ExpandedTrainForm = ({
   const { t } = useTranslation(['operational-studies', 'translation']);
   const dateTimeLocale = useDateTimeLocale();
   const speedLimitTags = useSpeedLimitTags();
+  const categoryOptions = useCategoryOptions();
 
   const pacedTrain = train.paced ? (train as PacedTrainWithPaced) : null;
   const occurenceId = isOccurrenceId(train.id) ? train.id : null;
@@ -177,6 +188,15 @@ const ExpandedTrainForm = ({
     [fields.comfort]
   );
 
+  const selectedCategoryId = useMemo(
+    () => (fields.category ? categoryOptionId(fields.category) : null),
+    [fields.category]
+  );
+  const selectedCategoryOption = useMemo(
+    () => categoryOptions.find((category) => category.id === selectedCategoryId),
+    [selectedCategoryId]
+  );
+
   const toggleBand = (
     <div className="toggle-band">
       <button className="header-toggle" onClick={() => onCollapse()}>
@@ -266,12 +286,17 @@ const ExpandedTrainForm = ({
           />
         </div>
         <div className="train-category">
-          <Input
-            id="train-header-category-input"
-            small
+          <Select
+            id="train-header-category-select"
             label={t('manageTrainSchedule.trainHeader.form.trainCategory')}
-            value={getCategoryName(train, t) ?? ''}
-            disabled
+            small
+            value={selectedCategoryOption}
+            options={categoryOptions}
+            getOptionLabel={(option) => option?.label ?? ''}
+            getOptionValue={(option) => option?.id ?? ''}
+            onChange={(value) => {
+              onFieldImmediateChange('category', value?.category ?? null);
+            }}
           />
         </div>
         <div className="train-rolling-stock">

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -40,18 +40,27 @@ function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
   return { ...train, ...fields };
 }
 
+function registerChange<K extends keyof TrainFieldsState>(
+  changedValues: Partial<TrainFieldsState>,
+  changedKey: K,
+  newValue: TrainFieldsState[K]
+) {
+  changedValues[changedKey] = newValue;
+}
+
 function extractChangesInFields(
   before: TrainFieldsState,
   after: TrainFieldsState,
   current?: TrainFieldsState
 ): Partial<TrainFieldsState> {
   const changedValues: Partial<TrainFieldsState> = {};
+
   for (const fieldName of Object.keys(before) as (keyof TrainFieldsState)[]) {
     if (
       after[fieldName] !== before[fieldName] &&
       (!current || after[fieldName] !== current[fieldName])
     ) {
-      changedValues[fieldName] = after[fieldName];
+      registerChange(changedValues, fieldName, after[fieldName]);
     }
   }
   return changedValues;

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -5,13 +5,14 @@ import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
+import type { ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import type { Train } from 'reducers/osrdconf/types';
 import { useDateTimeLocale } from 'utils/date';
 import { usePrevious } from 'utils/hooks/state';
 import { findExceptionInPacedTrainByOccurenceId } from 'utils/trainExceptions';
 import { isOccurrenceId } from 'utils/trainId';
-import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
+import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 import {
   getCategoryName,
@@ -31,12 +32,14 @@ export type ExpandedTrainFormProps = {
 type TrainFieldsState = {
   train_name: string;
   speed_limit_tag: string | null;
+  constraint_distribution: ConstraintDistribution;
 };
 
 function getFieldsFromTrain(train: Train): TrainFieldsState {
   return {
     train_name: train.train_name,
     speed_limit_tag: train.speed_limit_tag ?? null,
+    constraint_distribution: train.constraint_distribution,
   };
 }
 
@@ -134,6 +137,24 @@ const ExpandedTrainForm = ({
       setFields(newFields);
     },
     [fields]
+  );
+
+  const constraintDistributionsOptions: { id: ConstraintDistribution; label: string }[] = [
+    {
+      id: 'STANDARD',
+      label: t('manageTrainSchedule.allowances.distribution-linear'),
+    },
+    {
+      id: 'MARECO',
+      label: t('manageTrainSchedule.allowances.distribution-mareco'),
+    },
+  ];
+  const selectedConstraintDistributionOption = useMemo(
+    () =>
+      constraintDistributionsOptions.find(
+        (constraint) => constraint.id === fields.constraint_distribution
+      ),
+    [fields.constraint_distribution]
   );
 
   const toggleBand = (
@@ -256,16 +277,17 @@ const ExpandedTrainForm = ({
           />
         </div>
         <div className="train-recovery-margin">
-          <Input
-            id="train-header-recovery-margin-input"
-            small
+          <Select
+            id="train-header-recovery-margin-select"
             label={t('manageTrainSchedule.trainHeader.form.recoveryMargin')}
-            value={
-              train.constraint_distribution === 'MARECO'
-                ? t('manageTrainSchedule.allowances.distribution-mareco')
-                : t('manageTrainSchedule.allowances.distribution-linear')
-            }
-            disabled
+            small
+            value={selectedConstraintDistributionOption}
+            {...createFixedSelectOptions(constraintDistributionsOptions)}
+            onChange={(value) => {
+              if (value) {
+                onFieldImmediateChange('constraint_distribution', value.id);
+              }
+            }}
           />
         </div>
         <div className="train-comfort">

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -5,7 +5,7 @@ import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
-import type { ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
+import type { Comfort, ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import type { Train } from 'reducers/osrdconf/types';
 import { useDateTimeLocale } from 'utils/date';
@@ -16,7 +16,6 @@ import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiC
 
 import {
   getCategoryName,
-  getComfortType,
   getServiceInterval,
   getServiceWindow,
   getShortDepartureDate,
@@ -33,6 +32,7 @@ type TrainFieldsState = {
   train_name: string;
   speed_limit_tag: string | null;
   constraint_distribution: ConstraintDistribution;
+  comfort: Comfort | null;
 };
 
 function getFieldsFromTrain(train: Train): TrainFieldsState {
@@ -40,11 +40,12 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     train_name: train.train_name,
     speed_limit_tag: train.speed_limit_tag ?? null,
     constraint_distribution: train.constraint_distribution,
+    comfort: train.comfort ?? null,
   };
 }
 
 function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
-  return { ...train, ...fields };
+  return { ...train, ...fields, comfort: fields.comfort === null ? undefined : fields.comfort };
 }
 
 function registerChange<K extends keyof TrainFieldsState>(
@@ -155,6 +156,25 @@ const ExpandedTrainForm = ({
         (constraint) => constraint.id === fields.constraint_distribution
       ),
     [fields.constraint_distribution]
+  );
+
+  const comfortOptions: { id: Comfort; label: string }[] = [
+    {
+      id: 'STANDARD',
+      label: t('translation:rollingStock.comfortTypes.STANDARD'),
+    },
+    {
+      id: 'AIR_CONDITIONING',
+      label: t('translation:rollingStock.comfortTypes.AIR_CONDITIONING'),
+    },
+    {
+      id: 'HEATING',
+      label: t('translation:rollingStock.comfortTypes.HEATING'),
+    },
+  ];
+  const selectedComfortOption = useMemo(
+    () => comfortOptions.find((comfort) => comfort.id === fields.comfort),
+    [fields.comfort]
   );
 
   const toggleBand = (
@@ -291,12 +311,15 @@ const ExpandedTrainForm = ({
           />
         </div>
         <div className="train-comfort">
-          <Input
-            id="train-header-comfort-input"
-            small
+          <Select
+            id="train-header-comfort-select"
             label={t('manageTrainSchedule.trainHeader.form.comfort')}
-            value={getComfortType(train, t) ?? ''}
-            disabled
+            small
+            value={selectedComfortOption}
+            {...createFixedSelectOptions(comfortOptions)}
+            onChange={(value) => {
+              onFieldImmediateChange('comfort', value?.id ?? null);
+            }}
           />
         </div>
         <div className="train-electric-profile loose-field">

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -1,15 +1,17 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { Button, Checkbox, Input } from '@osrd-project/ui-core';
+import { Button, Checkbox, Input, Select } from '@osrd-project/ui-core';
 import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
+import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import type { Train } from 'reducers/osrdconf/types';
 import { useDateTimeLocale } from 'utils/date';
 import { usePrevious } from 'utils/hooks/state';
 import { findExceptionInPacedTrainByOccurenceId } from 'utils/trainExceptions';
 import { isOccurrenceId } from 'utils/trainId';
+import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 import {
   getCategoryName,
@@ -28,11 +30,13 @@ export type ExpandedTrainFormProps = {
 
 type TrainFieldsState = {
   train_name: string;
+  speed_limit_tag: string | null;
 };
 
 function getFieldsFromTrain(train: Train): TrainFieldsState {
   return {
     train_name: train.train_name,
+    speed_limit_tag: train.speed_limit_tag ?? null,
   };
 }
 
@@ -77,6 +81,7 @@ const ExpandedTrainForm = ({
 }: ExpandedTrainFormProps) => {
   const { t } = useTranslation(['operational-studies', 'translation']);
   const dateTimeLocale = useDateTimeLocale();
+  const speedLimitTags = useSpeedLimitTags();
 
   const pacedTrain = train.paced ? (train as PacedTrainWithPaced) : null;
   const occurenceId = isOccurrenceId(train.id) ? train.id : null;
@@ -109,13 +114,24 @@ const ExpandedTrainForm = ({
   );
 
   const onFieldBlur = useCallback(
-    async (_fieldName: keyof TrainFieldsState) => {
+    (_fieldName: keyof TrainFieldsState) => {
       const changes = extractChangesInFields(fieldsFromTrain, fields);
 
       if (Object.keys(changes).length) {
         const updatedTrain = applyFieldsToTrain(fields, train);
         onPersistTrain(updatedTrain);
       }
+    },
+    [fields, fieldsFromTrain]
+  );
+
+  const onFieldImmediateChange = useCallback(
+    (fieldName: keyof TrainFieldsState, newValue: TrainFieldsState[typeof fieldName]) => {
+      const newFields = { ...fields, [fieldName]: newValue };
+      const updatedTrain = applyFieldsToTrain(newFields, train);
+      onPersistTrain(updatedTrain);
+
+      setFields(newFields);
     },
     [fields]
   );
@@ -227,12 +243,16 @@ const ExpandedTrainForm = ({
           />
         </div>
         <div className="train-composition-code">
-          <Input
-            id="train-header-composition-code-input"
-            small
+          <Select
+            id="train-header-composition-code-select"
             label={t('manageTrainSchedule.trainHeader.form.compositionCode')}
-            value={train.speed_limit_tag ?? ''}
-            disabled
+            small
+            placeholder={t('manageTrainSchedule.noSpeedLimitByTag')}
+            value={fields.speed_limit_tag ?? ''}
+            {...createStandardSelectOptions(speedLimitTags)}
+            onChange={(value) => {
+              onFieldImmediateChange('speed_limit_tag', value ?? null);
+            }}
           />
         </div>
         <div className="train-recovery-margin">

--- a/front/src/utils/uiCoreHelpers.ts
+++ b/front/src/utils/uiCoreHelpers.ts
@@ -1,9 +1,9 @@
 // TODO: Remove undefined when osrd-ui's value type is optional
-type SelectFixedOption =
-  | {
+type SelectFixedOption<T> =
+  | (T & {
       label: string;
       id: string;
-    }
+    })
   | undefined;
 
 // Utility to create standardized options for <Select> components.
@@ -17,8 +17,8 @@ export const createStandardSelectOptions = <T>(opts: T[]) => ({
 
 // Utility function for handling fixed label-value object arrays
 // structure may vary, and custom label/value mappings are needed.
-export const createFixedSelectOptions = (opts: SelectFixedOption[]) => ({
+export const createFixedSelectOptions = <T>(opts: SelectFixedOption<T>[]) => ({
   options: opts,
-  getOptionLabel: (option: SelectFixedOption) => option?.label ?? '',
-  getOptionValue: (option: SelectFixedOption) => option?.id ?? '',
+  getOptionLabel: (option: SelectFixedOption<T>) => option?.label ?? '',
+  getOptionValue: (option: SelectFixedOption<T>) => option?.id ?? '',
 });


### PR DESCRIPTION
Fixes #16529.

Contains in the first commit nearly the same code as in #17094; beside that, it's a very naive yet successful implementation of the speed limit tag (composition code), constraint distribution (recovery margin), comfort and train category selectors.

<img width="982" height="356" alt="image" src="https://github.com/user-attachments/assets/ac360cd6-6925-4632-870e-ce81dd602749" />
