### PR TITLE
editoast: add unique constraints on OperationalPoint

### DIFF
--- a/editoast/editoast_models/src/infra_objects.rs
+++ b/editoast/editoast_models/src/infra_objects.rs
@@ -288,7 +288,7 @@ impl OperationalPointModel {
 
         Ok(dsl::infra_object_operational_point
             .filter(dsl::infra_id.eq(infra_id))
-            .filter(sql::<Nullable<BigInt>>("(data->'uic')::int").eq_any(uic))
+            .filter(sql::<Nullable<BigInt>>("NULLIF(data->>'uic', 'null')::int").eq_any(uic))
             .load(&mut conn.write().await)
             .await?
             .into_iter()

--- a/editoast/migrations/2026-06-10-120651-0000_add_unique_constraint_on_op_fields/down.sql
+++ b/editoast/migrations/2026-06-10-120651-0000_add_unique_constraint_on_op_fields/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS domestic_unique_index;
+DROP INDEX IF EXISTS uic_unique_index;
+DROP INDEX IF EXISTS plc_unique_index;

--- a/editoast/migrations/2026-06-10-120651-0000_add_unique_constraint_on_op_fields/up.sql
+++ b/editoast/migrations/2026-06-10-120651-0000_add_unique_constraint_on_op_fields/up.sql
@@ -1,0 +1,37 @@
+-- Your SQL goes here
+UPDATE infra_object_operational_point
+SET data = jsonb_set(data, '{main_code}', data->'id')
+WHERE data->>'main_code' = '???';
+
+-- The overtake PR has an id following this pattern
+-- "id" : "OVERTAKE_1_2_A;Strasbourg"
+-- The new secondary code will retrieve : OVERTAKE_{op_number}_{direction}
+-- "secondary_code" : "OVERTAKE_1_A"
+UPDATE infra_object_operational_point
+SET data = jsonb_set(data, '{secondary_code}', to_jsonb(CONCAT('OVERTAKE_', split_part(data->>'id', '_', 2), '_', split_part(split_part(data->>'id', '_', 4), ';', 1))))
+WHERE data->>'secondary_name' = 'OVERTAKE';
+
+CREATE SEQUENCE secondary_code_seq;
+UPDATE infra_object_operational_point i
+-- Add the ID as suffix to secondary code to the duplicated domestic codes
+SET data = jsonb_set(data, '{secondary_code}', to_jsonb(CONCAT(COALESCE(data->>'secondary_code', 'secondary_code'), '_', nextval('secondary_code_seq'))))
+FROM (
+     SELECT infra_id,
+     data->>'main_code' AS main_code,
+     data->>'secondary_code' AS secondary_code,
+     data->>'country_code' AS country_code
+     FROM infra_object_operational_point
+     GROUP BY infra_id,
+     data->>'main_code',
+     data->>'secondary_code',
+     data->>'country_code'
+     HAVING COUNT(*) > 1) AS duplicates
+WHERE i.infra_id = duplicates.infra_id
+     AND i.data->>'main_code' IS NOT DISTINCT FROM duplicates.main_code
+     AND i.data->>'secondary_code' IS NOT DISTINCT FROM duplicates.secondary_code
+     AND i.data->>'country_code' IS NOT DISTINCT FROM duplicates.country_code;
+DROP SEQUENCE secondary_code_seq;
+
+CREATE UNIQUE INDEX domestic_unique_index ON infra_object_operational_point(infra_id, (data->>'country_code'), (data->>'main_code'), (data->>'secondary_code')) NULLS NOT DISTINCT;
+CREATE UNIQUE INDEX uic_unique_index ON infra_object_operational_point(infra_id, (data->>'uic'), (data->>'secondary_code'));
+CREATE UNIQUE INDEX plc_unique_index ON infra_object_operational_point(infra_id, (data->>'plc'));

--- a/tests/data/infras/overlapping_routes/infra.json
+++ b/tests/data/infras/overlapping_routes/infra.json
@@ -76,7 +76,7 @@
                     "track": "t_a1"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "A",
             "secondary_name": "0",
             "uic": 8700
         },
@@ -93,7 +93,7 @@
                     "track": "t_a2"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "AA",
             "secondary_name": "0",
             "uic": 8700
         },
