### PR TITLE
Add whitespace in adjacent compound selector

### DIFF
--- a/front/src/applications/rollingStockEditor/styles.scss
+++ b/front/src/applications/rollingStockEditor/styles.scss
@@ -130,7 +130,7 @@
 
     @media screen and (min-width: 767px) {
       &-text {
-        *td,
+        * td,
         .formResistance {
           @media screen and (min-width: 1140px) {
             font-size: medium;


### PR DESCRIPTION
Fixes this deprecation warning:

    DEPRECATION WARNING [adjacent-compounds] on line 133, column 9 of src/applications/rollingStockEditor/styles.scss:
    Adjacent compound selectors must be separated by whitespace. This will be an error in Dart Sass 2.0.0. Suggestion:

    * td

    More info: https://sass-lang.com/d/adjacent-compounds
        ╷
    133 │         *td,
        │         ^^^
        ╵