### PR TITLE
editoast: views: use `axum_test` properly

### DIFF
--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -971,16 +971,14 @@ mod tests {
             .await;
 
         let mut privileges = app
-            .fetch(
-                app.post("/authz/me/privileges")
-                    .by_user(toto.as_ref())
-                    .json(&json!({
-                       "infra": [infra1, infra2, infra3, infra4]
-                    })),
-            )
+            .post("/authz/me/privileges")
+            .by_user(toto.as_ref())
+            .json(&json!({
+               "infra": [infra1, infra2, infra3, infra4]
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
+            .assert_status_ok()
+            .json::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
             .remove(&ResourceType::Infra)
             .unwrap()
             .into_iter()
@@ -1040,16 +1038,14 @@ mod tests {
             .await;
 
         let mut privileges = app
-            .fetch(
-                app.post("/authz/me/privileges")
-                    .by_user(tata.as_ref())
-                    .json(&json!({
-                       "infra": [infra1, infra2, infra3, infra4]
-                    })),
-            )
+            .post("/authz/me/privileges")
+            .by_user(tata.as_ref())
+            .json(&json!({
+               "infra": [infra1, infra2, infra3, infra4]
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
+            .assert_status_ok()
+            .json::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
             .remove(&ResourceType::Infra)
             .unwrap()
             .into_iter()
@@ -1089,12 +1085,14 @@ mod tests {
         let app = test_app!().build();
         let Infra { id: infra, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
         let mut privileges = app
-            .fetch(app.post("/authz/me/privileges").skip_authz().json(&json!({
+            .post("/authz/me/privileges")
+            .skip_authz()
+            .json(&json!({
                "infra": [infra]
-            })))
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
+            .assert_status_ok()
+            .json::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
             .remove(&ResourceType::Infra)
             .unwrap()
             .into_iter()
@@ -1133,17 +1131,15 @@ mod tests {
             .await;
 
         // Ask the grant of the user for the infra
-        let request = app
+        let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
             .post("/authz/me/grants")
             .by_user(user.as_ref())
             .json(&json!({
                 "infra": [infra.id],
-            }));
-        let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // Check the direct grant is there
         assert_eq!(
@@ -1162,17 +1158,15 @@ mod tests {
             .await;
 
         // Ask the grant of the user for the infra again
-        let request = app
+        let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
             .post("/authz/me/grants")
             .by_user(user.as_ref())
             .json(&json!({
                 "infra": [infra.id, infra_no_grant.id, infra_no_grant.id + 1000],
-            }));
-        let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // Check the inherited grant from the group has overridden by the user's direct grant
         // Unreadable and non-existent infras are filtered out
@@ -1207,14 +1201,12 @@ mod tests {
         }
 
         // Get the full user list for the infra
-        let request_all = app
-            .get(&format!("/authz/{}/{}", ResourceType::Infra, infra.id))
-            .by_user(user.as_ref());
         let subjects: Vec<SubjectGrant> = app
-            .fetch(request_all)
+            .get(&format!("/authz/{}/{}", ResourceType::Infra, infra.id))
+            .by_user(user.as_ref())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(subjects.len(), 6);
     }
 
@@ -1255,13 +1247,11 @@ mod tests {
             .await;
 
         let subjects: Vec<SubjectGrant> = app
-            .fetch(
-                app.get(&format!("/authz/{}/{}", ResourceType::Infra, infra.id))
-                    .by_user(alice.as_ref()),
-            )
+            .get(&format!("/authz/{}/{}", ResourceType::Infra, infra.id))
+            .by_user(alice.as_ref())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let grants = subjects
             .into_iter()
@@ -1294,8 +1284,7 @@ mod tests {
 
         // Create a new user and add it as a writer to the infra with the grant API
         let writer = authz::User::from(app.user("writer", "Writer").create().await);
-        let request_grant = app
-            .post("/authz/grants")
+        app.post("/authz/grants")
             .by_user(owner.as_ref())
             .json(&json!({
                 "grant": [
@@ -1306,8 +1295,7 @@ mod tests {
                         "grant": InfraGrant::Writer
                     }
                 ]
-            }));
-        app.fetch(request_grant)
+            }))
             .await
             .assert_status(StatusCode::CREATED);
 
@@ -1318,8 +1306,7 @@ mod tests {
         );
 
         // Remove the user from the API
-        let request_revoke = app
-            .post("/authz/grants")
+        app.post("/authz/grants")
             .by_user(owner.as_ref())
             .json(&json!({
                 "revoke": [
@@ -1329,10 +1316,9 @@ mod tests {
                         "resource_id": *infra
                     }
                 ]
-            }));
-        app.fetch(request_revoke)
+            }))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         // Check that the new user has the good grant
         assert_eq!(openfga.infra_direct_grant(writer, infra).await, None);
@@ -1353,21 +1339,19 @@ mod tests {
             .create()
             .await;
 
-        app.fetch(
-            app.post("/authz/grants")
-                .by_user(writer.as_ref())
-                .json(&json!({
-                    "revoke": [
-                        {
-                            "subject_id": reader.id,
-                            "resource_type": ResourceType::Infra,
-                            "resource_id": infra.id
-                        }
-                    ]
-                })),
-        )
-        .await
-        .assert_status(StatusCode::FORBIDDEN);
+        app.post("/authz/grants")
+            .by_user(writer.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": reader.id,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": infra.id
+                    }
+                ]
+            }))
+            .await
+            .assert_status_forbidden();
 
         app.assert_infra_grant(infra.id, reader.id, Some(InfraGrant::Reader));
     }
@@ -1387,21 +1371,19 @@ mod tests {
             .create()
             .await;
 
-        app.fetch(
-            app.post("/authz/grants")
-                .by_user(admin.as_ref())
-                .json(&json!({
-                    "revoke": [
-                        {
-                            "subject_id": reader.id,
-                            "resource_type": ResourceType::Infra,
-                            "resource_id": infra.id
-                        }
-                    ]
-                })),
-        )
-        .await
-        .assert_status(StatusCode::NO_CONTENT);
+        app.post("/authz/grants")
+            .by_user(admin.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": reader.id,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": infra.id
+                    }
+                ]
+            }))
+            .await
+            .assert_status_no_content();
 
         app.assert_infra_grant(infra.id, reader.id, None);
     }
@@ -1421,21 +1403,19 @@ mod tests {
             .create()
             .await;
 
-        app.fetch(
-            app.post("/authz/grants")
-                .by_user(admin.as_ref())
-                .json(&json!({
-                    "revoke": [
-                        {
-                            "subject_id": owner.id,
-                            "resource_type": ResourceType::Infra,
-                            "resource_id": infra.id
-                        }
-                    ]
-                })),
-        )
-        .await
-        .assert_status(StatusCode::NO_CONTENT);
+        app.post("/authz/grants")
+            .by_user(admin.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": owner.id,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": infra.id
+                    }
+                ]
+            }))
+            .await
+            .assert_status_no_content();
 
         app.assert_infra_grant(infra.id, owner.id, None);
     }
@@ -1455,21 +1435,19 @@ mod tests {
             .create()
             .await;
 
-        app.fetch(
-            app.post("/authz/grants")
-                .by_user(alice.as_ref())
-                .json(&json!({
-                    "revoke": [
-                        {
-                            "subject_id": bob.id,
-                            "resource_type": ResourceType::Infra,
-                            "resource_id": infra.id
-                        }
-                    ]
-                })),
-        )
-        .await
-        .assert_status(StatusCode::FORBIDDEN);
+        app.post("/authz/grants")
+            .by_user(alice.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": bob.id,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": infra.id
+                    }
+                ]
+            }))
+            .await
+            .assert_status_forbidden();
 
         app.assert_infra_grant(infra.id, bob.id, Some(InfraGrant::Owner));
     }
@@ -1496,28 +1474,26 @@ mod tests {
         let bob = authz::User::from(bob);
         let alice_and_bob = authz::Group::from(alice_and_bob);
 
-        app.fetch(
-            app.post("/authz/grants")
-                .by_user(alice_info.as_ref())
-                .json(&json!({
-                    "grant": [
-                        {
-                            "subject_id": *alice_and_bob,
-                            "resource_type": ResourceType::Infra,
-                            "resource_id": *infra,
-                            "grant": InfraGrant::Writer
-                        },
-                        {
-                            "subject_id": *bob,
-                            "resource_type": ResourceType::Infra,
-                            "resource_id": *infra,
-                            "grant": InfraGrant::Reader
-                        }
-                    ]
-                })),
-        )
-        .await
-        .assert_status(StatusCode::CREATED);
+        app.post("/authz/grants")
+            .by_user(alice_info.as_ref())
+            .json(&json!({
+                "grant": [
+                    {
+                        "subject_id": *alice_and_bob,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": *infra,
+                        "grant": InfraGrant::Writer
+                    },
+                    {
+                        "subject_id": *bob,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": *infra,
+                        "grant": InfraGrant::Reader
+                    }
+                ]
+            }))
+            .await
+            .assert_status(StatusCode::CREATED);
 
         assert_eq!(
             openfga.infra_direct_grant(alice, infra).await,
@@ -1535,21 +1511,19 @@ mod tests {
         app.assert_infra_grant(*infra, *bob, Some(InfraGrant::Writer)); // inherited group grant
         app.assert_infra_grant(*infra, *alice, Some(InfraGrant::Owner)); // inherited group grant superseded by direct user grant
 
-        app.fetch(
-            app.post("/authz/grants")
-                .by_user(alice_info.as_ref())
-                .json(&json!({
-                    "revoke": [
-                        {
-                            "subject_id": *alice_and_bob,
-                            "resource_type": ResourceType::Infra,
-                            "resource_id": *infra
-                        }
-                    ]
-                })),
-        )
-        .await
-        .assert_status(StatusCode::NO_CONTENT);
+        app.post("/authz/grants")
+            .by_user(alice_info.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": *alice_and_bob,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": *infra
+                    }
+                ]
+            }))
+            .await
+            .assert_status_no_content();
 
         assert_eq!(openfga.infra_direct_grant(alice_and_bob, infra).await, None); // group grant removed
         assert_eq!(
@@ -1571,8 +1545,7 @@ mod tests {
             .await;
 
         // Adding OWNER on the same user/infra
-        let request_revoke = app
-            .post("/authz/grants")
+        app.post("/authz/grants")
             .by_user(user.as_ref())
             .json(&json!({
                 "grant": [
@@ -1583,8 +1556,7 @@ mod tests {
                         "grant": InfraGrant::Owner
                     }
                 ]
-            }));
-        app.fetch(request_revoke)
+            }))
             .await
             .assert_status(StatusCode::CREATED);
     }
@@ -1603,17 +1575,18 @@ mod tests {
         );
 
         // Adding OWNER on the same user/infra
-        let request_grant = app.post("/authz/grants").skip_authz().json(&json!({
-            "grant": [
-                {
-                    "subject_id": *user,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": *infra,
-                    "grant": InfraGrant::Owner
-                }
-            ]
-        }));
-        app.fetch(request_grant)
+        app.post("/authz/grants")
+            .skip_authz()
+            .json(&json!({
+                "grant": [
+                    {
+                        "subject_id": *user,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": *infra,
+                        "grant": InfraGrant::Owner
+                    }
+                ]
+            }))
             .await
             .assert_status(StatusCode::CREATED);
 
@@ -1623,18 +1596,19 @@ mod tests {
         );
 
         // Remove the grant
-        let request_revoke = app.post("/authz/grants").skip_authz().json(&json!({
-            "revoke": [
-                {
-                    "subject_id": *user,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": *infra
-                }
-            ]
-        }));
-        app.fetch(request_revoke)
+        app.post("/authz/grants")
+            .skip_authz()
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": *user,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": *infra
+                    }
+                ]
+            }))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         assert_eq!(openfga.infra_direct_grant(user, infra).await, None);
     }
