### PR TITLE
editoast: drop disabled authorization mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,6 @@ services:
       TELEMETRY_ENDPOINT: "http://jaeger:4317"
       OSRD_MQ_URL: "amqp://osrd:password@rabbitmq:5672/%2f"
       FGA_API_URL: "http://openfga:8091"
-      EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
       EDITOAST_NO_CACHE: ${EDITOAST_NO_CACHE:-false}
       S3_ACCESS_KEY_ID: access_key
       S3_SECRET_ACCESS_KEY: secret_key

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -197,7 +197,6 @@ services:
       TELEMETRY_ENDPOINT: "http://jaeger:4319"
       OSRD_MQ_URL: "amqp://osrd:password@rabbitmq:5673/%2f"
       FGA_API_URL: "http://openfga:8191"
-      EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
       EDITOAST_NO_CACHE: ${EDITOAST_NO_CACHE:-false}
       S3_ACCESS_KEY_ID: access_key
       S3_SECRET_ACCESS_KEY: secret_key

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -187,22 +187,9 @@ EDITOAST_NO_CACHE=true ./osrd-compose up -d
 
 ## Authorization
 
-### How to disable authorizations
+### Authorization bypass
 
-By default editoast is running with authorization enabled.
-You can disable it by using the environment variable `EDITOAST_ENABLE_AUTHORIZATION=false`
-
-```sh
-EDITOAST_ENABLE_AUTHORIZATION=false cargo run -- runserver
-```
-
-If you run the stack with docker:
-
-```sh
-EDITOAST_ENABLE_AUTHORIZATION=false docker compose up
-```
-
-If your client has a direct access to editoast, an other possibility is to add the header `x-osrd-skip-authz` in your requests.
+Trusted services behind the gateway or direct clients can bypass authorization for a request by adding the `x-osrd-skip-authz` header.
 
 ### User & role management
 

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -200,10 +200,6 @@ pub enum RollingStockGrant {
 )]
 pub enum Role {
     /// A user with this role short-circuits all role and permission checks
-    ///
-    /// Alternatively, especially for development, the `EDITOAST_ENABLE_AUTHORIZATION` environment variable can be set to `false`
-    /// when no user identity header is present. (This is the case when editoast is queried directly and
-    /// not through the gateway.)
     Admin,
     Stdcm,
     OperationalStudies,

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -29,7 +29,6 @@ pub struct AuthenticationParameters {
     pub name: Option<String>,
     pub impersonate: Option<String>,
     pub skip: bool,
-    pub authorization_enabled: bool,
 }
 
 impl Authentication {
@@ -38,12 +37,6 @@ impl Authentication {
         let authn = match params {
             AuthenticationParameters {
                 skip: true,
-                identity,
-                name,
-                ..
-            }
-            | AuthenticationParameters {
-                authorization_enabled: false,
                 identity,
                 name,
                 ..

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -64,10 +64,6 @@ pub struct RunserverArgs {
     address: String,
     #[command(flatten)]
     core: CoreArgs,
-    /// If this option is set to false, any role and permission check will be bypassed. Even if no user is
-    /// provided by the request headers of if the provided user doesn't have the required privileges.
-    #[clap(long, env = "EDITOAST_ENABLE_AUTHORIZATION", default_value_t = true)]
-    enable_authorization: bool,
     /// The timeout to use when performing the healthcheck, in milliseconds
     #[clap(long, env = "EDITOAST_HEALTH_CHECK_TIMEOUT_MS", default_value_t = 1000)]
     health_check_timeout_ms: u64,
@@ -91,7 +87,6 @@ pub async fn runserver(
                 core_client_channels_size,
                 worker_pool_id,
             },
-        enable_authorization,
         health_check_timeout_ms,
         root_url,
         dynamic_assets_path,
@@ -115,7 +110,6 @@ pub async fn runserver(
         address,
         health_check_timeout: Duration::milliseconds(health_check_timeout_ms as i64),
         map_layers_max_zoom: map_layers_config.max_zoom as u8,
-        enable_authorization,
         postgres_config: postgres.into(),
         osrdyne_config: views::OsrdyneConfig {
             mq_url,

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -133,8 +133,8 @@ pub(in crate::views) async fn whoami(
     let skip = matches!(authn, crate::authentication::Authentication::Skip { .. });
     if let Some(editoast_models::User { id, name }) = user {
         let mut roles = HashSet::from_iter(roles);
-        // authorization is disabled (by CLI or header x-osrd-skip-authz) but identity headers are
-        // provided so we could fetch the user's roles, but Admin may be lacking
+        // Authorization is skipped by header, but identity headers are provided so we could fetch
+        // the user's roles, though Admin may be lacking.
         if skip {
             roles.insert(Role::Admin);
         }
@@ -426,7 +426,7 @@ pub(in crate::views) async fn user_privileges(
             }
         }
     } else {
-        // Authorization is skipped (--enable-authorization or header), everyone has full access
+        // Authorization is skipped by header, everyone has full access
         debug_assert!(matches!(
             authn,
             crate::authentication::Authentication::Skip { .. }
@@ -954,7 +954,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn me_privileges() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let Infra { id: infra1, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
         let Infra { id: infra2, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
         let Infra { id: infra3, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
@@ -1023,7 +1023,7 @@ mod tests {
     // TODO: merge with the previous test once test deadlocks are fixed
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn me_privileges_bis() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let Infra { id: infra1, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
         let Infra { id: infra2, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
         let Infra { id: infra3, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
@@ -1085,11 +1085,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn me_privileges_authz_disabled() {
-        let app = test_app!().enable_authorization(false).build();
+    async fn me_privileges_skip_authz() {
+        let app = test_app!().build();
         let Infra { id: infra, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
         let mut privileges = app
-            .fetch(app.post("/authz/me/privileges").json(&json!({
+            .fetch(app.post("/authz/me/privileges").skip_authz().json(&json!({
                "infra": [infra]
             })))
             .await
@@ -1121,7 +1121,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_me_grants() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
         let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
@@ -1188,7 +1188,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn users_grants_for_resource_id_test() {
         // This test start with an infra with one owner, one writer, and 5 readers
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
         let user = app
@@ -1220,7 +1220,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn groups_grants_on_resource() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         let alice = app
             .user("alice", "Alice")
@@ -1281,7 +1281,7 @@ mod tests {
         // This test starts with a user that is the owner of an infra.
         // Then it creates a new user and adds it as a writer to the infra.
         // Finally, it removes the new user from the infra.
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let openfga = app.openfga();
         let infra = authz::Infra(create_small_infra(&mut db_pool.get_ok()).await.id);
@@ -1340,7 +1340,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn only_owners_can_revoke_infra_grants() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         let writer = app
             .user("writer", "Writer")
@@ -1374,7 +1374,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn admins_can_revoke_infra_grants() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         let admin = app
             .user("admin", "Admin")
@@ -1408,7 +1408,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn last_infra_owner_can_be_revoked_by_admin() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         let admin = app
             .user("admin", "Admin")
@@ -1442,7 +1442,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn owner_cannot_revoke_another_infra_owner() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         let alice = app
             .user("alice", "Alice")
@@ -1476,7 +1476,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn give_grant_to_groups() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let openfga = app.openfga();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         let alice = app
@@ -1560,7 +1560,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn adding_a_grant_that_already_exists() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
         let user = app
@@ -1591,7 +1591,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn skipped_authz_can_set_and_remove_grants() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let openfga = app.openfga();
         let db_pool = app.db_pool();
         let infra = authz::Infra(create_small_infra(&mut db_pool.get_ok()).await.id);
@@ -1641,7 +1641,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn remove_a_grant_that_doesnt_exists() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
         let owner = app
@@ -1673,7 +1673,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn whoami_test() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let user = app
             .user("test", "test")
             .with_roles([Role::OperationalStudies])
@@ -1699,7 +1699,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn whoami_impersonation() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let impersonator = app
             .user("impersonator", "Impersonator")
             .with_roles([Role::Admin])
@@ -1733,7 +1733,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn whoami_new_impersonator_always_forbidden() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let impersonated = app
             .user("impersonated", "Impersonated")
             .with_roles([Role::Stdcm])
@@ -1761,7 +1761,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn whoami_skip_with_user_info() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let user = app
             .user("bob", "Bob")
             .with_roles([Role::Admin])
@@ -1786,14 +1786,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn whoami_authorization_disabled() {
-        let app = test_app!()
-            .enable_authorization(false)
-            .with_openfga_store()
-            .build();
+    async fn whoami_skip_with_unprivileged_user_info() {
+        let app = test_app!().build();
         let user = app.user("test", "test").create().await;
 
-        let request = app.get("/authz/me").by_user(user.as_ref());
+        let request = app.get("/authz/me").by_user(user.as_ref()).skip_authz();
         let WhoamiResponse { roles, .. } = app
             .fetch(request)
             .await
@@ -1805,7 +1802,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_groups_test() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
         let user_1 = app.user("test1", "test1").create().await;
         let user_2 = app.user("test2", "test2").create().await;
         let group_1 = app
@@ -1854,14 +1851,14 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn user_groups_authorization_disabled() {
-        let app = test_app!()
-            .enable_authorization(false)
-            .with_openfga_store()
-            .build();
+    async fn user_groups_skip_authz_is_unauthorized() {
+        let app = test_app!().build();
         let user = app.user("test", "test").create().await;
 
-        let request = app.get("/authz/me/groups").by_user(user.as_ref());
+        let request = app
+            .get("/authz/me/groups")
+            .by_user(user.as_ref())
+            .skip_authz();
         app.fetch(request)
             .await
             .assert_status(StatusCode::UNAUTHORIZED);
@@ -1869,7 +1866,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_groups_test() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
 
         // Create an admin user
         let admin = app
@@ -1900,7 +1897,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_groups_forbidden_non_admin() {
-        let app = test_app!().enable_authorization(true).build();
+        let app = test_app!().build();
 
         // Create a non-admin user
         let user = app

--- a/editoast/src/views/catalog_entry.rs
+++ b/editoast/src/views/catalog_entry.rs
@@ -155,7 +155,7 @@ pub(in crate::views) async fn delete(
 mod tests {
     use crate::fixtures::create_catalog_entry;
     use crate::fixtures::create_catalog_entry_with_name;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     use super::*;
     use editoast_models::catalog_entry::CatalogEntry;
@@ -163,7 +163,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn catalog_entry_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let catalog_entry_form = CatalogEntryForm {
             name: Some("test".to_string()),
@@ -188,7 +188,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn catalog_entry_get() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;
@@ -206,7 +206,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn catalog_entry_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;
@@ -224,7 +224,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn catalog_entry_unexisting_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.delete("/catalog_entries/999999");
 
@@ -234,7 +234,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn catalog_entry_put() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;
@@ -262,7 +262,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn catalog_entry_list_paginated() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let catalog_entry_1 =

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -139,7 +139,7 @@ mod tests {
     use serde::Deserialize;
 
     use super::*;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     #[derive(Deserialize, Clone, Debug)]
     struct PostDocumentResponse {
@@ -148,7 +148,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn document_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let request = app
@@ -160,9 +160,8 @@ mod tests {
             .bytes("Document post test data".into());
 
         // Insert document
-        let response = request.await;
-        response.assert_status(StatusCode::CREATED);
-        let new_doc = response.json::<PostDocumentResponse>().document_key;
+        let response = app.fetch(request).await.assert_status(StatusCode::CREATED);
+        let new_doc = response.json_into::<PostDocumentResponse>().document_key;
 
         // Get create document
         let document = Document::retrieve(pool.get_ok(), new_doc)
@@ -175,7 +174,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_document() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         // Insert document test
@@ -187,16 +186,18 @@ mod tests {
             .expect("Failed to create document");
 
         // Get document test
-        let response = app.get(&format!("/documents/{}", document.id)).await;
-        response.assert_status(StatusCode::OK);
-        let response = response.as_bytes();
+        let response = app
+            .fetch(app.get(&format!("/documents/{}", document.id)))
+            .await
+            .assert_status(StatusCode::OK)
+            .bytes();
 
-        assert_eq!(response.as_ref(), b"Document post test data");
+        assert_eq!(response.as_slice(), b"Document post test data");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn document_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         // Insert document test
@@ -208,10 +209,9 @@ mod tests {
             .expect("Failed to create document");
 
         // Delete document request
-        let response = app
-            .delete(format!("/documents/{}", document.id).as_str())
-            .await;
-        response.assert_status(StatusCode::NO_CONTENT);
+        app.fetch(app.delete(format!("/documents/{}", document.id).as_str()))
+            .await
+            .assert_status(StatusCode::NO_CONTENT);
 
         // Get create document
         let document = Document::exists(&mut pool.get_ok(), document.id)

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -172,72 +172,75 @@ mod tests {
 
     use super::*;
     use crate::fixtures::create_electrical_profile_set;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use schemas::infra::ElectricalProfile;
     use schemas::infra::TrackRange;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_electrical_profile_list() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let _set_1 = create_electrical_profile_set(&mut pool.get_ok()).await;
         let _set_2 = create_electrical_profile_set(&mut pool.get_ok()).await;
 
-        let response = app.get("/electrical_profile_set").await;
-        response.assert_status(StatusCode::OK);
-        let response: Vec<LightElectricalProfileSet> = response.json();
+        let response: Vec<LightElectricalProfileSet> = app
+            .fetch(app.get("/electrical_profile_set"))
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert!(response.len() >= 2);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_electrical_profile() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
-        let response = app.get("/electrical_profile_set/666").await;
-        response.assert_status(StatusCode::NOT_FOUND);
+        app.fetch(app.get("/electrical_profile_set/666"))
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_electrical_profile() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
-        let response = app
-            .get(&format!(
-                "/electrical_profile_set/{}",
-                electrical_profile_set.id
-            ))
-            .await;
-        response.assert_status(StatusCode::OK);
+        app.fetch(app.get(&format!(
+            "/electrical_profile_set/{}",
+            electrical_profile_set.id
+        )))
+        .await
+        .assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_electrical_profile_level_order() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
-        let response = app.get("/electrical_profile_set/666/level_order").await;
-        response.assert_status(StatusCode::NOT_FOUND);
+        app.fetch(app.get("/electrical_profile_set/666/level_order"))
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_get_level_order_some() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
-        let response = app
-            .get(&format!(
+        let level_order: HashMap<String, Vec<String>> = app
+            .fetch(app.get(&format!(
                 "/electrical_profile_set/{}/level_order",
                 electrical_profile_set.id
-            ))
-            .await;
-        response.assert_status(StatusCode::OK);
-        let level_order: HashMap<String, Vec<String>> = response.json();
+            )))
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         assert_eq!(level_order.len(), 1);
         assert_eq!(
@@ -248,25 +251,25 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unexisting_electrical_profile() {
-        let app = TestAppBuilder::default_app();
-        let response = app.delete("/electrical_profile_set/666").await;
-        response.assert_status(StatusCode::NOT_FOUND);
+        let app = test_app!().skip_authz().build();
+        app.fetch(app.delete("/electrical_profile_set/666"))
+            .await
+            .assert_status(StatusCode::NOT_FOUND);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_electrical_profile() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
-        let response = app
-            .delete(&format!(
-                "/electrical_profile_set/{}",
-                electrical_profile_set.id
-            ))
-            .await;
-        response.assert_status(StatusCode::NO_CONTENT);
+        app.fetch(app.delete(&format!(
+            "/electrical_profile_set/{}",
+            electrical_profile_set.id
+        )))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
 
         let exists = ElectricalProfileSet::exists(&mut pool.get_ok(), electrical_profile_set.id)
             .await
@@ -277,7 +280,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let ep_set = ElectricalProfileSetData {
@@ -289,12 +292,11 @@ mod tests {
             level_order: Default::default(),
         };
 
-        let response = app
-            .post("/electrical_profile_set/?name=elec")
-            .json(&ep_set)
-            .await;
-        response.assert_status(StatusCode::OK);
-        let created_ep: ElectricalProfileSet = response.json();
+        let created_ep: ElectricalProfileSet = app
+            .fetch(app.post("/electrical_profile_set/?name=elec").json(&ep_set))
+            .await
+            .assert_status(StatusCode::OK)
+            .json_into();
 
         let created_ep = ElectricalProfileSet::retrieve(pool.get_ok(), created_ep.id)
             .await

--- a/editoast/src/views/fonts.rs
+++ b/editoast/src/views/fonts.rs
@@ -57,13 +57,13 @@ pub(in crate::views) async fn fonts(
 
 #[cfg(test)]
 mod tests {
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     use axum::http::StatusCode;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_font() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/fonts/IBMPlexSans/0-255.pbf");
         let response = app.fetch(request).await.assert_status(StatusCode::OK);
         assert_eq!("application/octet-stream", response.content_type());
@@ -79,7 +79,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_font_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/fonts/Comic%20Sans/0-255.pbf");
         app.fetch(request)
             .await

--- a/editoast/src/views/health.rs
+++ b/editoast/src/views/health.rs
@@ -96,13 +96,12 @@ pub async fn check_health(
 
 #[cfg(test)]
 mod tests {
+    use crate::views::test_app;
     use reqwest::StatusCode;
-
-    use crate::views::test_app::TestAppBuilder;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn health() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/health");
         app.fetch(request).await.assert_status(StatusCode::OK);
     }

--- a/editoast/src/views/icons.rs
+++ b/editoast/src/views/icons.rs
@@ -55,13 +55,13 @@ pub(in crate::views) async fn icons(
 
 #[cfg(test)]
 mod tests {
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     use axum::http::StatusCode;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_icons() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/icons/TVM300/REP%20TGV.svg");
         let response = app.fetch(request).await.assert_status(StatusCode::OK);
         assert_eq!("image/svg+xml", response.content_type());
@@ -77,7 +77,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_icons_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/icons/TVM300/NOT_A_THING.svg");
         app.fetch(request)
             .await

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -124,7 +124,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::infra_cache::operation::create::apply_create_operation;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use editoast_models::Infra;
     use editoast_models::prelude::*;
     use schemas::infra::Detector;
@@ -134,7 +134,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_attached_detector() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         // Create empty infra

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -367,8 +367,8 @@ mod tests {
     use crate::infra_cache::operation::Operation;
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::views::infra::errors::query_errors;
+    use crate::views::test_app;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
     use schemas::infra::ApplicableDirectionsTrackRange;
     use schemas::infra::Detector;
     use schemas::infra::Electrification;
@@ -398,7 +398,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_no_fix() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
@@ -415,7 +415,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fix_invalid_ref_punctual_objects() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let mut small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
@@ -490,7 +490,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fix_invalid_ref_route_entry_exit() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
@@ -718,7 +718,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn invalid_switch_ports() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
@@ -756,7 +756,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn odd_buffer_stop_location() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
@@ -809,7 +809,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn empty_object() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
@@ -851,7 +851,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn out_of_range_must_be_ignored() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
@@ -916,7 +916,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(1250., 5)]
     async fn out_of_range_must_be_deleted(#[case] pos: f64, #[case] error_count: usize) {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
@@ -979,7 +979,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn out_of_range_must_be_updated() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
@@ -1037,7 +1037,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn missing_track_extremity_buffer_stop_fix() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -511,7 +511,7 @@ fn track_range_from_endpoint(
 mod tests {
     use crate::fixtures::create_small_infra;
     use crate::views::infra::delimited_area::DelimitedAreaResponse;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use axum::http::StatusCode;
     use editoast_models::Infra;
 
@@ -528,7 +528,7 @@ mod tests {
         entries: Vec<DirectedLocation>,
         exits: Vec<DirectedLocation>,
     ) -> Vec<DirectionalTrackRange> {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
         let Infra { id: infra_id, .. } = create_small_infra(&mut pool.get_ok()).await;
         let request = app

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -990,12 +990,12 @@ pub mod tests {
     use crate::generated_data::infra_error::InfraError;
     use crate::generated_data::infra_error::InfraErrorType;
     use crate::views::infra::errors::query_errors;
+    use crate::views::test_app;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
     use editoast_models::infra::ObjectQueryable;
 
     async fn setup_split_track_test() -> (TestApp, Infra) {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
@@ -1009,7 +1009,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_return_404_with_bad_infra() {
         // Init
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         // Make a call with a bad infra ID
         let request = app
@@ -1028,7 +1028,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_return_404_with_bad_id() {
         // Init
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
@@ -1049,7 +1049,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_fail_with_bad_distance() {
         // Init
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
@@ -1110,7 +1110,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_edition_updates_modification_date() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let mut small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let mut infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
@@ -1152,7 +1152,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn apply_edit_transaction_should_work() {
         // Init
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let conn = &mut db_pool.get().await.unwrap();
 
@@ -1195,7 +1195,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn apply_edit_transaction_should_rollback() {
         // Init
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let conn = &mut db_pool.get().await.unwrap();
         let mut small_infra = create_small_infra(conn).await;

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -133,11 +133,11 @@ mod tests {
     use axum::http::StatusCode;
 
     use crate::fixtures::create_empty_infra;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_errors_get() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -92,14 +92,14 @@ mod tests {
 
     use crate::fixtures::create_empty_infra;
     use crate::infra_cache::operation::create::apply_create_operation;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use schemas::infra::TrackSection;
     use schemas::infra::TrackSectionExtensions;
     use schemas::primitives::BoundingBox;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_correct_bbox_for_existing_line_code() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -146,7 +146,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_bad_request_when_line_code_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -834,8 +834,9 @@ pub mod tests {
     use crate::fixtures::create_small_infra;
     use crate::generated_data;
     use crate::infra_cache::operation::create::apply_create_operation;
+    use crate::views::test_app;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
+
     use editoast_models::infra::DEFAULT_INFRA_VERSION;
     use editoast_models::infra_objects::get_geometry_layer_table;
     use editoast_models::infra_objects::get_table;
@@ -849,7 +850,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_clone_empty() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -876,7 +877,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_clone() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
@@ -952,7 +953,8 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_delete() {
         let pool = DbConnectionPoolV2::for_tests();
-        let app = TestAppBuilder::new()
+        let app = test_app!()
+            .skip_authz()
             .db_pool(pool)
             .core_client(CoreClient::Mocked(MockingClient::default()))
             .build();
@@ -970,14 +972,14 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_list() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/infra/");
         app.fetch(request).await.assert_status(StatusCode::OK);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn default_infra_create() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app
             .post("/infra")
@@ -999,7 +1001,7 @@ pub mod tests {
     async fn infra_get() {
         let core_client = CoreClient::Mocked(MockingClient::default());
 
-        let app = TestAppBuilder::new().core_client(core_client).build();
+        let app = test_app!().skip_authz().core_client(core_client).build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -1016,7 +1018,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_rename() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -1040,7 +1042,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_refresh() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -1058,7 +1060,7 @@ pub mod tests {
     // Slow test
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn infra_refresh_force() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -1074,7 +1076,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_speed_limit_tags() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let builtin_tags = app.speed_limit_tag_ids();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1104,7 +1106,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_all_voltages() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let infra_1 = create_empty_infra(&mut db_pool.get_ok()).await;
         let infra_2 = create_empty_infra(&mut db_pool.get_ok()).await;
@@ -1157,7 +1159,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(false)]
     async fn infra_get_voltages(#[case] include_rolling_stock_modes: bool) {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -1208,7 +1210,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_switch_types() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -1227,7 +1229,7 @@ pub mod tests {
     async fn infra_lock() {
         let core_client = CoreClient::Mocked(MockingClient::default());
 
-        let app = TestAppBuilder::new().core_client(core_client).build();
+        let app = test_app!().skip_authz().core_client(core_client).build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -1258,7 +1260,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn match_operational_points() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let mut infra = create_small_infra(&mut db_pool.get_ok()).await;
         let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &infra)
@@ -1319,7 +1321,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn match_operational_point_input_with_incompatible_op_id_gets_filtered_out() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
         let operational_point_references = vec![
@@ -1353,7 +1355,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_infra_cache() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let infra_caches = dashmap::DashMap::new();
@@ -1381,7 +1383,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_infra_cache_mut() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let infra_caches = dashmap::DashMap::new();

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -163,14 +163,14 @@ mod tests {
     use crate::fixtures::create_empty_infra;
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::views::infra::objects::ObjectQueryable;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use schemas::infra::Switch;
     use schemas::infra::SwitchType;
     use schemas::primitives::OSRDIdentified;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_invalid_ids() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -185,7 +185,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_no_ids() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -199,7 +199,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_should_return_switch() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -245,7 +245,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_duplicate_ids() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -260,7 +260,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_switch_types() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -297,7 +297,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_list_ids() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -245,14 +245,14 @@ mod tests {
     use super::*;
     use crate::fixtures::create_empty_infra;
     use crate::infra_cache::operation::create::apply_create_operation;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use schemas::infra::RAILJSON_VERSION;
     use schemas::infra::SwitchType;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn test_get_railjson() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -279,7 +279,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn test_post_railjson() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let railjson = RailJson {

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -312,7 +312,7 @@ mod tests {
     use crate::views::infra::routes::RoutesFromNodesPositions;
     use crate::views::infra::routes::RoutesResponse;
     use crate::views::infra::routes::WaypointType;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
     use schemas::infra::Route;
@@ -386,7 +386,7 @@ mod tests {
             ),
         ];
 
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
@@ -441,7 +441,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_routes_should_return_routes_from_buffer_stop_and_detector() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
@@ -534,7 +534,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_routes_should_return_empty_response() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -360,8 +360,9 @@ mod tests {
     use crate::fixtures::create_fast_rolling_stock;
     use crate::fixtures::create_small_infra;
     use crate::fixtures::create_timetable_with_train_schedule_set;
-    use crate::views::test_app::TestAppBuilder;
     use crate::views::test_app::TestResponse;
+    use crate::views::test_app::test_app;
+
     use chrono::TimeDelta;
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::PathfindingResultSuccess;
@@ -532,7 +533,7 @@ mod tests {
         track: &str,
         lc_position: f64,
     ) -> (TestResponse, Identifier, TrainSchedule) {
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =

--- a/editoast/src/views/operational_studies/hierarchy/project.rs
+++ b/editoast/src/views/operational_studies/hierarchy/project.rs
@@ -368,12 +368,10 @@ pub mod tests {
 
     use crate::fixtures::create_project;
     use crate::views::test_app;
-    use crate::views::test_app::TestAppBuilder;
-    use crate::views::test_app::TestRequestExt;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let project_name = "test_project";
@@ -400,30 +398,8 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn project_post_should_fail_when_authorization_is_enabled() {
-        let app = test_app!().enable_authorization(true).build();
-        let user = app
-            .user("bob", "Bob")
-            .with_roles([Role::Stdcm])
-            .create()
-            .await;
-
-        let request = app.post("/projects").by_user(user.as_ref()).json(&json!({
-            "name": "test_project_failed",
-            "description": "",
-            "objectives": "",
-            "funders": "",
-        }));
-
-        // OpsWrite is required to complete this request successfully.
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::FORBIDDEN);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_list() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -447,7 +423,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_get() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -465,7 +441,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -485,7 +461,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_patch() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -518,7 +494,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_update_image() {
-        let app = test_app!().build();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         // no image by default

--- a/editoast/src/views/operational_studies/hierarchy/scenario.rs
+++ b/editoast/src/views/operational_studies/hierarchy/scenario.rs
@@ -424,7 +424,7 @@ mod tests {
     use crate::fixtures::create_scenario_fixtures_set;
     use crate::fixtures::create_study;
     use crate::fixtures::create_timetable;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     pub fn scenario_url(scenario_id: Option<i64>) -> String {
         format!(
@@ -435,7 +435,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_scenario() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
@@ -454,7 +454,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_scenarios() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
@@ -483,7 +483,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn post_scenario() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let project = create_project(&mut pool.get_ok(), "project_test_name").await;
@@ -537,7 +537,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_scenario() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
@@ -568,7 +568,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_scenario_with_unavailable_infra() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
@@ -587,7 +587,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_infra_id_scenario() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
@@ -617,7 +617,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_scenario() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;

--- a/editoast/src/views/operational_studies/hierarchy/study.rs
+++ b/editoast/src/views/operational_studies/hierarchy/study.rs
@@ -452,12 +452,12 @@ pub mod tests {
     use super::*;
     use crate::fixtures::create_project;
     use crate::fixtures::create_study;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use editoast_models::study::Study;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -488,7 +488,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_list() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -517,7 +517,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_get() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -539,7 +539,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_get_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -556,7 +556,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
@@ -579,7 +579,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_patch() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;

--- a/editoast/src/views/operational_studies/macro_view/macro_nodes.rs
+++ b/editoast/src/views/operational_studies/macro_view/macro_nodes.rs
@@ -344,7 +344,7 @@ pub mod test {
 
     use super::*;
     use crate::fixtures::create_scenario_fixtures_set;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     impl PartialEq<MacroNodeResponse> for MacroNode {
         fn eq(&self, other: &MacroNodeResponse) -> bool {
@@ -375,7 +375,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let fixtures =
@@ -413,7 +413,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 
@@ -447,7 +447,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 
@@ -463,7 +463,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_node_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.get("/macro_nodes/999999");
 
@@ -474,7 +474,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 10).await;
 
@@ -494,7 +494,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 

--- a/editoast/src/views/operational_studies/macro_view/macro_notes.rs
+++ b/editoast/src/views/operational_studies/macro_view/macro_notes.rs
@@ -327,7 +327,7 @@ pub mod test {
 
     use super::*;
     use crate::fixtures::create_scenario_fixtures_set;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     impl PartialEq<MacroNoteResponse> for MacroNoteForm {
         fn eq(&self, other: &MacroNoteResponse) -> bool {
@@ -341,7 +341,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_notes() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let fixtures1 =
@@ -402,7 +402,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_note() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let fixtures =
@@ -449,7 +449,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_note_scenario_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures =
             create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
@@ -473,7 +473,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_note() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures =
             create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
@@ -501,7 +501,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_note_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.get("/macro_notes/999999");
 
@@ -512,7 +512,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_note() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures =
             create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
@@ -554,7 +554,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_note_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let update = MacroNoteForm {
             x: 30,
@@ -573,7 +573,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_note() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let fixtures =
             create_scenario_fixtures_set(&mut db_pool.get_ok(), "test_scenario_name").await;
@@ -603,7 +603,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_note_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.delete("/macro_notes/999999");
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -561,7 +561,7 @@ pub mod tests {
     use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::path::pathfinding::PathfindingInput;
     use crate::views::path::pathfinding::PathfindingResult;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     fn pathfinding_input(path_items: Vec<PathItemLocation>) -> PathfindingInput {
         PathfindingInput {
@@ -600,7 +600,7 @@ pub mod tests {
             .response(StatusCode::OK)
             .json(pathfinding_result(0))
             .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let path_items = vec![
@@ -639,7 +639,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn pathfinding_with_invalid_path_items_returns_invalid_path_items() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let path_items = vec![
@@ -698,7 +698,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn pathfinding_with_invalid_path_items_due_to_local_track_name() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let path_items = vec![
@@ -755,7 +755,7 @@ pub mod tests {
             .response(StatusCode::OK)
             .json(pathfinding_result(1))
             .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let path_items = vec![

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -135,7 +135,7 @@ mod tests {
     use super::PathProperties;
     use crate::fixtures::create_small_infra;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app::test_app;
 
     fn path_properties_response() -> core_client::path_properties::PathPropertiesResponse {
         core_client::path_properties::PathPropertiesResponse {
@@ -161,7 +161,7 @@ mod tests {
             .json(path_properties_response())
             .finish();
 
-        TestAppBuilder::new().core_client(core.into()).build()
+        test_app!().skip_authz().core_client(core.into()).build()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -965,7 +965,7 @@ pub async fn extract_train_details<T: TrainScheduleLike>(
 mod tests {
     use super::*;
     use crate::fixtures::create_small_infra;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use rstest::rstest;
     use schemas::infra::Direction;
     use schemas::infra::DirectionalTrackRange;
@@ -1187,7 +1187,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_simple_project_train_path_op() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let trigrams = ["SWS", "MWS", "MES", "NS", "SS"];
@@ -1249,7 +1249,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_simple_reverse_project_train_path_op() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let trigrams = ["SWS", "MWS", "MES", "NS", "SS"];
@@ -1312,7 +1312,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_points_project_train_path_op() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let trigrams = ["SWS", "MWS", "MES", "NS", "SS"];
@@ -1370,7 +1370,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_no_matching_points_project_train_path_op() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let op_cache = OperationalPointCache::load_path_items::<PathItemLocation>(

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -688,8 +688,8 @@ pub mod tests {
     use crate::fixtures::create_study;
     use crate::fixtures::create_timetable_with_train_schedule_set;
     use crate::fixtures::simple_paced_train_changeset;
+    use crate::views::test_app;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
     use editoast_models::rolling_stock::RollingStock;
 
     impl TestApp {
@@ -721,7 +721,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_successfully() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -757,7 +757,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_locked_rolling_stock_successfully() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -784,7 +784,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_duplicate_name() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -807,7 +807,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_usage_with_no_usage_returns_empty_ok() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let stock_name = Uuid::new_v4().to_string();
         let rolling_stock = fast_rolling_stock_form(stock_name.as_str());
         let request = app.rolling_stock_create_request(&rolling_stock);
@@ -827,7 +827,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_usage_with_related_schedules_returns_schedules_list() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let create_rolling_stock_request =
@@ -936,7 +936,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_invalid_rolling_stock_id_returns_404_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let _ = RollingStock::delete_static(&mut db_pool.get_ok(), 1).await;
 
@@ -949,7 +949,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_base_power_class_empty() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let rs_name = "fast_rolling_stock_name";
         let mut fast_rolling_stock_form = fast_rolling_stock_form(rs_name);
@@ -973,7 +973,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_invalid_effort_curve() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let invalid_payload = schemas::fixtures::rolling_stock_with_invalid_effort_curves_json();
 
@@ -993,7 +993,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_with_etcs_brake_params() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rolling_stock_form = simple_etcs_level2_rolling_stock();
@@ -1026,7 +1026,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_by_id() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -1046,7 +1046,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_by_name() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -1065,7 +1065,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_rolling_stock_by_id() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.rolling_stock_get_by_id_request(0);
 
@@ -1076,7 +1076,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_rolling_stock_by_name() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request =
             app.get(format!("/rolling_stock/name/{}", "unexisting_rolling_stock_name").as_str());
@@ -1089,7 +1089,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_unlocked_rolling_stock() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -1126,7 +1126,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_with_new_categories() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let fast_rolling_stock =
@@ -1178,7 +1178,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_categories_should_fail_when_invalid() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let fast_rolling_stock =
@@ -1220,7 +1220,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_failure_name_already_used() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let first_rs_name = "first_fast_rolling_stock_name";
@@ -1254,7 +1254,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_locked_rolling_stock_fails() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1286,7 +1286,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_lock_rolling_stock_failed() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let id: i64 = rand::random();
         let request = app
@@ -1300,7 +1300,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_lock_rolling_stock_successfully() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -1327,7 +1327,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_unlock_rolling_stock_successfully() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1362,7 +1362,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_power_restrictions_list() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -1387,7 +1387,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_locked_rolling_stock_fails() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1423,7 +1423,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unlocked_unused_rolling_stock_succeeds() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -1448,7 +1448,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unlocked_used_rolling_stock_requires_force_flag() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -282,7 +282,7 @@ mod tests {
     use super::LightRollingStockWithLiveriesCountList;
     use crate::error::InternalError;
     use crate::fixtures::create_fast_rolling_stock;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     fn is_sorted(data: &[i64]) -> bool {
         for elem in data.windows(2) {
@@ -295,7 +295,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_light_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/light_rolling_stock");
         app.fetch(request).await.assert_status(StatusCode::OK);
     }
@@ -303,7 +303,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -325,7 +325,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock_by_name() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
@@ -347,7 +347,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_light_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.get(format!("/light_rolling_stock/{}", -1).as_str());
 
@@ -358,7 +358,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_light_rolling_stock_increasing_ids() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let generated_rolling_stock = (0..10)
@@ -419,7 +419,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn light_rolling_stock_max_page_size() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.get("/light_rolling_stock/?page_size=1010");
 

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -231,8 +231,8 @@ pub(in crate::views) async fn patch_by_id_locked(
 #[cfg(test)]
 mod tests {
     use super::TowedRollingStockCountList;
+    use crate::views::test_app;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
     use axum::http::StatusCode;
     use common::units;
     use editoast_models::TowedRollingStock;
@@ -279,7 +279,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_and_list_towed_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let name = Uuid::new_v4().to_string();
         let towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
@@ -303,7 +303,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unknown_towed_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let id: i64 = rand::random();
 
@@ -314,7 +314,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_and_get_towed_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let name = Uuid::new_v4().to_string();
         let created_towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
@@ -334,7 +334,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_unknown_towed_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let name = Uuid::new_v4().to_string();
         let towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED).await;
@@ -350,7 +350,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_towed_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let name = Uuid::new_v4().to_string();
         let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED).await;
@@ -375,7 +375,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_lock_on_unknown_towed_rolling_stock() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let id: i64 = rand::random(); // <-- doesn't exist
         app.fetch(
@@ -388,7 +388,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_locked_towed_rolling_stock_fails() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let name = Uuid::new_v4().to_string();
         let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
@@ -405,7 +405,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn modify_locked_towed_rolling_stock_after_unlocked() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let name = Uuid::new_v4().to_string();
         let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -796,11 +796,11 @@ pub mod tests {
     use super::*;
     use crate::fixtures::create_simple_paced_train;
     use crate::fixtures::create_train_schedule_set;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn search_trainschedule_post_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         // Create a train_schedule_set in the database
@@ -828,7 +828,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn search_trainschedule_post_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         // Create a train_schedule_set in the database

--- a/editoast/src/views/server.rs
+++ b/editoast/src/views/server.rs
@@ -84,7 +84,6 @@ pub struct ServerConfig {
     pub address: String,
     pub health_check_timeout: Duration,
     pub map_layers_max_zoom: u8,
-    pub enable_authorization: bool,
     pub postgres_config: PostgresConfig,
     pub osrdyne_config: OsrdyneConfig,
     pub valkey_config: cache::Config,
@@ -330,16 +329,7 @@ impl Server {
 
     pub async fn start(self) -> std::io::Result<()> {
         let Self { app_state, router } = self;
-        let ServerConfig {
-            address,
-            port,
-            enable_authorization,
-            ..
-        } = app_state.config.as_ref();
-
-        if !*enable_authorization {
-            warn!("authorization disabled — all role and permission checks are bypassed");
-        }
+        let ServerConfig { address, port, .. } = app_state.config.as_ref();
 
         info!("Running server...");
         let service = ServiceExt::<axum::extract::Request>::into_make_service(router);

--- a/editoast/src/views/server/middlewares.rs
+++ b/editoast/src/views/server/middlewares.rs
@@ -22,7 +22,7 @@ use crate::views::Regulator;
 
 #[tracing::instrument(skip_all, fields(authn))]
 pub(in crate::views) async fn authentication_extraction_middleware(
-    State(AppState { config, .. }): State<AppState>,
+    State(AppState { .. }): State<AppState>,
     mut req: Request,
     next: Next,
 ) -> Result<Response> {
@@ -54,7 +54,6 @@ pub(in crate::views) async fn authentication_extraction_middleware(
         name,
         impersonate,
         skip: skip_authz,
-        authorization_enabled: config.enable_authorization,
     })
     .map_err(
         |AuthenticationParameters {
@@ -62,14 +61,12 @@ pub(in crate::views) async fn authentication_extraction_middleware(
              name,
              impersonate,
              skip,
-             authorization_enabled,
          }| {
             tracing::error!(
                 identity,
                 name,
                 impersonate,
                 skip,
-                authorization_enabled,
                 "invalid authentication parameters"
             );
             AuthorizationError::Unauthorized
@@ -251,7 +248,6 @@ pub(in crate::views) async fn authentication_validation_middleware(
 pub type AuthenticationExt = axum::extract::Extension<Authentication>;
 
 async fn authenticate(
-    enable_authorization: bool,
     headers: &axum::http::HeaderMap,
     regulator: Regulator,
 ) -> Result<Authentication, AuthorizationError> {
@@ -278,14 +274,6 @@ async fn authenticate(
     let skip_authz = headers.contains_key(SKIP_AUTHZ);
 
     let (user, identity) = match (identity, name) {
-        (identity, name) if !enable_authorization => {
-            tracing::debug!(
-                identity,
-                name,
-                "authorization disabled — all role and permission checks are bypassed"
-            );
-            return Ok(Authentication::SkipAuthorization { identity, name });
-        }
         (identity, name) if skip_authz => {
             tracing::debug!(identity, name, "authorization skipped by request");
             return Ok(Authentication::SkipAuthorization { identity, name });
@@ -339,14 +327,12 @@ async fn authenticate(
 }
 
 pub(in crate::views) async fn authentication_middleware(
-    State(AppState {
-        regulator, config, ..
-    }): State<AppState>,
+    State(AppState { regulator, .. }): State<AppState>,
     mut req: Request,
     next: Next,
 ) -> Result<Response> {
     let headers = req.headers();
-    let authorizer = authenticate(config.enable_authorization, headers, regulator).await?;
+    let authorizer = authenticate(headers, regulator).await?;
     req.extensions_mut().insert(authorizer);
     Ok(next.run(req).await)
 }

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -81,13 +81,13 @@ pub(in crate::views) async fn sprites(
 
 #[cfg(test)]
 mod tests {
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     use axum::http::StatusCode;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_signaling_systems() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/sprites/signaling_systems");
         let response: Vec<String> = app
             .fetch(request)
@@ -104,7 +104,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_sprites() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/sprites/TVM300/REP%20TGV.svg");
         let response = app.fetch(request).await.assert_status(StatusCode::OK);
         assert_eq!("image/svg+xml", response.content_type());
@@ -120,7 +120,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_sprites_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/sprites/TVM300/NOT_A_THING.svg");
         app.fetch(request)
             .await

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -307,12 +307,12 @@ pub mod tests {
     use editoast_models::stdcm_search_environment::fixtures::stdcm_search_env_fixtures;
 
     use super::*;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_stdcm_search_env() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let (
@@ -366,7 +366,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_stdcm_search_env_with_bad_default_speed_limit_tag() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let (
@@ -410,7 +410,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn retrieve_stdcm_search_env() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let pool = app.db_pool();
 
@@ -469,7 +469,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn retrieve_stdcm_search_env_not_found() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         StdcmSearchEnvironment::delete_all(&mut pool.get_ok())
@@ -487,7 +487,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_stdcm_search_env() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let (
@@ -530,7 +530,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_stdcm_search_env() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let pool = app.db_pool();
 

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -186,12 +186,12 @@ pub mod tests {
     use crate::fixtures::simple_paced_train_changeset;
     use crate::fixtures::simple_sub_category;
     use crate::views::sub_categories::SubCategoryPage;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use editoast_models::prelude::*;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let request = app.post("/sub_category").json(&json!([
@@ -246,7 +246,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_duplicated_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.post("/sub_category").json(&json!([
             {
@@ -274,7 +274,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_get() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_sub_category_1 = simple_sub_category(
@@ -307,7 +307,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn sub_category_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let created_sub_category = simple_sub_category(

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -167,7 +167,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::views::temporary_speed_limits::TemporarySpeedLimitCreateResponse;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use editoast_models::TemporarySpeedLimit;
 
     struct TimePeriod {
@@ -260,7 +260,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_temporary_speed_limits_succeeds() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let group_name = Uuid::new_v4().to_string();
@@ -302,7 +302,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_temporary_speed_limit_groups_with_identical_name_fails() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let group_name = Uuid::new_v4().to_string();
         let request = app.create_temporary_speed_limit_group_request(
@@ -324,7 +324,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_ltv_with_invalid_invalid_time_period_fails() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let time_period = TimePeriod {
             start_date_time: Utc::now() + Duration::days(1),
@@ -344,7 +344,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore] // TODO is this something we want to enforce ?
     async fn create_ltv_with_no_tracks_fails() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.create_temporary_speed_limit_group_request(
             RequestParameters::new().with_track_ranges(vec![]),

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -78,16 +78,12 @@ impl SpanExporter for NoopSpanExporter {
 /// It allows configuring some parameters for the app service.
 /// Currently it allows setting the database connection pool (v1 or v2) and the core client.
 ///
-/// Use [TestAppBuilder::default_app] to get a default app with a v2 database connection pool
-/// and a default core client (mocking disabled).
-///
 /// The `db_pool_v1` parameter is only relevant while the pool migration is ongoing.
 pub(crate) struct TestAppBuilder {
     test_name: String,
     db_pool: Option<DbConnectionPoolV2>,
     core_client: Option<CoreClient>,
     enable_authorization: bool,
-    openfga_store: bool,
     enable_telemetry: bool,
     root_url: Option<Url>,
     trains_traffic: TrainsTrafficPool,
@@ -99,8 +95,7 @@ impl TestAppBuilder {
             test_name: String::from("editoast-test"),
             db_pool: None,
             core_client: None,
-            enable_authorization: false,
-            openfga_store: false,
+            enable_authorization: true,
             enable_telemetry: true,
             root_url: None,
             trains_traffic: TrainsTrafficPool::new(),
@@ -125,17 +120,8 @@ impl TestAppBuilder {
         self
     }
 
-    /// Setting this to true implies [with_openfga_store]
-    pub fn enable_authorization(mut self, enable_authorization: bool) -> Self {
-        self.enable_authorization = enable_authorization;
-        if enable_authorization {
-            self.openfga_store = true;
-        }
-        self
-    }
-
-    pub fn with_openfga_store(mut self) -> Self {
-        self.openfga_store = true;
+    pub fn skip_authz(mut self) -> Self {
+        self.enable_authorization = false;
         self
     }
 
@@ -157,10 +143,6 @@ impl TestAppBuilder {
         self
     }
 
-    pub fn default_app() -> TestApp {
-        TestAppBuilder::new().build()
-    }
-
     pub fn build(self) -> TestApp {
         // Generate test server config
         let config = ServerConfig {
@@ -168,7 +150,6 @@ impl TestAppBuilder {
             port: 0,
             address: String::default(),
             health_check_timeout: chrono::Duration::milliseconds(500),
-            enable_authorization: self.enable_authorization,
             map_layers_max_zoom: 18,
             postgres_config: PostgresConfig {
                 database_url: Url::parse("postgres://osrd:password@localhost:5432/osrd").unwrap(),
@@ -250,7 +231,7 @@ impl TestAppBuilder {
             fga_connection_settings.clone(),
         ))
         .expect("Failed creating OpenFGA authorization store");
-        if self.openfga_store {
+        if self.enable_authorization {
             let migrations_store_name = fga::test_utilities::sanitize_store_name_length(&format!(
                 "migrations@{}",
                 self.test_name
@@ -310,6 +291,7 @@ impl TestAppBuilder {
             test_name: self.test_name,
             server,
             app_state,
+            enable_authorization: self.enable_authorization,
             tracing_guard,
         }
     }
@@ -342,7 +324,11 @@ pub(crate) struct TestApp {
     test_name: String,
     server: TestServer,
     app_state: AppState,
-    #[expect(unused)] // included here to extend its lifetime, not meant to be used in any way
+    enable_authorization: bool,
+    #[expect(
+        unused,
+        reason = "included here to extend its lifetime, not meant to be used in any way"
+    )]
     tracing_guard: tracing::subscriber::DefaultGuard,
 }
 
@@ -390,7 +376,10 @@ impl TestApp {
         )
     }
 
-    pub async fn fetch(&self, req: TestRequest) -> TestResponse {
+    pub async fn fetch(&self, mut req: TestRequest) -> TestResponse {
+        if !self.enable_authorization {
+            req = req.skip_authz(); // x-osrd-skip-authz
+        }
         tracing::trace!(request = ?req);
         let response = req.await;
         TestResponse::new(response)
@@ -506,10 +495,8 @@ impl<'a> UserBuilder<'a> {
             infras_grant,
         } = self;
 
-        if !roles.is_empty() && !app.app_state.config.enable_authorization {
-            panic!(
-                "Authorization must be enabled and a model must be provided to grant a user some roles"
-            );
+        if (!roles.is_empty() || !infras_grant.is_empty()) && !app.enable_authorization {
+            panic!("An OpenFGA model must be provided to grant a user roles or infra grants");
         }
         let regulator = &app.app_state.regulator;
 
@@ -518,7 +505,7 @@ impl<'a> UserBuilder<'a> {
             editoast_models::User::register(app.db_pool().get().await.unwrap(), identities, name)
                 .await
                 .expect("User should be created successfully");
-        if app.app_state.config.enable_authorization {
+        if app.enable_authorization {
             v2::add_roles(authz::Subject::user(user.id), roles)
                 .authorize(&special_authorizers::Authorize(regulator.openfga()))
                 .await
@@ -579,10 +566,10 @@ impl<'a> GroupBuilder<'a> {
             members,
             infras_grant,
         } = self;
-        let authz_disabled = !app.app_state.config.enable_authorization;
-        if !roles.is_empty() && authz_disabled {
+        let needs_openfga = !roles.is_empty() || !members.is_empty() || !infras_grant.is_empty();
+        if needs_openfga && !app.enable_authorization {
             panic!(
-                "Authorization must be enabled and a model must be provided to grant a group some roles"
+                "An OpenFGA model must be provided to grant a group roles, members, or infra grants"
             );
         }
         let regulator = &app.app_state.regulator;
@@ -593,7 +580,7 @@ impl<'a> GroupBuilder<'a> {
                 .expect("group should be created successfully")
                 .id;
         let group = authz::identity::Group { id, info };
-        if !authz_disabled {
+        if app.enable_authorization {
             let group_auth = authz::Group(group.id);
             v2::add_roles(group_auth.into(), roles)
                 .authorize(&special_authorizers::Authorize(regulator.openfga()))

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -90,9 +90,10 @@ pub(crate) struct TestAppBuilder {
 }
 
 impl TestAppBuilder {
-    pub fn new() -> Self {
+    /// Prefer using [`test_app!`] macro instead
+    pub fn new(test_name: String) -> Self {
         Self {
-            test_name: String::from("editoast-test"),
+            test_name,
             db_pool: None,
             core_client: None,
             enable_authorization: true,
@@ -100,14 +101,6 @@ impl TestAppBuilder {
             root_url: None,
             trains_traffic: TrainsTrafficPool::new(),
         }
-    }
-
-    /// Configures the name of the test
-    ///
-    /// Used to name the OpenFGA store created for the test.
-    pub fn test_name(mut self, test_name: String) -> Self {
-        self.test_name = test_name;
-        self
     }
 
     pub fn db_pool(mut self, db_pool: DbConnectionPoolV2) -> Self {
@@ -304,7 +297,7 @@ impl TestAppBuilder {
 /// The crate `stdext` is required.
 macro_rules! test_app {
     () => {
-        $crate::views::test_app::TestAppBuilder::new().test_name(
+        $crate::views::test_app::TestAppBuilder::new(
             stdext::function_name!()
                 .split("::")
                 .filter(|x| *x != "{{closure}}")

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1143,12 +1143,12 @@ mod tests {
     use crate::fixtures::create_train_schedule_exception;
     use crate::fixtures::create_train_schedule_set;
     use crate::fixtures::simple_paced_train_base;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use editoast_models::train_schedule::TrainScheduleChangeset;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_timetable() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get(&format!("/timetable/{}/train_schedules", 0));
         app.fetch(request)
             .await
@@ -1157,7 +1157,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn timetable_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         // Insert timetable
@@ -1180,7 +1180,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn timetable_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let timetable = create_timetable(&mut pool.get_ok()).await;
@@ -1200,7 +1200,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_timetable_train_schedules() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         // Setup timetable 1 data
@@ -1308,7 +1308,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_not_found_timetable_train_schedules() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get(format!("/timetable/{}/train_schedules", 0).as_str());
         let response: InternalError = app
             .fetch(request)
@@ -1661,7 +1661,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_set_links_train_schedule_sets_to_timetable() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let timetable = create_timetable(&mut db_pool.get().await.unwrap()).await;
@@ -1688,7 +1688,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_get_local_track_names_simple_train_schedule() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -456,7 +456,7 @@ mod tests {
 
     use crate::fixtures::create_fast_rolling_stock;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app::test_app;
     use crate::views::timetable::similar_trains::trains_traffic::TrainTraffic;
 
     use super::*;
@@ -587,7 +587,8 @@ mod tests {
         app: TestApp,
     }
     async fn init_test(trains_traffic: Vec<TrainTraffic>) -> InitTestResponse {
-        let app = TestAppBuilder::new()
+        let app = test_app!()
+            .skip_authz()
             .with_trains_traffic(trains_traffic.clone())
             .build();
         let db_pool = app.db_pool();

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -607,7 +607,7 @@ mod tests {
     use crate::fixtures::create_timetable;
     use crate::fixtures::create_towed_rolling_stock;
     use crate::views::path::pathfinding::PathfindingResult;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app::test_app;
     use crate::views::timetable::simulation_empty_response;
     use crate::views::timetable::stdcm::Request;
     use crate::views::timetable::stdcm::request::ConsistSchedule;
@@ -972,7 +972,7 @@ mod tests {
             core
         };
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1057,7 +1057,7 @@ mod tests {
             })
             .finish();
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1101,7 +1101,7 @@ mod tests {
             })
             .finish();
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1155,7 +1155,7 @@ mod tests {
             })
             .finish();
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1228,7 +1228,7 @@ mod tests {
             })
             .finish();
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1417,7 +1417,7 @@ mod tests {
             })
             .finish();
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1517,7 +1517,7 @@ mod tests {
             })
             .finish();
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1656,7 +1656,7 @@ mod tests {
             })
             .finish();
 
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1870,8 +1870,9 @@ mod tests {
     use crate::fixtures::simple_sub_category;
     use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::path::pathfinding::PathfindingResult;
+    use crate::views::test_app;
     use crate::views::test_app::TestApp;
-    use crate::views::test_app::TestAppBuilder;
+
     use crate::views::test_app::TestResponse;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::simulation;
@@ -1903,7 +1904,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
@@ -1929,7 +1930,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_with_sub_category() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let created_sub_category = simple_sub_category(
@@ -1988,7 +1989,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_paced_train_resets_exceptions_when_interval_changes() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let (timetable, train_schedule_set) =
@@ -2061,7 +2062,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_paced_train() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let (timetable, train_schedule_set) =
@@ -2103,7 +2104,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_delete() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
@@ -2128,7 +2129,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_not_found_train_schedule() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get(&format!("/train_schedules/{}", 0));
 
         let response: InternalError = app
@@ -2142,7 +2143,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_train_schedule() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
@@ -2207,7 +2208,8 @@ mod tests {
         .await;
 
         let core = mocked_core_pathfinding_sim_and_proj();
-        let app = TestAppBuilder::new()
+        let app = test_app!()
+            .skip_authz()
             .db_pool(db_pool)
             .core_client(core.into())
             .build();
@@ -2381,7 +2383,8 @@ mod tests {
     async fn paced_train_simulation_summary() {
         // Setup tests tools
         let core = mocked_core_pathfinding_sim_and_proj();
-        let app = TestAppBuilder::new()
+        let app = test_app!()
+            .skip_authz()
             .db_pool(DbConnectionPoolV2::for_tests())
             .core_client(core.into())
             .build();
@@ -2608,7 +2611,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_infra_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
         let paced_train =
@@ -2633,7 +2636,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_not_found() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
         let small_infra = create_small_infra(&mut pool.get_ok()).await;
 
@@ -2653,7 +2656,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_with_invalid_exception_key() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
         let small_infra = create_small_infra(&mut pool.get_ok()).await;
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
@@ -2695,7 +2698,7 @@ mod tests {
                 "status": "success"
             }))
             .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
 
         create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
@@ -2744,7 +2747,7 @@ mod tests {
                 "status": "success"
             }))
             .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
 
         create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
@@ -2813,7 +2816,7 @@ mod tests {
                 "status": "success"
             }))
             .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
 
         let (timetable, train_schedule_set) =
@@ -2886,7 +2889,8 @@ mod tests {
             .expect("Failed to create paced train");
 
         let core = mocked_core_pathfinding_sim_and_proj();
-        let app = TestAppBuilder::new()
+        let app = test_app!()
+            .skip_authz()
             .db_pool(db_pool)
             .core_client(core.into())
             .build();
@@ -3025,7 +3029,7 @@ mod tests {
             .response(StatusCode::OK)
             .json(simulation_empty_response())
             .finish();
-        let app = TestAppBuilder::new().core_client(core.into()).build();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =
@@ -3151,7 +3155,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn move_train_schedules_to_another_train_schedule_set() {
-        let app = TestAppBuilder::new().build();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
         let train_schedule =

--- a/editoast/src/views/timetable/train_schedule_exceptions.rs
+++ b/editoast/src/views/timetable/train_schedule_exceptions.rs
@@ -288,12 +288,12 @@ mod tests {
     use crate::error::InternalError;
     use crate::fixtures::create_timetable_with_simple_paced_train;
     use crate::fixtures::create_train_schedule_exception;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use crate::views::timetable::train_schedule_exceptions::TrainScheduleExceptionForm;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_exception_created_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let mut conn = pool.get_ok();
@@ -340,7 +340,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_exception_invalid_occurrence_index_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let mut conn = pool.get_ok();
@@ -374,7 +374,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_exception_duplicated_occurrence_index_post() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let mut conn = pool.get_ok();
@@ -418,7 +418,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_exception_deleted() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let mut conn = pool.get_ok();
@@ -465,7 +465,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_exception_update() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let (timetable, train_schedule) =
@@ -524,7 +524,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn train_schedule_exception_invalid_occurrence_index_update() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let (timetable, train_schedule) =

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -327,7 +327,7 @@ mod tests {
     use crate::fixtures::create_catalog_entry;
     use crate::fixtures::create_train_schedule_set;
     use crate::fixtures::simple_paced_train_base;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
     use crate::views::timetable::train_schedule::TrainScheduleResponse;
     use crate::views::train_schedule_set::TrainScheduleSetForm;
     use crate::views::train_schedule_set::TrainScheduleSetResponse;
@@ -353,7 +353,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_train_schedule() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
@@ -400,7 +400,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_trains_for_train_schedule_set() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
@@ -446,7 +446,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_train_schedule_set_without_catalog_entry() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let train_schedule_set_form = TrainScheduleSetForm {
             catalog_entry_id: None,
             name: Some("test".to_string()),
@@ -481,7 +481,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_train_schedule_set_with_catalog_entry() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;
         let catalog_entry_id = catalog_entry.id;
@@ -519,7 +519,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_train_schedule_set() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let db_pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
@@ -548,7 +548,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_train_schedule_set_with_catalog_entry() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let db_pool = app.db_pool();
         let (train_schedule_set, catalog_entry) =
@@ -591,7 +591,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_train_schedule_sets() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
         let train_schedule_set_1 =
             create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
@@ -645,7 +645,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_train_schedule_set() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let db_pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
@@ -664,7 +664,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn put_train_schedule_set() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let db_pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
@@ -701,7 +701,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn put_train_schedule_set_with_catalog_entry() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let db_pool = app.db_pool();
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;

--- a/editoast/src/views/version.rs
+++ b/editoast/src/views/version.rs
@@ -21,13 +21,12 @@ pub(in crate::views) async fn version(
 
 #[cfg(test)]
 mod tests {
+    use crate::views::test_app;
     use std::collections::HashMap;
-
-    use crate::views::test_app::TestAppBuilder;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn version() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let request = app.get("/version");
         let response: HashMap<String, Option<String>> = app.fetch(request).await.json_into();
         assert!(response.contains_key("git_describe"));

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -446,12 +446,12 @@ pub mod tests {
 
     use super::*;
     use crate::fixtures::create_work_schedules_fixture_set;
-    use crate::views::test_app::TestAppBuilder;
+    use crate::views::test_app;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_create() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         let request = app.post("/work_schedules").json(&json!({
@@ -484,7 +484,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_create_fail_start_date_after_end_date() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         let request = app.post("/work_schedules").json(&json!({
             "work_schedule_group_name": "work schedule group name",
@@ -505,7 +505,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_create_fail_name_already_used() {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
         WorkScheduleGroup::changeset()
@@ -588,7 +588,7 @@ pub mod tests {
         #[case] expected_path_position_ranges: Vec<Vec<(u64, u64)>>,
     ) {
         // GIVEN
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
         let conn = &mut pool.get_ok();
 
@@ -678,7 +678,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn work_schedule_endpoints_workflow() {
-        let app = TestAppBuilder::default_app();
+        let app = test_app!().skip_authz().build();
 
         // Create a new group
         let create_group_request = app.post("/work_schedules/group").json(&json!({}));

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -130,7 +130,7 @@ pub(in crate::views) async fn worker_load(
 mod tests {
     use super::*;
     use crate::fixtures::create_empty_infra;
-    use crate::views::test_app::TestAppBuilder;
+
     use core_client::CoreClient;
     use core_client::mocking::MockingClient;
     use database::DbConnectionPoolV2;
@@ -143,6 +143,8 @@ mod tests {
     #[case(false, WorkerStatus::NotReady)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn worker_load_test(#[case] loaded: bool, #[case] expected: WorkerStatus) {
+        use crate::views::test_app::test_app;
+
         let db_pool = DbConnectionPoolV2::for_tests();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
@@ -152,7 +154,8 @@ mod tests {
             .json(json!({ "loaded": loaded }))
             .finish();
 
-        let app = TestAppBuilder::new()
+        let app = test_app!()
+            .skip_authz()
             .db_pool(db_pool)
             .core_client(CoreClient::Mocked(core))
             .build();


### PR DESCRIPTION
Editoast used to support disabling authorization logic entirely through
`editoast runserver --enable-authorization` flag. This commit removes it
as we barely use it in practice, no deployment uses it and it creates
superfluous edge cases in our user and permission management.
Support for `x-osrd-skip-authz` header still remains.

Tests now enable authorization by default as well to match `runserver`
default behavior. Authorization in tests are still optional, but
`TestAppBuilder` now requires **opting out explicitly**.

Having had to change all `TestApp` initializations, use of `test_app!`
macro has been harmonized (it captures the test name) and `default_app`
has been removed.
