### PR TITLE
front: bump oxlint 1.65 to 1.69

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -124,7 +124,7 @@
         "json-key-path-list": "^2.0.3",
         "openapi-types": "^12.1.3",
         "oxfmt": "^0.53.0",
-        "oxlint": "^1.65.0",
+        "oxlint": "^1.69.0",
         "oxlint-tsgolint": "^0.23.0",
         "pdfjs-dist": "^6.0.227",
         "sass": "^1.101.0",
@@ -4692,9 +4692,9 @@
       ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.65.0.tgz",
-      "integrity": "sha512-jDVaGNURT5pEA9qcabh6WusIoBNybOMMDPCx+EFt+gxo6rVvoUf0+73Xy5x81+ZrxU+ewk5uRBYifjy5pgkcnA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.69.0.tgz",
+      "integrity": "sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==",
       "cpu": [
         "arm"
       ],
@@ -4709,9 +4709,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.65.0.tgz",
-      "integrity": "sha512-v0z80IWNA7c9RhUydq9YprBxCVZrQ6Ixls2tdxUC1F/1FFqSfa7xTX+EJf0mj6+BKRg2zWXqWfcbJUnETlLlIw==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.69.0.tgz",
+      "integrity": "sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==",
       "cpu": [
         "arm64"
       ],
@@ -4726,9 +4726,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.65.0.tgz",
-      "integrity": "sha512-pL/mG/5gMzBwp1gdc5+Cwi87F9j3XRnPxHGyVj5Zd+dCEV5YkKt0L70PB3EGmEEHxgn4H+jnMS3xLuXs6mZW/Q==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.69.0.tgz",
+      "integrity": "sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==",
       "cpu": [
         "arm64"
       ],
@@ -4743,9 +4743,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.65.0.tgz",
-      "integrity": "sha512-jVTneaeuHtqTrKYnhrdH1buhnSorinvpy1sv43ayclfWx/e/DfdRWv+h1fopJcHQbYr5WMcZMmDvnfEBkPZ+1A==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.69.0.tgz",
+      "integrity": "sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==",
       "cpu": [
         "x64"
       ],
@@ -4760,9 +4760,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.65.0.tgz",
-      "integrity": "sha512-8lJQ7B6RloYDUhwVdbSpwT2eKsCN5KP1Scn18ly1tytCuhXhbs0nkfKHT4jWWZBJqmynWuzd+78bF7wILrj6pw==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.69.0.tgz",
+      "integrity": "sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==",
       "cpu": [
         "x64"
       ],
@@ -4777,9 +4777,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.65.0.tgz",
-      "integrity": "sha512-EgmZY+DeWhLLEnNl70/49j3ltA8I6X9kxMfexupWi2Vwfp6RonGsBaHtGoedLolaU37ne7eDUgoxa3CFB95GZA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.69.0.tgz",
+      "integrity": "sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==",
       "cpu": [
         "arm"
       ],
@@ -4794,9 +4794,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.65.0.tgz",
-      "integrity": "sha512-OJMWmAYRVBCPPxnYr3j5sXRwHPh1bAuMlTStGco1Z8q3HkvSH4h+A10E9MiRNYmLhUuli5a2P5wmfj8cagiF5Q==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.69.0.tgz",
+      "integrity": "sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==",
       "cpu": [
         "arm"
       ],
@@ -4811,13 +4811,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.65.0.tgz",
-      "integrity": "sha512-D8uNi50LsYKgS0vGARZDRx05TBZeSxAVdLGddSEqQLSU7xsiqdImHPEw55xq8sKA5rCc/4au/5uS7FQALWdLCg==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.69.0.tgz",
+      "integrity": "sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4828,13 +4831,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.65.0.tgz",
-      "integrity": "sha512-IpbA8QGbwFehQhO+YaHwmoI81f93xvywpspf8HrdPCWOIeKwYfM1dhVhO4YKfZewTRRQEPY/JFjTOXTgkwhKrA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.69.0.tgz",
+      "integrity": "sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4845,13 +4851,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.65.0.tgz",
-      "integrity": "sha512-ZSe8HgaZdgyHSv2+/pTG68z10+OarB18CkFKQOhRs3lmmP/p2vuigedK2e9d0ztoG2DU/duJzhxXBSjy/492HQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.69.0.tgz",
+      "integrity": "sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4862,13 +4871,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.65.0.tgz",
-      "integrity": "sha512-DcTERf++v6HyPHukKAr0JFTRqB+YeDEvqzRgNDMaz7jITPf+tlJIwRxodlAqoXMYhNVEZhXdQM5RAAYH8/oPuw==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.69.0.tgz",
+      "integrity": "sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4879,13 +4891,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.65.0.tgz",
-      "integrity": "sha512-xjhMwuFJwRh40NOBzol4gM5gqAa0xPCJU+GQLM6BydV8TbfkIA7JeyCFNhyfbE9Q/5EWcKYTx62R0cRcjP7DAA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.69.0.tgz",
+      "integrity": "sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4896,13 +4911,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.65.0.tgz",
-      "integrity": "sha512-lrWSXb8JzboPWYBG6Kunt/eemvjo2oCFXktShsm3yMToY7HjzKLjxh7CljSvGnnZH9oohNFHOKc9xYpGKCPm6w==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.69.0.tgz",
+      "integrity": "sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4913,13 +4931,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.65.0.tgz",
-      "integrity": "sha512-A7xfghw250m4a1sPV+q44Mow2G5bhiC9FBvhAuIhJS6QovWnqzuL5AFQPEuwOB+PM4DhABkqxVa3Iwe3Y/nFlQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.69.0.tgz",
+      "integrity": "sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4930,13 +4951,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.65.0.tgz",
-      "integrity": "sha512-reqOun1+pWO3fW6cv7bsa8hHG0TN3t/82qPdaoJo90FwugXiMjKhZMChmH5Z01cFNRHmxN4+543Fy8478cM/iA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.69.0.tgz",
+      "integrity": "sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4947,9 +4971,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.65.0.tgz",
-      "integrity": "sha512-KQpqOb/juDBO0xyloDkVDhOVxDUgAfZ2OAAVq99TJScJDzT319xry1QzB9LQohV9QGnA7p6m/XATZkMXc84lwA==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.69.0.tgz",
+      "integrity": "sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==",
       "cpu": [
         "arm64"
       ],
@@ -4964,9 +4988,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.65.0.tgz",
-      "integrity": "sha512-xfqcOc3nJFeAd1kDY4T9d3XeJIhr00twaaW0kOAzGPyUHkruXtNJv6zz1Ra9fRtSek5VpW2Yoj5AcwPIlT0ZiQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.69.0.tgz",
+      "integrity": "sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==",
       "cpu": [
         "arm64"
       ],
@@ -4981,9 +5005,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.65.0.tgz",
-      "integrity": "sha512-JV+pXm45p8sdgs3c7LOPAohW23optCNZETFOXUcjn6cS4PYZhEU/RI54Z5dHdMudab3nw7T48PZILthM+Q0COQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.69.0.tgz",
+      "integrity": "sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==",
       "cpu": [
         "ia32"
       ],
@@ -4998,9 +5022,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.65.0.tgz",
-      "integrity": "sha512-D7L/oBbskLss21bYrRbFuIs81AiSQV+wRzwck54dOkHIlq2qu1xjLz8u6jCqGH8Fltk8bB5DLBpVhE7v/fA8XQ==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.69.0.tgz",
+      "integrity": "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==",
       "cpu": [
         "x64"
       ],
@@ -15028,9 +15052,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz",
-      "integrity": "sha512-ChUuE3Q7XnAbscvT4XLMsH7HFJmLgLVv9lu+RRgFL5wSXnDqUOzTp5IS8qWDBGd/ZDSzQ2tbX8fjAmijlGLC7A==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.69.0.tgz",
+      "integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -15043,31 +15067,35 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.65.0",
-        "@oxlint/binding-android-arm64": "1.65.0",
-        "@oxlint/binding-darwin-arm64": "1.65.0",
-        "@oxlint/binding-darwin-x64": "1.65.0",
-        "@oxlint/binding-freebsd-x64": "1.65.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.65.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.65.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.65.0",
-        "@oxlint/binding-linux-arm64-musl": "1.65.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.65.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.65.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.65.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.65.0",
-        "@oxlint/binding-linux-x64-gnu": "1.65.0",
-        "@oxlint/binding-linux-x64-musl": "1.65.0",
-        "@oxlint/binding-openharmony-arm64": "1.65.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.65.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.65.0",
-        "@oxlint/binding-win32-x64-msvc": "1.65.0"
+        "@oxlint/binding-android-arm-eabi": "1.69.0",
+        "@oxlint/binding-android-arm64": "1.69.0",
+        "@oxlint/binding-darwin-arm64": "1.69.0",
+        "@oxlint/binding-darwin-x64": "1.69.0",
+        "@oxlint/binding-freebsd-x64": "1.69.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.69.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.69.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.69.0",
+        "@oxlint/binding-linux-arm64-musl": "1.69.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.69.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.69.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.69.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.69.0",
+        "@oxlint/binding-linux-x64-gnu": "1.69.0",
+        "@oxlint/binding-linux-x64-musl": "1.69.0",
+        "@oxlint/binding-openharmony-arm64": "1.69.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.69.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.69.0",
+        "@oxlint/binding-win32-x64-msvc": "1.69.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.22.1"
+        "oxlint-tsgolint": ">=0.22.1",
+        "vite-plus": "*"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
           "optional": true
         }
       }

--- a/front/package.json
+++ b/front/package.json
@@ -124,7 +124,7 @@
     "json-key-path-list": "^2.0.3",
     "openapi-types": "^12.1.3",
     "oxfmt": "^0.53.0",
-    "oxlint": "^1.65.0",
+    "oxlint": "^1.69.0",
     "oxlint-tsgolint": "^0.23.0",
     "pdfjs-dist": "^6.0.227",
     "sass": "^1.101.0",

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -145,6 +145,8 @@ const IntervalEditorComponent = (
     setSelectedData(selected !== null && data[selected] ? data[selected] : null);
   }, [selected, data]);
 
+  const openHelpModal = useCallback(() => openModal(<HelpModal />, 'lg'), [openModal]);
+
   return (
     <div className="linear-metadata">
       <div className="header">
@@ -154,7 +156,7 @@ const IntervalEditorComponent = (
           className="btn btn-unstyled p-1 ml-1"
           aria-label={t('common.help-display')}
           title={t('common.help-display')}
-          onClick={() => openModal(<HelpModal />, 'lg')}
+          onClick={openHelpModal}
         >
           <MdOutlineHelpOutline />
         </button>

--- a/front/src/applications/operationalStudies/components/Study/AddOrEditStudyModal.tsx
+++ b/front/src/applications/operationalStudies/components/Study/AddOrEditStudyModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Note, Pencil, Trash } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
@@ -209,6 +209,18 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
   ) {
     maxStudyStartDate = currentStudy.actual_end_date;
   }
