### PR TITLE
front: add button to open the itinerary modal from header

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -422,6 +422,7 @@
       "alertMissingRequestedPoint": "At least two path steps are required to define an itinerary",
       "cancel": "Cancel",
       "cancelMapSelection": "Cancel",
+      "edit": "Edit itinerary",
       "focusLocationOnMap": "Focus the map on this operational point",
       "frameAll": "Center on all path steps on map",
       "intermediateWaypointsPanel": {

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -422,6 +422,7 @@
       "alertMissingRequestedPoint": "Il faut au minimum deux points de passage pour définir un itinéraire",
       "cancel": "Annuler",
       "cancelMapSelection": "Annuler",
+      "edit": "Modifier l’itinéraire",
       "focusLocationOnMap": "Centrer la carte sur ce point remarquable",
       "frameAll": "Centrer sur tous les points de passage sur la carte",
       "intermediateWaypointsPanel": {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -60,7 +60,7 @@ import { computePathStepCoordinates, getOpKey, isOpRefMetadata } from './utils';
 
 type ItineraryModalProps = {
   itineraryModalIsOpen: boolean;
-  setItineraryModalIsOpen: (isOpen: boolean) => void;
+  onClose: ({ withChanges }: { withChanges: boolean }) => void;
   displayTrainScheduleManagement: string;
 };
 
@@ -74,7 +74,7 @@ export type ItineraryModalFormState = {
 
 const ItineraryModal = ({
   itineraryModalIsOpen,
-  setItineraryModalIsOpen,
+  onClose,
   displayTrainScheduleManagement,
 }: ItineraryModalProps) => {
   const { t } = useTranslation('operational-studies', {
@@ -125,9 +125,9 @@ const ItineraryModal = ({
       : 'intermediateWaypointsPanel.showLabel'
   );
 
-  const closeModal = () => {
+  const closeModal = ({ withChanges }: { withChanges: boolean }) => {
     modalRef.current?.close();
-    setItineraryModalIsOpen(false);
+    onClose({ withChanges });
   };
 
   const handleCancelMapSelection = useCallback(() => {
@@ -138,7 +138,7 @@ const ItineraryModal = ({
     if (mapSelectionStepId !== null) {
       handleCancelMapSelection();
     } else {
-      closeModal();
+      closeModal({ withChanges: false });
     }
   }, [mapSelectionStepId, handleCancelMapSelection]);
 
@@ -415,7 +415,8 @@ const ItineraryModal = ({
   useEffect(() => {
     if (
       displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.edit ||
-      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.add
+      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.add ||
+      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.itinerary
     ) {
       const formattedPathSteps = storePathSteps
         .filter((pathStep): pathStep is PathStep => pathStep !== null)
@@ -573,7 +574,7 @@ const ItineraryModal = ({
     );
 
     launchPathfinding(pathStepsFromV2, modalFormState.rollingStockId, { isInitialization: true });
-    closeModal();
+    closeModal({ withChanges: true });
   };
 
   useModalFocusTrap(modalRef, handleEscapeOrClose);
@@ -856,10 +857,19 @@ const ItineraryModal = ({
             label={t('cancel')}
             variant="Cancel"
             size="medium"
-            onClick={closeModal}
+            onClick={() => closeModal({ withChanges: false })}
             dataTestID="close-itinerary-modal"
           />
-          <Button label={t('next')} variant="Primary" size="medium" onClick={submitItinerary} />
+          <Button
+            label={
+              displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.itinerary
+                ? t('edit')
+                : t('next')
+            }
+            variant="Primary"
+            size="medium"
+            onClick={submitItinerary}
+          />
         </div>
       </div>
       {waypointsPanelOpen && (

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainScheduleLeftPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainScheduleLeftPanel.tsx
@@ -50,7 +50,12 @@ const ManageTrainScheduleLeftPanel = ({
   const { openModal, closeModal } = useModal();
 
   const [isWorking, setIsWorking] = useState(false);
-  const [itineraryModalIsOpen, setItineraryModalIsOpen] = useState(false);
+  const [itineraryModalIsOpen, setItineraryModalIsOpen] = useState(
+    displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.add ||
+      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.edit ||
+      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.itinerary
+  );
+  const [itineraryChanged, setItineraryChanged] = useState(false);
 
   const leaveManageTrainSchedule = () => {
     setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.none);
@@ -79,12 +84,16 @@ const ManageTrainScheduleLeftPanel = ({
 
   useEffect(() => {
     if (
-      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.add ||
-      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.edit
+      displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.itinerary &&
+      !itineraryModalIsOpen
     ) {
-      setItineraryModalIsOpen(true);
+      if (itineraryChanged) {
+        updateTimetable();
+      } else {
+        leaveManageTrainSchedule();
+      }
     }
-  }, [displayTrainScheduleManagement]);
+  }, [displayTrainScheduleManagement, itineraryModalIsOpen, itineraryChanged]);
 
   return (
     <div className="scenario-timetable-manage-train-schedule left-column">
@@ -199,7 +208,10 @@ const ManageTrainScheduleLeftPanel = ({
       {itineraryModalIsOpen && (
         <ItineraryModal
           itineraryModalIsOpen={itineraryModalIsOpen}
-          setItineraryModalIsOpen={setItineraryModalIsOpen}
+          onClose={({ withChanges }) => {
+            setItineraryModalIsOpen(false);
+            setItineraryChanged(withChanges);
+          }}
           displayTrainScheduleManagement={displayTrainScheduleManagement}
         />
       )}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -214,6 +214,8 @@ const ScenarioContent = ({ activeBoards }: ScenarioContentProps) => {
                 activeBoards={activeBoards}
                 updateTrainScheduleDepartureTime={updateTrainScheduleDepartureTimeWithNge}
                 upsertTrainSchedules={upsertTrainSchedulesWithNge}
+                setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
+                setTrainScheduleToEditData={setTrainScheduleToEditData}
               />
             )}
             {activeBoards.has('macro') && (

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -25,6 +25,7 @@ import TimeStopsTableWrapper from 'modules/timesStops/TimeStopsTableWrapper';
 import TrainHeader from 'modules/trainHeader/TrainHeader';
 import { findExceptionWithOccurrenceId } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
+import type { TrainScheduleToEditData } from 'reducers/osrdconf/types';
 import { toggleDisplayOnlyPathSteps, updateSelectedTrain } from 'reducers/simulationResults';
 import {
   getDisplayOnlyPathSteps,
@@ -56,6 +57,8 @@ type SimulationResultsProps = {
   activeBoards: Set<Board>;
   updateTrainScheduleDepartureTime: (trainId: number, newDepartureTime: Date) => Promise<void>;
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
+  setDisplayTrainScheduleManagement: (type: string) => void;
+  setTrainScheduleToEditData: (trainScheduleToEditData?: TrainScheduleToEditData) => void;
 };
 
 const SimulationResults = ({
@@ -67,6 +70,8 @@ const SimulationResults = ({
   activeBoards,
   updateTrainScheduleDepartureTime,
   upsertTrainSchedules,
+  setTrainScheduleToEditData,
+  setDisplayTrainScheduleManagement,
 }: SimulationResultsProps) => {
   const { t } = useTranslation('operational-studies');
   const dispatch = useAppDispatch();
@@ -369,6 +374,8 @@ const SimulationResults = ({
                 train={simulationResults.train}
                 trainSchedulesWithDetails={trainSchedulesWithDetails}
                 upsertTrainSchedules={upsertTrainSchedules}
+                setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
+                setTrainScheduleToEditData={setTrainScheduleToEditData}
               />
             }
             customFooter={

--- a/front/src/applications/operationalStudies/views/Scenario/consts.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/consts.ts
@@ -3,4 +3,5 @@ export const MANAGE_TRAIN_SCHEDULE_TYPES = Object.freeze({
   add: 'ADD',
   edit: 'EDIT',
   catalog: 'CATALOG',
+  itinerary: 'ITINERARY',
 });

--- a/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
+++ b/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
@@ -18,12 +18,17 @@ import {
 export type CollapsedTrainOverviewProps = {
   train: Train;
   onExpand: () => void;
+  onItineraryOpened: () => void;
 };
 
 /**
  * A simple line that shows an overview of the key properties of a train.
  */
-const CollapsedTrainOverview = ({ train, onExpand }: CollapsedTrainOverviewProps) => {
+const CollapsedTrainOverview = ({
+  train,
+  onExpand,
+  onItineraryOpened,
+}: CollapsedTrainOverviewProps) => {
   const { t } = useTranslation(['operational-studies', 'translation']);
   const dateTimeLocale = useDateTimeLocale();
 
@@ -68,9 +73,8 @@ const CollapsedTrainOverview = ({ train, onExpand }: CollapsedTrainOverviewProps
         <Button
           label={t('manageTrainSchedule.trainHeader.itinerary')}
           variant="Quiet"
-          onClick={() => {}}
+          onClick={onItineraryOpened}
           size="small"
-          isDisabled
         />
       </div>
       <button className="header-toggle" onClick={() => onExpand()}>

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -23,6 +23,7 @@ export type ExpandedTrainFormProps = {
   train: Train;
   onCollapse: () => void;
   onPersistTrain: (updatedTrain: Train, addedExceptions?: { startTime: Date }[]) => Promise<void>;
+  onItineraryOpened: () => void;
 };
 
 type TrainFieldsState = {
@@ -59,7 +60,12 @@ function extractChangesInFields(
 /**
  * A header-shaped form that allow users to set most of the properties of a train, beside the itinerary itself.
  */
-const ExpandedTrainForm = ({ train, onCollapse, onPersistTrain }: ExpandedTrainFormProps) => {
+const ExpandedTrainForm = ({
+  train,
+  onCollapse,
+  onPersistTrain,
+  onItineraryOpened,
+}: ExpandedTrainFormProps) => {
   const { t } = useTranslation(['operational-studies', 'translation']);
   const dateTimeLocale = useDateTimeLocale();
 
@@ -265,9 +271,8 @@ const ExpandedTrainForm = ({ train, onCollapse, onPersistTrain }: ExpandedTrainF
           <Button
             label={t('manageTrainSchedule.trainHeader.itinerary')}
             variant="Quiet"
-            onClick={() => {}}
+            onClick={onItineraryOpened}
             size="small"
-            isDisabled
           />
         </div>
       </div>

--- a/front/src/modules/trainHeader/TrainHeader.tsx
+++ b/front/src/modules/trainHeader/TrainHeader.tsx
@@ -1,23 +1,28 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import { updateTrainSchedule } from 'applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule';
+import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/views/Scenario/consts';
 import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/trainSchedule/types';
 import { setFailure } from 'reducers/main';
-import type { Train } from 'reducers/osrdconf/types';
+import { selectTrainToEdit } from 'reducers/osrdconf/operationalStudiesConf';
+import type { Train, TrainScheduleToEditData } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { extractEditoastIdFromTrainId, isOccurrenceId } from 'utils/trainId';
 
 import CollapsedTrainOverview from './CollapsedTrainOverview';
 import ExpandedTrainForm from './ExpandedTrainForm';
+import { applyOccurrenceOnPacedTrain } from './utils/applyOccurrenceOnPacedTrain';
 
 export type TrainHeaderProps = {
   train: Train;
   trainSchedulesWithDetails: PacedTrainWithDetails[];
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
+  setDisplayTrainScheduleManagement: (type: string) => void;
+  setTrainScheduleToEditData: (trainScheduleToEditData?: TrainScheduleToEditData) => void;
 };
 
 /**
@@ -29,6 +34,8 @@ const TrainHeader = ({
   train,
   trainSchedulesWithDetails,
   upsertTrainSchedules,
+  setDisplayTrainScheduleManagement,
+  setTrainScheduleToEditData,
 }: TrainHeaderProps) => {
   const [expanded, setExpanded] = useState(false);
   const { t } = useTranslation(['operational-studies']);
@@ -72,6 +79,23 @@ const TrainHeader = ({
     }
   };
 
+  const onItineraryOpened = useCallback(() => {
+    dispatch(
+      selectTrainToEdit({
+        trainSchedule: occurrenceId
+          ? applyOccurrenceOnPacedTrain(originalPacedTrain, train, occurrenceId)
+          : originalPacedTrain,
+        isOccurrence: !!occurrenceId,
+      })
+    );
+    setTrainScheduleToEditData({
+      trainScheduleId,
+      originalPacedTrain: originalPacedTrain ?? train,
+      occurrenceId,
+    });
+    setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.edit);
+  }, [train, originalPacedTrain, trainScheduleId, occurrenceId]);
+
   if (expanded) {
     return (
       <ExpandedTrainForm
@@ -81,6 +105,7 @@ const TrainHeader = ({
           setExpanded(false);
         }}
         onPersistTrain={onPersistTrain}
+        onItineraryOpened={onItineraryOpened}
       />
     );
   }
@@ -91,6 +116,7 @@ const TrainHeader = ({
       onExpand={() => {
         setExpanded(true);
       }}
+      onItineraryOpened={onItineraryOpened}
     />
   );
 };

--- a/front/src/modules/trainHeader/TrainHeader.tsx
+++ b/front/src/modules/trainHeader/TrainHeader.tsx
@@ -93,7 +93,7 @@ const TrainHeader = ({
       originalPacedTrain: originalPacedTrain ?? train,
       occurrenceId,
     });
-    setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.edit);
+    setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.itinerary);
   }, [train, originalPacedTrain, trainScheduleId, occurrenceId]);
 
   if (expanded) {

--- a/front/src/modules/trainHeader/utils/applyOccurrenceOnPacedTrain.ts
+++ b/front/src/modules/trainHeader/utils/applyOccurrenceOnPacedTrain.ts
@@ -1,0 +1,54 @@
+import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import {
+  extractOccurrenceDetailsFromPacedTrain,
+  findExceptionWithOccurrenceId,
+} from 'modules/trainSchedule/helpers/pacedTrain';
+import type { PacedTrainWithDetails } from 'modules/trainSchedule/types';
+import type { OccurrenceId, Train } from 'reducers/osrdconf/types';
+
+/**
+ * Apply occurrence-related properties to a paced train, so that the resulting paced train
+ * can be given to the old edition modal.
+ *
+ * Loosely adapted from useOccurrenceActions' editOccurrence callback.
+ *
+ * TODO: This should be deleted as soon as we move away from the old edition modal and we don't
+ * rely on the store state anymore.
+ */
+export function applyOccurrenceOnPacedTrain(
+  originalPacedTrain: PacedTrainWithDetails,
+  train: Train,
+  occurrenceId: OccurrenceId
+): PacedTrainWithDetails {
+  if (!originalPacedTrain.paced) return originalPacedTrain;
+
+  const occurrenceToUpdateException = findExceptionWithOccurrenceId(
+    originalPacedTrain.paced.exceptions,
+    occurrenceId
+  );
+
+  const rawPacedTrain: Omit<TrainSchedule, 'paced'> = {
+    ...originalPacedTrain,
+    train_name: train.train_name,
+    speed_limit_tag: train.speed_limit_tag,
+    rolling_stock_name: train.rolling_stock_name,
+    start_time: train.start_time,
+  };
+
+  const {
+    train_name,
+    start_time,
+    speed_limit_tag,
+    rolling_stock_name: rollingStockName,
+    ...occurrenceProps
+  } = extractOccurrenceDetailsFromPacedTrain(rawPacedTrain, occurrenceToUpdateException);
+
+  return {
+    ...originalPacedTrain,
+    ...occurrenceProps,
+    name: train_name,
+    startTime: new Date(start_time),
+    speedLimitTag: speed_limit_tag ?? null,
+    rollingStockName,
+  };
+}


### PR DESCRIPTION
Closes #16528.

This is basically a matter of wiring stuff together; here, we call the new itinerary modal using the "old" way (i.e. by calling the old modal with the right parameters in the store), and in another commit, I even go the extra mile to hide the "old" part of the modal by closing it as soon as we close the itinerary modal.

So to recap, on click on that itinerary button:
- We set the stuff needed to open the modal (i.e. `trainScheduleToEditData`); to set the proper train, we simply copy how it's done in `useOccurrenceActions`, with a big `TODO` to get rid of all that as soon as we get rid of the old itinerary modal;
- We set `displayTrainScheduleManagement` to `MANAGE_TRAIN_SCHEDULE_TYPES.itinerary`;
- As soon as we exit the itinerary modal, we call `updateTimetable` immediately if it was closed by saving (i.e. if `withChanges` is true), and close the old modal immediately.

If you have that in mind, it should be very straightforward to review: there is not much more here :)