@@ -110,7 +110,7 @@
                     "track": "t_b1"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "B",
             "secondary_name": "0",
             "uic": 8700
         },
@@ -127,7 +127,7 @@
                     "track": "t_b2"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "BB",
             "secondary_name": "0",
             "uic": 8700
         }

--- a/tests/data/infras/tiny_infra/infra.json
+++ b/tests/data/infras/tiny_infra/infra.json
@@ -61,7 +61,7 @@
                     "track": "ne.micro.foo_b"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "FOO",
             "secondary_name": "0",
             "uic": 8700
         },
@@ -78,7 +78,7 @@
                     "track": "ne.micro.bar_a"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "BAR",
             "secondary_name": "0",
             "uic": 8700
         }

--- a/tests/data/infras/y_infra/infra.json
+++ b/tests/data/infras/y_infra/infra.json
@@ -91,7 +91,7 @@
                     "track": "t_a"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "A",
             "secondary_name": "0",
             "uic": 8700
         },
@@ -108,7 +108,7 @@
                     "track": "t_b"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "B",
             "secondary_name": "0",
             "uic": 8700
         },
@@ -125,7 +125,7 @@
                     "track": "t_center"
                 }
             ],
-            "secondary_code": "BV",
+            "secondary_code": "C",
             "secondary_name": "0",
             "uic": 8700
         }

--- a/tests/infra-scripts/overlapping_routes.py
+++ b/tests/infra-scripts/overlapping_routes.py
@@ -30,10 +30,10 @@ def _build_scenario_data():
     builder = InfraBuilder()
 
     # Create operational points
-    op_a1 = builder.add_operational_point("op.a1")
-    op_a2 = builder.add_operational_point("op.a2")
-    op_b1 = builder.add_operational_point("op.b1")
-    op_b2 = builder.add_operational_point("op.b2")
+    op_a1 = builder.add_operational_point(label="op.a1", secondary_code="A")
+    op_a2 = builder.add_operational_point(label="op.a2", secondary_code="AA")
+    op_b1 = builder.add_operational_point(label="op.b1", secondary_code="B")
+    op_b2 = builder.add_operational_point(label="op.b2", secondary_code="BB")
 
     # Create track sections
 

--- a/tests/infra-scripts/tiny_infra.py
+++ b/tests/infra-scripts/tiny_infra.py
@@ -12,8 +12,12 @@ def _build_scenario_data():
     builder = InfraBuilder()
 
     # Create operational points
-    station_foo = builder.add_operational_point("op.station_foo")
-    station_bar = builder.add_operational_point("op.station_bar")
+    station_foo = builder.add_operational_point(
+        label="op.station_foo", secondary_code="FOO"
+    )
+    station_bar = builder.add_operational_point(
+        label="op.station_bar", secondary_code="BAR"
+    )
 
     # Create track sections
 

--- a/tests/infra-scripts/y_infra.py
+++ b/tests/infra-scripts/y_infra.py
@@ -33,9 +33,9 @@ def _build_scenario_data() -> ScenarioData:
     builder = InfraBuilder()
 
     # Create operational points
-    op_a = builder.add_operational_point("op.a")
-    op_b = builder.add_operational_point("op.b")
-    op_c = builder.add_operational_point("op.c")
+    op_a = builder.add_operational_point(label="op.a", secondary_code="A")
+    op_b = builder.add_operational_point(label="op.b", secondary_code="B")
+    op_c = builder.add_operational_point(label="op.c", secondary_code="C")
 
     # Create track sections
     t_a = builder.add_track_section(length=10_000, label="t_a")


### PR DESCRIPTION
closes #16523
This PR add uniqueness constraints on the following groups
- (country_code, main_code, secondary_code)
- (uic, secondary_code)
- (plc)

The previous data was not following these constraints so there were some modifications based on certain patterns
- All the fake `OVERTAKE` PR had `secondary_code: '0'`, they were replaced with the information from their id such as `secondary_code: OVERTAKE_{op_number}_{direction}`
- All the PR that had `main_code: '???'` because of missing information were replaced by their id `main_code: {id}`
- For the remaining duplicates, the secondary_code were replaced by `secondary_code: {secondary_code}_{id}`