@@ -1654,8 +1628,7 @@ mod tests {
         let other = app.user("other", "Other").create().await;
 
         // Remove the READER grant should not fail
-        let request_grant = app
-            .post("/authz/grants")
+        app.post("/authz/grants")
             .by_user(owner.as_ref())
             .json(&json!({
                 "revoke": [
@@ -1665,10 +1638,9 @@ mod tests {
                         "resource_id": infra.id,
                     }
                 ]
-            }));
-        app.fetch(request_grant)
+            }))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1680,12 +1652,12 @@ mod tests {
             .create()
             .await;
 
-        let request = app.get("/authz/me").by_user(user.as_ref());
         let user_data = app
-            .fetch(request)
+            .get("/authz/me")
+            .by_user(user.as_ref())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<WhoamiResponse>();
+            .assert_status_ok()
+            .json::<WhoamiResponse>();
 
         assert_eq!(
             user_data,
@@ -1711,15 +1683,13 @@ mod tests {
             .create()
             .await;
 
-        let request = app
+        let user_data = app
             .get("/authz/me")
             .by_user(impersonator.as_ref())
-            .impersonate(impersonated.as_ref());
-        let user_data = app
-            .fetch(request)
+            .impersonate(impersonated.as_ref())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<WhoamiResponse>();
+            .assert_status_ok()
+            .json::<WhoamiResponse>();
 
         assert_eq!(
             user_data,
@@ -1741,16 +1711,14 @@ mod tests {
             .await;
         let identity = "Who's there?".to_owned();
 
-        let request = app
-            .get("/authz/me")
+        app.get("/authz/me")
             .by_user(&authz::identity::UserInfo {
                 identities: vec![identity.clone()],
                 name: "No one.".to_owned(),
             })
-            .impersonate(impersonated.as_ref());
-        app.fetch(request)
+            .impersonate(impersonated.as_ref())
             .await
-            .assert_status(StatusCode::FORBIDDEN);
+            .assert_status_forbidden();
 
         assert_eq!(
             editoast_models::User::retrieve_by_identity(&identity, app.db_pool().get_ok()).await,
@@ -1768,12 +1736,13 @@ mod tests {
             .create()
             .await;
 
-        let request = app.get("/authz/me").by_user(user.as_ref()).skip_authz();
         let user_data = app
-            .fetch(request)
+            .get("/authz/me")
+            .by_user(user.as_ref())
+            .skip_authz()
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<WhoamiResponse>();
+            .assert_status_ok()
+            .json::<WhoamiResponse>();
 
         assert_eq!(
             user_data,
@@ -1790,12 +1759,13 @@ mod tests {
         let app = test_app!().build();
         let user = app.user("test", "test").create().await;
 
-        let request = app.get("/authz/me").by_user(user.as_ref()).skip_authz();
         let WhoamiResponse { roles, .. } = app
-            .fetch(request)
+            .get("/authz/me")
+            .by_user(user.as_ref())
+            .skip_authz()
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<WhoamiResponse>();
+            .assert_status_ok()
+            .json::<WhoamiResponse>();
 
         assert_eq!(roles, HashSet::from([Role::Admin]));
     }
@@ -1812,19 +1782,18 @@ mod tests {
             .await;
         let group_2 = app.group("group_2").with_members([&user_1]).create().await;
 
-        let request_1 = app.get("/authz/me/groups").by_user(user_1.as_ref());
-        let request_2 = app.get("/authz/me/groups").by_user(user_2.as_ref());
-
         let mut groups_user_1 = app
-            .fetch(request_1)
+            .get("/authz/me/groups")
+            .by_user(user_1.as_ref())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<Vec<Group>>();
+            .assert_status_ok()
+            .json::<Vec<Group>>();
         let groups_user_2 = app
-            .fetch(request_2)
+            .get("/authz/me/groups")
+            .by_user(user_2.as_ref())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<Vec<Group>>();
+            .assert_status_ok()
+            .json::<Vec<Group>>();
 
         groups_user_1.sort_by_key(|g| g.id);
 
@@ -1855,13 +1824,11 @@ mod tests {
         let app = test_app!().build();
         let user = app.user("test", "test").create().await;
 
-        let request = app
-            .get("/authz/me/groups")
+        app.get("/authz/me/groups")
             .by_user(user.as_ref())
-            .skip_authz();
-        app.fetch(request)
+            .skip_authz()
             .await
-            .assert_status(StatusCode::UNAUTHORIZED);
+            .assert_status_unauthorized();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1881,12 +1848,12 @@ mod tests {
         let group_3 = app.group("G3").create().await;
 
         // List all groups as admin
-        let request = app.get("/authz/groups").by_user(admin.as_ref());
         let groups = app
-            .fetch(request)
+            .get("/authz/groups")
+            .by_user(admin.as_ref())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<Vec<Group>>();
+            .assert_status_ok()
+            .json::<Vec<Group>>();
 
         // Verify all groups are returned
         assert_eq!(groups.len(), 3);
@@ -1907,9 +1874,9 @@ mod tests {
             .await;
 
         // Try to list groups as non-admin
-        let request = app.get("/authz/groups").by_user(user.as_ref());
-        app.fetch(request)
+        app.get("/authz/groups")
+            .by_user(user.as_ref())
             .await
-            .assert_status(StatusCode::FORBIDDEN);
+            .assert_status_forbidden();
     }
 }

--- a/editoast/src/views/catalog_entry.rs
+++ b/editoast/src/views/catalog_entry.rs
@@ -169,14 +169,12 @@ mod tests {
             name: Some("test".to_string()),
         };
 
-        let request = app
-            .post("/catalog_entries")
-            .json(&json!(catalog_entry_form));
         let catalog_entry: CatalogEntry = app
-            .fetch(request)
+            .post("/catalog_entries")
+            .json(&json!(catalog_entry_form))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
         assert_eq!(
             catalog_entry,
             CatalogEntry {
@@ -193,12 +191,11 @@ mod tests {
 
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;
 
-        let request = app.get("/catalog_entries");
         let catalog_entries = app
-            .fetch(request)
+            .get("/catalog_entries")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<CatalogEntryPage>();
+            .assert_status_ok()
+            .json::<CatalogEntryPage>();
         let results = catalog_entries.results;
         assert_eq!(results.len(), 1);
         assert_eq!(results, vec![catalog_entry]);
@@ -211,10 +208,10 @@ mod tests {
 
         let catalog_entry = create_catalog_entry(&mut db_pool.get().await.unwrap()).await;
 
-        let request = app.delete(format!("/catalog_entries/{}", catalog_entry.id).as_str());
-
-        let response = app.fetch(request).await;
-        response.assert_status(StatusCode::NO_CONTENT);
+        let response = app
+            .delete(format!("/catalog_entries/{}", catalog_entry.id).as_str())
+            .await;
+        response.assert_status_no_content();
 
         let exists = CatalogEntry::exists(&mut db_pool.get_ok(), catalog_entry.id)
             .await
@@ -226,10 +223,8 @@ mod tests {
     async fn catalog_entry_unexisting_delete() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.delete("/catalog_entries/999999");
-
-        let response = app.fetch(request).await;
-        response.assert_status(StatusCode::NOT_FOUND);
+        let response = app.delete("/catalog_entries/999999").await;
+        response.assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -243,14 +238,12 @@ mod tests {
             name: Some("test2".to_string()),
         };
 
-        let request = app
-            .put(format!("/catalog_entries/{}", catalog_entry.id).as_str())
-            .json(&json!(catalog_entry_form));
         let catalog_entry_result: CatalogEntry = app
-            .fetch(request)
+            .put(format!("/catalog_entries/{}", catalog_entry.id).as_str())
+            .json(&json!(catalog_entry_form))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(
             catalog_entry_result,
             CatalogEntry {
@@ -269,12 +262,8 @@ mod tests {
             create_catalog_entry_with_name(&mut db_pool.get().await.unwrap(), "test_1").await;
         let catalog_entry_2 =
             create_catalog_entry_with_name(&mut db_pool.get().await.unwrap(), "test_2").await;
-        let request = app.get("/catalog_entries");
-        let catalog_entries: CatalogEntryPage = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        let catalog_entries: CatalogEntryPage =
+            app.get("/catalog_entries").await.assert_status_ok().json();
         let results = catalog_entries.results;
         assert_eq!(results, vec![catalog_entry_1, catalog_entry_2]);
     }

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -151,17 +151,18 @@ mod tests {
         let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
-        let request = app
+        // Insert document
+        let new_doc = app
             .post("/documents")
             .add_header(
                 header::CONTENT_TYPE,
                 header::HeaderValue::from_str("text/plain").unwrap(),
             )
-            .bytes("Document post test data".into());
-
-        // Insert document
-        let response = app.fetch(request).await.assert_status(StatusCode::CREATED);
-        let new_doc = response.json_into::<PostDocumentResponse>().document_key;
+            .bytes("Document post test data".into())
+            .await
+            .assert_status(StatusCode::CREATED)
+            .json::<PostDocumentResponse>()
+            .document_key;
 
         // Get create document
         let document = Document::retrieve(pool.get_ok(), new_doc)
@@ -186,13 +187,11 @@ mod tests {
             .expect("Failed to create document");
 
         // Get document test
-        let response = app
-            .fetch(app.get(&format!("/documents/{}", document.id)))
-            .await
-            .assert_status(StatusCode::OK)
-            .bytes();
+        let response = app.get(&format!("/documents/{}", document.id)).await;
+        response.assert_status_ok();
+        let response = response.into_bytes();
 
-        assert_eq!(response.as_slice(), b"Document post test data");
+        assert_eq!(response.as_ref(), b"Document post test data");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -209,9 +208,9 @@ mod tests {
             .expect("Failed to create document");
 
         // Delete document request
-        app.fetch(app.delete(format!("/documents/{}", document.id).as_str()))
+        app.delete(format!("/documents/{}", document.id).as_str())
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         // Get create document
         let document = Document::exists(&mut pool.get_ok(), document.id)

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -166,8 +166,6 @@ pub enum ElectricalProfilesError {
 
 #[cfg(test)]
 mod tests {
-
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -185,10 +183,10 @@ mod tests {
         let _set_2 = create_electrical_profile_set(&mut pool.get_ok()).await;
 
         let response: Vec<LightElectricalProfileSet> = app
-            .fetch(app.get("/electrical_profile_set"))
+            .get("/electrical_profile_set")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(response.len() >= 2);
     }
@@ -197,9 +195,9 @@ mod tests {
     async fn get_unexisting_electrical_profile() {
         let app = test_app!().skip_authz().build();
 
-        app.fetch(app.get("/electrical_profile_set/666"))
+        app.get("/electrical_profile_set/666")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -209,21 +207,21 @@ mod tests {
 
         let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
-        app.fetch(app.get(&format!(
+        app.get(&format!(
             "/electrical_profile_set/{}",
             electrical_profile_set.id
-        )))
+        ))
         .await
-        .assert_status(StatusCode::OK);
+        .assert_status_ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_electrical_profile_level_order() {
         let app = test_app!().skip_authz().build();
 
-        app.fetch(app.get("/electrical_profile_set/666/level_order"))
+        app.get("/electrical_profile_set/666/level_order")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -234,13 +232,13 @@ mod tests {
         let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
         let level_order: HashMap<String, Vec<String>> = app
-            .fetch(app.get(&format!(
+            .get(&format!(
                 "/electrical_profile_set/{}/level_order",
                 electrical_profile_set.id
-            )))
+            ))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(level_order.len(), 1);
         assert_eq!(
@@ -252,9 +250,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unexisting_electrical_profile() {
         let app = test_app!().skip_authz().build();
-        app.fetch(app.delete("/electrical_profile_set/666"))
+        app.delete("/electrical_profile_set/666")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -264,12 +262,12 @@ mod tests {
 
         let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
-        app.fetch(app.delete(&format!(
+        app.delete(&format!(
             "/electrical_profile_set/{}",
             electrical_profile_set.id
-        )))
+        ))
         .await
-        .assert_status(StatusCode::NO_CONTENT);
+        .assert_status_no_content();
 
         let exists = ElectricalProfileSet::exists(&mut pool.get_ok(), electrical_profile_set.id)
             .await
@@ -293,10 +291,11 @@ mod tests {
         };
 
         let created_ep: ElectricalProfileSet = app
-            .fetch(app.post("/electrical_profile_set/?name=elec").json(&ep_set))
+            .post("/electrical_profile_set/?name=elec")
+            .json(&ep_set)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let created_ep = ElectricalProfileSet::retrieve(pool.get_ok(), created_ep.id)
             .await

--- a/editoast/src/views/fonts.rs
+++ b/editoast/src/views/fonts.rs
@@ -59,15 +59,13 @@ pub(in crate::views) async fn fonts(
 mod tests {
     use crate::views::test_app;
 
-    use axum::http::StatusCode;
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_font() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/fonts/IBMPlexSans/0-255.pbf");
-        let response = app.fetch(request).await.assert_status(StatusCode::OK);
+        let response = app.get("/fonts/IBMPlexSans/0-255.pbf").await;
+        response.assert_status_ok();
         assert_eq!("application/octet-stream", response.content_type());
-        let response = response.bytes();
+        let response = response.into_bytes();
         let expected = std::fs::read(
             app.config()
                 .dynamic_assets_path
@@ -80,9 +78,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_font_not_found() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/fonts/Comic%20Sans/0-255.pbf");
-        app.fetch(request)
+        app.get("/fonts/Comic%20Sans/0-255.pbf")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 }

--- a/editoast/src/views/health.rs
+++ b/editoast/src/views/health.rs
@@ -97,12 +97,10 @@ pub async fn check_health(
 #[cfg(test)]
 mod tests {
     use crate::views::test_app;
-    use reqwest::StatusCode;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn health() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/health");
-        app.fetch(request).await.assert_status(StatusCode::OK);
+        app.get("/health").await.assert_status_ok();
     }
 }

--- a/editoast/src/views/icons.rs
+++ b/editoast/src/views/icons.rs
@@ -57,15 +57,13 @@ pub(in crate::views) async fn icons(
 mod tests {
     use crate::views::test_app;
 
-    use axum::http::StatusCode;
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_icons() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/icons/TVM300/REP%20TGV.svg");
-        let response = app.fetch(request).await.assert_status(StatusCode::OK);
+        let response = app.get("/icons/TVM300/REP%20TGV.svg").await;
+        response.assert_status_ok();
         assert_eq!("image/svg+xml", response.content_type());
-        let response = response.bytes();
+        let response = response.into_bytes();
         let expected = std::fs::read(
             app.config()
                 .dynamic_assets_path
@@ -78,9 +76,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_icons_not_found() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/icons/TVM300/NOT_A_THING.svg");
-        app.fetch(request)
+        app.get("/icons/TVM300/NOT_A_THING.svg")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 }

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -160,10 +160,10 @@ mod tests {
             .await
             .expect("Failed to create detector object");
 
-        let req =
-            app.get(format!("/infra/{}/attached/{}/", empty_infra.id, track.get_id()).as_str());
-
-        let response: HashMap<ObjectType, Vec<String>> = app.fetch(req).await.json_into();
+        let response: HashMap<ObjectType, Vec<String>> = app
+            .get(format!("/infra/{}/attached/{}/", empty_infra.id, track.get_id()).as_str())
+            .await
+            .json();
         assert_eq!(response.get(&ObjectType::Detector).unwrap().len(), 1);
     }
 }

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -346,13 +346,11 @@ pub enum AutoFixesEditoastError {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use schemas::infra::BufferStop;
     use schemas::infra::BufferStopExtension;
+    use std::collections::HashMap;
 
     use super::*;
     use crate::fixtures::create_empty_infra;
@@ -404,10 +402,10 @@ mod tests {
         let small_infra_id = small_infra.id;
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(small_infra_id))
+            .auto_fixes_request(small_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(operations.is_empty());
     }
@@ -461,10 +459,10 @@ mod tests {
 
         // WHEN
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(small_infra_id))
+            .auto_fixes_request(small_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // THEN
         let (infra_errors_after_fix, _) = query_errors(&mut db_pool.get_ok(), &small_infra).await;
@@ -505,10 +503,10 @@ mod tests {
             .expect("Failed to delete BufferStop");
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(small_infra_id))
+            .auto_fixes_request(small_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(operations.contains(&Operation::Delete(DeleteOperation {
             obj_id: "rt.DE0->buffer_stop.4".to_string(),
@@ -743,10 +741,10 @@ mod tests {
         .expect("Failed to create invalid_switch object");
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(small_infra_id))
+            .auto_fixes_request(small_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(operations.contains(&Operation::Delete(DeleteOperation {
             obj_id: invalid_switch.get_id().to_string(),
@@ -796,10 +794,10 @@ mod tests {
         }
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(empty_infra_id))
+            .auto_fixes_request(empty_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(operations.contains(&Operation::Delete(DeleteOperation {
             obj_id: bs_odd.get_id().clone(),
@@ -831,10 +829,10 @@ mod tests {
         }
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(empty_infra_id))
+            .auto_fixes_request(empty_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         for obj in [
             &electrification,
@@ -897,10 +895,10 @@ mod tests {
         }
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(empty_infra_id))
+            .auto_fixes_request(empty_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         for obj in [&track, &electrification, &speed_section] {
             assert!(!operations.contains(&Operation::Delete(DeleteOperation {
@@ -960,10 +958,10 @@ mod tests {
         }
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(empty_infra_id))
+            .auto_fixes_request(empty_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(operations.len(), error_count);
 
@@ -1018,10 +1016,10 @@ mod tests {
         }
 
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(empty_infra_id))
+            .auto_fixes_request(empty_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         for obj in [&operational_point, &level_crossing] {
             assert!(operations.iter().any(|op| {
@@ -1054,10 +1052,10 @@ mod tests {
 
         // WHEN
         let operations: Vec<Operation> = app
-            .fetch(app.auto_fixes_request(empty_infra_id))
+            .auto_fixes_request(empty_infra_id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // THEN
         assert_eq!(operations.len(), 2);

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -512,7 +512,6 @@ mod tests {
     use crate::fixtures::create_small_infra;
     use crate::views::infra::delimited_area::DelimitedAreaResponse;
     use crate::views::test_app;
-    use axum::http::StatusCode;
     use editoast_models::Infra;
 
     use schemas::infra::Direction;
@@ -531,19 +530,17 @@ mod tests {
         let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
         let Infra { id: infra_id, .. } = create_small_infra(&mut pool.get_ok()).await;
-        let request = app
+        let DelimitedAreaResponse { track_ranges } = app
             .get(&format!("/infra/{infra_id}/delimited_area"))
             .json(&json!({
                 "infra_id": infra_id,
                 "entries": entries,
                 "exits": exits,
             }
-            ));
-        let DelimitedAreaResponse { track_ranges } = app
-            .fetch(request)
+            ))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         track_ranges
     }
 

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -982,7 +982,6 @@ enum EditionError {
 
 #[cfg(test)]
 pub mod tests {
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -999,9 +998,9 @@ pub mod tests {
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
-        let req_refresh =
-            app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str());
-        app.fetch(req_refresh).await.assert_status(StatusCode::OK);
+        app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str())
+            .await
+            .assert_status_ok();
 
         (app, small_infra)
     }
@@ -1012,17 +1011,15 @@ pub mod tests {
         let app = test_app!().skip_authz().build();
 
         // Make a call with a bad infra ID
-        let request = app
-            .post("/infra/123456789/split_track_section/")
+
+        // Check that we receive a 404
+        app.post("/infra/123456789/split_track_section/")
             .json(&json!({
                 "track": String::from("INVALID-ID"),
                 "offset": 1,
-            }));
-
-        // Check that we receive a 404
-        app.fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1033,17 +1030,15 @@ pub mod tests {
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
         // Make a call with a bad ID
-        let request = app
-            .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+
+        // Check that we receive a 404
+        app.post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track":"INVALID-ID",
                 "offset": 1,
-            }));
-
-        // Check that we receive a 404
-        app.fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1054,17 +1049,15 @@ pub mod tests {
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
         // Make a call with a bad distance
-        let request = app
-            .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+
+        // Check that we receive an error
+        app.post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": "TA0",
                 "offset": 5000000,
-            }));
-
-        // Check that we receive an error
-        app.fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::BAD_REQUEST);
+            .assert_status_bad_request();
     }
 
     #[rstest::rstest]
@@ -1079,17 +1072,15 @@ pub mod tests {
         let (init_errors, _) = query_errors(&mut db_pool.get_ok(), &small_infra).await;
 
         // Make a call to split the track section
-        let request = app
+        let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": track,
                 "offset": offset,
-            }));
-        let res: Vec<String> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // Check the response
         assert_eq!(res.len(), 2);
@@ -1262,17 +1253,15 @@ pub mod tests {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        let request = app
+        let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": "TD0",
                 "offset": offset,
-            }));
-        let res: Vec<String> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(res.len(), 2);
         let expected_track_id = &res[expected_track_index];
@@ -1305,17 +1294,15 @@ pub mod tests {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        let request = app
+        let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": "TD0",
                 "offset": 15_000_000,
-            }));
-        let res: Vec<String> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(res.len(), 2);
         let expected_track_id = &res[expected_track_index];
@@ -1342,17 +1329,15 @@ pub mod tests {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        let request = app
+        let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": track,
                 "offset": offset,
-            }));
-        let res: Vec<String> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(res.len(), 2);
         let expected_track_id = &res[expected_track_index];
@@ -1377,17 +1362,15 @@ pub mod tests {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        let request = app
+        let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": "TA6",
                 "offset": 2_000_000,
-            }));
-        let res: Vec<String> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(res.len(), 2);
         let expected_track_id = &res[expected_track_index];
@@ -1413,17 +1396,15 @@ pub mod tests {
         let (app, small_infra) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
-        let request = app
+        let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
             .json(&json!({
                 "track": track,
                 "offset": offset,
-            }));
-        let res: Vec<String> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(res.len(), 2);
         let expected_track_id = &res[expected_track_index];

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -130,7 +130,6 @@ pub(in crate::views) async fn query_errors(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::StatusCode;
 
     use crate::fixtures::create_empty_infra;
     use crate::views::test_app;
@@ -144,13 +143,14 @@ mod tests {
         let error_type = "overlapping_electrifications";
         let level = "warnings";
 
-        let req = app.get(
+        app.get(
             format!(
                 "/infra/{}/errors?error_type={}&level={}",
                 empty_infra.id, error_type, level
             )
             .as_str(),
-        );
-        app.fetch(req).await.assert_status(StatusCode::OK);
+        )
+        .await
+        .assert_status_ok();
     }
 }

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -81,7 +81,6 @@ pub(in crate::views) async fn get_line_bbox(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::StatusCode;
     use geos::geojson::Geometry;
     use pretty_assertions::assert_eq;
 
@@ -126,13 +125,11 @@ mod tests {
             .await
             .expect("Failed to create track section object");
 
-        let request =
-            app.get(format!("/infra/{}/lines/{line_code}/bbox/", empty_infra.id).as_str());
         let bounding_box: BoundingBox = app
-            .fetch(request)
+            .get(format!("/infra/{}/lines/{line_code}/bbox/", empty_infra.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(
             bounding_box,
             BoundingBox {
@@ -151,15 +148,14 @@ mod tests {
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let not_existing_line_code = 123456789;
-        let request = app.get(
+        app.get(
             format!(
                 "/infra/{}/lines/{not_existing_line_code}/bbox/",
                 empty_infra.id
             )
             .as_str(),
-        );
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::BAD_REQUEST);
+        )
+        .await
+        .assert_status_bad_request();
     }
 }

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -873,14 +873,11 @@ pub mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let request =
-            app.post(format!("/infra/{}/clone/?name=cloned_infra", empty_infra.id).as_str());
-
         let cloned_infra_id: i64 = app
-            .fetch(request)
+            .post(format!("/infra/{}/clone/?name=cloned_infra", empty_infra.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let cloned_infra = Infra::retrieve(db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
@@ -917,14 +914,11 @@ pub mod tests {
             .await
             .expect("Failed to create switch_type object");
 
-        let req_clone =
-            app.post(format!("/infra/{small_infra_id}/clone/?name=cloned_infra").as_str());
-
         let cloned_infra_id: i64 = app
-            .fetch(req_clone)
+            .post(format!("/infra/{small_infra_id}/clone/?name=cloned_infra").as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let _cloned_infra = Infra::retrieve(db_pool.get_ok(), cloned_infra_id)
             .await
@@ -980,34 +974,31 @@ pub mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        app.fetch(app.delete_infra_request(empty_infra.id))
+        app.delete_infra_request(empty_infra.id)
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
-        app.fetch(app.delete_infra_request(empty_infra.id))
+        app.delete_infra_request(empty_infra.id)
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_list() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/infra/");
-        app.fetch(request).await.assert_status(StatusCode::OK);
+        app.get("/infra/").await.assert_status_ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn default_infra_create() {
         let app = test_app!().skip_authz().build();
 
-        let request = app
-            .post("/infra")
-            .json(&json!({ "name": "create_infra_test" }));
         let infra: Infra = app
-            .fetch(request)
+            .post("/infra")
+            .json(&json!({ "name": "create_infra_test" }))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         assert_eq!(infra.name, "create_infra_test");
         assert_eq!(infra.railjson_version, RAILJSON_VERSION);
@@ -1024,15 +1015,15 @@ pub mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let req = app.get(format!("/infra/{}", empty_infra.id).as_str());
-
-        app.fetch(req).await.assert_status(StatusCode::OK);
+        app.get(format!("/infra/{}", empty_infra.id).as_str())
+            .await
+            .assert_status_ok();
 
         empty_infra.delete(&mut db_pool.get_ok()).await.unwrap();
 
-        let req = app.get(format!("/infra/{}", empty_infra.id).as_str());
-
-        app.fetch(req).await.assert_status(StatusCode::NOT_FOUND);
+        app.get(format!("/infra/{}", empty_infra.id).as_str())
+            .await
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1041,15 +1032,12 @@ pub mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let req = app
-            .put(format!("/infra/{}", empty_infra.id).as_str())
-            .json(&json!({"name": "rename_test"}));
-
         let infra: Infra = app
-            .fetch(req)
+            .put(format!("/infra/{}", empty_infra.id).as_str())
+            .json(&json!({"name": "rename_test"}))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(infra.name, "rename_test");
     }
@@ -1065,13 +1053,11 @@ pub mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let req = app.post(format!("/infra/refresh/?infras={}", empty_infra.id).as_str());
-
         let refreshed_infras: InfraRefreshedResponse = app
-            .fetch(req)
+            .post(format!("/infra/refresh/?infras={}", empty_infra.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(refreshed_infras.infra_refreshed, vec![empty_infra.id]);
     }
 
@@ -1083,13 +1069,11 @@ pub mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let req =
-            app.post(format!("/infra/refresh/?infras={}&force=true", empty_infra.id).as_str());
         let refreshed_infras: InfraRefreshedResponse = app
-            .fetch(req)
+            .post(format!("/infra/refresh/?infras={}&force=true", empty_infra.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert!(refreshed_infras.infra_refreshed.contains(&empty_infra.id));
     }
 
@@ -1109,13 +1093,11 @@ pub mod tests {
             .await
             .expect("Failed to create speed section object");
 
-        let req = app.get(format!("/infra/{}/speed_limit_tags/", empty_infra.id).as_str());
-
         let mut speed_limit_tags: Vec<String> = app
-            .fetch(req)
+            .get(format!("/infra/{}/speed_limit_tags/", empty_infra.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let mut test_tags = builtin_tags.0.clone();
         test_tags.push("test_tag".to_string());
@@ -1158,13 +1140,7 @@ pub mod tests {
         )
         .await;
 
-        let req = app.get("/infra/voltages/");
-
-        let voltages: Vec<String> = app
-            .fetch(req)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        let voltages: Vec<String> = app.get("/infra/voltages/").await.assert_status_ok().json();
 
         assert!(voltages.len() >= 3);
         assert!(voltages.contains(&String::from("0V")));
@@ -1200,28 +1176,22 @@ pub mod tests {
         )
         .await;
 
-        let req = app.get(
-            format!(
-                "/infra/{}/voltages/?include_rolling_stock_modes={}",
-                empty_infra.id, include_rolling_stock_modes
+        let voltages: Vec<String> = app
+            .get(
+                format!(
+                    "/infra/{}/voltages/?include_rolling_stock_modes={}",
+                    empty_infra.id, include_rolling_stock_modes
+                )
+                .as_str(),
             )
-            .as_str(),
-        );
+            .await
+            .assert_status_ok()
+            .json();
 
         if !include_rolling_stock_modes {
-            let voltages: Vec<String> = app
-                .fetch(req)
-                .await
-                .assert_status(StatusCode::OK)
-                .json_into();
             assert_eq!(voltages[0], "0");
             assert_eq!(voltages.len(), 1);
         } else {
-            let voltages: Vec<String> = app
-                .fetch(req)
-                .await
-                .assert_status(StatusCode::OK)
-                .json_into();
             assert!(voltages.contains(&String::from("25000V")));
             assert!(voltages.len() >= 2);
         }
@@ -1233,13 +1203,11 @@ pub mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let req = app.get(format!("/infra/{}/switch_types/", empty_infra.id).as_str());
-
         let switch_types: Vec<SwitchType> = app
-            .fetch(req)
+            .get(format!("/infra/{}/switch_types/", empty_infra.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(switch_types.len(), 5);
     }
@@ -1253,9 +1221,9 @@ pub mod tests {
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         // Lock infra
-        let req = app.post(format!("/infra/{}/lock/", empty_infra.id).as_str());
-
-        app.fetch(req).await.assert_status(StatusCode::NO_CONTENT);
+        app.post(format!("/infra/{}/lock/", empty_infra.id).as_str())
+            .await
+            .assert_status_no_content();
 
         // Check lock
         let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
@@ -1265,9 +1233,9 @@ pub mod tests {
         assert!(infra.locked);
 
         // Unlock infra
-        let req = app.post(format!("/infra/{}/unlock/", empty_infra.id).as_str());
-
-        app.fetch(req).await.assert_status(StatusCode::NO_CONTENT);
+        app.post(format!("/infra/{}/unlock/", empty_infra.id).as_str())
+            .await
+            .assert_status_no_content();
 
         // Check lock
         let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
@@ -1302,16 +1270,14 @@ pub mod tests {
                 secondary_code: None,
             },
         ];
-        let request = app
+        let response: MatchOperationalPointsResponse = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
             .json(&json!({
                 "operational_point_references": operational_point_references,
-            }));
-        let response: MatchOperationalPointsResponse = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let response_op_identifiers = response
             .related_operational_points
             .iter()
@@ -1353,16 +1319,14 @@ pub mod tests {
                 secondary_code: Some("PAUL".into()),
             },
         ];
-        let request = app
+        let response: MatchOperationalPointsResponse = app
             .post(format!("/infra/{}/match_operational_points", infra.id).as_str())
             .json(&json!({
                 "operational_point_references": operational_point_references,
-            }));
-        let response: MatchOperationalPointsResponse = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let response_op_identifiers = response
             .related_operational_points
             .iter()

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -153,7 +153,6 @@ pub(in crate::views) async fn list_objects_ids(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
 
     use schemas::primitives::Identifier;
@@ -174,13 +173,10 @@ mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let request = app
-            .post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
-            .json(&["invalid_id"]);
-
-        app.fetch(request)
+        app.post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
+            .json(&["invalid_id"])
             .await
-            .assert_status(StatusCode::BAD_REQUEST);
+            .assert_status_bad_request();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -189,11 +185,10 @@ mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let request = app
-            .post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
-            .json(&vec![""; 0]);
-
-        app.fetch(request).await.assert_status(StatusCode::OK);
+        app.post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
+            .json(&vec![""; 0])
+            .await
+            .assert_status_ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -217,16 +212,14 @@ mod tests {
         .expect("Failed to create switch object");
 
         // WHEN
-        let request = app
-            .post(format!("/infra/{}/objects/Switch", empty_infra.id).as_str())
-            .json(&vec!["switch_001"]);
 
         // THEN
         let switch_object: Vec<ObjectQueryable> = app
-            .fetch(request)
+            .post(format!("/infra/{}/objects/Switch", empty_infra.id).as_str())
+            .json(&vec!["switch_001"])
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let expected_switch_object = vec![ObjectQueryable {
             obj_id: switch.get_id().to_string(),
             railjson: json!({
@@ -249,13 +242,10 @@ mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
-        let request = app
-            .post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
-            .json(&vec!["id"; 2]);
-
-        app.fetch(request)
+        app.post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
+            .json(&vec!["id"; 2])
             .await
-            .assert_status(StatusCode::BAD_REQUEST);
+            .assert_status_bad_request();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -274,15 +264,12 @@ mod tests {
         .await
         .expect("Failed to create switch type object");
 
-        let request = app
-            .post(format!("/infra/{}/objects/SwitchType", empty_infra.id).as_str())
-            .json(&vec![switch_type.id.clone()]);
-
         let switch_type_object: Vec<ObjectQueryable> = app
-            .fetch(request)
+            .post(format!("/infra/{}/objects/SwitchType", empty_infra.id).as_str())
+            .json(&vec![switch_type.id.clone()])
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let expected_switch_type_object = vec![ObjectQueryable {
             obj_id: switch_type.get_id().to_string(),
             railjson: json!({
@@ -318,13 +305,11 @@ mod tests {
             .await
             .expect("Failed to create switch type object");
 
-        let request = app.get(format!("/infra/{}/objects/SwitchType/ids", empty_infra.id).as_str());
-
         let response = app
-            .fetch(request)
+            .get(format!("/infra/{}/objects/SwitchType/ids", empty_infra.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<JsonValue>();
+            .assert_status_ok()
+            .json::<JsonValue>();
 
         assert!(matches!(response, JsonValue::Object(_)));
         let mut ids = response

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -264,13 +264,11 @@ mod tests {
         .await
         .expect("Failed to create SwitchType object");
 
-        let request = app.get(&format!("/infra/{}/railjson", empty_infra.id));
-
         let railjson: RailJson = app
-            .fetch(request)
+            .get(&format!("/infra/{}/railjson", empty_infra.id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(railjson.version, RAILJSON_VERSION);
         assert_eq!(railjson.extended_switch_types.len(), 1);
@@ -296,15 +294,12 @@ mod tests {
             ..Default::default()
         };
 
-        let req = app
-            .post("/infra/railjson?name=post_railjson_test")
-            .json(&railjson);
-
         let res: PostRailjsonResponse = app
-            .fetch(req)
+            .post("/infra/railjson?name=post_railjson_test")
+            .json(&railjson)
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         assert!(
             Infra::delete_static(&mut db_pool.get_ok(), res.infra)

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -299,7 +299,6 @@ pub(in crate::views) async fn get_routes_nodes(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
 
     use serde_json::json;
@@ -430,11 +429,7 @@ mod tests {
                 .json(&params);
             println!("{request:?}  body:\n    {params}");
 
-            let got: RoutesFromNodesPositions = app
-                .fetch(request)
-                .await
-                .assert_status(StatusCode::OK)
-                .json_into();
+            let got: RoutesFromNodesPositions = request.await.assert_status_ok().json();
             compare_result(got, expected_result)
         }
     }
@@ -495,14 +490,11 @@ mod tests {
 
         // BufferStop Routes
         let waypoint_type = WaypointType::BufferStop;
-        let request =
-            app.get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/bs_stop").as_str());
-
         let routes: RoutesResponse = app
-            .fetch(request)
+            .get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/bs_stop").as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             routes,
@@ -514,14 +506,11 @@ mod tests {
 
         // Detector Routes
         let waypoint_type = WaypointType::Detector;
-        let request = app
-            .get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/detector_001").as_str());
-
         let routes: RoutesResponse = app
-            .fetch(request)
+            .get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/detector_001").as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             routes,
@@ -539,19 +528,17 @@ mod tests {
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let waypoint_type = WaypointType::Detector;
-        let request = app.get(
-            format!(
-                "/infra/{}/routes/{waypoint_type}/NOT_EXISTING_WAYPOINT_ID",
-                empty_infra.id
-            )
-            .as_str(),
-        );
-
         let routes: RoutesResponse = app
-            .fetch(request)
+            .get(
+                format!(
+                    "/infra/{}/routes/{waypoint_type}/NOT_EXISTING_WAYPOINT_ID",
+                    empty_infra.id
+                )
+                .as_str(),
+            )
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             routes,

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -233,7 +233,6 @@ pub(in crate::views) async fn cache_and_get_mvt_tile(
 
 #[cfg(test)]
 mod tests {
-    use axum::http::StatusCode;
     use rstest::rstest;
     use std::collections::HashMap;
     use url::Url;
@@ -252,12 +251,11 @@ mod tests {
                 .into();
 
         let app = test_app!().build();
-        let request = app.get("/layers/layer/track_sections/mvt/does_not_exist?infra=2");
         let body: InternalError = app
-            .fetch(request)
+            .get("/layers/layer/track_sections/mvt/does_not_exist?infra=2")
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
         assert_eq!(body, error);
     }
 
@@ -285,12 +283,11 @@ mod tests {
         };
 
         let app = test_app!().root_url(root_url).build();
-        let request = app.get("/layers/layer/track_sections/mvt/geo?infra=2");
         let body: ViewMetadata = app
-            .fetch(request)
+            .get("/layers/layer/track_sections/mvt/geo?infra=2")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(expected_body, body);
     }
 }

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -360,8 +360,8 @@ mod tests {
     use crate::fixtures::create_fast_rolling_stock;
     use crate::fixtures::create_small_infra;
     use crate::fixtures::create_timetable_with_train_schedule_set;
-    use crate::views::test_app::TestResponse;
     use crate::views::test_app::test_app;
+    use axum_test::TestResponse;
 
     use chrono::TimeDelta;
     use core_client::mocking::MockingClient;
@@ -575,18 +575,16 @@ mod tests {
             .await
             .expect("Failed to create train");
 
-        let request = app
-            .post("/level_crossing_occupancy")
-            .json(&LevelCrossingOccupancyForm {
-                train_ids: vec![train.id],
-                level_crossing_ids: vec![level_crossing.obj_id.clone().into()],
-                infra_id: small_infra.id,
-                timetable_id: timetable.id,
-                electrical_profile_set_id: None,
-            });
-
         (
-            app.fetch(request).await,
+            app.post("/level_crossing_occupancy")
+                .json(&LevelCrossingOccupancyForm {
+                    train_ids: vec![train.id],
+                    level_crossing_ids: vec![level_crossing.obj_id.clone().into()],
+                    infra_id: small_infra.id,
+                    timetable_id: timetable.id,
+                    electrical_profile_set_id: None,
+                })
+                .await,
             level_crossing.obj_id.clone().into(),
             train,
         )
@@ -599,7 +597,7 @@ mod tests {
             init_level_crossing_test(750.0, "LC_TC1", "TC1").await;
 
         let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> =
-            response.assert_status(StatusCode::OK).json_into();
+            response.assert_status_ok().json();
 
         assert!(occupancies.contains_key(&level_crossing_id));
         let lc_occupancies = occupancies.get(&level_crossing_id).unwrap();
@@ -629,7 +627,7 @@ mod tests {
             init_level_crossing_test(750.0, "LC_TX1", "TX1").await;
 
         let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> =
-            response.assert_status(StatusCode::OK).json_into();
+            response.assert_status_ok().json();
 
         // Level crossing should exist but have no occupancies
         assert_eq!(

--- a/editoast/src/views/operational_studies/hierarchy/project.rs
+++ b/editoast/src/views/operational_studies/hierarchy/project.rs
@@ -376,18 +376,17 @@ pub mod tests {
 
         let project_name = "test_project";
 
-        let request = app.post("/projects").json(&json!({
-            "name": project_name,
-            "description": "",
-            "objectives": "",
-            "funders": "",
-        }));
-
         let response: ProjectWithStudyCount = app
-            .fetch(request)
+            .post("/projects")
+            .json(&json!({
+                "name": project_name,
+                "description": "",
+                "objectives": "",
+                "funders": "",
+            }))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         let project = Project::retrieve(pool.get_ok(), response.project.id)
             .await
@@ -404,13 +403,8 @@ pub mod tests {
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
-        let request = app.get("/projects/");
-
-        let response: ProjectWithStudyCountList = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        let response: ProjectWithStudyCountList =
+            app.get("/projects/").await.assert_status_ok().json();
 
         let project_retrieved = response
             .results
@@ -428,13 +422,11 @@ pub mod tests {
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
-        let request = app.get(format!("/projects/{}", created_project.id).as_str());
-
         let response: ProjectWithStudyCount = app
-            .fetch(request)
+            .get(format!("/projects/{}", created_project.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.project, created_project);
     }
@@ -446,11 +438,9 @@ pub mod tests {
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
-        let request = app.delete(format!("/projects/{}", created_project.id).as_str());
-
-        app.fetch(request)
+        app.delete(format!("/projects/{}", created_project.id).as_str())
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let exists = Project::exists(&mut db_pool.get_ok(), created_project.id)
             .await
@@ -469,18 +459,15 @@ pub mod tests {
         let updated_name = "rename_test";
         let updated_budget = 20000;
 
-        let request = app
+        let response: ProjectWithStudyCount = app
             .patch(format!("/projects/{}", created_project.id).as_str())
             .json(&json!({
                 "name": updated_name,
                 "budget": updated_budget
-            }));
-
-        let response: ProjectWithStudyCount = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let project = Project::retrieve(db_pool.get_ok(), response.project.id)
             .await
@@ -542,12 +529,12 @@ pub mod tests {
             .expect("Failed to create image");
 
         // let's add one
-        let request = app
-            .patch(format!("/projects/{}", project.id).as_str())
+        app.patch(format!("/projects/{}", project.id).as_str())
             .json(&json!({
                 "image": image.id
-            }));
-        app.fetch(request).await.assert_status(StatusCode::OK);
+            }))
+            .await
+            .assert_status_ok();
 
         check_image(db_pool.get_ok(), Some(image.id)).await;
 
@@ -560,12 +547,12 @@ pub mod tests {
             .await
             .expect("Failed to create new image");
 
-        let request = app
-            .patch(format!("/projects/{}", project.id).as_str())
+        app.patch(format!("/projects/{}", project.id).as_str())
             .json(&json!({
                 "image": new_image.id
-            }));
-        app.fetch(request).await.assert_status(StatusCode::OK);
+            }))
+            .await
+            .assert_status_ok();
 
         check_image(db_pool.get_ok(), Some(new_image.id)).await;
         assert!(
@@ -575,12 +562,12 @@ pub mod tests {
         );
 
         // now we remove the image
-        let request = app
-            .patch(format!("/projects/{}", project.id).as_str())
+        app.patch(format!("/projects/{}", project.id).as_str())
             .json(&json!({
                 "image": null
-            }));
-        app.fetch(request).await.assert_status(StatusCode::OK);
+            }))
+            .await
+            .assert_status_ok();
 
         check_image(db_pool.get_ok(), None).await;
         assert!(

--- a/editoast/src/views/operational_studies/hierarchy/scenario.rs
+++ b/editoast/src/views/operational_studies/hierarchy/scenario.rs
@@ -441,13 +441,7 @@ mod tests {
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(Some(fixtures.scenario.id));
-        let request = app.get(&url);
-
-        let response: ScenarioResponse = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        let response: ScenarioResponse = app.get(&url).await.assert_status_ok().json();
 
         assert_eq!(response.scenario, fixtures.scenario);
     }
@@ -460,15 +454,12 @@ mod tests {
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(None);
-        let request = app
-            .get(&url)
-            .add_query_params(json!({"study_id": fixtures.scenario.study_id}));
-
         let mut response: ListScenariosResponse = app
-            .fetch(request)
+            .get(&url)
+            .add_query_params(json!({"study_id": fixtures.scenario.study_id}))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(!response.results.is_empty());
         assert_eq!(
@@ -500,20 +491,19 @@ mod tests {
         let scenario_tags = Tags::new(vec!["tag1".to_string(), "tag2".to_string()]);
 
         // Insert scenario
-        let request = app.post(&url).json(&json!({
-            "name": scenario_name,
-            "description": scenario_description,
-            "infra_id": scenario_infra_id,
-            "timetable_id": scenario_timetable_id,
-            "tags": scenario_tags,
-            "study_id": study.id
-        }));
-
         let response: ScenarioWithDetails = app
-            .fetch(request)
+            .post(&url)
+            .json(&json!({
+                "name": scenario_name,
+                "description": scenario_description,
+                "infra_id": scenario_infra_id,
+                "timetable_id": scenario_timetable_id,
+                "tags": scenario_tags,
+                "study_id": study.id
+            }))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         assert_eq!(response.scenario.name, scenario_name);
         assert_eq!(response.scenario.description, scenario_description);
@@ -549,16 +539,16 @@ mod tests {
         let scenario_tags = Tags::new(vec!["patched_tag1".to_string(), "patched_tag2".to_string()]);
 
         // Update scenario
-        let request = app.patch(&url).json(&json!({
-            "name": scenario_name,
-            "description": scenario_description,
-            "tags": scenario_tags
-        }));
         let response: ScenarioWithDetails = app
-            .fetch(request)
+            .patch(&url)
+            .json(&json!({
+                "name": scenario_name,
+                "description": scenario_description,
+                "tags": scenario_tags
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.scenario.name, scenario_name);
         assert_eq!(response.scenario.description, scenario_description);
@@ -576,13 +566,12 @@ mod tests {
         let url = scenario_url(Some(fixtures.scenario.id));
 
         // Update scenario
-        let request = app.patch(&url).json(&json!({
-            "infra_id": 999999999,
-        }));
-
-        app.fetch(request)
+        app.patch(&url)
+            .json(&json!({
+                "infra_id": 999999999,
+            }))
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -601,15 +590,15 @@ mod tests {
         let scenario_name = "new patched scenario V2";
         let scenario_other_infra_id = other_infra.id;
 
-        let request = app.patch(&url).json(&json!({
-            "name": scenario_name,
-            "infra_id": scenario_other_infra_id,
-        }));
         let response: ScenarioWithDetails = app
-            .fetch(request)
+            .patch(&url)
+            .json(&json!({
+                "name": scenario_name,
+                "infra_id": scenario_other_infra_id,
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.scenario.infra_id, scenario_other_infra_id);
         assert_eq!(response.scenario.name, scenario_name);
@@ -623,11 +612,7 @@ mod tests {
         let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(Some(fixtures.scenario.id));
-        let request = app.delete(&url);
-
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NO_CONTENT);
+        app.delete(&url).await.assert_status_no_content();
 
         let exists = Scenario::exists(&mut pool.get_ok(), fixtures.scenario.id)
             .await

--- a/editoast/src/views/operational_studies/hierarchy/study.rs
+++ b/editoast/src/views/operational_studies/hierarchy/study.rs
@@ -462,20 +462,20 @@ pub mod tests {
 
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
-        let request = app.post("/studies/").json(&json!({
-            "name": "study_test",
-            "description": "Study description",
-            "state": "Starting",
-            "business_code": "",
-            "service_code": "",
-            "study_type": "",
-            "project_id": created_project.id,
-        }));
         let response: StudyWithScenarioCount = app
-            .fetch(request)
+            .post("/studies/")
+            .json(&json!({
+                "name": "study_test",
+                "description": "Study description",
+                "state": "Starting",
+                "business_code": "",
+                "service_code": "",
+                "study_type": "",
+                "project_id": created_project.id,
+            }))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         let study = Study::retrieve(db_pool.get_ok(), response.study.id)
             .await
@@ -496,15 +496,12 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app
-            .get("/studies")
-            .add_query_param("project_id", created_project.id);
-
         let response: StudyListResponse = app
-            .fetch(request)
+            .get("/studies")
+            .add_query_param("project_id", created_project.id)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let studies_retrieved = response
             .results
@@ -525,13 +522,11 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app.get(&format!("/studies/{}", created_study.id));
-
         let response: StudyResponse = app
-            .fetch(request)
+            .get(&format!("/studies/{}", created_study.id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.study, created_study);
         assert_eq!(response.study.project_id, created_project.id);
@@ -547,11 +542,9 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app.get(&format!("/studies/{}", created_study.id + 1000));
-
-        app.fetch(request)
+        app.get(&format!("/studies/{}", created_study.id + 1000))
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -564,11 +557,9 @@ pub mod tests {
         let created_study =
             create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
 
-        let request = app.delete(&format!("/studies/{}", created_study.id));
-
-        app.fetch(request)
+        app.delete(&format!("/studies/{}", created_study.id))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let exists = Study::exists(&mut db_pool.get_ok(), created_study.id)
             .await
@@ -590,14 +581,13 @@ pub mod tests {
         let study_name = "rename_test";
         let study_budget = 20000;
 
-        let request = app
-            .patch(&format!("/studies/{}", created_study.id))
+        app.patch(&format!("/studies/{}", created_study.id))
             .json(&json!({
                 "name": study_name,
                 "budget": study_budget,
-            }));
-
-        app.fetch(request).await.assert_status(StatusCode::OK);
+            }))
+            .await
+            .assert_status_ok();
 
         let updated_study = Study::retrieve(db_pool.get_ok(), created_study.id)
             .await

--- a/editoast/src/views/operational_studies/macro_view/macro_nodes.rs
+++ b/editoast/src/views/operational_studies/macro_view/macro_nodes.rs
@@ -392,15 +392,15 @@ pub mod test {
             is_collapsed: false,
         }];
 
-        let request = app.post("/macro_nodes").json(&MacroNodeBatchForm {
-            macro_nodes: nodes_data.clone(),
-            scenario_id: fixtures.scenario.id,
-        });
         let response: MacroNodeBatchResponse = app
-            .fetch(request)
+            .post("/macro_nodes")
+            .json(&MacroNodeBatchForm {
+                macro_nodes: nodes_data.clone(),
+                scenario_id: fixtures.scenario.id,
+            })
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         let node = MacroNode::retrieve(db_pool.get_ok(), response.macro_nodes[0].id)
             .await
@@ -427,14 +427,12 @@ pub mod test {
             path_item_key: "A->B".to_string(),
             is_collapsed: false,
         };
-        let request = app
-            .put(&format!("/macro_nodes/{}", fixtures.nodes[0].id))
-            .json(&node_data);
         let response: MacroNodeResponse = app
-            .fetch(request)
+            .put(&format!("/macro_nodes/{}", fixtures.nodes[0].id))
+            .json(&node_data)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let node = MacroNode::retrieve(db_pool.get_ok(), fixtures.nodes[0].id)
             .await
@@ -451,12 +449,11 @@ pub mod test {
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 
-        let request = app.get(&format!("/macro_nodes/{}", fixtures.nodes[0].id));
         let response: MacroNodeResponse = app
-            .fetch(request)
+            .get(&format!("/macro_nodes/{}", fixtures.nodes[0].id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(fixtures.nodes[0] == response);
     }
@@ -465,11 +462,9 @@ pub mod test {
     async fn get_node_not_found() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.get("/macro_nodes/999999");
-
-        app.fetch(request)
+        app.get("/macro_nodes/999999")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -478,15 +473,14 @@ pub mod test {
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 10).await;
 
-        let request = app.get(&format!(
-            "/macro_nodes?page=1&page_size=5&scenario_id={}",
-            fixtures.scenario.id
-        ));
         let response: MacroNodeListResponse = app
-            .fetch(request)
+            .get(&format!(
+                "/macro_nodes?page=1&page_size=5&scenario_id={}",
+                fixtures.scenario.id
+            ))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(10, response.stats.count);
         assert_eq!(5, response.results.len());
@@ -498,10 +492,9 @@ pub mod test {
         let db_pool = app.db_pool();
         let fixtures = create_macro_node_fixtures_set(&mut db_pool.get_ok(), 1).await;
 
-        let request = app.delete(&format!("/macro_nodes/{}", fixtures.nodes[0].id));
-        app.fetch(request)
+        app.delete(&format!("/macro_nodes/{}", fixtures.nodes[0].id))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let found = MacroNode::exists(&mut db_pool.get_ok(), fixtures.nodes[0].id)
             .await

--- a/editoast/src/views/operational_studies/macro_view/macro_notes.rs
+++ b/editoast/src/views/operational_studies/macro_view/macro_notes.rs
@@ -375,15 +375,14 @@ pub mod test {
                 .expect("Failed to create macro note");
         }
 
-        let request = app.get(&format!(
-            "/macro_notes?page=1&page_size=3&scenario_id={}",
-            fixtures1.scenario.id
-        ));
         let response: MacroNoteListResponse = app
-            .fetch(request)
+            .get(&format!(
+                "/macro_notes?page=1&page_size=3&scenario_id={}",
+                fixtures1.scenario.id
+            ))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let ids: Vec<i64> = response.results.iter().map(|note| note.id).collect();
         let mut sorted_ids = ids.clone();
@@ -425,15 +424,15 @@ pub mod test {
             },
         ];
 
-        let request = app.post("/macro_notes").json(&MacroNoteBatchForm {
-            macro_notes: notes_data.clone(),
-            scenario_id: fixtures.scenario.id,
-        });
         let response: MacroNoteBatchResponse = app
-            .fetch(request)
+            .post("/macro_notes")
+            .json(&MacroNoteBatchForm {
+                macro_notes: notes_data.clone(),
+                scenario_id: fixtures.scenario.id,
+            })
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         assert_eq!(notes_data.len(), response.macro_notes.len());
 
@@ -462,13 +461,13 @@ pub mod test {
             labels: Tags::new(vec!["A".to_string()]),
         }];
 
-        let request = app.post("/macro_notes").json(&MacroNoteBatchForm {
-            macro_notes: notes_data.clone(),
-            scenario_id: fixtures.scenario.id + 1,
-        });
-        app.fetch(request)
+        app.post("/macro_notes")
+            .json(&MacroNoteBatchForm {
+                macro_notes: notes_data.clone(),
+                scenario_id: fixtures.scenario.id + 1,
+            })
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -488,13 +487,11 @@ pub mod test {
             .await
             .expect("Failed to create macro note");
 
-        let request = app.get(&format!("/macro_notes/{}", note.id));
-
         let response: MacroNoteResponse = app
-            .fetch(request)
+            .get(&format!("/macro_notes/{}", note.id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(MacroNoteResponse::from(note), response);
     }
@@ -503,11 +500,9 @@ pub mod test {
     async fn get_note_not_found() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.get("/macro_notes/999999");
-
-        app.fetch(request)
+        app.get("/macro_notes/999999")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -535,13 +530,12 @@ pub mod test {
             labels: Tags::new(vec!["New label".to_string(), "B".to_string()]),
         };
 
-        let request = app.put(&format!("/macro_notes/{}", note.id)).json(&update);
-
         let response: MacroNoteResponse = app
-            .fetch(request)
+            .put(&format!("/macro_notes/{}", note.id))
+            .json(&update)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let note = MacroNote::retrieve(db_pool.get_ok(), note.id)
             .await
@@ -564,11 +558,10 @@ pub mod test {
             labels: Tags::new(vec!["New label".to_string(), "B".to_string()]),
         };
 
-        let request = app.put("/macro_notes/999999999").json(&update);
-
-        app.fetch(request)
+        app.put("/macro_notes/999999999")
+            .json(&update)
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -589,11 +582,9 @@ pub mod test {
             .await
             .expect("Failed to create macro note");
 
-        let request = app.delete(&format!("/macro_notes/{}", note.id));
-
-        app.fetch(request)
+        app.delete(&format!("/macro_notes/{}", note.id))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let still_exists = MacroNote::exists(&mut db_pool.get_ok(), note.id)
             .await
@@ -605,10 +596,8 @@ pub mod test {
     async fn delete_note_not_found() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.delete("/macro_notes/999999");
-
-        app.fetch(request)
+        app.delete("/macro_notes/999999")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 }

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -620,15 +620,12 @@ pub mod tests {
             }),
         ];
 
-        let request = app
-            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
-            .json(&pathfinding_input(path_items));
-
         let pathfinding_result: PathfindingResult = app
-            .fetch(request)
+            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
+            .json(&pathfinding_input(path_items))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(
             pathfinding_result,
             PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
@@ -666,15 +663,12 @@ pub mod tests {
             }),
         ];
 
-        let request = app
-            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
-            .json(&pathfinding_input(path_items));
-
         let pathfinding_result: PathfindingResult = app
-            .fetch(request)
+            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
+            .json(&pathfinding_input(path_items))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(
             pathfinding_result,
             PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
@@ -718,15 +712,12 @@ pub mod tests {
             }),
         ];
 
-        let request = app
-            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
-            .json(&pathfinding_input(path_items));
-
         let pathfinding_result: PathfindingResult = app
-            .fetch(request)
+            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
+            .json(&pathfinding_input(path_items))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(
             pathfinding_result,
             PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
@@ -775,15 +766,12 @@ pub mod tests {
             }),
         ];
 
-        let request = app
-            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
-            .json(&pathfinding_input(path_items));
-
         let pathfinding_res: PathfindingResult = app
-            .fetch(request)
+            .post(format!("/infra/{}/pathfinding/blocks", small_infra.id).as_str())
+            .json(&pathfinding_input(path_items))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(pathfinding_res, pathfinding_result(1));
     }
 }

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -171,14 +171,9 @@ mod tests {
         let url = format!("/infra/{}/path_properties", infra.id);
 
         // Should succeed
-        let request = app.post(&url).json(&json!(
+        let response: PathProperties = app.post(&url).json(&json!(
             {"track_section_ranges": [{ "track_section": "TD0", "begin": 0, "end": 20000, "direction": "START_TO_STOP" }]})
-        );
-        let response: PathProperties = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        ).await.assert_status_ok().json();
         let path_properties_response = path_properties_response();
         assert_eq!(response.slopes, path_properties_response.slopes);
         assert_eq!(response.curves, path_properties_response.curves);
@@ -200,14 +195,9 @@ mod tests {
         let url = format!("/infra/{}/path_properties", infra.id);
 
         // Should succeed
-        let request = app.post(&url).json(&json!(
+        let response: PathProperties = app.post(&url).json(&json!(
             {"track_section_ranges": [{ "track_section": "TD0", "begin": 0, "end": 20000, "direction": "START_TO_STOP" }]})
-        );
-        let response: PathProperties = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        ).await.assert_status_ok().json();
         let path_properties_response = path_properties_response();
         assert_eq!(response.slopes, path_properties_response.slopes);
         assert_eq!(response.curves, path_properties_response.curves);

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -671,7 +671,6 @@ async fn create_compound_image(
 
 #[cfg(test)]
 pub mod tests {
-    use axum::http::StatusCode;
     use editoast_models::rolling_stock::TrainMainCategory;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
@@ -727,13 +726,13 @@ pub mod tests {
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock_form = fast_rolling_stock_form(rs_name);
 
-        let request = app.rolling_stock_create_request(&fast_rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .rolling_stock_create_request(&fast_rolling_stock_form)
+            .await;
 
         // THEN
-        let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
+        let response: RollingStock = raw_response.assert_status_ok().json();
         // Check if the rolling stock was created in the database
         let rolling_stock = RollingStock::retrieve(db_pool.get_ok(), response.id)
             .await
@@ -763,15 +762,14 @@ pub mod tests {
         let locked_rs_name = "locked_fast_rolling_stock_name";
         let locked_fast_rolling_stock_form = fast_rolling_stock_form(locked_rs_name);
 
-        let request = app
-            .post("/rolling_stock?locked=true")
-            .json(&locked_fast_rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .post("/rolling_stock?locked=true")
+            .json(&locked_fast_rolling_stock_form)
+            .await;
 
         // THEN
-        let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
+        let response: RollingStock = raw_response.assert_status_ok().json();
         // Check if the rolling stock was created in the database with locked = true
         let rolling_stock = RollingStock::retrieve(db_pool.get_ok(), response.id)
             .await
@@ -791,13 +789,11 @@ pub mod tests {
         let _ = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
         let new_fast_rolling_stock_form = fast_rolling_stock_form(rs_name);
 
-        let request = app.rolling_stock_create_request(&new_fast_rolling_stock_form);
-
         let response: InternalError = app
-            .fetch(request)
+            .rolling_stock_create_request(&new_fast_rolling_stock_form)
             .await
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
+            .assert_status_bad_request()
+            .json();
 
         assert_eq!(
             response.error_type,
@@ -810,18 +806,16 @@ pub mod tests {
         let app = test_app!().skip_authz().build();
         let stock_name = Uuid::new_v4().to_string();
         let rolling_stock = fast_rolling_stock_form(stock_name.as_str());
-        let request = app.rolling_stock_create_request(&rolling_stock);
         let RollingStock { id, .. } = app
-            .fetch(request)
+            .rolling_stock_create_request(&rolling_stock)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
-        let request = app.get(&format!("/rolling_stock/{id}/usage"));
+            .assert_status_ok()
+            .json();
         let related_schedules: Vec<ScenarioReference> = app
-            .fetch(request)
+            .get(&format!("/rolling_stock/{id}/usage"))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert!(related_schedules.is_empty());
     }
 
@@ -832,18 +826,16 @@ pub mod tests {
 
         let create_rolling_stock_request =
             app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
-        let rolling_stock: RollingStock = app
-            .fetch(create_rolling_stock_request)
+        let rolling_stock: RollingStock = (create_rolling_stock_request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let create_other_rolling_stock_request =
             app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
-        let other_rolling_stock: RollingStock = app
-            .fetch(create_other_rolling_stock_request)
+        let other_rolling_stock: RollingStock = (create_other_rolling_stock_request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let project = create_project(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
         let study = create_study(
@@ -904,12 +896,11 @@ pub mod tests {
             .await
             .unwrap();
 
-        let request = app.get(&format!("/rolling_stock/{}/usage", rolling_stock.id));
         let related_scenarios: Vec<ScenarioReference> = app
-            .fetch(request)
+            .get(&format!("/rolling_stock/{}/usage", rolling_stock.id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let expected_scenarios = [
             ScenarioReference {
                 project_id: project.id,
@@ -940,10 +931,9 @@ pub mod tests {
         let db_pool = app.db_pool();
         let _ = RollingStock::delete_static(&mut db_pool.get_ok(), 1).await;
 
-        let request = app.get("/rolling_stock/1/usage");
-        app.fetch(request)
+        app.get("/rolling_stock/1/usage")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -955,15 +945,13 @@ pub mod tests {
         let mut fast_rolling_stock_form = fast_rolling_stock_form(rs_name);
         fast_rolling_stock_form.base_power_class = Some("".to_string());
 
-        let request = app.rolling_stock_create_request(&fast_rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .rolling_stock_create_request(&fast_rolling_stock_form)
+            .await;
 
         // THEN
-        let response: InternalError = raw_response
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
+        let response: InternalError = raw_response.assert_status_bad_request().json();
 
         assert_eq!(
             response.error_type,
@@ -977,17 +965,14 @@ pub mod tests {
 
         let invalid_payload = schemas::fixtures::rolling_stock_with_invalid_effort_curves_json();
 
-        let request = app
-            .post("/rolling_stock")
+        app.post("/rolling_stock")
             .add_header(
                 axum::http::header::CONTENT_TYPE,
                 axum::http::header::HeaderValue::from_str("application/json").unwrap(),
             )
-            .bytes(invalid_payload.into());
-
-        app.fetch(request)
+            .bytes(invalid_payload.into())
             .await
-            .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
+            .assert_status_unprocessable_entity();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -999,10 +984,11 @@ pub mod tests {
         let rolling_stock_form = simple_etcs_level2_rolling_stock();
 
         // WHEN
-        let request = app.rolling_stock_create_request(&rolling_stock_form);
-        let raw_response = app.fetch(request);
-
-        let response: RollingStock = raw_response.await.assert_status(StatusCode::OK).json_into();
+        let response: RollingStock = app
+            .rolling_stock_create_request(&rolling_stock_form)
+            .await
+            .assert_status_ok()
+            .json();
         // Check if the rolling stock was created in the database
         let rolling_stock = RollingStock::retrieve(db_pool.get_ok(), response.id)
             .await
@@ -1032,13 +1018,13 @@ pub mod tests {
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
-        let request = app.rolling_stock_get_by_id_request(fast_rolling_stock.id);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .await;
 
         // THEN
-        let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
+        let response: RollingStock = raw_response.assert_status_ok().json();
 
         assert_eq!(response, fast_rolling_stock);
     }
@@ -1052,13 +1038,13 @@ pub mod tests {
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
-        let request = app.get(format!("/rolling_stock/name/{rs_name}").as_str());
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .get(format!("/rolling_stock/name/{rs_name}").as_str())
+            .await;
 
         // THEN
-        let response: RollingStock = raw_response.assert_status(StatusCode::OK).json_into();
+        let response: RollingStock = raw_response.assert_status_ok().json();
 
         assert_eq!(response, fast_rolling_stock);
     }
@@ -1067,23 +1053,18 @@ pub mod tests {
     async fn get_unexisting_rolling_stock_by_id() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.rolling_stock_get_by_id_request(0);
-
-        app.fetch(request)
+        app.rolling_stock_get_by_id_request(0)
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_rolling_stock_by_name() {
         let app = test_app!().skip_authz().build();
 
-        let request =
-            app.get(format!("/rolling_stock/name/{}", "unexisting_rolling_stock_name").as_str());
-
-        app.fetch(request)
+        app.get(format!("/rolling_stock/name/{}", "unexisting_rolling_stock_name").as_str())
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1100,15 +1081,14 @@ pub mod tests {
         let updated_rs_name = "updated_fast_rolling_stock_name";
         rolling_stock_form.name = updated_rs_name.to_string();
 
-        let request = app
-            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
-            .json(&&rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .json(&&rolling_stock_form)
+            .await;
 
         // THEN
-        raw_response.assert_status(StatusCode::OK);
+        raw_response.assert_status_ok();
 
         let updated_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
@@ -1146,15 +1126,14 @@ pub mod tests {
         let other_categories = vec![schemas::rolling_stock::TrainMainCategory::RegionalTrain];
         rolling_stock_form.other_categories = other_categories;
 
-        let request = app
-            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
-            .json(&&rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .json(&&rolling_stock_form)
+            .await;
 
         // THEN
-        raw_response.assert_status(StatusCode::OK);
+        raw_response.assert_status_ok();
 
         let updated_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
@@ -1192,17 +1171,14 @@ pub mod tests {
         let other_categories = vec![*primary_category.clone()];
         rolling_stock_form.other_categories = other_categories.clone();
 
-        let request = app
-            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
-            .json(&&rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .json(&&rolling_stock_form)
+            .await;
 
         // THEN
-        let response = raw_response
-            .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
-            .string();
+        let response = raw_response.assert_status_unprocessable_entity().text();
         assert_eq!(
             response,
             "Failed to deserialize the JSON body into the target type: invalid rolling-stock: primary_category: The primary_category cannot be listed in other_categories for rolling stocks."
@@ -1233,17 +1209,14 @@ pub mod tests {
 
         let second_fast_rolling_stock_form: RollingStockForm = second_fast_rolling_stock.into();
 
-        let request = app
-            .put(format!("/rolling_stock/{}", first_fast_rolling_stock.id).as_str())
-            .json(&second_fast_rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .put(format!("/rolling_stock/{}", first_fast_rolling_stock.id).as_str())
+            .json(&second_fast_rolling_stock_form)
+            .await;
 
         // THEN
-        let response: InternalError = raw_response
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
+        let response: InternalError = raw_response.assert_status_bad_request().json();
 
         assert_eq!(
             response.error_type,
@@ -1272,15 +1245,14 @@ pub mod tests {
             schemas::fixtures::fast_rolling_stock();
         second_fast_rolling_stock_form.name = "second_fast_rolling_stock_name".to_owned();
 
-        let request = app
-            .put(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())
-            .json(&second_fast_rolling_stock_form);
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .put(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())
+            .json(&second_fast_rolling_stock_form)
+            .await;
 
         // THEN
-        let response: InternalError = raw_response.assert_status(StatusCode::CONFLICT).json_into();
+        let response: InternalError = raw_response.assert_status_conflict().json();
         assert_eq!(response.error_type, "editoast:rollingstocks:IsLocked");
     }
 
@@ -1289,13 +1261,10 @@ pub mod tests {
         let app = test_app!().skip_authz().build();
 
         let id: i64 = rand::random();
-        let request = app
-            .patch(&format!("/rolling_stock/{id}/locked"))
-            .json(&json!({ "locked": true }));
-
-        app.fetch(request)
+        app.patch(&format!("/rolling_stock/{id}/locked"))
+            .json(&json!({ "locked": true }))
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1308,13 +1277,10 @@ pub mod tests {
 
         assert!(!fast_rolling_stock.locked);
 
-        let request = app
-            .patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
-            .json(&json!({ "locked": true }));
-
-        app.fetch(request)
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let fast_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
@@ -1342,13 +1308,10 @@ pub mod tests {
             .expect("Failed to create rolling stock");
         assert!(locked_fast_rolling_stock.locked);
 
-        let request = app
-            .patch(format!("/rolling_stock/{}/locked", locked_fast_rolling_stock.id).as_str())
-            .json(&json!({ "locked": false }));
-
-        app.fetch(request)
+        app.patch(format!("/rolling_stock/{}/locked", locked_fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": false }))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let fast_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), locked_fast_rolling_stock.id)
@@ -1369,13 +1332,11 @@ pub mod tests {
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
         let power_restrictions = fast_rolling_stock.power_restrictions.clone();
 
-        let request = app.get("/rolling_stock/power_restrictions");
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app.get("/rolling_stock/power_restrictions").await;
 
         // THEN
-        let response: Vec<String> = raw_response.assert_status(StatusCode::OK).json_into();
+        let response: Vec<String> = raw_response.assert_status_ok().json();
         let power_restrictions = serde_json::to_string(&power_restrictions)
             .expect("Failed to convert power_restrictions to string");
         assert!(power_restrictions.contains(&"C2".to_string()));
@@ -1401,14 +1362,13 @@ pub mod tests {
             .await
             .expect("Failed to create rolling stock");
 
-        let request =
-            app.delete(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str());
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .delete(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())
+            .await;
 
         // THEN
-        let response: InternalError = raw_response.assert_status(StatusCode::CONFLICT).json_into();
+        let response: InternalError = raw_response.assert_status_conflict().json();
 
         assert_eq!(response.error_type, "editoast:rollingstocks:IsLocked");
 
@@ -1430,13 +1390,13 @@ pub mod tests {
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
         assert!(!fast_rolling_stock.locked);
 
-        let request = app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str());
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .await;
 
         // THEN
-        raw_response.assert_status(StatusCode::NO_CONTENT);
+        raw_response.assert_status_no_content();
 
         let rolling_stock_exists =
             RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
@@ -1480,15 +1440,13 @@ pub mod tests {
             .await
             .expect("Failed to create paced train");
 
-        let request = app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str());
-        let request_forced =
-            app.delete(format!("/rolling_stock/{}?force=true", fast_rolling_stock.id).as_str());
-
         // WHEN
-        let raw_response = app.fetch(request).await;
+        let raw_response = app
+            .delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .await;
 
         // THEN
-        let response: InternalError = raw_response.assert_status(StatusCode::CONFLICT).json_into();
+        let response: InternalError = raw_response.assert_status_conflict().json();
         assert_eq!(response.error_type, "editoast:rollingstocks:IsUsed");
 
         let rolling_stock_exists =
@@ -1499,10 +1457,12 @@ pub mod tests {
         assert!(rolling_stock_exists);
 
         // WHEN
-        let raw_response_forced = app.fetch(request_forced).await;
+        let raw_response_forced = app
+            .delete(format!("/rolling_stock/{}?force=true", fast_rolling_stock.id).as_str())
+            .await;
 
         // THEN
-        raw_response_forced.assert_status(StatusCode::NO_CONTENT);
+        raw_response_forced.assert_status_no_content();
 
         let rolling_stock_exists =
             RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -271,10 +271,8 @@ impl From<ModeEffortCurves> for LightModeEffortCurves {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
+    use std::collections::HashSet;
 
     use editoast_models::prelude::*;
 
@@ -296,8 +294,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_light_rolling_stock() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/light_rolling_stock");
-        app.fetch(request).await.assert_status(StatusCode::OK);
+        app.get("/light_rolling_stock").await.assert_status_ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -309,14 +306,12 @@ mod tests {
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
-        let request = app.get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str());
-
         // WHEN
         let response: LightRollingStockWithLiveries = app
-            .fetch(request)
+            .get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // THEN
         assert_eq!(response.rolling_stock.id, fast_rolling_stock.id);
@@ -331,14 +326,12 @@ mod tests {
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
-        let request = app.get(format!("/light_rolling_stock/name/{rs_name}").as_str());
-
         // WHEN
         let response: LightRollingStockWithLiveries = app
-            .fetch(request)
+            .get(format!("/light_rolling_stock/name/{rs_name}").as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // THEN
         assert_eq!(response.rolling_stock.id, fast_rolling_stock.id);
@@ -349,11 +342,9 @@ mod tests {
     async fn get_unexisting_light_rolling_stock() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.get(format!("/light_rolling_stock/{}", -1).as_str());
-
-        app.fetch(request)
+        app.get(format!("/light_rolling_stock/{}", -1).as_str())
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -389,20 +380,15 @@ mod tests {
             .map(|rs| rs.id)
             .collect::<HashSet<_>>();
 
-        let request = app.get("/light_rolling_stock/");
         let response: LightRollingStockWithLiveriesCountList = app
-            .fetch(request)
+            .get("/light_rolling_stock/")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let count = response.stats.count;
         let uri = format!("/light_rolling_stock/?page_size={count}");
-        let request = app.get(&uri);
-        let response: LightRollingStockWithLiveriesCountList = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        let response: LightRollingStockWithLiveriesCountList =
+            app.get(&uri).await.assert_status_ok().json();
 
         // Ensure that AT LEAST all the rolling stocks create above are returned, in order
         let vec_ids = response
@@ -421,10 +407,8 @@ mod tests {
     async fn light_rolling_stock_max_page_size() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.get("/light_rolling_stock/?page_size=1010");
-
-        app.fetch(request)
+        app.get("/light_rolling_stock/?page_size=1010")
             .await
-            .assert_status(StatusCode::BAD_REQUEST);
+            .assert_status_bad_request();
     }
 }

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -233,7 +233,6 @@ mod tests {
     use super::TowedRollingStockCountList;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
-    use axum::http::StatusCode;
     use common::units;
     use editoast_models::TowedRollingStock;
 
@@ -266,32 +265,26 @@ mod tests {
             "const_gamma": 1.0,
         });
 
-        let request = app
-            .post("/towed_rolling_stock")
+        app.post("/towed_rolling_stock")
             .add_query_param("locked", locked)
-            .json(&towed_rolling_stock_json);
-
-        app.fetch(request)
+            .json(&towed_rolling_stock_json)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into()
+            .assert_status_ok()
+            .json()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_and_list_towed_rolling_stock() {
         let app = test_app!().skip_authz().build();
-
         let name = Uuid::new_v4().to_string();
         let towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED).await;
 
         let towed_rolling_stocks: TowedRollingStockCountList = app
-            .fetch(
-                app.get("/towed_rolling_stock")
-                    .add_query_param("page_size", 50),
-            )
+            .get("/towed_rolling_stock")
+            .add_query_param("page_size", 50)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(
             towed_rolling_stocks
@@ -307,9 +300,9 @@ mod tests {
 
         let id: i64 = rand::random();
 
-        app.fetch(app.get(&format!("/towed_rolling_stock/{id}")))
+        app.get(&format!("/towed_rolling_stock/{id}"))
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -324,10 +317,10 @@ mod tests {
         let id = created_towed_rolling_stock.id;
 
         let get_towed_rolling_stock: TowedRollingStock = app
-            .fetch(app.get(&format!("/towed_rolling_stock/{id}")))
+            .get(&format!("/towed_rolling_stock/{id}"))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(get_towed_rolling_stock, created_towed_rolling_stock);
     }
@@ -340,12 +333,10 @@ mod tests {
         let towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED).await;
 
         let id: i64 = rand::random(); // <-- doesn't exist
-        app.fetch(
-            app.put(&format!("/towed_rolling_stock/{id}"))
-                .json(&towed_rolling_stock),
-        )
-        .await
-        .assert_status(StatusCode::NOT_FOUND);
+        app.put(&format!("/towed_rolling_stock/{id}"))
+            .json(&towed_rolling_stock)
+            .await
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -358,13 +349,11 @@ mod tests {
         let id = towed_rolling_stock.id;
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
         let updated_towed_rolling_stock: TowedRollingStock = app
-            .fetch(
-                app.put(&format!("/towed_rolling_stock/{id}"))
-                    .json(&towed_rolling_stock),
-            )
+            .put(&format!("/towed_rolling_stock/{id}"))
+            .json(&towed_rolling_stock)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(updated_towed_rolling_stock.name, name);
         assert_eq!(
@@ -378,12 +367,10 @@ mod tests {
         let app = test_app!().skip_authz().build();
 
         let id: i64 = rand::random(); // <-- doesn't exist
-        app.fetch(
-            app.patch(&format!("/towed_rolling_stock/{id}/locked"))
-                .json(&json!({ "locked": false })),
-        )
-        .await
-        .assert_status(StatusCode::NOT_FOUND);
+        app.patch(&format!("/towed_rolling_stock/{id}/locked"))
+            .json(&json!({ "locked": false }))
+            .await
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -395,12 +382,10 @@ mod tests {
 
         let id = towed_rolling_stock.id;
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
-        app.fetch(
-            app.put(&format!("/towed_rolling_stock/{id}"))
-                .json(&towed_rolling_stock),
-        )
-        .await
-        .assert_status(StatusCode::CONFLICT);
+        app.put(&format!("/towed_rolling_stock/{id}"))
+            .json(&towed_rolling_stock)
+            .await
+            .assert_status_conflict();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -412,17 +397,13 @@ mod tests {
 
         let id = towed_rolling_stock.id;
         towed_rolling_stock.mass = units::kilogram::new(13000.0);
-        app.fetch(
-            app.patch(&format!("/towed_rolling_stock/{id}/locked"))
-                .json(&json!({ "locked": false })),
-        )
-        .await
-        .assert_status(StatusCode::NO_CONTENT);
-        app.fetch(
-            app.put(&format!("/towed_rolling_stock/{id}"))
-                .json(&towed_rolling_stock),
-        )
-        .await
-        .assert_status(StatusCode::OK);
+        app.patch(&format!("/towed_rolling_stock/{id}/locked"))
+            .json(&json!({ "locked": false }))
+            .await
+            .assert_status_no_content();
+        app.put(&format!("/towed_rolling_stock/{id}"))
+            .json(&towed_rolling_stock)
+            .await
+            .assert_status_ok();
     }
 }

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -794,8 +794,6 @@ pub struct SearchConfigFinder;
 
 #[cfg(test)]
 pub mod tests {
-
-    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
 
     use serde_json::json;
@@ -817,17 +815,16 @@ pub mod tests {
         let train = create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
 
         // The body
-        let request = app.post("/search").json(&json!({
-            "object": "trainschedule",
-            "query": ["and", ["=", ["train_name"], train.train_name],
-                             ["=", ["train_schedule_set_id"], train.train_schedule_set_id]],
-        }));
-
         let response: Vec<SearchResultItemTrainSchedule> = app
-            .fetch(request)
+            .post("/search")
+            .json(&json!({
+                "object": "trainschedule",
+                "query": ["and", ["=", ["train_name"], train.train_name],
+                                 ["=", ["train_schedule_set_id"], train.train_schedule_set_id]],
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.len(), 1);
         assert_eq!(response[0].train_name, train.train_name);
@@ -847,17 +844,16 @@ pub mod tests {
         let train_name = "NonExistingTrain";
 
         // The body
-        let request = app.post("/search").json(&json!({
-            "object": "trainschedule",
-            "query": ["and", ["=", ["train_name"], train_name],
-                             ["=", ["train_schedule_set_id"], train_schedule_set.id]],
-        }));
-
         let response: Vec<SearchResultItemTrainSchedule> = app
-            .fetch(request)
+            .post("/search")
+            .json(&json!({
+                "object": "trainschedule",
+                "query": ["and", ["=", ["train_name"], train_name],
+                                 ["=", ["train_schedule_set_id"], train_schedule_set.id]],
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.len(), 0);
     }

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -83,17 +83,14 @@ pub(in crate::views) async fn sprites(
 mod tests {
     use crate::views::test_app;
 
-    use axum::http::StatusCode;
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_signaling_systems() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/sprites/signaling_systems");
         let response: Vec<String> = app
-            .fetch(request)
+            .get("/sprites/signaling_systems")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert!(response.contains(&"BAL".to_string()));
         assert!(response.contains(&"BAPR".to_string()));
@@ -105,10 +102,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_sprites() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/sprites/TVM300/REP%20TGV.svg");
-        let response = app.fetch(request).await.assert_status(StatusCode::OK);
+        let response = app.get("/sprites/TVM300/REP%20TGV.svg").await;
+        response.assert_status_ok();
         assert_eq!("image/svg+xml", response.content_type());
-        let response = response.bytes();
+        let response = response.into_bytes();
         let expected = std::fs::read(
             app.config()
                 .dynamic_assets_path
@@ -121,9 +118,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_sprites_not_found() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/sprites/TVM300/NOT_A_THING.svg");
-        app.fetch(request)
+        app.get("/sprites/TVM300/NOT_A_THING.svg")
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 }

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -345,14 +345,13 @@ pub mod tests {
             allowed_tracks: None,
         };
 
-        let request = app.post("/stdcm/search_environment").json(&form);
-
         // WHEN
         let stdcm_search_env = app
-            .fetch(request)
+            .post("/stdcm/search_environment")
+            .json(&form)
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into::<StdcmSearchEnvironment>();
+            .json::<StdcmSearchEnvironment>();
 
         // THEN
         let stdcm_search_env_in_db =
@@ -399,12 +398,11 @@ pub mod tests {
             allowed_tracks: None,
         };
 
-        let request = app.post("/stdcm/search_environment").json(&form);
-
         // WHEN
-        app.fetch(request)
+        app.post("/stdcm/search_environment")
+            .json(&form)
             .await
-            .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
+            .assert_status_unprocessable_entity();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -452,14 +450,12 @@ pub mod tests {
                 .expect("Failed to create stdcm search environment");
         }
 
-        let request = app.get("/stdcm/search_environment");
-
         // WHEN
         let stdcm_search_env = app
-            .fetch(request)
+            .get("/stdcm/search_environment")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<StdcmSearchEnvironmentResponse>();
+            .assert_status_ok()
+            .json::<StdcmSearchEnvironmentResponse>();
 
         // THEN
         assert_eq!(stdcm_search_env.enabled_from, enabled_from);
@@ -477,11 +473,10 @@ pub mod tests {
             .expect("Failed to delete all search environments");
 
         // WHEN
-        let request = app.get("/stdcm/search_environment");
-        let response = app.fetch(request).await;
+        let response = app.get("/stdcm/search_environment").await;
 
         // THEN
-        response.assert_status(StatusCode::NO_CONTENT);
+        response.assert_status_no_content();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -512,12 +507,10 @@ pub mod tests {
             .await
             .expect("Failed to create stdcm search environment");
 
-        let request = app.delete(&format!("/stdcm/search_environment/{}", env.id));
-
         // WHEN
-        app.fetch(request)
+        app.delete(&format!("/stdcm/search_environment/{}", env.id))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         // THEN
         let deleted_env_exists = StdcmSearchEnvironment::exists(&mut pool.get_ok(), env.id)
@@ -570,14 +563,12 @@ pub mod tests {
             .await
             .expect("Failed to create stdcm search environment");
 
-        let request = app.get("/stdcm/search_environment/list");
-
         // WHEN
         let stdcm_search_env_response = app
-            .fetch(request)
+            .get("/stdcm/search_environment/list")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<StdcmSearchEnvListResponse>();
+            .assert_status_ok()
+            .json::<StdcmSearchEnvListResponse>();
 
         // THEN
         let created_ids = HashSet::from([env1.id, env2.id, env3.id]);

--- a/editoast/src/views/sub_categories.rs
+++ b/editoast/src/views/sub_categories.rs
@@ -175,7 +175,6 @@ async fn delete_sub_category_and_fallback_to_main(
 
 #[cfg(test)]
 pub mod tests {
-    use axum::http::StatusCode;
     use editoast_models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
 
@@ -194,30 +193,29 @@ pub mod tests {
         let app = test_app!().skip_authz().build();
         let db_pool = app.db_pool();
 
-        let request = app.post("/sub_category").json(&json!([
-            {
-                "code": "tjv",
-                "name": "TJV",
-                "main_category": schemas::rolling_stock::TrainMainCategory::HighSpeedTrain,
-                "color": "#FF0000",
-                "background_color": "#FF0000",
-                "hovered_color": "#FF0000",
-            },
-            {
-                "code": "ter",
-                "name": "TER",
-                "main_category": schemas::rolling_stock::TrainMainCategory::CommuterTrain,
-                "color": "#00FF00",
-                "background_color": "#00FF00",
-                "hovered_color": "#00FF00",
-            }
-        ]));
-
         let response: Vec<SubCategory> = app
-            .fetch(request)
+            .post("/sub_category")
+            .json(&json!([
+                {
+                    "code": "tjv",
+                    "name": "TJV",
+                    "main_category": schemas::rolling_stock::TrainMainCategory::HighSpeedTrain,
+                    "color": "#FF0000",
+                    "background_color": "#FF0000",
+                    "hovered_color": "#FF0000",
+                },
+                {
+                    "code": "ter",
+                    "name": "TER",
+                    "main_category": schemas::rolling_stock::TrainMainCategory::CommuterTrain,
+                    "color": "#00FF00",
+                    "background_color": "#00FF00",
+                    "hovered_color": "#00FF00",
+                }
+            ]))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         let created_sub_category1 = response.first().unwrap();
 
         let sub_category_1 = editoast_models::SubCategory::retrieve(
@@ -248,28 +246,27 @@ pub mod tests {
     async fn sub_category_duplicated_post() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.post("/sub_category").json(&json!([
-            {
-                "code": "tjv",
-                "name": "TJV",
-                "main_category": schemas::rolling_stock::TrainMainCategory::HighSpeedTrain,
-                "color": "#FF0000",
-                "background_color": "#FF0000",
-                "hovered_color": "#FF0000",
-            },
-            {
-                "code": "tjv",
-                "name": "TJV",
-                "main_category": schemas::rolling_stock::TrainMainCategory::CommuterTrain,
-                "color": "#00FF00",
-                "background_color": "#00FF00",
-                "hovered_color": "#00FF00",
-            }
-        ]));
-
-        app.fetch(request)
+        app.post("/sub_category")
+            .json(&json!([
+                {
+                    "code": "tjv",
+                    "name": "TJV",
+                    "main_category": schemas::rolling_stock::TrainMainCategory::HighSpeedTrain,
+                    "color": "#FF0000",
+                    "background_color": "#FF0000",
+                    "hovered_color": "#FF0000",
+                },
+                {
+                    "code": "tjv",
+                    "name": "TJV",
+                    "main_category": schemas::rolling_stock::TrainMainCategory::CommuterTrain,
+                    "color": "#00FF00",
+                    "background_color": "#00FF00",
+                    "hovered_color": "#00FF00",
+                }
+            ]))
             .await
-            .assert_status(StatusCode::BAD_REQUEST);
+            .assert_status_bad_request();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -293,12 +290,7 @@ pub mod tests {
         .await
         .expect("Failed to create sub category");
 
-        let request = app.get("/sub_category");
-        let response: SubCategoryPage = app
-            .fetch(request)
-            .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+        let response: SubCategoryPage = app.get("/sub_category").await.assert_status_ok().json();
         assert_eq!(
             response.results,
             vec![created_sub_category_1.into(), created_sub_category_2.into()]
@@ -336,13 +328,12 @@ pub mod tests {
             .await
             .expect("Failed to create paced train");
 
-        let request = app.delete(&format!(
+        app.delete(&format!(
             "/sub_category/{}",
             created_sub_category.code.clone()
-        ));
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NO_CONTENT);
+        ))
+        .await
+        .assert_status_no_content();
 
         let paced_train_1 =
             editoast_models::TrainSchedule::retrieve(db_pool.get_ok(), paced_train_1.id)

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -266,19 +266,17 @@ mod tests {
         let group_name = Uuid::new_v4().to_string();
         let request_obj_id = Uuid::new_v4().to_string();
 
-        let request = app.create_temporary_speed_limit_group_request(
-            RequestParameters::new()
-                .with_group_name(group_name.clone())
-                .with_obj_id(request_obj_id.clone()),
-        );
-
         // Speed limit group checks
 
         let TemporarySpeedLimitCreateResponse { group_id } = app
-            .fetch(request)
+            .create_temporary_speed_limit_group_request(
+                RequestParameters::new()
+                    .with_group_name(group_name.clone())
+                    .with_obj_id(request_obj_id.clone()),
+            )
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
         let created_group = TemporarySpeedLimitGroup::retrieve(pool.get_ok(), group_id)
             .await
             .expect("Failed to retrieve the created temporary speed limit group")
@@ -305,21 +303,24 @@ mod tests {
         let app = test_app!().skip_authz().build();
 
         let group_name = Uuid::new_v4().to_string();
-        let request = app.create_temporary_speed_limit_group_request(
-            RequestParameters::new().with_group_name(group_name.clone()),
-        );
-        let _ = app.fetch(request).await.assert_status(StatusCode::CREATED);
-
-        let request = app.create_temporary_speed_limit_group_request(RequestParameters::new());
-        let _ = app.fetch(request).await.assert_status(StatusCode::CREATED);
-
-        let request = app.create_temporary_speed_limit_group_request(
-            RequestParameters::new().with_group_name(group_name.clone()),
-        );
         let _ = app
-            .fetch(request)
+            .create_temporary_speed_limit_group_request(
+                RequestParameters::new().with_group_name(group_name.clone()),
+            )
             .await
-            .assert_status(StatusCode::BAD_REQUEST);
+            .assert_status(StatusCode::CREATED);
+
+        let _ = app
+            .create_temporary_speed_limit_group_request(RequestParameters::new())
+            .await
+            .assert_status(StatusCode::CREATED);
+
+        let _ = app
+            .create_temporary_speed_limit_group_request(
+                RequestParameters::new().with_group_name(group_name.clone()),
+            )
+            .await
+            .assert_status_bad_request();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -331,14 +332,12 @@ mod tests {
             end_date_time: Utc::now(),
         };
 
-        let request = app.create_temporary_speed_limit_group_request(
-            RequestParameters::new().with_time_period(time_period),
-        );
-
         let _ = app
-            .fetch(request)
+            .create_temporary_speed_limit_group_request(
+                RequestParameters::new().with_time_period(time_period),
+            )
             .await
-            .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
+            .assert_status_unprocessable_entity();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -346,13 +345,11 @@ mod tests {
     async fn create_ltv_with_no_tracks_fails() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.create_temporary_speed_limit_group_request(
-            RequestParameters::new().with_track_ranges(vec![]),
-        );
-
         let _ = app
-            .fetch(request)
+            .create_temporary_speed_limit_group_request(
+                RequestParameters::new().with_track_ranges(vec![]),
+            )
             .await
-            .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
+            .assert_status_unprocessable_entity();
     }
 }

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -5,6 +5,7 @@
 use authz::v2;
 use authz::v2::TestClientExt;
 use authz::v2::special_authorizers;
+use axum::http::Method;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -17,6 +18,7 @@ use authz::identity::GroupInfo;
 use authz::identity::UserInfo;
 use axum::Router;
 use axum_test::TestRequest;
+use axum_test::TestResponse;
 use axum_test::TestServer;
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 use common::tracing::SpanUploading;
@@ -369,33 +371,33 @@ impl TestApp {
         )
     }
 
-    pub async fn fetch(&self, mut req: TestRequest) -> TestResponse {
-        if !self.enable_authorization {
-            req = req.skip_authz(); // x-osrd-skip-authz
+    pub fn method(&self, method: Method, path: &str) -> TestRequest {
+        let request = self.server.method(method, &trim_path(path));
+        if self.enable_authorization {
+            request
+        } else {
+            request.skip_authz() // x-osrd-skip-authz
         }
-        tracing::trace!(request = ?req);
-        let response = req.await;
-        TestResponse::new(response)
     }
 
     pub fn get(&self, path: &str) -> TestRequest {
-        self.server.get(&trim_path(path))
+        self.method(Method::GET, path)
     }
 
     pub fn post(&self, path: &str) -> TestRequest {
-        self.server.post(&trim_path(path))
+        self.method(Method::POST, path)
     }
 
     pub fn put(&self, path: &str) -> TestRequest {
-        self.server.put(&trim_path(path))
+        self.method(Method::PUT, path)
     }
 
     pub fn patch(&self, path: &str) -> TestRequest {
-        self.server.patch(&trim_path(path))
+        self.method(Method::PATCH, path)
     }
 
     pub fn delete(&self, path: &str) -> TestRequest {
-        self.server.delete(&trim_path(path))
+        self.method(Method::DELETE, path)
     }
 
     fn authz_subject(&self, subject_id: i64) -> authz::Subject {
@@ -649,107 +651,21 @@ fn trim_path(path: &str) -> String {
     }
 }
 
-pub struct TestResponse {
-    inner: axum_test::TestResponse,
-    log_payload: bool,
+pub trait TestResponseExt {
+    fn last_jsonl<T: DeserializeOwned>(&self) -> T;
+    fn jsonl<T: DeserializeOwned>(&self) -> Vec<T>;
 }
 
-impl TestResponse {
-    #[tracing::instrument(name = "Response", level = "debug", skip(inner), fields(status = ?inner.status_code()))]
-    fn new(inner: axum_test::TestResponse) -> Self {
-        tracing::trace!(response = ?inner);
-        Self {
-            inner,
-            log_payload: true,
-        }
-    }
-
-    #[allow(unused)]
-    pub fn log_payload(mut self, log_payload: bool) -> Self {
-        self.log_payload = log_payload;
-        self
-    }
-
-    #[track_caller]
-    fn render_response_lossy(self) -> String {
-        if !self.log_payload {
-            return "payload logging disabled".to_string();
-        }
-        let bytes = self.inner.into_bytes();
-        serde_json::from_slice::<serde_json::Value>(&bytes)
-            .ok()
-            .and_then(|json| serde_json::to_string_pretty(&json).ok())
-            .unwrap_or_else(|| "cannot render response body".to_string())
-    }
-
-    #[track_caller]
-    pub fn assert_status(self, expected_status: axum::http::StatusCode) -> Self {
-        let actual_status = self.inner.status_code();
-        if actual_status != expected_status {
-            let body = self.render_response_lossy();
-            pretty_assertions::assert_eq!(
-                actual_status,
-                expected_status,
-                "unexpected status code body={body}"
-            );
-            unreachable!("should have already panicked")
-        } else {
-            self
-        }
-    }
-
-    pub fn bytes(self) -> Vec<u8> {
-        self.inner.into_bytes().into()
-    }
-
-    pub fn string(self) -> String {
-        String::from_utf8(self.bytes()).expect("body should be valid UTF-8")
-    }
-
-    #[track_caller]
-    pub fn content_type(&self) -> String {
-        self.inner
-            .header("Content-Type")
-            .to_str()
-            .expect("Content-Type header should be valid UTF-8")
-            .to_string()
-    }
-
+impl TestResponseExt for TestResponse {
     #[tracing::instrument(
         name = "Deserialization",
         level = "debug",
         skip(self),
-        fields(response_status = ?self.inner.status_code())
+        fields(response_status = ?self.status_code())
     )]
     #[track_caller]
-    pub fn json_into<T: DeserializeOwned>(self) -> T {
-        let body = self.bytes();
-        serde_json::from_slice(body.as_ref()).unwrap_or_else(|err| {
-            tracing::error!(error = ?err, "Error deserializing test response into the desired type");
-            let actual: serde_json::Value =
-                serde_json::from_slice(body.as_ref()).unwrap_or_else(|err| {
-                    tracing::error!(
-                        error = ?err,
-                        ?body,
-                        "Failed to deserialize test response body into JSON"
-                    );
-                    panic!("could not deserialize test response into JSON");
-                });
-            let pretty = serde_json::to_string_pretty(&actual).unwrap();
-            tracing::error!(body = %pretty, "Actual JSON value");
-            panic!("could not deserialize test request");
-        })
-    }
-
-    #[tracing::instrument(
-        name = "Deserialization",
-        level = "debug",
-        skip(self),
-        fields(response_status = ?self.inner.status_code())
-    )]
-    #[track_caller]
-    pub fn last_jsonl_into<T: DeserializeOwned>(self) -> T {
-        self.jsonl_into()
+    fn last_jsonl<T: DeserializeOwned>(&self) -> T {
+        self.jsonl()
             .into_iter()
             .last()
             .expect("Response should not be empty")
@@ -759,11 +675,11 @@ impl TestResponse {
         name = "Deserialization",
         level = "debug",
         skip(self),
-        fields(response_status = ?self.inner.status_code())
+        fields(response_status = ?self.status_code())
     )]
     #[track_caller]
-    pub fn jsonl_into<T: DeserializeOwned>(self) -> Vec<T> {
-        let body = self.string();
+    fn jsonl<T: DeserializeOwned>(&self) -> Vec<T> {
+        let body = self.text();
 
         body.lines()
             .map(|line| {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1150,10 +1150,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_unexisting_timetable() {
         let app = test_app!().skip_authz().build();
-        let request = app.get(&format!("/timetable/{}/train_schedules", 0));
-        app.fetch(request)
+        app.get(&format!("/timetable/{}/train_schedules", 0))
             .await
-            .assert_status(StatusCode::NOT_FOUND);
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1162,13 +1161,12 @@ mod tests {
         let pool = app.db_pool();
 
         // Insert timetable
-        let request = app.post("/timetable");
 
         let created_timetable: TimetableResult = app
-            .fetch(request)
+            .post("/timetable")
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         let retrieved_timetable =
             Timetable::retrieve(pool.get_ok(), created_timetable.timetable_id)
@@ -1186,11 +1184,9 @@ mod tests {
 
         let timetable = create_timetable(&mut pool.get_ok()).await;
 
-        let request = app.delete(format!("/timetable/{}", timetable.id).as_str());
-
-        app.fetch(request)
+        app.delete(format!("/timetable/{}", timetable.id).as_str())
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let exists = Timetable::exists(&mut pool.get_ok(), timetable.id)
             .await
@@ -1279,12 +1275,11 @@ mod tests {
         )
         .await;
 
-        let request = app.get(format!("/timetable/{}/train_schedules", timetable1.id).as_str());
         let list: ListTrainSchedulesResponse = app
-            .fetch(request)
+            .get(format!("/timetable/{}/train_schedules", timetable1.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // Check if the timetable has the two train schedules
         assert_eq!(list.results.len(), 2);
@@ -1310,12 +1305,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_not_found_timetable_train_schedules() {
         let app = test_app!().skip_authz().build();
-        let request = app.get(format!("/timetable/{}/train_schedules", 0).as_str());
         let response: InternalError = app
-            .fetch(request)
+            .get(format!("/timetable/{}/train_schedules", 0).as_str())
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
         assert_eq!(&response.error_type, "editoast:timetable:NotFound")
     }
 
@@ -1663,19 +1657,16 @@ mod tests {
         let train_schedule_set_form = TrainScheduleSetForm {
             train_schedule_set_ids: HashSet::from([train_schedule_set_id]),
         };
-        let request = app
-            .post(format!("/timetable/{}/train_schedule_sets", timetable.id).as_str())
-            .json(&train_schedule_set_form);
-        app.fetch(request)
+        app.post(format!("/timetable/{}/train_schedule_sets", timetable.id).as_str())
+            .json(&train_schedule_set_form)
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
-        let request = app.get(format!("/timetable/{}/train_schedule_sets", timetable.id).as_str());
         let train_schedule_sets: Vec<TrainScheduleSet> = app
-            .fetch(request)
+            .get(format!("/timetable/{}/train_schedule_sets", timetable.id).as_str())
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(train_schedule_sets, vec![train_schedule_set]);
     }
 
@@ -1753,15 +1744,12 @@ mod tests {
             infra_id: small_infra.id,
         };
 
-        let request = app
-            .post(format!("/timetable/{}/path_steps/local_track_names", timetable.id).as_str())
-            .json(&form);
-
         let response: HashMap<String, HashSet<String>> = app
-            .fetch(request)
+            .post(format!("/timetable/{}/path_steps/local_track_names", timetable.id).as_str())
+            .json(&form)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             response.get("Mid_West_station"),

--- a/editoast/src/views/timetable/similar_trains.rs
+++ b/editoast/src/views/timetable/similar_trains.rs
@@ -450,7 +450,6 @@ mod tests {
     use chrono::Duration;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
-    use reqwest::StatusCode;
     use rstest::rstest;
     use uuid::Uuid;
 
@@ -672,12 +671,12 @@ mod tests {
             },
             waypoints,
         };
-        let request = app.post("/similar_trains").json(&request);
         let response: Response = app
-            .fetch(request)
+            .post("/similar_trains")
+            .json(&request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {
@@ -820,12 +819,12 @@ mod tests {
             },
             waypoints,
         };
-        let request = app.post("/similar_trains").json(&request);
         let response: Response = app
-            .fetch(request)
+            .post("/similar_trains")
+            .json(&request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response, Response { similar_trains });
     }
@@ -912,12 +911,12 @@ mod tests {
                 },
             ],
         };
-        let request = app.post("/similar_trains").json(&request);
         let response: Response = app
-            .fetch(request)
+            .post("/similar_trains")
+            .json(&request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let expected_response = Response {
             similar_trains: vec![
@@ -1060,12 +1059,12 @@ mod tests {
                 },
             ],
         };
-        let request = app.post("/similar_trains").json(&request);
         let response: Response = app
-            .fetch(request)
+            .post("/similar_trains")
+            .json(&request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let expected_response = Response {
             similar_trains: vec![
@@ -1161,12 +1160,12 @@ mod tests {
                 },
             ],
         };
-        let request = app.post("/similar_trains").json(&request);
         let response: Response = app
-            .fetch(request)
+            .post("/similar_trains")
+            .json(&request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let expected_response = Response {
             similar_trains: vec![
@@ -1294,12 +1293,12 @@ mod tests {
                 },
             ],
         };
-        let request = app.post("/similar_trains").json(&request);
         let response: Response = app
-            .fetch(request)
+            .post("/similar_trains")
+            .json(&request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {
@@ -1327,12 +1326,12 @@ mod tests {
                 },
             ],
         };
-        let request = app.post("/similar_trains").json(&request);
         let response: Response = app
-            .fetch(request)
+            .post("/similar_trains")
+            .json(&request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         let expected_response = Response {
             similar_trains: vec![SimilarTrainItem {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -607,6 +607,7 @@ mod tests {
     use crate::fixtures::create_timetable;
     use crate::fixtures::create_towed_rolling_stock;
     use crate::views::path::pathfinding::PathfindingResult;
+    use crate::views::test_app::TestResponseExt as _;
     use crate::views::test_app::test_app;
     use crate::views::timetable::simulation_empty_response;
     use crate::views::timetable::stdcm::Request;
@@ -987,15 +988,12 @@ mod tests {
             None,
         ));
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule));
-
         let stdcm_response: StdcmProgression = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(None, consist_schedule))
             .await
-            .assert_status(StatusCode::OK)
-            .last_jsonl_into();
+            .assert_status_ok()
+            .last_jsonl();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
@@ -1072,15 +1070,12 @@ mod tests {
             None,
         ));
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule));
-
         let stdcm_response: InternalError = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(None, consist_schedule))
             .await
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
+            .assert_status_bad_request()
+            .json();
 
         assert_eq!(stdcm_response.error_type, expected_error_type.to_string());
         assert_eq!(
@@ -1116,15 +1111,12 @@ mod tests {
             None,
         ));
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule));
-
         let stdcm_response: StdcmProgression = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(None, consist_schedule))
             .await
-            .assert_status(StatusCode::OK)
-            .last_jsonl_into();
+            .assert_status_ok()
+            .last_jsonl();
 
         assert_eq!(
             stdcm_response,
@@ -1170,15 +1162,12 @@ mod tests {
             None,
         ));
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule));
-
         let stdcm_response: Vec<StdcmProgression> = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(None, consist_schedule))
             .await
-            .assert_status(StatusCode::OK)
-            .jsonl_into();
+            .assert_status_ok()
+            .jsonl();
 
         if let PathfindingResult::Success(path) =
             PathfindingResult::Success(pathfinding_result_success())
@@ -1243,15 +1232,12 @@ mod tests {
             None,
         ));
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule));
-
         let stdcm_response: Vec<StdcmProgression> = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(None, consist_schedule))
             .await
-            .assert_status(StatusCode::OK)
-            .jsonl_into();
+            .assert_status_ok()
+            .jsonl();
 
         assert_eq!(stdcm_response.len(), 3);
         assert_eq!(
@@ -1464,15 +1450,12 @@ mod tests {
         // Consist change
         // MWS -> SS
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&payload);
-
         let stdcm_response: StdcmProgression = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&payload)
             .await
-            .assert_status(StatusCode::OK)
-            .last_jsonl_into();
+            .assert_status_ok()
+            .last_jsonl();
 
         assert_eq!(
             stdcm_response,
@@ -1550,15 +1533,12 @@ mod tests {
         // Consist change
         // MES -> SES
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&payload);
-
         let stdcm_response: StdcmProgression = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&payload)
             .await
-            .assert_status(StatusCode::OK)
-            .last_jsonl_into();
+            .assert_status_ok()
+            .last_jsonl();
 
         assert_eq!(
             stdcm_response,
@@ -1673,15 +1653,12 @@ mod tests {
             Some(towed_rolling_stock.id),
         ));
 
-        let request = app
-            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule));
-
         let stdcm_response: StdcmProgression = app
-            .fetch(request)
+            .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .json(&get_stdcm_payload(None, consist_schedule))
             .await
-            .assert_status(StatusCode::OK)
-            .last_jsonl_into();
+            .assert_status_ok()
+            .last_jsonl();
 
         assert_eq!(
             stdcm_response,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1873,12 +1873,12 @@ mod tests {
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
 
-    use crate::views::test_app::TestResponse;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::simulation;
     use crate::views::timetable::simulation::SimulationResponseSuccess;
     use crate::views::timetable::simulation::SummaryResponse;
     use crate::views::timetable::simulation_empty_response;
+    use axum_test::TestResponse;
     use editoast_models::train_schedule::OccurrenceId;
     use editoast_models::train_schedule::TrainScheduleChangeset;
 
@@ -1910,7 +1910,8 @@ mod tests {
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
         let train_schedule = simple_paced_train_base();
         // Insert train schedule
-        let request = app
+
+        let response: Vec<TrainScheduleResponse> = app
             .post(
                 format!(
                     "/train_schedule_sets/{}/train_schedules",
@@ -1918,13 +1919,10 @@ mod tests {
                 )
                 .as_str(),
             )
-            .json(&json!(vec![train_schedule]));
-
-        let response: Vec<TrainScheduleResponse> = app
-            .fetch(request)
+            .json(&json!(vec![train_schedule]))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
         assert_eq!(response.len(), 1);
     }
 
@@ -1948,7 +1946,8 @@ mod tests {
         });
 
         // Insert train schedule
-        let request = app
+
+        let response: Vec<TrainScheduleResponse> = app
             .post(
                 format!(
                     "/train_schedule_sets/{}/train_schedules",
@@ -1956,13 +1955,10 @@ mod tests {
                 )
                 .as_str(),
             )
-            .json(&json!(vec![train_schedule]));
-
-        let response: Vec<TrainScheduleResponse> = app
-            .fetch(request)
+            .json(&json!(vec![train_schedule]))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         assert_eq!(response.len(), 1);
 
@@ -2034,16 +2030,13 @@ mod tests {
         updated_train_schedule.paced.as_mut().unwrap().interval =
             chrono::Duration::minutes(30).try_into().unwrap();
 
-        let request = app
-            .put(&format!(
-                "/train_schedules/{}?timetable_id={}",
-                train_schedule.id, timetable.id
-            ))
-            .json(&json!(&updated_train_schedule));
-
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NO_CONTENT);
+        app.put(&format!(
+            "/train_schedules/{}?timetable_id={}",
+            train_schedule.id, timetable.id
+        ))
+        .json(&json!(&updated_train_schedule))
+        .await
+        .assert_status_no_content();
 
         let exceptions_after = TrainScheduleException::retrieve_exceptions_by_train_schedules(
             &mut pool.get_ok(),
@@ -2076,19 +2069,16 @@ mod tests {
         paced_train_base.paced.as_mut().unwrap().interval =
             Duration::minutes(15).try_into().unwrap();
 
-        let request = app
-            .put(
-                format!(
-                    "/train_schedules/{}?timetable_id={}",
-                    paced_train.id, timetable.id
-                )
-                .as_str(),
+        app.put(
+            format!(
+                "/train_schedules/{}?timetable_id={}",
+                paced_train.id, timetable.id
             )
-            .json(&json!(&paced_train_base));
-
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .as_str(),
+        )
+        .json(&json!(&paced_train_base))
+        .await
+        .assert_status_no_content();
 
         let updated_paced_train =
             editoast_models::TrainSchedule::retrieve(pool.get_ok(), paced_train.id)
@@ -2111,14 +2101,11 @@ mod tests {
         let train_schedule =
             create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
 
-        let request = app
-            .delete("/train_schedules/")
-            .json(&json!({"ids": vec![train_schedule.id]}));
-
         let _ = app
-            .fetch(request)
+            .delete("/train_schedules/")
+            .json(&json!({"ids": vec![train_schedule.id]}))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let exists = editoast_models::TrainSchedule::exists(&mut pool.get_ok(), train_schedule.id)
             .await
@@ -2130,13 +2117,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_not_found_train_schedule() {
         let app = test_app!().skip_authz().build();
-        let request = app.get(&format!("/train_schedules/{}", 0));
-
         let response: InternalError = app
-            .fetch(request)
+            .get(&format!("/train_schedules/{}", 0))
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
 
         assert_eq!(&response.error_type, "editoast:train_schedule:NotFound")
     }
@@ -2150,13 +2135,11 @@ mod tests {
         let paced_train =
             create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
 
-        let request = app.get(&format!("/train_schedules/{}", paced_train.id));
-
         let response = app
-            .fetch(request)
+            .get(&format!("/train_schedules/{}", paced_train.id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<TrainScheduleResponse>();
+            .assert_status_ok()
+            .json::<TrainScheduleResponse>();
 
         assert_eq!(
             response.train_schedule,
@@ -2220,18 +2203,17 @@ mod tests {
     async fn paced_train_simulation() {
         let (app, infra_id, _timetable, train_schedule, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
-        let request = app.get(
-            format!(
-                "/train_schedules/{}/simulation/?infra_id={infra_id}",
-                train_schedule.id
-            )
-            .as_str(),
-        );
         let response: core_client::simulation::Response = app
-            .fetch(request)
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                    train_schedule.id
+                )
+                .as_str(),
+            )
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response, simulation_empty_response());
     }
@@ -2240,18 +2222,17 @@ mod tests {
     async fn paced_train_exception_simulation_with_invalid_exception_key() {
         let (app, infra_id, _timetable, train_schedule, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
-        let request = app.get(
-            format!(
-                "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id=9999",
-                train_schedule.id
-            )
-            .as_str(),
-        );
         let response: InternalError = app
-            .fetch(request)
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id=9999",
+                    train_schedule.id
+                )
+                .as_str(),
+            )
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
 
         assert_eq!(
             &response.error_type,
@@ -2263,18 +2244,17 @@ mod tests {
     async fn paced_train_exception_simulation() {
         let (app, infra_id, _timetable, train_schedule, exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
-        let request = app.get(
-            format!(
-                "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
-                train_schedule.id, exception.id
-            )
-            .as_str(),
-        );
         let response: simulation::Response = app
-            .fetch(request)
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                    train_schedule.id, exception.id
+                )
+                .as_str(),
+            )
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             response,
@@ -2337,18 +2317,17 @@ mod tests {
             .expect("Fail to update exception");
 
         // WHEN
-        let request = app.get(
-            format!(
-                "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
-                train_schedule.id, exception.id
-            )
-            .as_str(),
-        );
         let response: simulation::Response = app
-            .fetch(request)
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                    train_schedule.id, exception.id
+                )
+                .as_str(),
+            )
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         // THEN
         assert_eq!(
@@ -2367,14 +2346,11 @@ mod tests {
     async fn paced_train_simulation_not_found() {
         let (app, infra_id, _timetable, _train_schedule, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
-        let request =
-            app.get(format!("/train_schedules/{}/simulation/?infra_id={}", 0, infra_id).as_str());
-
         let response: InternalError = app
-            .fetch(request)
+            .get(format!("/train_schedules/{}/simulation/?infra_id={}", 0, infra_id).as_str())
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
 
         assert_eq!(&response.error_type, "editoast:train_schedule:NotFound")
     }
@@ -2491,19 +2467,16 @@ mod tests {
         )
         .await;
 
-        let request = app
+        let mut response: HashMap<i64, TrainScheduleSummaryResponse> = app
             .post("/train_schedules/simulation_summary")
             .json(&json!({
                 "infra_id": small_infra.id,
                 "timetable_id": timetable.id,
                 "ids": vec![train_schedule.id],
-            }));
-
-        let mut response: HashMap<i64, TrainScheduleSummaryResponse> = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(response.len(), 1);
 
         let TrainScheduleSummaryResponse {
@@ -2590,18 +2563,16 @@ mod tests {
         let (app, infra_id, _timetable, _paced_train_id, _exception) =
             app_infra_id_paced_train_id_for_simulation_tests().await;
         let timetable = create_timetable(&mut app.db_pool().get_ok()).await;
-        let request = app
+        let response: InternalError = app
             .post("/train_schedules/simulation_summary")
             .json(&json!({
                 "infra_id": infra_id,
                 "timetable_id": timetable.id,
                 "ids": vec![0],
-            }));
-        let response: InternalError = app
-            .fetch(request)
+            }))
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
 
         assert_eq!(
             &response.error_type,
@@ -2617,16 +2588,14 @@ mod tests {
         let paced_train =
             create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
 
-        let request = app.get(&format!(
-            "/train_schedules/{}/path?infra_id={}",
-            paced_train.id, 0
-        ));
-
         let response: InternalError = app
-            .fetch(request)
+            .get(&format!(
+                "/train_schedules/{}/path?infra_id={}",
+                paced_train.id, 0
+            ))
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
 
         assert_eq!(
             &response.error_type,
@@ -2640,16 +2609,14 @@ mod tests {
         let pool = app.db_pool();
         let small_infra = create_small_infra(&mut pool.get_ok()).await;
 
-        let request = app.get(&format!(
-            "/train_schedules/{}/path?infra_id={}",
-            0, small_infra.id
-        ));
-
         let response: InternalError = app
-            .fetch(request)
+            .get(&format!(
+                "/train_schedules/{}/path?infra_id={}",
+                0, small_infra.id
+            ))
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
 
         assert_eq!(&response.error_type, "editoast:train_schedule:NotFound");
     }
@@ -2662,18 +2629,17 @@ mod tests {
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
         let paced_train =
             create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
-        let request = app.get(
-            format!(
-                "/train_schedules/{}/path/?infra_id={}&exception_id=1234",
-                paced_train.id, small_infra.id
-            )
-            .as_str(),
-        );
         let response: InternalError = app
-            .fetch(request)
+            .get(
+                format!(
+                    "/train_schedules/{}/path/?infra_id={}&exception_id=1234",
+                    paced_train.id, small_infra.id
+                )
+                .as_str(),
+            )
             .await
-            .assert_status(StatusCode::NOT_FOUND)
-            .json_into();
+            .assert_status_not_found()
+            .json();
 
         assert_eq!(
             &response.error_type,
@@ -2707,16 +2673,14 @@ mod tests {
             create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
-        let request = app.get(&format!(
-            "/train_schedules/{}/path?infra_id={}",
-            paced_train.id, small_infra.id
-        ));
-
         let response = app
-            .fetch(request)
+            .get(&format!(
+                "/train_schedules/{}/path?infra_id={}",
+                paced_train.id, small_infra.id
+            ))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<PathfindingResult>();
+            .assert_status_ok()
+            .json::<PathfindingResult>();
 
         assert_eq!(
             response,
@@ -2778,16 +2742,14 @@ mod tests {
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
-        let request = app.get(&format!(
-            "/train_schedules/{}/path?infra_id={}&exception_id={}",
-            train_schedule.id, small_infra.id, change_rolling_stock_exception.id
-        ));
-
         let response = app
-            .fetch(request)
+            .get(&format!(
+                "/train_schedules/{}/path?infra_id={}&exception_id={}",
+                train_schedule.id, small_infra.id, change_rolling_stock_exception.id
+            ))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<PathfindingResult>();
+            .assert_status_ok()
+            .json::<PathfindingResult>();
 
         assert_eq!(
             response,
@@ -2844,16 +2806,14 @@ mod tests {
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
-        let request = app.get(&format!(
-            "/train_schedules/{}/path?infra_id={}&exception_id={}",
-            train_schedule.id, small_infra.id, change_train_name_exception.id
-        ));
-
         let response = app
-            .fetch(request)
+            .get(&format!(
+                "/train_schedules/{}/path?infra_id={}&exception_id={}",
+                train_schedule.id, small_infra.id, change_train_name_exception.id
+            ))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<PathfindingResult>();
+            .assert_status_ok()
+            .json::<PathfindingResult>();
 
         assert_eq!(
             response,
@@ -2896,25 +2856,25 @@ mod tests {
             .build();
 
         // TEST
-        let request = app.post("/train_schedules/project_path").json(&json!({
-            "infra_id": small_infra.id,
-            "timetable_id": timetable.id,
-            "electrical_profile_set_id": null,
-            "ids": vec![paced_train_fail.id, paced_train_valid.id],
-            "track_section_ranges": [
-                {
-                    "track_section": "TA1",
-                    "begin": 0,
-                    "end": 100,
-                    "direction": "START_TO_STOP"
-                }
-            ],
-        }));
         let response: HashMap<i64, ProjectPathTrainScheduleResult> = app
-            .fetch(request)
+            .post("/train_schedules/project_path")
+            .json(&json!({
+                "infra_id": small_infra.id,
+                "timetable_id": timetable.id,
+                "electrical_profile_set_id": null,
+                "ids": vec![paced_train_fail.id, paced_train_valid.id],
+                "track_section_ranges": [
+                    {
+                        "track_section": "TA1",
+                        "begin": 0,
+                        "end": 100,
+                        "direction": "START_TO_STOP"
+                    }
+                ],
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         // EXPECT
         // TODO: improve this test
         assert_eq!(response.len(), 2);
@@ -2962,8 +2922,9 @@ mod tests {
         )
         .await;
 
-        let request = app.post("/train_schedules/occupancy_blocks").json(
-            &json!({"ids": vec![train_schedule.id],
+        let response = app
+            .post("/train_schedules/occupancy_blocks")
+            .json(&json!({"ids": vec![train_schedule.id],
                 "infra_id": infra_id,
                 "timetable_id": timetable.id,
                 "path": {
@@ -2976,11 +2937,10 @@ mod tests {
                     "routes": [],
                     "blocks":[],
                 },
-            }),
-        );
-        let response = app.fetch(request).await;
+            }))
+            .await;
         let response: HashMap<i64, OccupancyBlocksTrainScheduleResult> =
-            response.assert_status(StatusCode::OK).json_into();
+            response.assert_status_ok().json();
         assert_eq!(response.len(), 1);
         // TODO fix mocked simulation to return path item times that respect times
         assert_eq!(
@@ -3058,8 +3018,7 @@ mod tests {
                 .expect("Failed to create exception");
         }
 
-        let request = app
-            .post("/train_schedules/track_occupancy")
+        app.post("/train_schedules/track_occupancy")
             .json(&TrackOccupancyForm {
                 train_schedule_ids: vec![train_schedule.id],
                 operational_point_reference,
@@ -3067,9 +3026,8 @@ mod tests {
                 timetable_id: timetable.id,
                 electrical_profile_set_id: None,
                 use_simulation,
-            });
-
-        app.fetch(request).await
+            })
+            .await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -3090,7 +3048,7 @@ mod tests {
             true,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
+            response.await.assert_status_ok().json();
 
         assert_eq!(track_occupancies.len(), 1);
         let item = &track_occupancies[0];
@@ -3119,7 +3077,7 @@ mod tests {
             true,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
+            response.await.assert_status_ok().json();
 
         assert_eq!(track_occupancies.len(), 1);
         let item = &track_occupancies[0];
@@ -3148,7 +3106,7 @@ mod tests {
             true,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
+            response.await.assert_status_ok().json();
 
         assert!(track_occupancies.is_empty());
     }
@@ -3167,11 +3125,10 @@ mod tests {
             train_schedule_ids: vec![train_schedule.id],
             train_schedule_set_id: train_schedule_set_to_move.id,
         };
-        let request = app.patch("/train_schedules/move").json(&move_form);
-
-        app.fetch(request)
+        app.patch("/train_schedules/move")
+            .json(&move_form)
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let train_schedule =
             editoast_models::TrainSchedule::retrieve(db_pool.get_ok(), train_schedule.id)
@@ -3226,7 +3183,7 @@ mod tests {
             use_simulation,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
+            response.await.assert_status_ok().json();
         assert_eq!(track_occupancies.len(), 1);
         assert_eq!(
             track_occupancies[0].local_track_name,
@@ -3269,7 +3226,7 @@ mod tests {
             false,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
+            response.await.assert_status_ok().json();
 
         assert_eq!(track_occupancies.len(), 1);
         assert_eq!(track_occupancies[0].local_track_name, local_track_name);
@@ -3301,7 +3258,7 @@ mod tests {
             false,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
+            response.await.assert_status_ok().json();
 
         assert!(track_occupancies.is_empty());
     }
@@ -3441,7 +3398,7 @@ mod tests {
             true,
         );
         let track_occupancies: Vec<TrackSectionOccupancy> =
-            response.await.assert_status(StatusCode::OK).json_into();
+            response.await.assert_status_ok().json();
         assert!(!track_occupancies.is_empty());
     }
 }

--- a/editoast/src/views/timetable/train_schedule_exceptions.rs
+++ b/editoast/src/views/timetable/train_schedule_exceptions.rs
@@ -279,7 +279,6 @@ mod tests {
     use editoast_models::prelude::Retrieve;
     use editoast_models::prelude::*;
     use editoast_models::train_schedule_exception::TrainScheduleExceptionChangeset;
-    use reqwest::StatusCode;
     use schemas::TrainScheduleExceptionChangeGroups;
     use schemas::paced_train::StartTimeChangeGroup;
     use schemas::paced_train::TrainNameChangeGroup;
@@ -319,15 +318,12 @@ mod tests {
             };
 
         // Insert train schedule exception
-        let request = app
-            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
-            .json(&json!(&train_schedule_exception_form));
-
         let response: schemas::TrainScheduleException = app
-            .fetch(request)
+            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
+            .json(&json!(&train_schedule_exception_form))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.occurrence_index, None);
         assert_eq!(
@@ -356,15 +352,12 @@ mod tests {
             };
 
         // Insert train schedule exception
-        let request = app
-            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
-            .json(&json!(&train_schedule_exception_form));
-
         let response: InternalError = app
-            .fetch(request)
+            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
+            .json(&json!(&train_schedule_exception_form))
             .await
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
+            .assert_status_bad_request()
+            .json();
 
         assert_eq!(
             &response.error_type,
@@ -400,15 +393,12 @@ mod tests {
             };
 
         // Insert train schedule exception
-        let request = app
-            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
-            .json(&json!(&train_schedule_exception_form));
-
         let response: InternalError = app
-            .fetch(request)
+            .post(format!("/timetable/{}/train_schedule_exception", timetable.id).as_str())
+            .json(&json!(&train_schedule_exception_form))
             .await
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
+            .assert_status_bad_request()
+            .json();
 
         assert_eq!(
             &response.error_type,
@@ -448,13 +438,12 @@ mod tests {
                 .expect("Failed to retrieve train schedule exception");
         assert!(exists);
 
-        let request = app.post("/train_schedule_exceptions/delete").json(&json!({
-            "ids": [train_schedule_exception.id]
-        }));
-
-        app.fetch(request)
+        app.post("/train_schedule_exceptions/delete")
+            .json(&json!({
+                "ids": [train_schedule_exception.id]
+            }))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let exists =
             TrainScheduleException::exists(&mut pool.get_ok(), train_schedule_exception.id)
@@ -497,13 +486,10 @@ mod tests {
             };
 
         // Update train schedule exception
-        let request = app
-            .put(format!("/train_schedule_exception/{}", train_schedule_exception.id).as_str())
-            .json(&json!(&train_schedule_exception_form));
-
-        app.fetch(request)
+        app.put(format!("/train_schedule_exception/{}", train_schedule_exception.id).as_str())
+            .json(&json!(&train_schedule_exception_form))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         let updated_exception = editoast_models::TrainScheduleException::retrieve(
             pool.get_ok(),
@@ -556,15 +542,12 @@ mod tests {
             };
 
         // Update train schedule exception
-        let request = app
-            .put(format!("/train_schedule_exception/{}", train_schedule_exception.id).as_str())
-            .json(&json!(&train_schedule_exception_form));
-
         let response: InternalError = app
-            .fetch(request)
+            .put(format!("/train_schedule_exception/{}", train_schedule_exception.id).as_str())
+            .json(&json!(&train_schedule_exception_form))
             .await
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
+            .assert_status_bad_request()
+            .json();
 
         assert_eq!(
             &response.error_type,

--- a/editoast/src/views/train_schedule_set.rs
+++ b/editoast/src/views/train_schedule_set.rs
@@ -366,7 +366,7 @@ mod tests {
 
         let train_schedules = vec![train_schedule_1, train_schedule_2.clone()];
 
-        let request = app
+        let response: Vec<TrainScheduleResponse> = app
             .post(
                 format!(
                     "/train_schedule_sets/{}/train_schedules",
@@ -374,13 +374,10 @@ mod tests {
                 )
                 .as_str(),
             )
-            .json(&train_schedules);
-
-        let response: Vec<TrainScheduleResponse> = app
-            .fetch(request)
+            .json(&train_schedules)
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         assert!(response.len() == 2);
 
@@ -411,7 +408,7 @@ mod tests {
         train_schedule_2.paced.as_mut().unwrap().interval =
             Duration::seconds(45).try_into().unwrap();
 
-        let request = app
+        let _: Vec<TrainScheduleResponse> = app
             .post(
                 format!(
                     "/train_schedule_sets/{}/train_schedules",
@@ -419,27 +416,22 @@ mod tests {
                 )
                 .as_str(),
             )
-            .json(&vec![train_schedule_1, train_schedule_2]);
-
-        let _: Vec<TrainScheduleResponse> = app
-            .fetch(request)
+            .json(&vec![train_schedule_1, train_schedule_2])
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
-
-        let request = app.get(
-            format!(
-                "/train_schedule_sets/{}/train_schedules",
-                train_schedule_set.id
-            )
-            .as_str(),
-        );
+            .json();
 
         let response: Vec<TrainScheduleResponse> = app
-            .fetch(request)
+            .get(
+                format!(
+                    "/train_schedule_sets/{}/train_schedules",
+                    train_schedule_set.id
+                )
+                .as_str(),
+            )
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.len(), 2);
     }
@@ -453,14 +445,12 @@ mod tests {
             description: String::default(),
             published: false,
         };
-        let request = app
-            .post("/train_schedule_sets")
-            .json(&train_schedule_set_form);
         let response: TrainScheduleSetResponse = app
-            .fetch(request)
+            .post("/train_schedule_sets")
+            .json(&train_schedule_set_form)
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         let expected_response = TrainScheduleSet {
             id: 1,
@@ -491,14 +481,12 @@ mod tests {
             description: String::default(),
             published: false,
         };
-        let request = app
-            .post("/train_schedule_sets")
-            .json(&train_schedule_set_form);
         let response: TrainScheduleSetResponse = app
-            .fetch(request)
+            .post("/train_schedule_sets")
+            .json(&train_schedule_set_form)
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into();
+            .json();
 
         let expected_response = TrainScheduleSet {
             id: 1,
@@ -524,12 +512,11 @@ mod tests {
         let db_pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
 
-        let request = app.get(&format!("/train_schedule_sets/{}", train_schedule_set.id));
         let response: TrainScheduleSetResponse = app
-            .fetch(request)
+            .get(&format!("/train_schedule_sets/{}", train_schedule_set.id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             response,
@@ -555,12 +542,11 @@ mod tests {
             create_train_schedule_set_linked_to_catalog_entry(&mut db_pool.get().await.unwrap())
                 .await;
 
-        let request = app.get(&format!("/train_schedule_sets/{}", train_schedule_set.id));
         let response: TrainScheduleSetResponse = app
-            .fetch(request)
+            .get(&format!("/train_schedule_sets/{}", train_schedule_set.id))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             response,
@@ -597,12 +583,11 @@ mod tests {
             create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
         let train_schedule_set_2 =
             create_train_schedule_set_published(&mut db_pool.get().await.unwrap()).await;
-        let request = app.get("/train_schedule_sets?published=false");
         let response: Vec<TrainScheduleSetResponse> = app
-            .fetch(request)
+            .get("/train_schedule_sets?published=false")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(response.len(), 1);
         assert_eq!(
             response,
@@ -612,12 +597,11 @@ mod tests {
             }]
         );
 
-        let request = app.get("/train_schedule_sets?published=true");
         let response: Vec<TrainScheduleSetResponse> = app
-            .fetch(request)
+            .get("/train_schedule_sets?published=true")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(response.len(), 1);
         assert_eq!(
             response,
@@ -627,12 +611,11 @@ mod tests {
             }]
         );
 
-        let request = app.get("/train_schedule_sets?catalog_entry_id=1");
         let response: Vec<TrainScheduleSetResponse> = app
-            .fetch(request)
+            .get("/train_schedule_sets?catalog_entry_id=1")
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(response.len(), 1);
         assert_eq!(
             response,
@@ -650,10 +633,9 @@ mod tests {
         let db_pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get().await.unwrap()).await;
         let train_schedule_set_id = train_schedule_set.id;
-        let request = app.delete(&format!("/train_schedule_sets/{}", train_schedule_set_id));
-        app.fetch(request)
+        app.delete(&format!("/train_schedule_sets/{}", train_schedule_set_id))
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         assert!(
             !TrainScheduleSet::exists(&mut db_pool.get().await.unwrap(), train_schedule_set_id)
@@ -675,14 +657,12 @@ mod tests {
             description: "test description".to_string(),
             published: false,
         };
-        let request = app
-            .put(&format!("/train_schedule_sets/{}", train_schedule_set_id))
-            .json(&train_schedule_set_form);
         let response: TrainScheduleSetResponse = app
-            .fetch(request)
+            .put(&format!("/train_schedule_sets/{}", train_schedule_set_id))
+            .json(&train_schedule_set_form)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             response,
@@ -713,14 +693,12 @@ mod tests {
             description: "test description".to_string(),
             published: true,
         };
-        let request = app
-            .put(&format!("/train_schedule_sets/{}", train_schedule_set_id))
-            .json(&train_schedule_set_form);
         let response: TrainScheduleSetResponse = app
-            .fetch(request)
+            .put(&format!("/train_schedule_sets/{}", train_schedule_set_id))
+            .json(&train_schedule_set_form)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
 
         assert_eq!(
             response,

--- a/editoast/src/views/version.rs
+++ b/editoast/src/views/version.rs
@@ -27,8 +27,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn version() {
         let app = test_app!().skip_authz().build();
-        let request = app.get("/version");
-        let response: HashMap<String, Option<String>> = app.fetch(request).await.json_into();
+        let response: HashMap<String, Option<String>> = app.get("/version").await.json();
         assert!(response.contains_key("git_describe"));
     }
 }

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -454,23 +454,21 @@ pub mod tests {
         let app = test_app!().skip_authz().build();
         let pool = app.db_pool();
 
-        let request = app.post("/work_schedules").json(&json!({
-            "work_schedule_group_name": "work schedule group name",
-            "work_schedules": [{
-                "start_date_time": "2024-01-01T08:00:00Z",
-                "end_date_time": "2024-01-01T09:00:00Z",
-                "track_ranges": [],
-                "obj_id": "work_schedule_obj_id",
-                "work_schedule_type": "CATENARY"
-            }]
-        }));
-
-        // WHEN
         let work_schedule_response = app
-            .fetch(request)
+            .post("/work_schedules")
+            .json(&json!({
+                "work_schedule_group_name": "work schedule group name",
+                "work_schedules": [{
+                    "start_date_time": "2024-01-01T08:00:00Z",
+                    "end_date_time": "2024-01-01T09:00:00Z",
+                    "track_ranges": [],
+                    "obj_id": "work_schedule_obj_id",
+                    "work_schedule_type": "CATENARY"
+                }]
+            }))
             .await
             .assert_status(StatusCode::CREATED)
-            .json_into::<WorkScheduleCreateResponse>();
+            .json::<WorkScheduleCreateResponse>();
 
         // THEN
         let created_group = WorkScheduleGroup::retrieve(
@@ -486,20 +484,19 @@ pub mod tests {
     async fn work_schedule_create_fail_start_date_after_end_date() {
         let app = test_app!().skip_authz().build();
 
-        let request = app.post("/work_schedules").json(&json!({
-            "work_schedule_group_name": "work schedule group name",
-            "work_schedules": [{
-                "start_date_time": "2024-01-01T08:00:00Z",
-                "end_date_time": "2024-01-01T07:00:00Z",
-                "track_ranges": [],
-                "obj_id": "work_schedule_obj_id",
-                "work_schedule_type": "CATENARY"
-            }]
-        }));
-
-        app.fetch(request)
+        app.post("/work_schedules")
+            .json(&json!({
+                "work_schedule_group_name": "work schedule group name",
+                "work_schedules": [{
+                    "start_date_time": "2024-01-01T08:00:00Z",
+                    "end_date_time": "2024-01-01T07:00:00Z",
+                    "track_ranges": [],
+                    "obj_id": "work_schedule_obj_id",
+                    "work_schedule_type": "CATENARY"
+                }]
+            }))
             .await
-            .assert_status(StatusCode::UNPROCESSABLE_ENTITY);
+            .assert_status_unprocessable_entity();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -515,22 +512,21 @@ pub mod tests {
             .await
             .expect("Failed to create work schedule group");
 
-        let request = app.post("/work_schedules").json(&json!({
-            "work_schedule_group_name": "duplicated work schedule group name",
-            "work_schedules": [{
-                "start_date_time": "2024-01-01T08:00:00Z",
-                "end_date_time": "2024-01-01T09:00:00Z",
-                "track_ranges": [],
-                "obj_id": "work_schedule_obj_id",
-                "work_schedule_type": "CATENARY"
-            }]
-        }));
-
         let work_schedule_response = app
-            .fetch(request)
+            .post("/work_schedules")
+            .json(&json!({
+                "work_schedule_group_name": "duplicated work schedule group name",
+                "work_schedules": [{
+                    "start_date_time": "2024-01-01T08:00:00Z",
+                    "end_date_time": "2024-01-01T09:00:00Z",
+                    "track_ranges": [],
+                    "obj_id": "work_schedule_obj_id",
+                    "work_schedule_type": "CATENARY"
+                }]
+            }))
             .await
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into::<crate::error::InternalError>();
+            .assert_status_bad_request()
+            .json::<crate::error::InternalError>();
 
         assert_eq!(
             &work_schedule_response.error_type,
@@ -621,42 +617,40 @@ pub mod tests {
         let (work_schedule_group, work_schedules) =
             create_work_schedules_fixture_set(conn, working_schedules_changeset).await;
 
-        let request = app.post("/work_schedules/project_path").json(&json!({
-            "work_schedule_group_id": work_schedule_group.id,
-            "path_track_ranges": [
-                {
-                    "track_section": "a",
-                    "begin": 0,
-                    "end": 100000,
-                    "direction": "START_TO_STOP"
-                },
-                {
-                    "track_section": "b",
-                    "begin": 0,
-                    "end": 100000,
-                    "direction": "START_TO_STOP"
-                },
-                {
-                    "track_section": "c",
-                    "begin": 0,
-                    "end": 100000,
-                    "direction": "START_TO_STOP"
-                },
-                {
-                    "track_section": "d",
-                    "begin": 0,
-                    "end": 100000,
-                    "direction": "START_TO_STOP"
-                }
-            ]
-        }));
-
-        // WHEN
         let work_schedule_project_response = app
-            .fetch(request)
+            .post("/work_schedules/project_path")
+            .json(&json!({
+                "work_schedule_group_id": work_schedule_group.id,
+                "path_track_ranges": [
+                    {
+                        "track_section": "a",
+                        "begin": 0,
+                        "end": 100000,
+                        "direction": "START_TO_STOP"
+                    },
+                    {
+                        "track_section": "b",
+                        "begin": 0,
+                        "end": 100000,
+                        "direction": "START_TO_STOP"
+                    },
+                    {
+                        "track_section": "c",
+                        "begin": 0,
+                        "end": 100000,
+                        "direction": "START_TO_STOP"
+                    },
+                    {
+                        "track_section": "d",
+                        "begin": 0,
+                        "end": 100000,
+                        "direction": "START_TO_STOP"
+                    }
+                ]
+            }))
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<Vec<WorkScheduleProjection>>();
+            .assert_status_ok()
+            .json::<Vec<WorkScheduleProjection>>();
 
         // THEN
         let expected: Vec<WorkScheduleProjection> = expected_path_position_ranges
@@ -682,47 +676,43 @@ pub mod tests {
 
         // Create a new group
         let create_group_request = app.post("/work_schedules/group").json(&json!({}));
-        let group_creation_response = app
-            .fetch(create_group_request)
+        let group_creation_response = (create_group_request)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<WorkScheduleGroupCreateResponse>();
+            .assert_status_ok()
+            .json::<WorkScheduleGroupCreateResponse>();
         let group_id = group_creation_response.work_schedule_group_id;
         let work_schedule_url = format!("/work_schedules/group/{group_id}");
 
         // Add a work schedule
         let ref_obj_id = Uuid::new_v4().to_string();
-        let request = app.put(&work_schedule_url).json(&json!([{
-                "start_date_time": "2024-01-01T08:00:00Z",
-                "end_date_time": "2024-01-01T09:00:00Z",
-                "track_ranges": [],
-                "obj_id": ref_obj_id,
-                "work_schedule_type": "CATENARY"
-            }]
-        ));
-        app.fetch(request).await.assert_status(StatusCode::OK);
+        app.put(&work_schedule_url)
+            .json(&json!([{
+                    "start_date_time": "2024-01-01T08:00:00Z",
+                    "end_date_time": "2024-01-01T09:00:00Z",
+                    "track_ranges": [],
+                    "obj_id": ref_obj_id,
+                    "work_schedule_type": "CATENARY"
+                }]
+            ))
+            .await
+            .assert_status_ok();
 
         // Get the content of the group
-        let request = app.get(&work_schedule_url);
         let response = app
-            .fetch(request)
+            .get(&work_schedule_url)
             .await
-            .assert_status(StatusCode::OK)
-            .json_into::<GroupContentResponse>();
+            .assert_status_ok()
+            .json::<GroupContentResponse>();
         let work_schedules = response.results;
         assert_eq!(1, work_schedules.len());
         assert_eq!(ref_obj_id, work_schedules[0].obj_id);
 
         // Delete it
-        let request = app.delete(&work_schedule_url);
-        app.fetch(request)
+        app.delete(&work_schedule_url)
             .await
-            .assert_status(StatusCode::NO_CONTENT);
+            .assert_status_no_content();
 
         // Try to access it
-        let request = app.get(&work_schedule_url);
-        app.fetch(request)
-            .await
-            .assert_status(StatusCode::NOT_FOUND);
+        app.get(&work_schedule_url).await.assert_status_not_found();
     }
 }

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -159,15 +159,15 @@ mod tests {
             .db_pool(db_pool)
             .core_client(CoreClient::Mocked(core))
             .build();
-        let req = app.post("/worker_load").json(&WorkerLoadForm {
-            infra_id: empty_infra.id,
-            timetable_id: None,
-        });
         let response: WorkerStatus = app
-            .fetch(req)
+            .post("/worker_load")
+            .json(&WorkerLoadForm {
+                infra_id: empty_infra.id,
+                timetable_id: None,
+            })
             .await
-            .assert_status(StatusCode::OK)
-            .json_into();
+            .assert_status_ok()
+            .json();
         assert_eq!(response, expected);
     }
 }


### PR DESCRIPTION
> [!WARNING]
> Using [difftastic](https://difftastic.wilfred.me.uk/) or any other structural diff tool is probably the best way to review this PR. Most of the noise disappears. 

Removes useless custom wrappers in `TestApp` and use `axum_test` like it's supposed to be.
Testing utilities were awkward since migrating from `actix` to `axum`.

Summary of changes:

- No more custom `TestResponse` wrapper: we use `axum_test::TestResponse` directly.
- Custom response utils are removed when an equivalent is provided by `axum_test`. Only our JSONL utils remain though an extension trait.
- Call chains in tests are linearized: `app.method("/abc").await.assert.json()` instead of needing intermediary bindings for the request.
- Better use of `axum_test` assertions on status codes.

No effort was put towards a more involved use of `axum_test` like using `assert_json_contains`.