### PR TITLE
front: improve vite's watcher configuration

### DIFF
--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -448,6 +448,7 @@
   },
   "options": {
     "typeAware": true,
+    "typeCheck": true,
     "reportUnusedDisableDirectives": "error"
   },
   "overrides": [

--- a/front/package.json
+++ b/front/package.json
@@ -143,7 +143,7 @@
     "start-container": "vite --host",
     "build": "npm run build --workspaces --if-present && vite build",
     "test": "npm run test --workspaces --if-present && vitest",
-    "lint": "npm run lint --workspaces --if-present && tsc && oxlint . --max-warnings 0 --ignore-pattern 'ui/**' && oxfmt . --check",
+    "lint": "npm run lint --workspaces --if-present && oxlint . --max-warnings 0 --ignore-pattern 'ui/**' && oxfmt . --check",
     "lint-fix": "npm run lint:fix --workspaces --if-present && oxlint . --fix --ignore-pattern 'ui/**' && oxfmt . --write",
     "generate-types": "exec scripts/generate-types.sh",
     "e2e-tests": "playwright test",

--- a/front/ui/storybook/package.json
+++ b/front/ui/storybook/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf storybook-static",
     "start": "storybook dev -p 6006",
     "build": "storybook build",
-    "lint": "tsc && oxlint . --max-warnings 0 && oxfmt . --check",
+    "lint": "oxlint . --max-warnings 0 && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "dependencies": {

--- a/front/ui/ui-charts/package.json
+++ b/front/ui/ui-charts/package.json
@@ -32,7 +32,7 @@
     "watch": "rollup -c -w",
     "test": "vitest run",
     "prepublishOnly": "npm run clean && npm run build",
-    "lint": "tsc && oxlint . --max-warnings 0 && oxfmt . --check",
+    "lint": "oxlint . --max-warnings 0 && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "peerDependencies": {

--- a/front/ui/ui-core/package.json
+++ b/front/ui/ui-core/package.json
@@ -32,7 +32,7 @@
     "watch": "rollup -c -w",
     "test": "vitest run",
     "prepublishOnly": "npm run clean && npm run build",
-    "lint": "tsc && oxlint . --max-warnings 0  && oxfmt . --check",
+    "lint": "oxlint . --max-warnings 0  && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "peerDependencies": {

--- a/front/ui/ui-warped-map/package.json
+++ b/front/ui/ui-warped-map/package.json
@@ -29,7 +29,7 @@
     "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
-    "lint": "tsc && oxlint . --max-warnings 0 && oxfmt . --check",
+    "lint": "oxlint . --max-warnings 0 && oxfmt . --check",
     "lint:fix": "oxlint . --fix && oxfmt . --write"
   },
   "dependencies": {

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -39,7 +39,6 @@ export default defineConfig(({ mode }) => {
       react(),
       {
         ...checker({
-          typescript: true,
           oxlint: true,
           overlay: env.OSRD_VITE_OVERLAY !== 'false' && {
             initialIsOpen: env.OSRD_VITE_OVERLAY_OPEN_BY_DEFAULT === 'true',

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -39,7 +39,21 @@ export default defineConfig(({ mode }) => {
       react(),
       {
         ...checker({
-          oxlint: true,
+          oxlint: {
+            lintCommand: 'oxlint',
+            // TODO: Remove this explicit list as soon as vite-plugin-checker handles concurrent
+            //       watch files properly (i.e. with a debounce) or at least remove `test-results`
+            //       and `playwright-report` from the default watch paths.
+            watchPath: [
+              'src',
+              'tests',
+              'ui/storybook/stories',
+              'ui/ui-charts/src',
+              'ui/ui-core/src',
+              'ui/ui-icons/scripts',
+              'ui/ui-warped-data/src',
+            ],
+          },
           overlay: env.OSRD_VITE_OVERLAY !== 'false' && {
             initialIsOpen: env.OSRD_VITE_OVERLAY_OPEN_BY_DEFAULT === 'true',
           },


### PR DESCRIPTION
Now that `oxlint` can call `tsc` by itself, let's use that instead of calling `tsc` manually, both in our `package.json` configurations (that's the first commit) but also in watch mode; let's also list all the directories we should watch to ensure `vite-plugin-checker` do not call `oxlint` repeatedly during e2e tests or on `npm build`.