### PR TITLE
editoast: fallback on buildid if git describe is not passed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
         test_data: tests/data
         static_assets: assets
       args:
-        OSRD_GIT_DESCRIBE: development
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
     environment:
       # Actual values in ./docker/osrdyne.yml (please maintain consistency)
       # Provided here only for reuse in compose layers and doc
@@ -174,7 +174,7 @@ services:
         static_assets: assets
       args:
         CARGO_PROFILE: dev
-        OSRD_GIT_DESCRIBE: development
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
     restart: unless-stopped
     ports: [ "8090:80" ]
     environment:
@@ -213,7 +213,7 @@ services:
       context: gateway
       dockerfile: Dockerfile
       args:
-        OSRD_GIT_DESCRIBE: development
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
         CARGO_PROFILE: dev
       additional_contexts:
         front_src: front
@@ -235,6 +235,7 @@ services:
       dockerfile: Dockerfile
       args:
         CARGO_PROFILE: dev
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
     restart: unless-stopped
     ports: [ "4242:4242" ]
     environment:

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -561,6 +561,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "buildid"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834a85d2478807f41c43251c7ad226e1185bc34feb2133872f796a11b57155ae"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1373,7 @@ dependencies = [
  "axum-streams",
  "axum-test",
  "axum-tracing-opentelemetry",
+ "buildid",
  "cache",
  "chrono",
  "clap",
@@ -5716,6 +5729,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5723,6 +5752,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -172,6 +172,7 @@ axum-streams = { version = "0.25.0", features = ["json"] }
 axum-tracing-opentelemetry = { version = "0.38.0", default-features = false, features = [
   "tracing_level_info",
 ] }
+buildid = "1.0.4"
 cache.workspace = true
 chrono.workspace = true
 clap.workspace = true

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -60,7 +60,7 @@ COPY --from=planner /editoast/recipe.json recipe.json
 COPY --from=planner /editoast/editoast_derive/ editoast_derive
 COPY --from=test_data . /tests/data
 COPY --from=openfga/cli:v0.6.5 /fga /usr/local/bin/fga
-ENV RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=mold"
+ENV RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=mold -C link-args=-Wl,--build-id"
 ENV RUSTDOCFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=mold"
 ENV LLVM_PROFILE_FILE="editoast-%p-%m.profraw"
 RUN cargo chef cook --tests --recipe-path recipe.json

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -129,7 +129,10 @@ async fn run() -> anyhow::Result<()> {
         Color::Auto => colored::control::set_override(std::io::stderr().is_terminal()),
     }
 
-    let app_version = client.app_version;
+    let app_version = client
+        .app_version
+        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+        .or_else(|| buildid::build_id().map(to_hex_string));
 
     match client.command {
         Commands::Runserver(args) => {
@@ -230,4 +233,16 @@ async fn run() -> anyhow::Result<()> {
             garbage_collector::run_garbage_collector(db_pool.into(), openfga_config).await
         }
     }
+}
+
+fn to_hex_string(bytes: &[u8]) -> String {
+    // From https://github.com/rust-lang-deprecated/rustc-serialize/blob/f15f3b520017996041efc075556c860a68a7bf52/src/hex.rs#L43
+    static CHARS: &[u8] = b"0123456789abcdef";
+
+    let mut v = Vec::with_capacity(bytes.len() * 2);
+    for &byte in bytes.iter() {
+        v.push(CHARS[(byte >> 4) as usize]);
+        v.push(CHARS[(byte & 0xf) as usize]);
+    }
+    String::from_utf8(v).expect("hex string is valid UTF-8")
 }


### PR DESCRIPTION
Editoast depends on having access to the current version through OSRD_GIT_DESCRIBE to do eg. valkey cache invalidation. This works well in production as the CI set it appropriately when building the images, but during local development this has to be set manually (or the caches need to be dropped manually).

Closes #10839.