+
+  const openDeleteItemsModal = useCallback(
+    () =>
+      openModal(
+        <DeleteItemsModal
+          handleDeleteItems={deleteStudy}
+          translationKey={t('study.confirm-delete', { count: 1 })}
+        />,
+        'sm'
+      ),
+    [openModal, deleteStudy, t]
+  );
 
   return (
     <div data-testid="study-edition-modal" className="study-edition-modal" ref={modalRef}>
@@ -462,15 +474,7 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
               data-testid="delete-study"
               className="btn btn-outline-danger mr-auto"
               type="button"
-              onClick={() =>
-                openModal(
-                  <DeleteItemsModal
-                    handleDeleteItems={deleteStudy}
-                    translationKey={t('study.confirm-delete', { count: 1 })}
-                  />,
-                  'sm'
-                )
-              }
+              onClick={openDeleteItemsModal}
             >
               <span className="mr-2">
                 <Trash />

--- a/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
+++ b/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Pencil } from '@osrd-project/ui-icons';
 import { skipToken } from '@reduxjs/toolkit/query';
@@ -209,6 +209,18 @@ const ProjectView = () => {
     getStudiesList();
   }, [sortOption, filter, projectStudies]);
 
+  const openAddOrEditProjectModal = useCallback(() => {
+    openModal(
+      <AddOrEditProjectModal
+        editionMode
+        project={project}
+        projectStudies={projectStudies?.results}
+      />,
+      'xl',
+      'no-close-modal'
+    );
+  }, [openModal, project, projectStudies]);
+
   return (
     <>
       <NavBar appName={<BreadCrumbs project={project} />} />
@@ -232,17 +244,7 @@ const ProjectView = () => {
                           data-testid="project-update-button"
                           className="project-details-title-modify-button"
                           type="button"
-                          onClick={() =>
-                            openModal(
-                              <AddOrEditProjectModal
-                                editionMode
-                                project={project}
-                                projectStudies={projectStudies?.results}
-                              />,
-                              'xl',
-                              'no-close-modal'
-                            )
-                          }
+                          onClick={openAddOrEditProjectModal}
                         >
                           <span className="project-details-title-modify-button-text">
                             {t('project.modifyProject')}

--- a/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/BoardWrapper.tsx
@@ -6,6 +6,8 @@ import MenuTriggerButton from 'common/MenuTriggerButton';
 import type { OSRDMenuItem } from 'common/OSRDMenu';
 import ResizableSection from 'common/ResizableSection';
 
+const NO_ITEMS: OSRDMenuItem[] = [];
+
 type ResizableProps = {
   height: number;
   setHeight: React.Dispatch<React.SetStateAction<number>>;
@@ -32,7 +34,7 @@ const BoardWrapper = ({
   hidden = false,
   name,
   fullName,
-  items = [],
+  items = NO_ITEMS,
   withFooter = false,
   footerClass,
   dataTestId,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/TrainScheduleSetCartItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/TrainScheduleSetCartItem.tsx
@@ -8,6 +8,13 @@ import type { CartManagement, EnhancedTrainScheduleSet, TrainScheduleSetImportTy
 
 const TRAINSCHEDULESET_IMPORT_TYPE: TrainScheduleSetImportType[] = ['reference', 'copy'];
 
+const renderOptionIcon = (set: TrainScheduleSetImportType) => {
+  if (set === 'copy') {
+    return <DesktopDownload />;
+  }
+  return <Broadcast />;
+};
+
 type TrainScheduleSetCartItemProps = CartManagement & {
   trainScheduleSet: EnhancedTrainScheduleSet;
   catalogEntry: CatalogEntry;
@@ -31,7 +38,7 @@ const TrainScheduleSetCartItem = ({
           value={importType}
           getOptionLabel={(set) => t(`importType.${set}`)}
           getOptionValue={(set) => `${set}`}
-          getOptionIcon={(set) => (set === 'copy' ? <DesktopDownload /> : <Broadcast />)}
+          getOptionIcon={renderOptionIcon}
           onChange={(set) => upsertToCart(trainScheduleSet.id, set)}
           options={TRAINSCHEDULESET_IMPORT_TYPE}
         />

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainScheduleLeftPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainScheduleLeftPanel.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 
 import { ChevronLeft, Pencil } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
@@ -97,6 +97,41 @@ const ManageTrainScheduleLeftPanel = ({
     }
   }, [displayTrainScheduleManagement, itineraryModalIsOpen, itineraryChanged]);
 
+  const openConfirmModal = useCallback(() => {
+    if (
+      trainScheduleToEditData &&
+      trainScheduleToEditData.originalPacedTrain.paced &&
+      trainScheduleToEditData.originalPacedTrain.paced.exceptions.length > 0 &&
+      (osrdConf.timeWindow.toISOString() !==
+        trainScheduleToEditData.originalPacedTrain.paced.timeWindow.toISOString() ||
+        osrdConf.interval.toISOString() !==
+          trainScheduleToEditData.originalPacedTrain.paced.interval.toISOString())
+    ) {
+      openModal(
+        <ConfirmModal
+          title={t('pacedTrains.resetExceptionsConfirmation')}
+          onConfirm={() => {
+            updateTimetable();
+            closeModal();
+          }}
+          onCancel={closeModal}
+          withCloseButton={false}
+        />,
+        'sm'
+      );
+    } else {
+      updateTimetable();
+    }
+  }, [
+    closeModal,
+    osrdConf.interval,
+    osrdConf.timeWindow,
+    trainScheduleToEditData,
+    updateTimetable,
+    openModal,
+    t,
+  ]);
+
   return (
     <div className="scenario-timetable-manage-train-schedule left-column">
       <div className="scenario-timetable-manage-train-schedule-header">
@@ -106,31 +141,7 @@ const ManageTrainScheduleLeftPanel = ({
               <button
                 className="btn btn-warning mb-2"
                 type="button"
-                onClick={() => {
-                  if (
-                    trainScheduleToEditData.originalPacedTrain.paced &&
-                    trainScheduleToEditData.originalPacedTrain.paced.exceptions.length > 0 &&
-                    (osrdConf.timeWindow.toISOString() !==
-                      trainScheduleToEditData.originalPacedTrain.paced.timeWindow.toISOString() ||
-                      osrdConf.interval.toISOString() !==
-                        trainScheduleToEditData.originalPacedTrain.paced.interval.toISOString())
-                  ) {
-                    openModal(
-                      <ConfirmModal
-                        title={t('pacedTrains.resetExceptionsConfirmation')}
-                        onConfirm={() => {
-                          updateTimetable();
-                          closeModal();
-                        }}
-                        onCancel={closeModal}
-                        withCloseButton={false}
-                      />,
-                      'sm'
-                    );
-                  } else {
-                    updateTimetable();
-                  }
-                }}
+                onClick={openConfirmModal}
                 data-testid="submit-edit-train-schedule"
               >
                 <span className="mr-2">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 
 import { X, ChevronDown, ChevronUp, Hubot, SignOut } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -92,6 +92,16 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
     >
       {username}
     </span>
+  );
+
+  const openAddandEditModal = useCallback(
+    () =>
+      openModal(
+        <AddAndEditScenarioModal editionMode scenario={scenario} />,
+        'xl',
+        'no-close-modal'
+      ),
+    [openModal, scenario]
   );
 
   return (
@@ -215,13 +225,7 @@ const ScenarioHeader = ({ activeBoards, toggleBoard }: ScenarioHeaderProps) => {
               className="edit-scenario"
               type="button"
               aria-label={t('main.editScenario')}
-              onClick={() =>
-                openModal(
-                  <AddAndEditScenarioModal editionMode scenario={scenario} />,
-                  'xl',
-                  'no-close-modal'
-                )
-              }
+              onClick={openAddandEditModal}
               title={t('main.editScenario')}
               data-testid="edit-scenario"
             >

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -48,6 +48,8 @@ export const HIDDEN_CHART_TOP_HEIGHT = 23;
 const SDD_INITIAL_HEIGHT = 460;
 const SDD_MIN_HEIGHT = 400;
 
+const NO_CONFLICTS: Conflict[] = [];
+
 type SimulationResultsProps = {
   scenarioData: { name: string; infraName: string };
   projectionData: ProjectionData | undefined;
@@ -72,7 +74,7 @@ const SimulationResults = ({
   projectionData,
   trainSchedulesWithDetails,
   trainSchedules,
-  conflicts = [],
+  conflicts = NO_CONFLICTS,
   activeBoards,
   updateTrainScheduleDepartureTime,
   upsertTrainSchedules,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
 import { ChevronDown, ChevronRight, Clock, Flame, Manchette } from '@osrd-project/ui-icons';
@@ -55,6 +55,18 @@ import { formatTrainDuration, getTrainCategoryClassName } from '../utils';
 import useOccurrenceActions from './hooks/useOccurrenceActions';
 import useOccurrences from './hooks/useOccurrences';
 import OccurrenceItem from './OccurrenceItem';
+
+const openConfirmModal = ({
+  openModal,
+  deleteAllExceptions,
+  title,
+}: {
+  openModal: (modal: React.ReactNode) => void;
+  deleteAllExceptions: () => void;
+  title: string;
+}) => {
+  openModal(<ConfirmModal onConfirm={() => deleteAllExceptions()} title={title} />);
+};
 
 type PacedTrainItemProps = {
   isInSelection: boolean;
@@ -319,6 +331,13 @@ const PacedTrainItem = ({
     [pacedTrain.summary, pacedTrain.paced.exceptions]
   );
 
+  const openDeleteModal = useCallback(async () => {
+    openModal(
+      <DeleteModal handleDelete={async () => deletePacedTrain()} selectedPacedTrainCount={1} />,
+      'sm'
+    );
+  }, [deletePacedTrain, openModal, t]);
+
   const content = (
     <div
       data-testid="scenario-train-schedule"
@@ -432,24 +451,15 @@ const PacedTrainItem = ({
           moveTrainSchedule={moveTrainSchedule}
           duplicateTrainSchedule={duplicatePacedTrain}
           editTrainSchedule={() => selectPacedTrainToEdit(pacedTrain)}
-          deleteTrainSchedule={async () => {
-            openModal(
-              <DeleteModal
-                handleDelete={async () => deletePacedTrain()}
-                selectedPacedTrainCount={1}
-              />,
-              'sm'
-            );
-          }}
+          deleteTrainSchedule={openDeleteModal}
           showResetExceptionsButton={pacedTrain.paced.exceptions.length > 0}
-          resetAllExceptions={() => {
-            openModal(
-              <ConfirmModal
-                onConfirm={() => deleteAllExceptions()}
-                title={t('timetable.resetAllExceptions')}
-              />
-            );
-          }}
+          resetAllExceptions={() =>
+            openConfirmModal({
+              openModal,
+              deleteAllExceptions,
+              title: t('timetable.resetAllExceptions'),
+            })
+          }
           showMovebutton={showMovebutton}
         />
       </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -18,6 +18,8 @@ import TrainScheduleSetDialog from './TrainScheduleSet/TrainScheduleSetDialog';
 import type { TimetableMode } from './types';
 import useFilterTrainSchedules from './useFilterTrainSchedules';
 
+const NO_TRAIN_SCHEDULES: TrainScheduleResponse[] = [];
+
 type TimetableProps = {
   setDisplayTrainScheduleManagement: (mode: string) => void;
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
@@ -41,7 +43,7 @@ const Timetable = ({
   removeAndUnselectTrains,
   handleDeleteTrainSchedules,
   trainScheduleToEditData,
-  trainSchedules = [],
+  trainSchedules = NO_TRAIN_SCHEDULES,
   trainSchedulesWithDetails,
   refreshNge,
   selectedTrainScheduleIds,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -24,6 +24,8 @@ import { postFullImportPayload } from '../ImportTrainSchedule/helpers/postPayloa
 import Timetable from './Timetable';
 import { copyTrainSchedulesToClipboard } from './utils';
 
+const NO_TRAIN_SCHEDULES: TrainScheduleResponse[] = [];
+
 type TimetableBoardWrapperProps = {
   setDisplayTrainScheduleManagement: (mode: string) => void;
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
@@ -44,7 +46,7 @@ const TimetableBoardWrapper = ({
   setTrainScheduleToEditData,
   removeTrainSchedules,
   trainScheduleToEditData,
-  trainSchedules = [],
+  trainSchedules = NO_TRAIN_SCHEDULES,
   trainSchedulesWithDetails,
   refreshNge,
   projectingOnSimulatedPathException,

--- a/front/src/applications/operationalStudies/views/Study/StudyView.tsx
+++ b/front/src/applications/operationalStudies/views/Study/StudyView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Pencil } from '@osrd-project/ui-icons';
 import { skipToken } from '@reduxjs/toolkit/query';
@@ -85,6 +85,16 @@ const StudyView = () => {
           pageSize: 1000,
         }
       : skipToken
+  );
+
+  const openAddorEditStudyModal = useCallback(
+    () =>
+      openModal(
+        <AddOrEditStudyModal editionMode study={study} scenarios={scenarios?.results} />,
+        'xl',
+        'no-close-modal'
+      ),
+    [study, scenarios, openModal]
   );
 
   const {
@@ -249,17 +259,7 @@ const StudyView = () => {
                     data-testid="study-modify-button"
                     className="study-details-modify-button"
                     type="button"
-                    onClick={() =>
-                      openModal(
-                        <AddOrEditStudyModal
-                          editionMode
-                          study={study}
-                          scenarios={scenarios?.results}
-                        />,
-                        'xl',
-                        'no-close-modal'
-                      )
-                    }
+                    onClick={openAddorEditStudyModal}
                   >
                     <span className="study-details-modify-button-text">
                       {t('study.modifyStudy')}

--- a/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
+++ b/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Upload } from '@osrd-project/ui-icons';
 import { skipToken } from '@reduxjs/toolkit/query';
@@ -176,6 +176,23 @@ const RollingStockEditor = () => {
     }
   };
 
+  const openUploadFileModal = useCallback(() => {
+    openModal(<UploadFileModal handleSubmit={importFile} />);
+  }, [openModal, importFile]);
+
+  const openRollingStockEditorFormModal = useCallback(() => {
+    openModal(
+      <RollingStockEditorFormModal
+        mainText={t('common.leaveEditionMode')}
+        request={() => {
+          setIsAdding(false);
+          setIsEditing(false);
+        }}
+        buttonText={t('common.confirm')}
+      />
+    );
+  }, [openModal, setIsAdding, setIsEditing]);
+
   return (
     <>
       <NavBar appName={<>{t('applications.rolling-stocks-editor')}</>} />
@@ -186,18 +203,7 @@ const RollingStockEditor = () => {
               className="rollingstock-editor-disablelist"
               role="button"
               tabIndex={0}
-              onClick={() => {
-                openModal(
-                  <RollingStockEditorFormModal
-                    mainText={t('common.leaveEditionMode')}
-                    request={() => {
-                      setIsAdding(false);
-                      setIsEditing(false);
-                    }}
-                    buttonText={t('common.confirm')}
-                  />
-                );
-              }}
+              onClick={openRollingStockEditorFormModal}
             >
               <span>{t('rollingStock.listDisabled')}</span>
             </div>
@@ -219,9 +225,7 @@ const RollingStockEditor = () => {
               className="d-flex justify-content-start mb-2 py-1 px-2"
               aria-label={t('rollingStock.importRollingStock')}
               title={t('rollingStock.importRollingStock')}
-              onClick={() => {
-                openModal(<UploadFileModal handleSubmit={importFile} />);
-              }}
+              onClick={openUploadFileModal}
             >
               <Upload className="mr-2" />
               {t('rollingStock.importRollingStock')}

--- a/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
+++ b/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 
 import { Alert } from '@osrd-project/ui-icons';
@@ -247,6 +247,22 @@ const CurveParamSelectors = ({
     if (powerRestrictionCodes) setPowerRestrictionList(powerRestrictionCodes);
   }, [powerRestrictionCodes]);
 
+  const openPowerRestrictionGridModal = useCallback(() => {
+    openModal(
+      <PowerRestrictionGridModal
+        powerRestrictionsList={powerRestrictionList}
+        updatePowerRestrictions={updatePowerRestrictionsList}
+        currentPowerRestrictions={[...rollingstockParams.powerRestrictions]}
+      />,
+      'lg'
+    );
+  }, [
+    powerRestrictionList,
+    rollingstockParams.powerRestrictions,
+    openModal,
+    updatePowerRestrictionsList,
+  ]);
+
   return (
     <div className="rollingstock-editor-effort-speed-curves">
       <div className="selector-container">
@@ -336,15 +352,7 @@ const CurveParamSelectors = ({
               selectNewItemButtonProps={{
                 options: powerRestrictionList,
                 selectNewItem: updatePowerRestrictionsList,
-                customOnClick: () =>
-                  openModal(
-                    <PowerRestrictionGridModal
-                      powerRestrictionsList={powerRestrictionList}
-                      updatePowerRestrictions={updatePowerRestrictionsList}
-                      currentPowerRestrictions={[...rollingstockParams.powerRestrictions]}
-                    />,
-                    'lg'
-                  ),
+                customOnClick: openPowerRestrictionGridModal,
               }}
               dataTestId="power-restriction-selector"
             />

--- a/front/src/applications/stdcm/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/applications/stdcm/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { skipToken } from '@reduxjs/toolkit/query';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -53,20 +55,22 @@ const ScenarioExplorer = ({
       <div className="scenario-explorator-card-noscenario">{t('noScenarioSelected')}</div>
     );
 
+  const openScenarioExplorerModal = useCallback(() => {
+    openModal(
+      <ScenarioExplorerModal
+        globalProjectId={globalProjectId}
+        globalStudyId={globalStudyId}
+        globalScenarioId={globalScenarioId}
+      />,
+      'lg'
+    );
+  }, [globalProjectId, globalStudyId, globalScenarioId, openModal]);
+
   return (
     <div
       className="scenario-explorator-card"
       data-testid="scenario-explorator"
-      onClick={() => {
-        openModal(
-          <ScenarioExplorerModal
-            globalProjectId={globalProjectId}
-            globalStudyId={globalStudyId}
-            globalScenarioId={globalScenarioId}
-          />,
-          'lg'
-        );
-      }}
+      onClick={openScenarioExplorerModal}
       role="button"
       tabIndex={0}
     >

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -298,6 +298,35 @@ const StdcmResults = ({
     );
   }, [pdfInstance, deploymentSettings, simulationReportSheetNumber]);
 
+  const openSendToRailwayManagerModal = useCallback(() => {
+    if (hasSimulationResults) {
+      openModal(
+        <SendToRailwayManagerModal
+          consist={selectedSimulation.inputs.consist}
+          stdcmResults={outputs}
+          linkedTrains={selectedSimulation.inputs.linkedTrains}
+          simulationReportSheetNumber={simulationReportSheetNumber}
+          similarTrains={similarTrains}
+          pdfBlob={pdfInstance.blob!}
+          onClose={closeModal}
+          onSuccess={handleSubmitSuccess}
+        />,
+        'xl',
+        'no-close-modal'
+      );
+    }
+  }, [
+    closeModal,
+    handleSubmitSuccess,
+    openModal,
+    outputs,
+    selectedSimulation.inputs.consist,
+    selectedSimulation.inputs.linkedTrains,
+    simulationReportSheetNumber,
+    similarTrains,
+    pdfInstance.blob,
+  ]);
+
   return (
     <>
       <StdcmSimulationNavigator
@@ -350,22 +379,7 @@ const StdcmResults = ({
                             label={t('transferSheetToRailManager')}
                             isDisabled={pdfInstance.loading}
                             isLoading={pdfInstance.loading}
-                            onClick={() => {
-                              openModal(
-                                <SendToRailwayManagerModal
-                                  consist={selectedSimulation.inputs.consist}
-                                  stdcmResults={outputs}
-                                  linkedTrains={selectedSimulation.inputs.linkedTrains}
-                                  simulationReportSheetNumber={simulationReportSheetNumber}
-                                  similarTrains={similarTrains}
-                                  pdfBlob={pdfInstance.blob!}
-                                  onClose={closeModal}
-                                  onSuccess={handleSubmitSuccess}
-                                />,
-                                'xl',
-                                'no-close-modal'
-                              );
-                            }}
+                            onClick={openSendToRailwayManagerModal}
                           />
                         ) : (
                           <div className="success-message">

--- a/front/src/common/BootstrapSNCF/ChipsSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/ChipsSNCF.tsx
@@ -14,6 +14,8 @@ enum colorClasses {
   white = 'bg-white text-dark',
 }
 
+const NO_TAGS: string[] = [];
+
 type Props = {
   tags?: string[];
   addTag: (tag: string) => void;
@@ -29,7 +31,7 @@ type Props = {
  * addTag is only called if the inputted tag is not already present in the tags array.
  */
 export default function ChipsSNCF({
-  tags = [],
+  tags = NO_TAGS,
   addTag,
   removeTag,
   title,

--- a/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
@@ -15,9 +15,11 @@ type DropdownSNCFProps = {
   noArrow?: boolean;
 };
 
+const NO_ITEMS: DropdownSNCFProps['items'] = [];
+
 const DropdownSNCF = ({
   titleContent,
-  items = [],
+  items = NO_ITEMS,
   type = 'transparent',
   className,
   noArrow = false,

--- a/front/src/common/BootstrapSNCF/InputSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/InputSNCF.tsx
@@ -47,6 +47,8 @@ export type InputSNCFProps = {
   ref?: React.RefObject<HTMLInputElement>;
 };
 
+const NO_INPUT_PROPS: InputSNCFProps['inputProps'] = {};
+
 const InputSNCF = ({
   // Basic input props
   id,
@@ -59,7 +61,7 @@ const InputSNCF = ({
   onChange,
   value,
   readonly = false,
-  inputProps = {},
+  inputProps = NO_INPUT_PROPS,
   list,
   // Error handling
   isInvalid = false,

--- a/front/src/common/BootstrapSNCF/SwitchSNCF/SwitchSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/SwitchSNCF/SwitchSNCF.tsx
@@ -21,9 +21,11 @@ export type SwitchSNCFProps = {
   disabled?: boolean;
 };
 
+const NO_OPTIONS: SwitchSNCFProps['options'] = [];
+
 const SwitchSNCF = ({
   type,
-  options = [],
+  options = NO_OPTIONS,
   onChange,
   checkedName,
   name,

--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -59,6 +59,12 @@ export type LinearMetadataDatavizProps<T> = IntervalItemBaseProps<T> & {
   onResize?: (index: number, gap: number, finalized: boolean) => void;
 };
 
+const DEFAULT_OPTIONS = {
+  resizingScale: false,
+  fullHeightItem: false,
+  showValues: false,
+};
+
 /**
  * Component that displays a linear metadata of a line.
  */
@@ -71,7 +77,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: string | number
   highlighted,
   intervalType,
   operationalPoints,
-  options = { resizingScale: false, fullHeightItem: false, showValues: false },
+  options = DEFAULT_OPTIONS,
   viewBox,
   onClick,
   onDoubleClick,

--- a/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
@@ -5,6 +5,8 @@ import SelectSNCF from 'common/BootstrapSNCF/SelectImprovedSNCF';
 
 import type { IntervalItem } from './types';
 
+const NO_UNITS: string[] = [];
+
 type IntervalsEditorMarginFormProps = {
   data: IntervalItem[];
   defaultUnit?: string;
@@ -22,7 +24,7 @@ const IntervalsEditorMarginForm = ({
   interval,
   selectedIntervalIndex,
   setData,
-  units = [],
+  units = NO_UNITS,
 }: IntervalsEditorMarginFormProps) => (
   <div className="intervals-editor-form-column">
     <div className="intervals-editor-form-input">

--- a/front/src/common/Map/Buttons/ButtonMapInfras.tsx
+++ b/front/src/common/Map/Buttons/ButtonMapInfras.tsx
@@ -7,15 +7,20 @@ import { useInfraID } from 'common/osrdContext';
 import InfraSelector from 'modules/infra/components/InfraSelector';
 
 const ButtonMapInfras = ({ isInEditor }: { isInEditor?: boolean }) => {
-  const { openModal } = useModal();
   const infraID = useInfraID();
+  const { openModal } = useModal();
   const { t } = useTranslation('translation');
+
+  const openInfraSelectorModal = () => {
+    openModal(<InfraSelector isInEditor={isInEditor} />, 'lg');
+  };
+
   return (
     <button
       type="button"
       title={t('Editor.nav.choose-infra')}
       className={cx('btn-rounded', 'btn-rounded-white', { 'btn-map-infras-blinking': !infraID })}
-      onClick={() => openModal(<InfraSelector isInEditor={isInEditor} />, 'lg')}
+      onClick={openInfraSelectorModal}
     >
       <span className="sr-only">Infrastructures</span>
       <GiRailway />

--- a/front/src/common/Map/DefaultBaseMap.tsx
+++ b/front/src/common/Map/DefaultBaseMap.tsx
@@ -34,6 +34,8 @@ type DefaultBaseMapProps = {
 const ZOOM_DEFAULT = 5;
 const ZOOM_DELTA = 1.5;
 
+const NO_PATH_STEP_MARKERS: MarkerInformation[] = [];
+
 /**
  * Default base map used to display a path and some markers.
  * No interactions are available, except zoom in/out, pan and reset pitch/bearing.
@@ -42,7 +44,7 @@ const DefaultBaseMap = ({
   mapId,
   infraId,
   geometry,
-  pathStepMarkers = [],
+  pathStepMarkers = NO_PATH_STEP_MARKERS,
   isFeasible = true,
   children,
   mapSettings,

--- a/front/src/common/NavBar/NavBar.tsx
+++ b/front/src/common/NavBar/NavBar.tsx
@@ -49,6 +49,8 @@ const NavBar = ({ appName }: NavBarProps) => {
     </div>
   );
 
+  const openUserSettingsModal = () => openModal(<UserSettings />);
+
   return (
     <div className={cx('nav-bar', { impersonated: impersonatedUser })}>
       <div
@@ -78,7 +80,7 @@ const NavBar = ({ appName }: NavBarProps) => {
             <button
               type="button"
               className="safe-word-btn"
-              onClick={() => openModal(<UserSettings />)}
+              onClick={openUserSettingsModal}
               aria-label={t('nav-bar.userSettings')}
               title={t('nav-bar.userSettings')}
             >

--- a/front/src/common/NavBar/UserActionsDropdown.tsx
+++ b/front/src/common/NavBar/UserActionsDropdown.tsx
@@ -29,14 +29,15 @@ const UserActionsDropdown = ({
   const { openModal } = useModal();
   const { t, i18n } = useTranslation();
 
+  const openUserSettingsModal = () => openModal(<UserSettings />);
+  const openChangeLanguageModal = () => openModal(<ChangeLanguageModal />, 'sm');
+  const openHelpModalSNCF = () => openModal(<HelpModalSNCF />, 'lg');
+  const openReleaseInformationModal = () => openModal(<ReleaseInformation />, 'lg');
+
   const dropdownItems = [
     {
       node: (
-        <button
-          type="button"
-          className="btn-link text-reset"
-          onClick={() => openModal(<ReleaseInformation />, 'lg')}
-        >
+        <button type="button" className="btn-link text-reset" onClick={openReleaseInformationModal}>
           <span className="mr-2">
             <Info />
           </span>
@@ -47,11 +48,7 @@ const UserActionsDropdown = ({
     },
     {
       node: (
-        <button
-          type="button"
-          className="btn-link text-reset"
-          onClick={() => openModal(<HelpModalSNCF />, 'lg')}
-        >
+        <button type="button" className="btn-link text-reset" onClick={openHelpModalSNCF}>
           <span className="mr-2">
             <Report />
           </span>
@@ -62,11 +59,7 @@ const UserActionsDropdown = ({
     },
     {
       node: (
-        <button
-          type="button"
-          className="btn-link text-reset"
-          onClick={() => openModal(<ChangeLanguageModal />, 'sm')}
-        >
+        <button type="button" className="btn-link text-reset" onClick={openChangeLanguageModal}>
           <span className="mr-2">
             {i18n.language && getUnicodeFlagIcon(languageCodeToCountryCode(i18n.language))}
           </span>
@@ -81,7 +74,7 @@ const UserActionsDropdown = ({
           data-testid="user-settings-btn"
           type="button"
           className="user-settings-btn btn-link text-reset"
-          onClick={() => openModal(<UserSettings />)}
+          onClick={openUserSettingsModal}
         >
           <span className="mr-2">
             <Gear variant="fill" />

--- a/front/src/common/SelectionToolbar.tsx
+++ b/front/src/common/SelectionToolbar.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { Trash } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 import { AiFillCheckCircle } from 'react-icons/ai';
@@ -23,6 +25,20 @@ const SelectionToolbar = ({
 }: SelectionToolbarProps) => {
   const { t } = useTranslation('operational-studies');
   const { openModal } = useModal();
+
+  const openDeleteItemsModal = useCallback(
+    () =>
+      openModal(
+        <DeleteItemsModal
+          handleDeleteItems={onDelete}
+          translationKey={t(`${item}.confirm-delete`, {
+            count: selectedItemCount,
+          })}
+        />,
+        'sm'
+      ),
+    [openModal, onDelete, t, item, selectedItemCount]
+  );
   return (
     <div className="selection-toolbar">
       <AiFillCheckCircle />
@@ -35,17 +51,7 @@ const SelectionToolbar = ({
         data-testid={dataTestId}
         className="btn btn-sm btn-danger"
         type="button"
-        onClick={() =>
-          openModal(
-            <DeleteItemsModal
-              handleDeleteItems={onDelete}
-              translationKey={t(`${item}.confirm-delete`, {
-                count: selectedItemCount,
-              })}
-            />,
-            'sm'
-          )
-        }
+        onClick={openDeleteItemsModal}
       >
         <Trash />
         <span className="ml-2">{t('operational-studies-management.delete')}</span>

--- a/front/src/common/authorization/components/GrantsManager.tsx
+++ b/front/src/common/authorization/components/GrantsManager.tsx
@@ -7,6 +7,7 @@ import { GRANTS_LABEL } from 'common/authorization/consts';
 
 import type { Grant, Privilege, ResourceType } from '../types';
 import GrantsManagerSubjects from './GrantsManagerSubjects';
+import { DEFAULT_SET } from 'common/consts';
 
 function getGrantLabel(userPrivileges: Set<Privilege>): keyof typeof GRANTS_LABEL {
   if (userPrivileges.has('can_delete')) return 'OWNER';
@@ -14,6 +15,8 @@ function getGrantLabel(userPrivileges: Set<Privilege>): keyof typeof GRANTS_LABE
   if (userPrivileges.has('can_read')) return 'READER';
   return 'NONE';
 }
+
+const EMPTY_USER_PRIVILEGES: Set<Privilege> = new Set();
 
 type GrantsManagerProps = {
   resourceId: number;
@@ -25,7 +28,7 @@ type GrantsManagerProps = {
 const GrantsManager = ({
   resourceId,
   resourceType,
-  userPrivileges = new Set(),
+  userPrivileges = EMPTY_USER_PRIVILEGES,
   onChangeSuccess,
 }: GrantsManagerProps) => {
   const { t } = useTranslation();

--- a/front/src/common/authorization/components/GrantsManager.tsx
+++ b/front/src/common/authorization/components/GrantsManager.tsx
@@ -7,7 +7,6 @@ import { GRANTS_LABEL } from 'common/authorization/consts';
 
 import type { Grant, Privilege, ResourceType } from '../types';
 import GrantsManagerSubjects from './GrantsManagerSubjects';
-import { DEFAULT_SET } from 'common/consts';
 
 function getGrantLabel(userPrivileges: Set<Privilege>): keyof typeof GRANTS_LABEL {
   if (userPrivileges.has('can_delete')) return 'OWNER';

--- a/front/src/common/authorization/components/GrantsManagerSubjects.tsx
+++ b/front/src/common/authorization/components/GrantsManagerSubjects.tsx
@@ -11,6 +11,8 @@ import type { Grant, Privilege, ResourceType } from '../types';
 import GrantManagerAddSubjectForm from './GrantManagerAddSubjectForm';
 import GrantsManagerSubject from './GrantsManagerSubject';
 
+const EMPTY_USER_PRIVILEGES: Set<Privilege> = new Set();
+
 type GrantsManagerSubjectsProps = {
   resourceId: number;
   resourceType: ResourceType;
@@ -21,7 +23,7 @@ type GrantsManagerSubjectsProps = {
 const GrantsManagerSubjects = ({
   resourceId,
   resourceType,
-  userPrivileges = new Set(),
+  userPrivileges = EMPTY_USER_PRIVILEGES,
   onChangeSuccess,
 }: GrantsManagerSubjectsProps) => {
   const { t } = useTranslation();

--- a/front/src/modules/SimulationReportSheet/Consist.tsx
+++ b/front/src/modules/SimulationReportSheet/Consist.tsx
@@ -102,6 +102,8 @@ const RollingStockDisplay = ({
   return <Text style={styles.consistAndRoute.consistInfoData}>{rollingStockName}</Text>;
 };
 
+const NO_CONSIST_CHANGES: ConsistChangeData[] = [];
+
 type ConsistProps = {
   rollingStockName: string;
   mass: string;
@@ -121,7 +123,7 @@ const Consist = ({
   speedLimitByTag,
   loadingGauge,
   towedRollingStockName,
-  consistChanges = [],
+  consistChanges = NO_CONSIST_CHANGES,
 }: ConsistProps) => {
   const { t } = useTranslation('stdcm');
 

--- a/front/src/modules/SimulationReportSheet/ConsistAndRoute.tsx
+++ b/front/src/modules/SimulationReportSheet/ConsistAndRoute.tsx
@@ -8,6 +8,8 @@ import Route from './Route';
 import styles from './styles/SimulationReportStyleSheet';
 import type { ConsistChangeData, RouteTableRow } from './types';
 
+const NO_CONSIST_CHANGES: ConsistChangeData[] = [];
+
 type ConsistAndRouteProps = {
   isStdcm?: boolean;
   stdcmLinkedTrains?: LinkedTrains;
@@ -29,7 +31,7 @@ const ConsistAndRoute = ({
   initialConsist,
   stdcmLinkedTrains,
   routeTableRows,
-  consistChanges = [],
+  consistChanges = NO_CONSIST_CHANGES,
 }: ConsistAndRouteProps) => {
   const { t } = useTranslation('stdcm');
 

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
@@ -12,7 +12,7 @@ import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
-const EMPTY_USER_PRIVILEGES = new Set();
+const EMPTY_USER_PRIVILEGES = new Set<Privilege>();
 
 type ActionBarProps = {
   infra: Infra;
@@ -27,7 +27,7 @@ const ActionsBar = ({
   isFocused,
   setIsFocused,
   inputValue,
-  userPrivileges = EMPTY_USER_PRIVILEGES as Set<Privilege>,
+  userPrivileges = EMPTY_USER_PRIVILEGES,
 }: ActionBarProps) => {
   const { t } = useTranslation();
   const [isWaiting, setIsWaiting] = useState(false);

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
@@ -12,6 +12,8 @@ import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
+const EMPTY_USER_PRIVILEGES = new Set();
+
 type ActionBarProps = {
   infra: Infra;
   isFocused?: number;
@@ -25,7 +27,7 @@ const ActionsBar = ({
   isFocused,
   setIsFocused,
   inputValue,
-  userPrivileges = new Set(),
+  userPrivileges = EMPTY_USER_PRIVILEGES as Set<Privilege>,
 }: ActionBarProps) => {
   const { t } = useTranslation();
   const [isWaiting, setIsWaiting] = useState(false);

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionItem.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionItem.tsx
@@ -12,7 +12,7 @@ import ActionsBar from './InfraSelectorEditionActionsBar';
 import InfraSelectorEditionActionsBarDelete from './InfraSelectorEditionActionsBarDelete';
 import { editoastUpToDateIndicator } from './InfraSelectorModalBodyStandard';
 
-const EMPTY_USER_PRIVILEGES = new Set();
+const EMPTY_USER_PRIVILEGES = new Set<Privilege>();
 
 type InfraSelectorEditionItemProps = {
   infra: Infra;
@@ -25,7 +25,7 @@ const InfraSelectorEditionItem = ({
   infra,
   isFocused,
   setIsFocused,
-  userPrivileges = EMPTY_USER_PRIVILEGES as Set<Privilege>,
+  userPrivileges = EMPTY_USER_PRIVILEGES,
 }: InfraSelectorEditionItemProps) => {
   const [value, setValue] = useState(infra.name);
   const [runningDelete, setRunningDelete] = useState(false);

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionItem.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionItem.tsx
@@ -12,6 +12,8 @@ import ActionsBar from './InfraSelectorEditionActionsBar';
 import InfraSelectorEditionActionsBarDelete from './InfraSelectorEditionActionsBarDelete';
 import { editoastUpToDateIndicator } from './InfraSelectorModalBodyStandard';
 
+const EMPTY_USER_PRIVILEGES = new Set();
+
 type InfraSelectorEditionItemProps = {
   infra: Infra;
   isFocused?: number;
@@ -23,7 +25,7 @@ const InfraSelectorEditionItem = ({
   infra,
   isFocused,
   setIsFocused,
-  userPrivileges = new Set(),
+  userPrivileges = EMPTY_USER_PRIVILEGES as Set<Privilege>,
 }: InfraSelectorEditionItemProps) => {
   const [value, setValue] = useState(infra.name);
   const [runningDelete, setRunningDelete] = useState(false);

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { ArrowSwitch, Route, Plus, Rocket, Trash } from '@osrd-project/ui-icons';
 import bbox from '@turf/bbox';
@@ -92,6 +92,17 @@ const Itinerary = ({ rollingStockId }: { rollingStockId: number | undefined }) =
     seeWholeItinerary();
   }, [pathProperties]);
 
+  const openModalWithSuggestedVias = useCallback(
+    () =>
+      openModal(
+        <ModalSuggestedVias
+          suggestedVias={pathStepsAndSuggestedOPs!}
+          launchPathfinding={launchPathfinding}
+        />
+      ),
+    [openModal, pathStepsAndSuggestedOPs, launchPathfinding]
+  );
+
   return (
     <div className="osrd-config-item">
       <div className="mb-2 d-flex">
@@ -129,14 +140,7 @@ const Itinerary = ({ rollingStockId }: { rollingStockId: number | undefined }) =
               data-testid="add-waypoints-button"
               className="col ml-1 my-1 text-white btn bg-info btn-sm"
               type="button"
-              onClick={() =>
-                openModal(
-                  <ModalSuggestedVias
-                    suggestedVias={pathStepsAndSuggestedOPs}
-                    launchPathfinding={launchPathfinding}
-                  />
-                )
-              }
+              onClick={openModalWithSuggestedVias}
             >
               <span className="mr-1">{t('addVias')}</span>
               <Plus />

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 import { Pencil, Trash } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
@@ -255,6 +255,18 @@ export default function AddOrEditProjectModal({
 
   useModalFocusTrap(modalRef, closeModal);
 
+  const openDeleteItemsModal = useCallback(
+    () =>
+      openModal(
+        <DeleteItemsModal
+          handleDeleteItems={removeProject}
+          translationKey={t('project.confirm-delete', { count: 1 })}
+        />,
+        'sm'
+      ),
+    [openModal, removeProject, t]
+  );
+
   return (
     <div className="project-edition-modal" ref={modalRef}>
       {clickedOutside && (
@@ -432,15 +444,7 @@ export default function AddOrEditProjectModal({
               data-testid="delete-project"
               className="btn btn-outline-danger mr-auto"
               type="button"
-              onClick={() =>
-                openModal(
-                  <DeleteItemsModal
-                    handleDeleteItems={removeProject}
-                    translationKey={t('project.confirm-delete', { count: 1 })}
-                  />,
-                  'sm'
-                )
-              }
+              onClick={openDeleteItemsModal}
             >
               <span className="mr-2">
                 <Trash />

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockSelector.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockSelector.tsx
@@ -61,21 +61,23 @@ const RollingStockSelector = ({
 
   const { t } = useTranslation();
 
+  const openRollingStockSelectorModal = useCallback(() => {
+    openModal(
+      <RollingStockModal
+        rollingStockId={rollingStockId}
+        ref2scroll={ref2scroll}
+        onSelectRollingStock={selectRollingStock}
+      />,
+      'lg'
+    );
+  }, [rollingStockId, ref2scroll, selectRollingStock]);
+
   return (
     <div className="osrd-config-item mb-2">
       <div
         className="osrd-config-item-container osrd-config-item-clickable"
         data-testid="rollingstock-selector"
-        onClick={() => {
-          openModal(
-            <RollingStockModal
-              rollingStockId={rollingStockId}
-              ref2scroll={ref2scroll}
-              onSelectRollingStock={selectRollingStock}
-            />,
-            'lg'
-          );
-        }}
+        onClick={openRollingStockSelectorModal}
         role="button"
         tabIndex={0}
       >

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Pencil, Trash } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -240,6 +240,18 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
     }
   };
 
+  const openDeleteItemsModal = useCallback(
+    () =>
+      openModal(
+        <DeleteItemsModal
+          handleDeleteItems={removeScenario}
+          translationKey={t('scenario.confirm-delete', { count: 1 })}
+        />,
+        'sm'
+      ),
+    [openModal, removeScenario, t]
+  );
+
   useEffect(() => {
     if (scenario) {
       initialValuesRef.current = { ...scenario };
@@ -367,15 +379,7 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
               data-testid="delete-scenario"
               className="btn btn-sm btn-outline-danger mr-auto"
               type="button"
-              onClick={() =>
-                openModal(
-                  <DeleteItemsModal
-                    handleDeleteItems={removeScenario}
-                    translationKey={t('scenario.confirm-delete', { count: 1 })}
-                  />,
-                  'sm'
-                )
-              }
+              onClick={openDeleteItemsModal}
             >
               <span className="mr-2">
                 <Trash />

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -149,6 +149,7 @@ type SpaceTimeChartWrapperProps = SpaceTimeChartWrapperBaseProps &
   );
 
 export const MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT = 561;
+const NO_CONFLICTS: Conflict[] = [];
 
 /**
  * Builds the hover input for the curve-style helper. Chart hover wins over
@@ -182,7 +183,7 @@ const SpaceTimeChartWrapper = ({
   operationalPoints,
   trainScheduleProjections,
   waypointsPanelData,
-  conflicts = [],
+  conflicts = NO_CONFLICTS,
   workSchedules,
   trackOccupancyDiagramsData,
   onCloseOccupancyLayer,

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -7,6 +7,7 @@ import {
   flexRender,
   getCoreRowModel,
   useReactTable,
+  type CellContext,
   type Row,
   type RowData,
 } from '@tanstack/react-table';
@@ -18,6 +19,7 @@ import type { ReceptionSignal } from 'common/api/osrdEditoastApi';
 import { SkeletonLoader } from 'common/Loaders';
 import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
 import { formatLocalTime, useDateTimeLocale } from 'utils/date';
+import type { Duration } from 'utils/duration';
 import { calculateTimeDifferenceInDays } from 'utils/timeManipulation';
 
 import DurationCell, { type DurationCellHandle } from './DurationCell';
@@ -192,12 +194,305 @@ const TimesStopsTable = ({
     []
   );
 
+  const returnMarginCell = ({
+    info,
+    showPolarity,
+    editable,
+    dataTestId,
+  }: {
+    info: CellContext<TimesStopsRowNew, MarginValue | undefined>;
+    showPolarity?: boolean;
+    editable?: boolean;
+    dataTestId: string;
+  }) => {
+    const { allRows } = info.table.options.meta!;
+    const isLastRow = info.row.index === allRows.length - 1;
+    if (info.table.options.meta!.isComputedDataPending && !isLastRow) {
+      return <SkeletonLoader className="cell-loading-placeholder" />;
+    }
+    const marginValue = info.getValue() ?? null;
+    return (
+      <MarginCell
+        data-testid={dataTestId}
+        marginValue={marginValue}
+        showPolarity={showPolarity}
+        editable={editable}
+      />
+    );
+  };
+
+  const returnRequestTheoreticalMarginCell = (
+    info: CellContext<TimesStopsRowNew, MarginValue | undefined>
+  ) => {
+    const { allRows } = info.table.options.meta!;
+    const row = info.row.original;
+    const isFirstRow = info.row.index === 0;
+    const isLastRow = info.row.index === allRows.length - 1;
+
+    if (isLastRow) return null;
+
+    const marginValue =
+      isScheduledOP(row) || !!row.requestedTheoreticalMargin
+        ? row.requestedTheoreticalMargin
+        : null;
+    const isInherited = !row.isTheoreticalMarginBoundary || !row.requestedTheoreticalMargin;
+
+    return (
+      <div data-testid="requested-theoretical-margin">
+        <MarginCell
+          data-testid="margin-cell-editable"
+          marginValue={marginValue ?? null}
+          editable={!isLastRow}
+          isInherited={isFirstRow ? false : isInherited}
+          isFirstRow={isFirstRow}
+          onCommit={(value) => info.table.options.meta!.onRequestedMarginChange(row, value)}
+        />
+      </div>
+    );
+  };
+
+  const returnShortSlipDistanceCell = (
+    info: CellContext<TimesStopsRowNew, boolean | undefined>
+  ) => {
+    const { closedSignal, shortSlipDistance } = info.row.original;
+    const isDisabled = !closedSignal;
+
+    return (
+      <Checkbox
+        id={`shortSlipDistance-${info.row.id}`}
+        data-testid="short-slip-distance"
+        small
+        checked={!!shortSlipDistance}
+        disabled={isDisabled}
+        onChange={() => {
+          if (!isDisabled) {
+            const signal = onStopSignalToReceptionSignal(closedSignal, !shortSlipDistance);
+            info.table.options.meta!.onReceptionSignalChange(info.row.original, signal);
+          }
+        }}
+      />
+    );
+  };
+
+  const returnPowerRestrictionCell = (info: CellContext<TimesStopsRowNew, string | null>) => {
+    const {
+      availablePowerRestrictions: codes,
+      powerRestrictionBlocks: blocks,
+      onPowerRestrictionChange: onRestrictionChange,
+    } = info.table.options.meta!;
+    const value = info.getValue();
+    const row = info.row.original;
+
+    // On the first row of an incompatible block, display the propagated restriction
+    // in a lighter style so the user can see which code is causing the warning and
+    // edit it directly at the boundary.
+    const blockInfo = blocks.get(row.id);
+    const showPropagated =
+      value === null && blockInfo?.isBlockStart && blockInfo.propagatedValue !== null;
+    const displayedValue = showPropagated ? blockInfo.propagatedValue : value;
+
+    return (
+      <div
+        className={cx('power-restriction-select-wrapper', {
+          'power-restriction-propagated': showPropagated,
+        })}
+      >
+        <select
+          data-testid="power-restriction-select"
+          value={displayedValue ?? ''}
+          onChange={(e) => {
+            const v = e.target.value;
+            onRestrictionChange(row, v === '' ? null : v);
+          }}
+        >
+          <option value="" data-testid="power-restriction-option-empty"></option>
+          <option
+            value={NO_POWER_RESTRICTION}
+            data-testid={`power-restriction-option-${NO_POWER_RESTRICTION}`}
+          >
+            Ø
+          </option>
+          {codes.map((c) => (
+            <option key={c} value={c} data-testid={`power-restriction-option-${c}`}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <TriangleDown className="power-restriction-arrow" />
+      </div>
+    );
+  };
+
+  const returnDepartureTimeCell = (info: CellContext<TimesStopsRowNew, Date | null>) => {
+    const row = info.row.original;
+    return (
+      <TimeCell
+        ref={registerTimeCellRef(info.row.index, 'requestedDeparture')}
+        {...info}
+        referenceDate={getDepartureReferenceDate(row, startTime)}
+        prefillValue={row.computedDeparture}
+        onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedDeparture')}
+        onTabKeyDown={(direction) =>
+          focusRequestedCellOnTab(info.row.index, 'requestedDeparture', direction)
+        }
+        onCommit={(date, propagationMode) =>
+          info.table.options.meta!.onDepartureChange(row, date, propagationMode)
+        }
+      />
+    );
+  };
+
+  const returnReceptionOnCloseSignalCell = (
+    info: CellContext<TimesStopsRowNew, boolean | undefined>
+  ) => {
+    const { closedSignal, stopDuration, shortSlipDistance } = info.row.original;
+    const isDisabled = !stopDuration;
+
+    return (
+      <Checkbox
+        id={`closedSignal-${info.row.id}`}
+        data-testid="signal-reception-closed"
+        small
+        checked={!!closedSignal}
+        disabled={isDisabled}
+        onChange={() => {
+          if (!isDisabled) {
+            const newClosedSignal = !closedSignal;
+            // When unchecking closedSignal, also reset shortSlipDistance to false
+            const signal = onStopSignalToReceptionSignal(
+              newClosedSignal,
+              newClosedSignal ? shortSlipDistance : false
+            );
+            info.table.options.meta!.onReceptionSignalChange(info.row.original, signal);
+          }
+        }}
+      />
+    );
+  };
+
+  const returnStopDurationCell = (info: CellContext<TimesStopsRowNew, Duration | null>) => (
+    <DurationCell
+      ref={registerTimeCellRef(info.row.index, 'stopDuration')}
+      {...info}
+      onChange={(e) =>
+        info.table.options.meta!.onStopDurationChange(info.row.original, e.target.value)
+      }
+    />
+  );
+
+  const returnStepStatusCell = (info: CellContext<TimesStopsRowNew, unknown>) => {
+    if (info.table.options.meta!.isComputedDataPending) {
+      return <span data-testid="step-status">&nbsp;</span>;
+    }
+
+    const { stepStatus, computedArrival, requestedArrival, pathStepId } = info.row.original;
+    const isPathStep = Boolean(pathStepId);
+
+    const isSuccessSchedule =
+      requestedArrival &&
+      computedArrival &&
+      !(stepStatus === 'marginNotHonored') &&
+      !(stepStatus === 'scheduleNotHonored');
+
+    const className = cx({
+      'success-schedule': isPathStep && isSuccessSchedule,
+      'warning-schedule': isPathStep && stepStatus === 'scheduleNotHonored',
+      'warning-margin': isPathStep && stepStatus === 'marginNotHonored',
+      'invalid-path-step': stepStatus === 'invalidPathStep',
+    });
+
+    return (
+      <span data-testid="step-status" className={className}>
+        &nbsp;
+      </span>
+    );
+  };
+
+  const returnOPCell = (info: CellContext<TimesStopsRowNew, string>) => {
+    const { name, secondaryCode, pathStepId } = info.row.original;
+    return (
+      <>
+        {pathStepId && <span className="requested-point-dot" data-testid="op-name-dot" />}
+        <span
+          className="op-full-name"
+          data-testid="op-full-name"
+          title={`${name}${secondaryCode ? ` ${secondaryCode}` : ''}`}
+        >
+          {name}
+        </span>
+        {secondaryCode && (
+          <span className="secondary-code" data-testid="secondary-code">
+            {secondaryCode}
+          </span>
+        )}
+      </>
+    );
+  };
+
+  const returnOPOnPathIndexCell = (info: CellContext<TimesStopsRowNew, unknown>) => (
+    <span data-testid="row-index">{info.row.original.opOnPathIndex + 1}</span>
+  );
+
+  const returnTrackNameCell = (info: CellContext<TimesStopsRowNew, string>) => {
+    const { pathStepId, hasRequestedTrack } = info.row.original;
+    return (
+      <>
+        {pathStepId && hasRequestedTrack && (
+          <span className="requested-point-dot" data-testid="track-name-dot" />
+        )}
+        <span data-testid="track-name" title={info.getValue()}>
+          {info.getValue() ?? ''}
+        </span>
+      </>
+    );
+  };
+
+  const returnArrivalTimeCell = (info: CellContext<TimesStopsRowNew, Date | null>) => {
+    const row = info.row.original;
+    const { allRows, onArrivalChange: onArrival } = info.table.options.meta!;
+    return (
+      <TimeCell
+        ref={registerTimeCellRef(info.row.index, 'requestedArrival')}
+        {...info}
+        referenceDate={getArrivalReferenceDate(row, allRows, startTime)}
+        prefillValue={row.computedArrival}
+        onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedArrival')}
+        onTabKeyDown={(direction) =>
+          focusRequestedCellOnTab(info.row.index, 'requestedArrival', direction)
+        }
+        onCommit={(date, propagationMode) => onArrival(row, date, propagationMode)}
+        disableClear={info.row.index === 0}
+      />
+    );
+  };
+
+  const returnCalculatedArrivalTimeCell = (info: CellContext<TimesStopsRowNew, Date | null>) => {
+    if (info.table.options.meta!.isComputedDataPending) {
+      return <SkeletonLoader className="cell-loading-placeholder" />;
+    }
+    const value = info.getValue();
+    return <span data-testid="computed-arrival">{value ? formatLocalTime(value) : ''}</span>;
+  };
+
+  const returnCalculatedDepartureTimeCell = (info: CellContext<TimesStopsRowNew, Date | null>) => {
+    if (info.table.options.meta!.isComputedDataPending) {
+      return <SkeletonLoader className="cell-loading-placeholder" />;
+    }
+    const value = info.getValue();
+    const isEmpty = !value;
+    return (
+      <span data-testid="computed-departure" className={cx({ 'cell-empty-dot': isEmpty })}>
+        {isEmpty ? '•' : formatLocalTime(value)}
+      </span>
+    );
+  };
+
   const columns = useMemo(
     () => [
       columnHelper.display({
         id: 'opOnPathIndex',
         header: '',
-        cell: (info) => <span data-testid="row-index">{info.row.original.opOnPathIndex + 1}</span>,
+        cell: returnOPOnPathIndexCell,
         meta: {
           className: 'col-index computed',
         },
@@ -205,59 +500,14 @@ const TimesStopsTable = ({
       columnHelper.display({
         id: 'stepStatus',
         header: '',
-        cell: (info) => {
-          if (info.table.options.meta!.isComputedDataPending) {
-            return <span data-testid="step-status">&nbsp;</span>;
-          }
-
-          const { stepStatus, computedArrival, requestedArrival, pathStepId } = info.row.original;
-          const isPathStep = Boolean(pathStepId);
-
-          const isSuccessSchedule =
-            requestedArrival &&
-            computedArrival &&
-            !(stepStatus === 'marginNotHonored') &&
-            !(stepStatus === 'scheduleNotHonored');
-
-          const className = cx({
-            'success-schedule': isPathStep && isSuccessSchedule,
-            'warning-schedule': isPathStep && stepStatus === 'scheduleNotHonored',
-            'warning-margin': isPathStep && stepStatus === 'marginNotHonored',
-            'invalid-path-step': stepStatus === 'invalidPathStep',
-          });
-
-          return (
-            <span data-testid="step-status" className={className}>
-              &nbsp;
-            </span>
-          );
-        },
+        cell: returnStepStatusCell,
         meta: {
           className: 'col-step-status computed',
         },
       }),
       columnHelper.accessor('name', {
         header: () => t('operational_point'),
-        cell: (info) => {
-          const { name, secondaryCode, pathStepId } = info.row.original;
-          return (
-            <>
-              {pathStepId && <span className="requested-point-dot" data-testid="op-name-dot" />}
-              <span
-                className="op-full-name"
-                data-testid="op-full-name"
-                title={`${name}${secondaryCode ? ` ${secondaryCode}` : ''}`}
-              >
-                {name}
-              </span>
-              {secondaryCode && (
-                <span className="secondary-code" data-testid="secondary-code">
-                  {secondaryCode}
-                </span>
-              )}
-            </>
-          );
-        },
+        cell: returnOPCell,
         meta: {
           className: 'col-name computed',
           title: t('operational_point'),
@@ -265,19 +515,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('track', {
         header: () => t('trackName'),
-        cell: (info) => {
-          const { pathStepId, hasRequestedTrack } = info.row.original;
-          return (
-            <>
-              {pathStepId && hasRequestedTrack && (
-                <span className="requested-point-dot" data-testid="track-name-dot" />
-              )}
-              <span data-testid="track-name" title={info.getValue()}>
-                {info.getValue() ?? ''}
-              </span>
-            </>
-          );
-        },
+        cell: returnTrackNameCell,
         meta: {
           className: 'col-track computed',
           title: t('trackName'),
@@ -285,24 +523,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('requestedArrival', {
         header: () => t('arrivalTime'),
-        cell: (info) => {
-          const row = info.row.original;
-          const { allRows, onArrivalChange: onArrival } = info.table.options.meta!;
-          return (
-            <TimeCell
-              ref={registerTimeCellRef(info.row.index, 'requestedArrival')}
-              {...info}
-              referenceDate={getArrivalReferenceDate(row, allRows, startTime)}
-              prefillValue={row.computedArrival}
-              onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedArrival')}
-              onTabKeyDown={(direction) =>
-                focusRequestedCellOnTab(info.row.index, 'requestedArrival', direction)
-              }
-              onCommit={(date, propagationMode) => onArrival(row, date, propagationMode)}
-              disableClear={info.row.index === 0}
-            />
-          );
-        },
+        cell: returnArrivalTimeCell,
         meta: {
           className: 'col-requested-arrival col-with-clock-time',
           tabbable: true,
@@ -311,13 +532,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('computedArrival', {
         header: () => t('calculatedArrivalTime'),
-        cell: (info) => {
-          if (info.table.options.meta!.isComputedDataPending) {
-            return <SkeletonLoader className="cell-loading-placeholder" />;
-          }
-          const value = info.getValue();
-          return <span data-testid="computed-arrival">{value ? formatLocalTime(value) : ''}</span>;
-        },
+        cell: returnCalculatedArrivalTimeCell,
         meta: {
           className: 'col-computed-arrival col-with-clock-time computed',
           title: t('calculatedArrivalTime'),
@@ -325,15 +540,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('stopDuration', {
         header: () => t('stopTime'),
-        cell: (info) => (
-          <DurationCell
-            ref={registerTimeCellRef(info.row.index, 'stopDuration')}
-            {...info}
-            onChange={(e) =>
-              info.table.options.meta!.onStopDurationChange(info.row.original, e.target.value)
-            }
-          />
-        ),
+        cell: returnStopDurationCell,
         meta: {
           className: 'col-stop-duration col-with-duration',
           tabbable: true,
@@ -342,24 +549,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('requestedDeparture', {
         header: () => t('departureTime'),
-        cell: (info) => {
-          const row = info.row.original;
-          return (
-            <TimeCell
-              ref={registerTimeCellRef(info.row.index, 'requestedDeparture')}
-              {...info}
-              referenceDate={getDepartureReferenceDate(row, startTime)}
-              prefillValue={row.computedDeparture}
-              onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedDeparture')}
-              onTabKeyDown={(direction) =>
-                focusRequestedCellOnTab(info.row.index, 'requestedDeparture', direction)
-              }
-              onCommit={(date, propagationMode) =>
-                info.table.options.meta!.onDepartureChange(row, date, propagationMode)
-              }
-            />
-          );
-        },
+        cell: returnDepartureTimeCell,
         meta: {
           className: 'col-requested-departure col-with-clock-time',
           tabbable: true,
@@ -368,18 +558,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('computedDeparture', {
         header: () => t('calculatedDepartureTime'),
-        cell: (info) => {
-          if (info.table.options.meta!.isComputedDataPending) {
-            return <SkeletonLoader className="cell-loading-placeholder" />;
-          }
-          const value = info.getValue();
-          const isEmpty = !value;
-          return (
-            <span data-testid="computed-departure" className={cx({ 'cell-empty-dot': isEmpty })}>
-              {isEmpty ? '•' : formatLocalTime(value)}
-            </span>
-          );
-        },
+        cell: returnCalculatedDepartureTimeCell,
         meta: {
           className: 'col-computed-departure col-with-clock-time computed',
           title: t('calculatedDepartureTime'),
@@ -387,31 +566,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('closedSignal', {
         header: () => t('receptionOnClosedSignal'),
-        cell: (info) => {
-          const { closedSignal, stopDuration, shortSlipDistance } = info.row.original;
-          const isDisabled = !stopDuration;
-
-          return (
-            <Checkbox
-              id={`closedSignal-${info.row.id}`}
-              data-testid="signal-reception-closed"
-              small
-              checked={!!closedSignal}
-              disabled={isDisabled}
-              onChange={() => {
-                if (!isDisabled) {
-                  const newClosedSignal = !closedSignal;
-                  // When unchecking closedSignal, also reset shortSlipDistance to false
-                  const signal = onStopSignalToReceptionSignal(
-                    newClosedSignal,
-                    newClosedSignal ? shortSlipDistance : false
-                  );
-                  info.table.options.meta!.onReceptionSignalChange(info.row.original, signal);
-                }
-              }}
-            />
-          );
-        },
+        cell: returnReceptionOnCloseSignalCell,
         meta: {
           className: 'col-closed-signal col-with-checkbox',
           title: t('receptionOnClosedSignalFull'),
@@ -419,26 +574,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('shortSlipDistance', {
         header: () => t('shortSlipDistance'),
-        cell: (info) => {
-          const { closedSignal, shortSlipDistance } = info.row.original;
-          const isDisabled = !closedSignal;
-
-          return (
-            <Checkbox
-              id={`shortSlipDistance-${info.row.id}`}
-              data-testid="short-slip-distance"
-              small
-              checked={!!shortSlipDistance}
-              disabled={isDisabled}
-              onChange={() => {
-                if (!isDisabled) {
-                  const signal = onStopSignalToReceptionSignal(closedSignal, !shortSlipDistance);
-                  info.table.options.meta!.onReceptionSignalChange(info.row.original, signal);
-                }
-              }}
-            />
-          );
-        },
+        cell: returnShortSlipDistanceCell,
         meta: {
           className: 'col-short-slip-distance col-with-checkbox',
           title: t('shortSlipDistance'),
@@ -446,87 +582,14 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('powerRestriction', {
         header: () => t('powerRestriction'),
-        cell: (info) => {
-          const {
-            availablePowerRestrictions: codes,
-            powerRestrictionBlocks: blocks,
-            onPowerRestrictionChange: onRestrictionChange,
-          } = info.table.options.meta!;
-          const value = info.getValue();
-          const row = info.row.original;
-
-          // On the first row of an incompatible block, display the propagated restriction
-          // in a lighter style so the user can see which code is causing the warning and
-          // edit it directly at the boundary.
-          const blockInfo = blocks.get(row.id);
-          const showPropagated =
-            value === null && blockInfo?.isBlockStart && blockInfo.propagatedValue !== null;
-          const displayedValue = showPropagated ? blockInfo.propagatedValue : value;
-
-          return (
-            <div
-              className={cx('power-restriction-select-wrapper', {
-                'power-restriction-propagated': showPropagated,
-              })}
-            >
-              <select
-                data-testid="power-restriction-select"
-                value={displayedValue ?? ''}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  onRestrictionChange(row, v === '' ? null : v);
-                }}
-              >
-                <option value="" data-testid="power-restriction-option-empty"></option>
-                <option
-                  value={NO_POWER_RESTRICTION}
-                  data-testid={`power-restriction-option-${NO_POWER_RESTRICTION}`}
-                >
-                  Ø
-                </option>
-                {codes.map((c) => (
-                  <option key={c} value={c} data-testid={`power-restriction-option-${c}`}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-              <TriangleDown className="power-restriction-arrow" />
-            </div>
-          );
-        },
+        cell: returnPowerRestrictionCell,
         meta: {
           className: 'col-power-restriction',
         },
       }),
       columnHelper.accessor('requestedTheoreticalMargin', {
         header: () => t('requestedTheoreticalMargin'),
-        cell: (info) => {
-          const { allRows } = info.table.options.meta!;
-          const row = info.row.original;
-          const isFirstRow = info.row.index === 0;
-          const isLastRow = info.row.index === allRows.length - 1;
-
-          if (isLastRow) return null;
-
-          const marginValue =
-            isScheduledOP(row) || !!row.requestedTheoreticalMargin
-              ? row.requestedTheoreticalMargin
-              : null;
-          const isInherited = !row.isTheoreticalMarginBoundary || !row.requestedTheoreticalMargin;
-
-          return (
-            <div data-testid="requested-theoretical-margin">
-              <MarginCell
-                data-testid="margin-cell-editable"
-                marginValue={marginValue ?? null}
-                editable={!isLastRow}
-                isInherited={isFirstRow ? false : isInherited}
-                isFirstRow={isFirstRow}
-                onCommit={(value) => info.table.options.meta!.onRequestedMarginChange(row, value)}
-              />
-            </div>
-          );
-        },
+        cell: returnRequestTheoreticalMarginCell,
         meta: {
           className: 'col-requested-theoretical-margin',
           title: t('requestedTheoreticalMargin'),
@@ -534,21 +597,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('computedTheoreticalMarginSeconds', {
         header: () => t('computedTheoreticalMargin'),
-        cell: (info) => {
-          const { allRows } = info.table.options.meta!;
-          const isLastRow = info.row.index === allRows.length - 1;
-          if (info.table.options.meta!.isComputedDataPending && !isLastRow) {
-            return <SkeletonLoader className="cell-loading-placeholder" />;
-          }
-          const marginValue = info.getValue() ?? null;
-          return (
-            <MarginCell
-              data-testid="computed-theoretical-margin"
-              marginValue={marginValue}
-              editable={false}
-            />
-          );
-        },
+        cell: (info) => returnMarginCell({ info, dataTestId: 'computed-theoretical-margin' }),
         meta: {
           className: 'col-computed-theoretical-margin computed computed-margin',
           title: t('computedTheoreticalMargin'),
@@ -556,17 +605,7 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('realMargin', {
         header: () => t('realMargin'),
-        cell: (info) => {
-          const { allRows } = info.table.options.meta!;
-          const isLastRow = info.row.index === allRows.length - 1;
-          if (info.table.options.meta!.isComputedDataPending && !isLastRow) {
-            return <SkeletonLoader className="cell-loading-placeholder" />;
-          }
-          const marginValue = info.getValue() ?? null;
-          return (
-            <MarginCell data-testid="real-margin" marginValue={marginValue} editable={false} />
-          );
-        },
+        cell: (info) => returnMarginCell({ info, dataTestId: 'real-margin' }),
         meta: {
           className: 'col-real-margin computed computed-margin',
           title: t('realMargin'),
@@ -574,22 +613,8 @@ const TimesStopsTable = ({
       }),
       columnHelper.accessor('marginsDifference', {
         header: () => t('diffMargins'),
-        cell: (info) => {
-          const { allRows } = info.table.options.meta!;
-          const isLastRow = info.row.index === allRows.length - 1;
-          if (info.table.options.meta!.isComputedDataPending && !isLastRow) {
-            return <SkeletonLoader className="cell-loading-placeholder" />;
-          }
-          const marginValue = info.getValue() ?? null;
-          return (
-            <MarginCell
-              data-testid="margins-difference"
-              marginValue={marginValue}
-              showPolarity
-              editable={false}
-            />
-          );
-        },
+        cell: (info) =>
+          returnMarginCell({ info, showPolarity: true, dataTestId: 'margins-difference' }),
         meta: {
           className: 'col-margins-difference computed computed-margin',
           title: t('diffMargins'),

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/split.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/split.stories.tsx
@@ -9,6 +9,7 @@ import {
   SpaceTimeChart,
   SpaceTimeChartCanvasContext,
   type SpaceTimeChartContextType,
+  type SplitPoint,
   useDraw,
   useManchetteWithSpaceTimeChart,
 } from '@osrd-project/ui-charts';
@@ -88,6 +89,8 @@ const FlatStep = ({ position }: { position: number }) => {
   return null;
 };
 
+const NO_SPLIT_POINTS: SplitPoint[] = [];
+
 /**
  * This component shows how to use the useManchetteWithSpaceTimeChart hook with split points:
  */
@@ -96,7 +99,7 @@ const SplitManchetteWithSpaceTimeChartWrapper = ({
   paths,
   selectedTrain,
   height = 561,
-  splitPoints = [],
+  splitPoints = NO_SPLIT_POINTS,
 }: {
   waypoints: typeof SAMPLE_WAYPOINTS;
   paths: typeof SAMPLE_CHART_PATHS;

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/horizontal-zoom.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/horizontal-zoom.stories.tsx
@@ -25,6 +25,10 @@ const MAX_ZOOM = 100;
 const MIN_ZOOM_MS_PER_PX = 600000;
 const MAX_ZOOM_MS_PER_PX = 625;
 const DEFAULT_ZOOM_MS_PER_PX = 7500;
+
+const NO_OPERATIONAL_POINTS: OperationalPoint[] = [];
+const NO_PATHS: (PathData & { color: string })[] = [];
+
 type SpaceTimeHorizontalZoomWrapperProps = {
   offset: number;
   operationalPoints: OperationalPoint[];
@@ -40,8 +44,8 @@ const timeScaleToZoomValue = (timeScale: number) =>
 
 const SpaceTimeHorizontalZoomWrapper = ({
   offset,
-  operationalPoints = [],
-  paths = [],
+  operationalPoints = NO_OPERATIONAL_POINTS,
+  paths = NO_PATHS,
 }: SpaceTimeHorizontalZoomWrapperProps) => {
   const [state, setState] = useState<{
     zoomValue: number;

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
@@ -38,6 +38,10 @@ const DEFAULT_ZOOM_MS_PER_PX = 10000;
 const MIN_SPACE_ZOOM = 10 * KILOMETER;
 const MAX_SPACE_ZOOM = 0.01 * KILOMETER;
 const DEFAULT_SPACE_ZOOM = 0.3 * KILOMETER;
+
+const NO_OPERATIONAL_POINTS: OperationalPoint[] = [];
+const NO_PATHS: (PathData & { color: string })[] = [];
+
 type SpaceTimeHorizontalZoomWrapperProps = {
   swapAxes: boolean;
   spaceOrigin: number;
@@ -83,8 +87,8 @@ const RectangleZoomWrapper = ({
   spaceOrigin,
   xOffset,
   yOffset,
-  operationalPoints = [],
-  paths = [],
+  operationalPoints = NO_OPERATIONAL_POINTS,
+  paths = NO_PATHS,
 }: SpaceTimeHorizontalZoomWrapperProps) => {
   const [state, setState] = useState<StoryState>({
     timeZoomValue: timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX),

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/work-schedules.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/work-schedules.stories.tsx
@@ -48,6 +48,9 @@ const SAMPLE_WORK_SCHEDULES: WorkSchedule[] = [
 
 const DEFAULT_HEIGHT = 550;
 
+const NO_OPERATIONAL_POINTS: OperationalPoint[] = [];
+const NO_PATHS: (PathData & { color: string })[] = [];
+
 type WorkSchedulesWrapperProps = {
   operationalPoints: OperationalPoint[];
   paths: (PathData & { color: string })[];
@@ -55,8 +58,8 @@ type WorkSchedulesWrapperProps = {
 };
 
 const WorkSchedulesWrapper = ({
-  operationalPoints = [],
-  paths = [],
+  operationalPoints = NO_OPERATIONAL_POINTS,
+  paths = NO_PATHS,
   workSchedules,
 }: WorkSchedulesWrapperProps) => {
   const [state, setState] = useState<{

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -243,6 +243,8 @@ const UnitField = function UnitField({
   );
 };
 
+const DEFAULT_UNITS: UnitProps[] = ['m', 's'];
+
 /**
  * Duration units can be set up via their shorthand strings (h, m, s, ms)
  * or more precisely through objects.
@@ -250,7 +252,7 @@ const UnitField = function UnitField({
  */
 const DurationInput = ({
   id,
-  units = ['m', 's'],
+  units = DEFAULT_UNITS,
   value = 0,
   onChange,
   padChar = '0',

--- a/front/ui/ui-core/src/components/Input.tsx
+++ b/front/ui/ui-core/src/components/Input.tsx
@@ -54,6 +54,8 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
     testIdPrefix?: string;
   };
 
+const DEFAULT_ICONS: IconConfig[] = [];
+
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     {
@@ -70,7 +72,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       narrow,
       inputFieldWrapperClassname = '',
       small = false,
-      withIcons = [],
+      withIcons = DEFAULT_ICONS,
       onKeyUp,
       onBlur,
       onCloseStatusMessage,

--- a/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
+++ b/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
@@ -7,6 +7,11 @@ import { type StatusWithMessage } from '../StatusMessage';
 import { TOLERANCE_RANGES } from './consts';
 import ToleranceRangeGrid from './ToleranceRangeGrid';
 
+const DEFAULT_TOLERANCE_VALUES = {
+  minusTolerance: TOLERANCE_RANGES[0].value,
+  plusTolerance: TOLERANCE_RANGES[0].value,
+};
+
 export type ToleranceValues = {
   minusTolerance: number;
   plusTolerance: number;
@@ -21,10 +26,7 @@ export type TolerancePickerProps = Omit<InputProps, 'value'> & {
 
 const TolerancePicker = ({
   onToleranceChange,
-  toleranceValues: { minusTolerance, plusTolerance } = {
-    minusTolerance: TOLERANCE_RANGES[0].value,
-    plusTolerance: TOLERANCE_RANGES[0].value,
-  },
+  toleranceValues: { minusTolerance, plusTolerance } = DEFAULT_TOLERANCE_VALUES,
   translateWarningMessage,
   testIdPrefix,
   ...inputProps

--- a/front/ui/ui-warped-map/src/components/WarpedMap.tsx
+++ b/front/ui/ui-warped-map/src/components/WarpedMap.tsx
@@ -13,6 +13,7 @@ import Loader from './Loader';
 import TransformedDataMap from './TransformedDataMap';
 
 const TIME_LABEL = 'Warping data';
+const PARTIAL_COMPONENTS_DEFAULTS = {};
 
 interface PathStatePayload {
   path: Feature<LineString>;
@@ -45,7 +46,7 @@ const WarpedMap = ({
   path,
   pathLayer,
   sources,
-  components: partialComponents = {},
+  components: partialComponents = PARTIAL_COMPONENTS_DEFAULTS,
   mapStyle,
   warpingOptions,
   log,


### PR DESCRIPTION
For the oxlint update in version 1.69, changes had to be made to comply with the rules:

  - [no-object-type-as-default-prop](https://oxc.rs/docs/guide/usage/linter/rules/react/no-object-type-as-default-prop.html#react-no-object-type-as-default-prop-oxlint)
  -  [no-unstable-nested-components ](https://oxc.rs/docs/guide/usage/linter/rules/react/no-unstable-nested-components.html#react-no-unstable-nested-components-oxlint)
  
closes #17174, closes #17237 