### PR TITLE
front: remove the residual line displayed in the TOD

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -139,9 +139,13 @@ const useLazyProjectTrains = ({
       // This is necessary to keep the reference up-to-date for future projections
       // and to ensure that the projected trains are correctly updated
       // when the projection type changes
-      const trainSchedule = trainSchedulesByIdRef.current.get(id);
+      let trainSchedule = trainSchedulesByIdRef.current.get(id);
       if (trainSchedule) {
-        trainSchedule.start_time = newDeparture.getTime();
+        trainSchedule = {
+          ...trainSchedule,
+          start_time: newDeparture.getTime(),
+        };
+        trainSchedulesByIdRef.current.set(id, trainSchedule);
       }
     },
     []

--- a/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -158,10 +158,18 @@ export const PathLayer = ({
               prevTime +
               ((breakPosition - prevPosition) / (position - prevPosition)) * (time - prevTime);
 
-            currentLine.push({
+            const breakPoint = {
               [timeAxis]: getTimePixel(breakTime),
               [spaceAxis]: getSpacePixel(breakPosition, readSpacePixelFromEnd),
-            } as Point);
+            } as Point;
+
+            if (isBeforeFlatStep) {
+              lines.push(currentLine);
+              currentLine = [breakPoint];
+            } else {
+              currentLine.push(breakPoint);
+            }
+
             previousBreakPosition = breakPosition;
           });
 


### PR DESCRIPTION
This PR removes the residual line visible in TOD path rendering :arrow_down: 


<img width="521" height="452" alt="image" src="https://github.com/user-attachments/assets/4625c79a-010d-4bf9-be32-fb50a634b156" />
