### PR TITLE
front: add intermediate waypoints from the panel

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -427,6 +427,7 @@
       "focusLocationOnMap": "Focus the map on this operational point",
       "frameAll": "Center on all path steps on map",
       "intermediateWaypointsPanel": {
+        "addWaypoint": "Add to itinerary",
         "collapseGroup": "Collapse intermediate points",
         "expandGroup": "Expand intermediate points",
         "hide": "Hide",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -427,6 +427,7 @@
       "focusLocationOnMap": "Centrer la carte sur ce point remarquable",
       "frameAll": "Centrer sur tous les points de passage sur la carte",
       "intermediateWaypointsPanel": {
+        "addWaypoint": "Ajouter à l'itinéraire",
         "collapseGroup": "Replier les points intermédiaires",
         "expandGroup": "Déplier les points intermédiaires",
         "hide": "Masquer",

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -176,6 +176,7 @@ export type CategoryColors = { base: string; strong: string; surface: string };
 export type ItineraryPathProperties = PathProperties & {
   length: number;
   incompatibleConstraints?: CoreIncompatibleConstraints;
+  pathItemPositions?: number[];
 };
 
 export type PathProjectionResultOperationalPoint = Omit<

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
@@ -3,9 +3,8 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ItineraryPathProperties } from 'applications/operationalStudies/types';
+import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
 import DotsLoader from 'common/DotsLoader';
-import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
-import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 import { groupOperationalPoints } from './utils';
@@ -16,6 +15,7 @@ type IntermediateWaypointsPanelProps = {
   pathProperties: ItineraryPathProperties | undefined;
   status: 'idle' | 'loading' | 'error' | 'success';
   onHide: () => void;
+  onAddWaypoint: (op: CoreOperationalPointOnPath, afterStepId: string) => void;
 };
 
 const IntermediateWaypointsPanel = ({
@@ -23,23 +23,37 @@ const IntermediateWaypointsPanel = ({
   pathProperties,
   status,
   onHide,
+  onAddWaypoint,
 }: IntermediateWaypointsPanelProps) => {
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTrainSchedule.itineraryModal.intermediateWaypointsPanel',
   });
 
-  const suggestedOps: SuggestedOP[] = useMemo(() => {
-    if (!pathProperties?.operational_points || !pathProperties.geometry) return [];
-    return formatSuggestedOperationalPoints(
-      pathProperties.operational_points,
-      pathProperties.geometry,
-      pathProperties.length
-    );
-  }, [pathProperties]);
+  // Name a requested step that matches no OP, mirroring the form's labels
+  // (PathStepItem). The last located step is the destination; the trailing
+  // placeholder has no location and is skipped.
+  const { t: tMain } = useTranslation('operational-studies', { keyPrefix: 'main' });
+  const lastLocatedStepId = pathSteps.filter((step) => step.location !== null).at(-1)?.id;
+  const getRequestedLabel = (step: PathStepV2) => {
+    const index = pathSteps.findIndex((s) => s.id === step.id);
+    if (index === 0) return tMain('requestedOrigin');
+    if (step.id === lastLocatedStepId) return tMain('requestedDestination');
+    return tMain('requestedPoint', { count: index + 1 });
+  };
+
+  // path_item_positions lines up with the located steps, in order. Pair them
+  // here so the grouping can look a step's position up by id.
+  const positionByStepId = useMemo(() => {
+    const locatedSteps = pathSteps.filter((step) => step.location !== null);
+    const positions = pathProperties?.pathItemPositions;
+    if (positions?.length !== locatedSteps.length) return undefined;
+    return new Map(locatedSteps.map((step, i) => [step.id, positions[i]]));
+  }, [pathSteps, pathProperties]);
 
   const groups = useMemo(
-    () => groupOperationalPoints(suggestedOps, pathSteps),
-    [suggestedOps, pathSteps]
+    () =>
+      groupOperationalPoints(pathProperties?.operational_points ?? [], pathSteps, positionByStepId),
+    [pathProperties, pathSteps, positionByStepId]
   );
 
   return (
@@ -55,7 +69,12 @@ const IntermediateWaypointsPanel = ({
       ) : status === 'success' ? (
         <div className="intermediate-waypoints-panel__list">
           {groups.map((group) => (
-            <WaypointGroup key={group.requestedStep.id} group={group} />
+            <WaypointGroup
+              key={group.requestedStep.id}
+              group={group}
+              requestedLabel={getRequestedLabel(group.requestedStep)}
+              onAdd={(op) => onAddWaypoint(op, group.requestedStep.id)}
+            />
           ))}
         </div>
       ) : (

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
@@ -3,15 +3,24 @@ import { useState } from 'react';
 import { ChevronDown, ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
+import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
+
 import type { WaypointGroup as WaypointGroupType } from './types';
 import WaypointRow from './WaypointRow';
 
 type WaypointGroupProps = {
   group: WaypointGroupType;
+  requestedLabel: string;
+  onAdd: (op: CoreOperationalPointOnPath) => void;
   defaultExpanded?: boolean;
 };
 
-const WaypointGroup = ({ group, defaultExpanded = true }: WaypointGroupProps) => {
+const WaypointGroup = ({
+  group,
+  requestedLabel,
+  onAdd,
+  defaultExpanded = true,
+}: WaypointGroupProps) => {
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTrainSchedule.itineraryModal.intermediateWaypointsPanel',
   });
@@ -35,13 +44,17 @@ const WaypointGroup = ({ group, defaultExpanded = true }: WaypointGroupProps) =>
         ) : (
           <span className="intermediate-waypoints-panel__group-toggle" aria-hidden />
         )}
-        <WaypointRow op={group.requestedOp} isRequested />
+        <WaypointRow
+          op={group.requestedOp}
+          fallbackName={requestedLabel}
+          count={group.duplicatesCount}
+        />
       </div>
       {expanded && hasIntermediates && (
         <ul className="intermediate-waypoints-panel__group-body">
           {group.intermediates.map((op) => (
-            <li key={op.opId ?? `${op.track}-${op.offsetOnTrack}-${op.positionOnPath}`}>
-              <WaypointRow op={op} isRequested={false} />
+            <li key={`${op.id}-${op.position}`}>
+              <WaypointRow op={op} onAdd={() => onAdd(op)} />
             </li>
           ))}
         </ul>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointRow.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointRow.tsx
@@ -1,48 +1,70 @@
 import { Dot, Plus } from '@osrd-project/ui-icons';
 import cx from 'classnames';
+import { useTranslation } from 'react-i18next';
 
-import type { SuggestedOP } from 'modules/trainSchedule/types';
+import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
 
 type WaypointRowProps = {
   /**
-   * The operational point this row displays, or undefined for a requested step
-   * that matches no OP along the path (for instance a map-click waypoint)
-   * which renders as a placeholder row:
+   * The OP to show, or undefined for a requested step that matches no OP along
+   * the path (for instance a map-click waypoint), rendered as a placeholder
    */
-  op: SuggestedOP | undefined;
-  isRequested: boolean;
+  op: CoreOperationalPointOnPath | undefined;
+  /**
+   * Name shown when `op` has none (a requested step matching no OP, like a
+   * track-offset point for instance)
+   */
+  fallbackName?: string;
+  /**
+   * Number of requested steps this row stands for. A "(n)" suffix is shown when
+   * the same OP was selected several times in a row.
+   */
+  count?: number;
+  /**
+   * Present on intermediate rows (renders the add button); absent on the
+   * requested header row
+   */
+  onAdd?: () => void;
 };
 
-const WaypointRow = ({ op, isRequested }: WaypointRowProps) => {
-  const station = !!op && op.isPassengerStation;
+const WaypointRow = ({ op, fallbackName, count, onAdd }: WaypointRowProps) => {
+  const { t } = useTranslation('operational-studies', {
+    keyPrefix: 'manageTrainSchedule.itineraryModal.intermediateWaypointsPanel',
+  });
+  const station = !!op && op.is_passenger_station;
 
   return (
     <div
       className={cx('intermediate-waypoints-panel__row', {
-        'intermediate-waypoints-panel__row--requested': isRequested,
+        'intermediate-waypoints-panel__row--requested': !onAdd,
       })}
       data-testid="intermediate-waypoint-row"
     >
-      <span className="intermediate-waypoints-panel__row-name">{op?.name ?? '-'}</span>
+      <span className="intermediate-waypoints-panel__row-name">
+        {op?.name ?? fallbackName ?? '-'}
+        {count && count > 1 ? (
+          <span className="intermediate-waypoints-panel__row-count"> ({count})</span>
+        ) : null}
+      </span>
       <span className="intermediate-waypoints-panel__row-station-icon" aria-hidden>
         {/* TODO: Replace this with the train-station icon from ui-icons once it's been added */}
         {station && <i className="icons-itinerary-train-station" />}
       </span>
-      <span className="intermediate-waypoints-panel__row-ch">{op?.secondaryCode ?? ''}</span>
-      {isRequested ? (
-        <span className="intermediate-waypoints-panel__row-status" aria-hidden>
-          <Dot variant="fill" />
-        </span>
-      ) : (
-        // TODO: Implement the logic behind this button, and enable it
+      <span className="intermediate-waypoints-panel__row-ch">{op?.secondary_code ?? ''}</span>
+      {onAdd ? (
         <button
           type="button"
           className="intermediate-waypoints-panel__row-add"
-          aria-hidden
-          disabled
+          aria-label={t('addWaypoint')}
+          title={t('addWaypoint')}
+          onClick={onAdd}
         >
           <Plus />
         </button>
+      ) : (
+        <span className="intermediate-waypoints-panel__row-status" aria-hidden>
+          <Dot variant="fill" />
+        </span>
       )}
     </div>
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import type { SuggestedOP } from 'modules/trainSchedule/types';
+import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 import { groupOperationalPoints } from '../utils';
@@ -17,21 +17,41 @@ const makeStep = (id: string, uic: number, ch = 'BV'): PathStepV2 => ({
   receptionSignal: null,
 });
 
+// A step matching no OP, as produced by a map-click waypoint
+const makeTrackOffsetStep = (id: string): PathStepV2 => ({
+  id,
+  location: { type: 'track_offset', track: 'xxx', offset: 50 },
+  arrival: null,
+  stopFor: null,
+  theoreticalMargin: null,
+  receptionSignal: null,
+});
+
 const makeOp = (
   id: string,
   uic: number,
   secondaryCode = 'BV',
-  positionOnPath = 0
-): SuggestedOP => ({
-  opId: id,
-  pathStepId: undefined,
+  position = 0
+): CoreOperationalPointOnPath => ({
+  id,
   name: `op-${id}`,
   uic,
-  secondaryCode,
-  offsetOnTrack: 0,
-  track: 'track-1',
-  positionOnPath,
+  secondary_code: secondaryCode,
+  main_code: '',
+  country_code: 'FR',
+  is_passenger_station: false,
+  position,
+  weight: null,
+  part: { track: 'track-1', position: 0, local_track_name: 'V1' },
 });
+
+// Flatten a grouping result into ids, so a whole result reads as one shape
+const summarize = (groups: ReturnType<typeof groupOperationalPoints>) =>
+  groups.map((group) => ({
+    step: group.requestedStep.id,
+    requestedOp: group.requestedOp?.id,
+    intermediates: group.intermediates.map((op) => op.id),
+  }));
 
 describe('groupOperationalPoints', () => {
   it('puts intermediate OPs between two requested steps in the first group', () => {
@@ -43,15 +63,10 @@ describe('groupOperationalPoints', () => {
       makeOp('o4', 2, 'BV', 300),
     ];
 
-    const groups = groupOperationalPoints(ops, steps);
-
-    expect(groups).toHaveLength(2);
-    expect(groups[0].requestedStep.id).toBe('s1');
-    expect(groups[0].requestedOp?.opId).toBe('o1');
-    expect(groups[0].intermediates.map((o) => o.opId)).toEqual(['o2', 'o3']);
-    expect(groups[1].requestedStep.id).toBe('s2');
-    expect(groups[1].requestedOp?.opId).toBe('o4');
-    expect(groups[1].intermediates).toEqual([]);
+    expect(summarize(groupOperationalPoints(ops, steps))).toEqual([
+      { step: 's1', requestedOp: 'o1', intermediates: ['o2', 'o3'] },
+      { step: 's2', requestedOp: 'o4', intermediates: [] },
+    ]);
   });
 
   it('handles two adjacent requested steps with no intermediates between them', () => {
@@ -63,51 +78,132 @@ describe('groupOperationalPoints', () => {
       makeOp('o3', 3, 'BV', 200),
     ];
 
-    const groups = groupOperationalPoints(ops, steps);
-
-    expect(groups[0].intermediates).toEqual([]);
-    expect(groups[1].intermediates.map((o) => o.opId)).toEqual(['oMid']);
-    expect(groups[2].intermediates).toEqual([]);
+    expect(summarize(groupOperationalPoints(ops, steps))).toEqual([
+      { step: 's1', requestedOp: 'o1', intermediates: [] },
+      { step: 's2', requestedOp: 'o2', intermediates: ['oMid'] },
+      { step: 's3', requestedOp: 'o3', intermediates: [] },
+    ]);
   });
 
   it('returns an empty array when there are no valid/located steps', () => {
-    const emptyStep: PathStepV2 = {
-      id: 's1',
-      location: null,
-      arrival: null,
-      stopFor: null,
-      theoreticalMargin: null,
-      receptionSignal: null,
-    };
+    const emptyStep = { ...makeStep('s1', 1), location: null };
     expect(groupOperationalPoints([makeOp('o1', 1)], [emptyStep])).toEqual([]);
   });
 
-  it('does not stall when a middle requested step matches no OP', () => {
-    // Simulate a map-click waypoint that no returned OP matches:
-    const trackOffsetStep: PathStepV2 = {
-      id: 's2',
-      location: { type: 'track_offset', track: 'xxx', offset: 50 },
-      arrival: null,
-      stopFor: null,
-      theoreticalMargin: null,
-      receptionSignal: null,
-    };
-    const steps = [makeStep('s1', 1), trackOffsetStep, makeStep('s3', 3)];
+  describe('with a middle step that matches no OP', () => {
+    const steps = [makeStep('s1', 1), makeTrackOffsetStep('s2'), makeStep('s3', 3)];
     const ops = [
       makeOp('o1', 1, 'BV', 0),
       makeOp('oMid', 99, 'BV', 100),
       makeOp('o3', 3, 'BV', 200),
     ];
 
-    const groups = groupOperationalPoints(ops, steps);
+    it('without positions, falls oMid back under the previous matched step (s1)', () => {
+      expect(summarize(groupOperationalPoints(ops, steps))).toEqual([
+        { step: 's1', requestedOp: 'o1', intermediates: ['oMid'] },
+        { step: 's2', requestedOp: undefined, intermediates: [] },
+        { step: 's3', requestedOp: 'o3', intermediates: [] },
+      ]);
+    });
 
-    expect(groups).toHaveLength(3);
-    expect(groups[0].requestedOp?.opId).toBe('o1');
-    expect(groups[0].intermediates.map((o) => o.opId)).toEqual(['oMid']);
-    expect(groups[1].requestedStep.id).toBe('s2');
-    expect(groups[1].requestedOp).toBeUndefined();
-    expect(groups[1].intermediates).toEqual([]);
-    expect(groups[2].requestedStep.id).toBe('s3');
-    expect(groups[2].requestedOp?.opId).toBe('o3');
+    it('with positions, files oMid under the step it actually follows (s2)', () => {
+      const positions = new Map([
+        ['s1', 0],
+        ['s2', 50],
+        ['s3', 200],
+      ]);
+      expect(summarize(groupOperationalPoints(ops, steps, positions))).toEqual([
+        { step: 's1', requestedOp: 'o1', intermediates: [] },
+        { step: 's2', requestedOp: undefined, intermediates: ['oMid'] },
+        { step: 's3', requestedOp: 'o3', intermediates: [] },
+      ]);
+    });
+  });
+
+  describe('with an OP crossed twice along the path', () => {
+    // The step targets the OP's second crossing (dupSecond, position 300)
+    const steps = [makeStep('s1', 1), makeStep('sDup', 2), makeStep('s3', 3)];
+    const ops = [
+      makeOp('o1', 1, 'BV', 0),
+      makeOp('dupFirst', 2, 'BV', 100),
+      makeOp('dupSecond', 2, 'BV', 300),
+      makeOp('o3', 3, 'BV', 400),
+    ];
+
+    it('without positions, falls back to the first crossing claiming the step', () => {
+      expect(summarize(groupOperationalPoints(ops, steps))).toEqual([
+        { step: 's1', requestedOp: 'o1', intermediates: [] },
+        { step: 'sDup', requestedOp: 'dupFirst', intermediates: ['dupSecond'] },
+        { step: 's3', requestedOp: 'o3', intermediates: [] },
+      ]);
+    });
+
+    it('with positions, only the crossing at the step position claims it', () => {
+      const positions = new Map([
+        ['s1', 0],
+        ['sDup', 300],
+        ['s3', 400],
+      ]);
+      expect(summarize(groupOperationalPoints(ops, steps, positions))).toEqual([
+        { step: 's1', requestedOp: 'o1', intermediates: ['dupFirst'] },
+        { step: 'sDup', requestedOp: 'dupSecond', intermediates: [] },
+        { step: 's3', requestedOp: 'o3', intermediates: [] },
+      ]);
+    });
+
+    it('with a pinned track, only the crossing on that track claims it', () => {
+      const pinnedStep: PathStepV2 = {
+        ...makeStep('sDup', 2),
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: { type: 'uic', uic: 2, secondary_code: 'BV' },
+          local_track_name: 'V2',
+        },
+      };
+      const onTrack = (op: CoreOperationalPointOnPath, localTrackName: string) => ({
+        ...op,
+        part: { ...op.part, local_track_name: localTrackName },
+      });
+      const trackedOps = [
+        makeOp('o1', 1, 'BV', 0),
+        onTrack(makeOp('dupFirst', 2, 'BV', 100), 'V1'),
+        onTrack(makeOp('dupSecond', 2, 'BV', 300), 'V2'),
+        makeOp('o3', 3, 'BV', 400),
+      ];
+
+      expect(
+        summarize(groupOperationalPoints(trackedOps, [steps[0], pinnedStep, steps[2]]))
+      ).toEqual([
+        { step: 's1', requestedOp: 'o1', intermediates: ['dupFirst'] },
+        { step: 'sDup', requestedOp: 'dupSecond', intermediates: [] },
+        { step: 's3', requestedOp: 'o3', intermediates: [] },
+      ]);
+    });
+  });
+
+  describe('with one OP selected twice as two consecutive steps', () => {
+    // sDupA and sDupB target the same OP (uic 2)
+    const steps = [
+      makeStep('s1', 1),
+      makeStep('sDupA', 2),
+      makeStep('sDupB', 2),
+      makeStep('s3', 3),
+    ];
+    const ops = [makeOp('o1', 1, 'BV', 0), makeOp('o2', 2, 'BV', 100), makeOp('o3', 3, 'BV', 200)];
+
+    it('collapses them into one group carrying a count', () => {
+      const groups = groupOperationalPoints(ops, steps);
+      expect(
+        groups.map((group) => ({
+          step: group.requestedStep.id,
+          requestedOp: group.requestedOp?.id,
+          count: group.duplicatesCount,
+        }))
+      ).toEqual([
+        { step: 's1', requestedOp: 'o1', count: 1 },
+        { step: 'sDupB', requestedOp: 'o2', count: 2 },
+        { step: 's3', requestedOp: 'o3', count: 1 },
+      ]);
+    });
   });
 });

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/types.ts
@@ -1,8 +1,9 @@
-import type { SuggestedOP } from 'modules/trainSchedule/types';
+import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 export type WaypointGroup = {
   requestedStep: PathStepV2;
-  requestedOp: SuggestedOP | undefined;
-  intermediates: SuggestedOP[];
+  requestedOp: CoreOperationalPointOnPath | undefined;
+  intermediates: CoreOperationalPointOnPath[];
+  duplicatesCount: number;
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
@@ -1,8 +1,33 @@
-import { matchPathStepAndOp } from 'modules/pathfinding/utils';
-import type { SuggestedOP } from 'modules/trainSchedule/types';
+import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
+import type {
+  CoreOperationalPointOnPath,
+  OperationalPointReference,
+} from 'common/api/osrdEditoastApi';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 import type { WaypointGroup } from './types';
+
+type LocatedStep = PathStepV2 & { location: NonNullable<PathStepV2['location']> };
+
+// Canonical key for an OP reference, so two references to the same OP compare equal.
+const opRefKey = (ref: OperationalPointReference) => {
+  switch (ref.type) {
+    case 'id':
+      return `id:${ref.operational_point}`;
+    case 'uic':
+      return `uic:${ref.uic}:${ref.secondary_code ?? ''}`;
+    case 'trigram':
+      return `trigram:${ref.trigram}:${ref.secondary_code ?? ''}`;
+  }
+};
+
+// Whether two steps target the same OP. A pinned track only disambiguates which
+// crossing is meant, so it is ignored here. Map-click (track_offset) waypoints
+// are never collapsed: each click is its own point.
+const isSameWaypoint = (a: LocatedStep, b: LocatedStep) => {
+  if (a.location.type === 'track_offset' || b.location.type === 'track_offset') return false;
+  return opRefKey(a.location.operational_point) === opRefKey(b.location.operational_point);
+};
 
 /**
  * Groups operational points along the computed path under the requested step
@@ -11,32 +36,73 @@ import type { WaypointGroup } from './types';
  *
  * A requested step may have no matching OP (for instance a map-click waypoint
  * that does not coincide with an operational point along the path). Such a
- * step keeps an undefined `requestedOp` and does not block the grouping of the
- * steps after it.
+ * step keeps an undefined `requestedOp`, in which case, its entry in
+ * `positionByStepId` is used to place the OPs that fall after it under it.
+ *
+ * Consecutive steps targeting the same OP (the same OP selected twice in a row)
+ * are collapsed into a single group whose `count` reflects how many steps it
+ * stands for.
  */
 export function groupOperationalPoints(
-  operationalPoints: SuggestedOP[],
-  pathSteps: PathStepV2[]
+  operationalPoints: CoreOperationalPointOnPath[],
+  pathSteps: PathStepV2[],
+  positionByStepId?: Map<string, number>
 ): WaypointGroup[] {
-  const validSteps = pathSteps.filter(
-    (step): step is PathStepV2 & { location: NonNullable<PathStepV2['location']> } =>
-      step.location !== null
-  );
+  const validSteps = pathSteps.filter((step): step is LocatedStep => step.location !== null);
 
   if (validSteps.length === 0) return [];
 
-  const groups: WaypointGroup[] = validSteps.map((step) => ({
+  // Collapse consecutive steps that target the same OP into one entry. Keep the
+  // run's last step so new waypoints anchor after the whole run, not between its
+  // duplicates.
+  const collapsedSteps: { step: LocatedStep; duplicatesCount: number }[] = [];
+  validSteps.forEach((step) => {
+    const previous = collapsedSteps.at(-1);
+    if (previous && isSameWaypoint(previous.step, step)) {
+      previous.duplicatesCount += 1;
+      previous.step = step;
+    } else {
+      collapsedSteps.push({ step, duplicatesCount: 1 });
+    }
+  });
+
+  const groups: WaypointGroup[] = collapsedSteps.map(({ step, duplicatesCount }) => ({
     requestedStep: step,
     requestedOp: undefined,
     intermediates: [],
+    duplicatesCount,
   }));
 
-  let currentGroupIndex = -1;
+  const isStepBeforeOp = (step: LocatedStep, op: CoreOperationalPointOnPath) => {
+    const position = positionByStepId?.get(step.id);
+    return position !== undefined && position < op.position;
+  };
 
+  // Walk the OPs in path order, moving a cursor onto the latest requested step
+  // each op has reached, then filing the op under that step's group.
+  let currentGroupIndex = -1;
   operationalPoints.forEach((op) => {
-    const matchedIndex = validSteps.findIndex(
-      (step, index) => index > currentGroupIndex && matchPathStepAndOp(step.location, op)
-    );
+    // Reach a step by position:
+    while (
+      currentGroupIndex + 1 < collapsedSteps.length &&
+      isStepBeforeOp(collapsedSteps[currentGroupIndex + 1].step, op)
+    ) {
+      currentGroupIndex += 1;
+    }
+
+    // Reach a step by identity:
+    const matchedIndex = collapsedSteps.findIndex(({ step }, index) => {
+      if (index <= currentGroupIndex || !matchOpRefAndOp(step.location, op)) return false;
+      // An OP crossed twice matches both steps by identity. Pick the right
+      // crossing: by position if known, else by pinned track.
+      const position = positionByStepId?.get(step.id);
+      if (position !== undefined) return position === op.position;
+      const pinnedTrack =
+        step.location.type === 'operational_point_part_reference'
+          ? step.location.local_track_name
+          : undefined;
+      return !pinnedTrack || pinnedTrack === op.part.local_track_name;
+    });
 
     if (matchedIndex !== -1) {
       currentGroupIndex = matchedIndex;

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } fro
 
 import { Button } from '@osrd-project/ui-core';
 import { ArrowSwitch, Fold, FrameAll, Plus, Unfold } from '@osrd-project/ui-icons';
+import along from '@turf/along';
 import bbox from '@turf/bbox';
+import { lineString } from '@turf/helpers';
 import cx from 'classnames';
 import type { Position } from 'geojson';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +15,7 @@ import { useManageTrainScheduleContext } from 'applications/operationalStudies/h
 import { useOperationalPointSearch } from 'applications/operationalStudies/hooks/useOperationalPointSearch';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type {
+  CoreOperationalPointOnPath,
   OperationalPointReference,
   PathProperties,
   PathItemLocation,
@@ -159,7 +162,10 @@ const ItineraryModal = ({
 
   const { launchPathfinding } = useManageTrainScheduleContext();
 
-  const { pathStepsMetadataById } = usePathStepsMetadata(pathSteps, pendingStepIdRef);
+  const { pathStepsMetadataById, setPathStepMetadata } = usePathStepsMetadata(
+    pathSteps,
+    pendingStepIdRef
+  );
   const { launchPathfindingV2, pathProperties, pathfindingError } = usePathfindingV2();
   const { convertFeatureClickToLocation } = useMapTrackSelection(infraId);
 
@@ -177,12 +183,15 @@ const ItineraryModal = ({
     [pathSteps, pathStepsMetadataById]
   );
 
-  const initCustomTracksEntry = (location: PathItemLocation | null) => {
-    const opKey = getOpKey(location);
-    if (opKey && !customTracksByOpKey.has(opKey)) {
-      setCustomTracksByOpKey((prev) => new Map(prev).set(opKey, []));
-    }
-  };
+  const initCustomTracksEntry = useCallback(
+    (location: PathItemLocation | null) => {
+      const opKey = getOpKey(location);
+      if (opKey && !customTracksByOpKey.has(opKey)) {
+        setCustomTracksByOpKey((prev) => new Map(prev).set(opKey, []));
+      }
+    },
+    [customTracksByOpKey]
+  );
 
   const applyOperationalPointToStep = (
     stepId: string,
@@ -251,6 +260,58 @@ const ItineraryModal = ({
     setActiveStepId(newStep.id);
     setInputForStep(newStep.id, '');
   };
+
+  const handleAddWaypoint = useCallback(
+    (op: CoreOperationalPointOnPath, afterStepId: string) => {
+      const insertIndex = pathSteps.findIndex((step) => step.id === afterStepId) + 1;
+      if (insertIndex === 0) return;
+
+      const newStep = createEmptyPathStep();
+
+      newStep.location = {
+        type: 'operational_point_part_reference',
+        operational_point: {
+          type: 'trigram',
+          trigram: op.main_code,
+          secondary_code: op.secondary_code,
+        },
+      };
+      initCustomTracksEntry(newStep.location);
+
+      // Sample the path geometry at the op position so the prefilled marker has
+      // coordinates:
+      const geometry = pathProperties?.geometry;
+      const coordinates = geometry
+        ? along(lineString(geometry.coordinates), op.position, { units: 'millimeters' }).geometry
+            .coordinates
+        : undefined;
+
+      // Pre-fill the metadata so the new step shows its name right away and
+      // is not briefly flagged invalid while its OP match is fetched
+      setPathStepMetadata(newStep.id, {
+        type: 'opRef',
+        isInvalid: false,
+        name: op.name,
+        uic: op.uic,
+        secondaryCode: op.secondary_code,
+        parts: coordinates
+          ? [
+              {
+                type: 'valid',
+                trackId: op.part.track,
+                trackName: op.part.local_track_name,
+                coordinates,
+              },
+            ]
+          : [],
+      });
+
+      setPathSteps((prev) =>
+        ensureTrailingEmptyStep(addElementAtIndex(prev, insertIndex, newStep))
+      );
+    },
+    [pathSteps, pathProperties, initCustomTracksEntry, setPathStepMetadata]
+  );
 
   const isStepInvalidAndIsEditing = (step: PathStepV2, metadata?: PathStepMetadata) => {
     if (!metadata?.isInvalid) return false;
@@ -884,6 +945,7 @@ const ItineraryModal = ({
             pathProperties={displayedPathProperties}
             status={waypointsPanelStatus}
             onHide={() => setWaypointsPanelOpen(false)}
+            onAddWaypoint={handleAddWaypoint}
           />
         </div>
       )}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/hooks/usePathStepsMetadata.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/hooks/usePathStepsMetadata.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useMemo, useState, type RefObject } from 'react';
 
 import { skipToken } from '@reduxjs/toolkit/query';
 import type { Position } from 'geojson';
@@ -153,6 +153,14 @@ export const usePathStepsMetadata = (
         const { local_track_name } = location;
 
         if (!matchedOp) {
+          // A just-added step has no match until /match_operational_points
+          // answers; keep its pre-filled metadata instead of flagging it
+          const previous = pathStepsMetadataById.get(pathStep.id);
+          if (previous && !previous.isInvalid && previous.type === 'opRef') {
+            newPathStepsMetadataById.set(pathStep.id, previous);
+            return;
+          }
+
           newPathStepsMetadataById.set(pathStep.id, {
             isInvalid: true,
             localTrackName: local_track_name ?? undefined,
@@ -164,7 +172,7 @@ export const usePathStepsMetadata = (
         const timetableTrackNames = localTrackNamesData?.[opRefKey] ?? [];
 
         const isValidLocalTrackName = local_track_name
-          ? matchedOp?.parts.some((part) => {
+          ? matchedOp.parts.some((part) => {
               const track = trackSectionsById[part.track];
               if (!track) return false;
               return local_track_name === part.local_track_name;
@@ -211,5 +219,11 @@ export const usePathStepsMetadata = (
     fetchAndSetMetadata();
   }, [pathStepsOperationalPoints, pathSteps, localTrackNamesData]);
 
-  return { pathStepsMetadataById, setPathStepsMetadataById };
+  const setPathStepMetadata = useCallback(
+    (id: string, metadata: PathStepMetadata) =>
+      setPathStepsMetadataById((prev) => new Map(prev).set(id, metadata)),
+    []
+  );
+
+  return { pathStepsMetadataById, setPathStepMetadata };
 };

--- a/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
@@ -85,7 +85,11 @@ const usePathfindingV2 = () => {
         };
         const pathPropertiesResult = await postPathProperties(pathPropertiesParams).unwrap();
 
-        setPathProperties({ ...pathPropertiesResult, length: pathfindingResult.length });
+        setPathProperties({
+          ...pathPropertiesResult,
+          length: pathfindingResult.length,
+          pathItemPositions: pathfindingResult.path_item_positions,
+        });
         return;
       }
 
@@ -107,6 +111,7 @@ const usePathfindingV2 = () => {
           ...pathPropertiesResult,
           length: pathfindingResult.relaxed_constraints_path.length,
           incompatibleConstraints: pathfindingResult.incompatible_constraints,
+          pathItemPositions: pathfindingResult.relaxed_constraints_path.path_item_positions,
         });
         setPathfindingError(t(`pathfindingErrors.${pathfindingResult.error_type}`));
         return;

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -271,6 +271,11 @@
             display: none;
           }
 
+          &[aria-expanded='true'] {
+            background-color: var(--black5);
+            color: var(--primary70);
+          }
+
           &[aria-expanded='true'],
           &:hover:not(:disabled) {
             padding-right: 12px;
@@ -650,7 +655,7 @@
       align-items: center;
       min-width: 0;
       height: 36px;
-      padding-right: 10px;
+      padding-right: 14px;
       color: var(--grey80);
       gap: $rowGap;
 
@@ -671,6 +676,12 @@
       }
     }
 
+    &__row-count {
+      font-size: 0.85em;
+      font-weight: 400;
+      color: var(--grey40);
+    }
+
     &__row-station-icon,
     &__row-status,
     &__row-add {
@@ -687,6 +698,7 @@
     &__row-ch {
       min-width: 20px;
       text-align: right;
+      font-family: var(--font-mono), monospace;
     }
 
     &__row-status {
@@ -694,10 +706,7 @@
     }
 
     &__row-add {
-      color: var(--grey20);
-      // TODO:
-      // Restore visible style for that button
-      // color: var(--primary60);
+      color: var(--primary60);
     }
   }
 


### PR DESCRIPTION
This PR implements #17056. It builds on the read-only panel from #16946 (related PR: #17021).

It makes the intermediate waypoints panel interactive: each suggested operational point along the path can now be added to the itinerary with a single click, and the surrounding plumbing was tightened so added waypoints show up correctly and don't flicker.

The PR is split in 3 independent commits:
1. The first commit covers the core of the feature, and checks all points from the acceptance criteria listed on the [original feature ticket](https://github.com/osrd-project/osrd-confidential/issues/1167).
2. The second commit improves how a path-step added from the new panel appears in the path-steps list (the left form)
3. The third commit fixes the `groupOperationalPoints` helper implemented in the previous PR, to properly place waypoints inserted directly on the map

**Note on OPs crossed several times by the path**

Waypoints added from the panel are added as OP references, so they behave like any regular path step. There is one exception though: when the path crosses the same OP several times (i.e. when multiple waypoints have both the same _name_ and _secondary code_), the pathfinding cannot tell the crossings apart, and always anchors an OP reference at the first crossing.

So for these OPs, only the first crossing is added as an OP reference, and the other crossings are added as exact track offsets instead. These steps behave like map-clicked points: they appear as "requested points", with no name and no track selection.