### PR TITLE
Display selected train in tod

### DIFF
--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -3,6 +3,7 @@ import type { TrainMainCategory } from 'common/api/osrdEditoastApi';
 import type { CategoryColors } from './types';
 
 export const SELECTED_CURVE_COLOR = '#1844EF';
+export const SELECTED_CURVE_SOFT_COLOR = '#72A8F7'; // Used for the TOD occupancy halo.
 export const SELECTED_CURVE_OUTLINE_COLOR = 'rgba(24, 68, 239, 0.1)';
 export const DRAGGED_CURVE_COLOR = '#180F47';
 export const DRAGGED_CURVE_OUTLINE_COLOR = 'rgba(255, 247, 0, 0.4)';
@@ -12,17 +13,23 @@ export const DEFAULT_TRAIN_PATH_COLORS: CategoryColors = {
   base: '#797671',
   strong: '#494641',
   surface: '#EBEBEA',
+  soft: '#b6b2af',
 };
 
 export const TRAIN_MAIN_CATEGORY_PATH_COLORS: Record<TrainMainCategory, CategoryColors> = {
-  HIGH_SPEED_TRAIN: { base: '#E5221A', strong: '#912420', surface: '#FAE7E6' },
-  INTERCITY_TRAIN: { base: '#B2539E', strong: '#732963', surface: '#FAE6F6' },
-  REGIONAL_TRAIN: { base: '#C75300', strong: '#803500', surface: '#FFE7D6' },
-  NIGHT_TRAIN: { base: '#8757E6', strong: '#58318F', surface: '#E5E7FF' },
-  COMMUTER_TRAIN: { base: '#127DB8', strong: '#165070', surface: '#D9F2FF' },
-  FREIGHT_TRAIN: { base: '#54823B', strong: '#2C4F19', surface: '#E4EDDF' },
-  FAST_FREIGHT_TRAIN: { base: '#13857B', strong: '#085953', surface: '#DAF7EE' },
-  TRAM_TRAIN: { base: '#687C5C', strong: '#444D3C', surface: '#E1EDD8' },
-  TOURISTIC_TRAIN: { base: '#8A714B', strong: '#594525', surface: '#EEE7D9' },
-  WORK_TRAIN: { base: '#996E00', strong: '#634A00', surface: '#FCEEC2' },
+  HIGH_SPEED_TRAIN: { base: '#E5221A', strong: '#912420', surface: '#FAE7E6', soft: '#ff7873' },
+  INTERCITY_TRAIN: { base: '#B2539E', strong: '#732963', surface: '#FAE6F6', soft: '#ea94d8' },
+  REGIONAL_TRAIN: { base: '#C75300', strong: '#803500', surface: '#FFE7D6', soft: '#ff8b38' },
+  NIGHT_TRAIN: { base: '#8757E6', strong: '#58318F', surface: '#E5E7FF', soft: '#b3a1ff' },
+  COMMUTER_TRAIN: { base: '#127DB8', strong: '#165070', surface: '#D9F2FF', soft: '#45abe2' },
+  FREIGHT_TRAIN: { base: '#54823B', strong: '#2C4F19', surface: '#E4EDDF', soft: '#86ba68' },
+  FAST_FREIGHT_TRAIN: {
+    base: '#13857B',
+    strong: '#085953',
+    surface: '#DAF7EE',
+    soft: '#55b7af',
+  },
+  TRAM_TRAIN: { base: '#687C5C', strong: '#444D3C', surface: '#E1EDD8', soft: '#93ad82' },
+  TOURISTIC_TRAIN: { base: '#8A714B', strong: '#594525', surface: '#EEE7D9', soft: '#b39e7e' },
+  WORK_TRAIN: { base: '#996E00', strong: '#634A00', surface: '#FCEEC2', soft: '#ffb700' },
 };

--- a/front/src/applications/operationalStudies/helpers/getSubCategoryColors.ts
+++ b/front/src/applications/operationalStudies/helpers/getSubCategoryColors.ts
@@ -1,0 +1,23 @@
+import chroma from 'chroma-js';
+
+import type { SubCategory } from 'common/api/osrdEditoastApi';
+
+import { DEFAULT_TRAIN_PATH_COLORS } from '../consts';
+import type { CategoryColors } from '../types';
+
+/**
+ * Builds the train path colors for a sub category.
+ *
+ * TODO: drop the workaround once the back exposes a `soft` color for sub categories.
+ */
+const getSubCategoryColors = (subCategory: SubCategory): CategoryColors => ({
+  ...DEFAULT_TRAIN_PATH_COLORS,
+  base: subCategory.color || DEFAULT_TRAIN_PATH_COLORS.base,
+  strong: subCategory.hovered_color || DEFAULT_TRAIN_PATH_COLORS.strong,
+  surface: subCategory.background_color || DEFAULT_TRAIN_PATH_COLORS.surface,
+  ...(subCategory.color && {
+    soft: chroma(subCategory.color).brighten(1.3).hex(),
+  }),
+});
+
+export default getSubCategoryColors;

--- a/front/src/applications/operationalStudies/hooks/__tests__/useCategoryColors.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useCategoryColors.spec.ts
@@ -60,6 +60,7 @@ describe('useCategoryColors', () => {
       base: '#ff0000',
       strong: '#cc0000',
       surface: '#ffe0e0',
+      soft: '#ff6b43',
     });
     expect(result.current.currentSubCategory).toEqual(mockSubCategories[0]);
   });

--- a/front/src/applications/operationalStudies/hooks/useCategoryColors.ts
+++ b/front/src/applications/operationalStudies/hooks/useCategoryColors.ts
@@ -5,6 +5,7 @@ import { useSubCategoryContext } from 'common/SubCategoryContext';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 
 import { DEFAULT_TRAIN_PATH_COLORS, TRAIN_MAIN_CATEGORY_PATH_COLORS } from '../consts';
+import getSubCategoryColors from '../helpers/getSubCategoryColors';
 import type { CategoryColors } from '../types';
 
 const useCategoryColors = (category: TrainCategory | null | undefined) => {
@@ -21,11 +22,7 @@ const useCategoryColors = (category: TrainCategory | null | undefined) => {
     }
 
     if (category && !isMainCategory(category) && currentSubCategory) {
-      return {
-        base: currentSubCategory.color || DEFAULT_TRAIN_PATH_COLORS.base,
-        strong: currentSubCategory.hovered_color || DEFAULT_TRAIN_PATH_COLORS.strong,
-        surface: currentSubCategory.background_color || DEFAULT_TRAIN_PATH_COLORS.surface,
-      };
+      return getSubCategoryColors(currentSubCategory);
     }
 
     return DEFAULT_TRAIN_PATH_COLORS;

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -173,7 +173,13 @@ export type StudyCardDetails = SearchResultItemStudy | StudyWithScenarios;
 
 export type ScenarioCardDetails = SearchResultItemScenario | ScenarioWithDetails;
 
-export type CategoryColors = { base: string; strong: string; surface: string };
+export type CategoryColors = {
+  base: string;
+  strong: string;
+  surface: string;
+  // Soft accent (palette shade 30), e.g. the GOV hover outline
+  soft: string;
+};
 
 export type ItineraryPathProperties = PathProperties & {
   length: number;

--- a/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import type { OccupancyZone, Track } from '@osrd-project/ui-charts';
+import type { Track } from '@osrd-project/ui-charts';
 import { v4 as uuidV4 } from 'uuid';
 
 import {
@@ -11,6 +11,7 @@ import {
   type TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import { matchPathStepAndOp } from 'modules/pathfinding/utils';
+import type { MovableOccupancyZone } from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones';
 import type { DeployedWaypoint } from 'modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import { findTrainScheduleAndException } from 'modules/trainSchedule/helpers/pacedTrain';
@@ -173,7 +174,12 @@ export default function useOccupancyZoneDrop({
   );
 
   return useCallback(
-    async (waypointId: string, trainId: TrainId, occupancyZone: OccupancyZone, track: Track) => {
+    async (
+      waypointId: string,
+      trainId: TrainId,
+      occupancyZone: MovableOccupancyZone,
+      track: Track
+    ) => {
       const occupancyZoneStartTime = new Date(occupancyZone.startTime);
 
       const { trainSchedule, exception } = findTrainScheduleAndException(

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -18,8 +18,8 @@ import {
   isPointPickingElement,
   isInteractiveWaypoint,
   isOccupancyPickingElement,
-  type Track,
   type OccupancyZone,
+  type Track,
 } from '@osrd-project/ui-charts';
 import { Slider } from '@osrd-project/ui-core';
 import cx from 'classnames';
@@ -82,6 +82,7 @@ import { getOccupancyBlocks } from './helpers/utils';
 import {
   parseOccupancyZonePathId,
   formatOccupancyZonePathId,
+  type MovableOccupancyZone,
   type OccupancyZoneReference,
 } from './helpers/zones';
 import ProjectionLoadingMessage from './ProjectionLoadingMessage';
@@ -100,7 +101,7 @@ type SpaceTimeChartWrapperBaseProps = {
     operationalPointId: string;
     operationalPointPosition: number;
     operationalPointName?: string;
-    zones?: OccupancyZone[];
+    zones?: MovableOccupancyZone[];
     tracks?: Track[];
     loading?: boolean;
   }[];
@@ -368,35 +369,31 @@ const SpaceTimeChartWrapper = ({
 
   const splitPoints = useMemo<SplitPoint[]>(
     () =>
-      buildSplitPoints(
-        trackOccupancyDiagramsData,
+      buildSplitPoints({
+        occupancyZonesLayers: trackOccupancyDiagramsData,
         paths,
-        hoveredItem,
-        !!draggingState,
         activeWaypointRef,
-        selectedTrainId,
+        selectedTrain: selection,
+        panelMode: panelSelectionMode,
         onCloseOccupancyLayer,
         handleWaypointClick,
         activeWaypointId,
         hoveredTrainIdForChart,
-        hoveredTrainId,
         isDraggingOccupancyZoneId,
-        dragOverTrackId,
-        setDragOverTrackId
-      ),
+        activeTrackId: dragOverTrackId,
+        onTrackDragOver: setDragOverTrackId,
+      }),
     [
       trackOccupancyDiagramsData,
       paths,
-      hoveredItem,
-      draggingState,
       subCategories,
       trainSchedulesWithDetails,
-      selectedTrainId,
+      selection,
+      panelSelectionMode,
       onCloseOccupancyLayer,
       handleWaypointClick,
       activeWaypointRef,
       hoveredTrainIdForChart,
-      hoveredTrainId,
       isDraggingOccupancyZoneId,
       dragOverTrackId,
       setDragOverTrackId,
@@ -565,6 +562,8 @@ const SpaceTimeChartWrapper = ({
 
   const handlePanelModeChange = (mode: PanelSelectionMode) => {
     setPanelSelectionMode(mode);
+
+    const by = selectedTrainBy === 'tod' ? 'tod' : 'std';
     if (mode === 'single') {
       const singleId =
         lastClickedOccurrenceId ??
@@ -572,55 +571,61 @@ const SpaceTimeChartWrapper = ({
           ? getFirstActiveOccurrenceId(selectedTrain, selectedTrainScheduleId)
           : undefined);
       if (singleId) {
-        dispatch(updateSelectedTrain({ id: singleId, by: 'std' }));
+        dispatch(updateSelectedTrain({ id: singleId, by }));
       }
       return;
     }
     if (selectedTrainScheduleId) {
-      dispatch(updateSelectedTrain({ id: selectedTrainScheduleId, by: 'std' }));
+      dispatch(updateSelectedTrain({ id: selectedTrainScheduleId, by }));
     }
   };
 
+  const commitSelection = (id: TrainId, by: 'std' | 'tod', panelMode: PanelSelectionMode) => {
+    if (selectedTrainId === id && selectedTrainBy === by) return;
+    if (isOccurrenceId(id)) setLastClickedOccurrenceId(id);
+    setPanelSelectionMode(panelMode);
+    dispatch(updateSelectedTrain({ id, by }));
+  };
+
   const handleClick: SpaceTimeChartProps['onClick'] = ({ event }) => {
+    if (draggingState) return;
+
+    const element = hoveredItem?.element;
+
     if (
-      !draggingState &&
-      selectedTrainId &&
-      (!hoveredItem ||
-        (!isSegmentPickingElement(hoveredItem.element) &&
-          !isPointPickingElement(hoveredItem.element)))
+      !element ||
+      (!isSegmentPickingElement(element) &&
+        !isPointPickingElement(element) &&
+        !isOccupancyPickingElement(element))
     ) {
-      dispatch(updateSelectedTrain({ id: selectedTrainId, by: 'timetable' }));
+      // Click outside any train → deselect (return to timetable selection).
+      if (selectedTrainId) dispatch(updateSelectedTrain({ id: selectedTrainId, by: 'timetable' }));
       return;
     }
-    if (
-      !draggingState &&
-      hoveredItem &&
-      (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
-    ) {
-      const clickedTrainId = hoveredItem.element.pathId;
+
+    // click on any STD curve
+    if (isSegmentPickingElement(element) || isPointPickingElement(element)) {
+      const clickedTrainId = element.pathId;
       if (isTrainId(clickedTrainId)) {
-        const { exception: clickedException } = findTrainScheduleAndException(
+        const { exception } = findTrainScheduleAndException(
           trainSchedulesWithDetails ?? [],
           clickedTrainId
         );
-        const isStartTimeException = !!clickedException?.start_time;
-
         // By default selecting an occurrence selects its whole paced train; alt-click (or
         // clicking a start_time exception) isolates the single occurrence.
-        const idToDispatch =
-          !event.altKey && !isStartTimeException
-            ? extractTrainScheduleIdFromTrainId(clickedTrainId)
-            : clickedTrainId;
-
+        const isolate = event.altKey || !!exception?.start_time;
+        const id = isolate ? clickedTrainId : extractTrainScheduleIdFromTrainId(clickedTrainId);
         setLastClickedOccurrenceId(isOccurrenceId(clickedTrainId) ? clickedTrainId : undefined);
-
-        if (selectedTrainId !== idToDispatch || selectedTrainBy !== 'std') {
-          // idToDispatch is an occurrence only on alt-click or a start_time exception:
-          // isolate it in the panel.
-          setPanelSelectionMode(isOccurrenceId(idToDispatch) ? 'single' : 'compliant');
-          dispatch(updateSelectedTrain({ id: idToDispatch, by: 'std' }));
-        }
+        commitSelection(id, 'std', isOccurrenceId(id) ? 'single' : 'compliant');
       }
+      return;
+    }
+
+    // Click on a TOD occupancy zone.
+    if (isOccupancyPickingElement(element)) {
+      const { trainId } = parseOccupancyZonePathId(element.pathId);
+      const { exception } = findTrainScheduleAndException(trainSchedulesWithDetails ?? [], trainId);
+      commitSelection(trainId, 'tod', exception?.path_and_schedule ? 'single' : 'compliant');
     }
   };
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -18,7 +18,6 @@ import {
   isPointPickingElement,
   isInteractiveWaypoint,
   isOccupancyPickingElement,
-  type OccupancyZone,
   type Track,
 } from '@osrd-project/ui-charts';
 import { Slider } from '@osrd-project/ui-core';
@@ -127,7 +126,7 @@ type SpaceTimeChartWrapperBaseProps = {
   onOccupancyZoneDrop?: (
     waypointId: string,
     trainId: TrainId,
-    zone: OccupancyZone,
+    zone: MovableOccupancyZone,
     track: Track
   ) => void;
   selectedProjectionId: TrainId;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
@@ -5,8 +5,6 @@ import {
   TrackOccupancyCanvas,
   TrackOccupancyManchette,
   WaypointComponent,
-  type HoveredItem,
-  type OccupancyZone,
   type SplitPoint,
   type Track,
 } from '@osrd-project/ui-charts';
@@ -14,18 +12,20 @@ import { keyBy, sortBy } from 'lodash';
 
 import type { CategoryColors } from 'applications/operationalStudies/types';
 import { Spinner } from 'common/Loaders';
+import getPathStyleV2 from 'modules/simulationResult/helpers/getPathStyleV2';
 import type { TrainId } from 'reducers/osrdconf/types';
+import type { SelectedTrain } from 'reducers/simulationResults/types';
 import { extractTrainScheduleIdFromOccurrenceId, isOccurrenceId } from 'utils/trainId';
 
-import getPathStyle from './helpers/getPathStyle';
-import { parseOccupancyZonePathId, formatOccupancyZonePathId } from './helpers/zones';
+import type { PanelSelectionMode } from './CurveSelectionSidePanel';
+import type { MovableOccupancyZone } from './helpers/zones';
 
 type OccupancyZonesLayers = {
   waypointId: string;
   operationalPointId: string;
   operationalPointPosition: number;
   operationalPointName?: string;
-  zones?: OccupancyZone[];
+  zones?: MovableOccupancyZone[];
   tracks?: Track[];
   loading?: boolean;
 };
@@ -35,34 +35,47 @@ type Path = {
   label: string;
   points: { time: number; position: number }[];
   colors: CategoryColors;
+  isSimulated?: boolean;
 };
 
-export function buildSplitPoints(
-  occupancyZonesLayers: OccupancyZonesLayers[] | undefined,
-  paths: Path[],
-  hoveredItem: HoveredItem | null,
-  isDragging: boolean,
-  activeWaypointRef?: React.RefObject<HTMLDivElement | null>,
-  selectedTrainId?: TrainId,
-  onCloseOccupancyLayer?: (waypointId: string) => void,
-  handleWaypointClick?: (waypointId: string) => void,
-  activeWaypointId?: string,
-  hoveredTrainIdForChart?: TrainId,
-  hoveredTrainId?: TrainId,
-  isDraggingOccupancyZoneId?: (waypointId: string, trainId: TrainId) => boolean,
-  activeTrackId?: string,
-  onTrackDragOver?: (trackId: string | undefined) => void
-): SplitPoint[] {
+type BuildSplitPointsProps = {
+  occupancyZonesLayers: OccupancyZonesLayers[] | undefined;
+  paths: Path[];
+  activeWaypointRef?: React.RefObject<HTMLDivElement | null>;
+  selectedTrain?: SelectedTrain;
+  panelMode?: PanelSelectionMode;
+  onCloseOccupancyLayer?: (waypointId: string) => void;
+  handleWaypointClick?: (waypointId: string) => void;
+  activeWaypointId?: string;
+  hoveredTrainIdForChart?: TrainId;
+  isDraggingOccupancyZoneId?: (waypointId: string, trainId: TrainId) => boolean;
+  activeTrackId?: string;
+  onTrackDragOver?: (trackId: string | undefined) => void;
+};
+
+export function buildSplitPoints({
+  occupancyZonesLayers,
+  paths,
+  activeWaypointRef,
+  selectedTrain,
+  panelMode,
+  onCloseOccupancyLayer,
+  handleWaypointClick,
+  activeWaypointId,
+  hoveredTrainIdForChart,
+  isDraggingOccupancyZoneId,
+  activeTrackId,
+  onTrackDragOver,
+}: BuildSplitPointsProps): SplitPoint[] {
   if (!occupancyZonesLayers?.length) return [];
 
   const pathsById = keyBy(paths, ({ id }) => id);
 
-  const countZonesByTrainScheduleId = (zones: OccupancyZone[] = []) => {
+  const countZonesByTrainScheduleId = (zones: MovableOccupancyZone[] = []) => {
     const counts = new Map<TrainId, Map<string, number>>();
     for (const zone of zones) {
-      const { trainId } = parseOccupancyZonePathId(zone.pathId);
-      if (isOccurrenceId(trainId)) {
-        const trainScheduleId = extractTrainScheduleIdFromOccurrenceId(trainId);
+      if (isOccurrenceId(zone.trainId)) {
+        const trainScheduleId = extractTrainScheduleIdFromOccurrenceId(zone.trainId);
         const trainScheduleIdCounts = counts.get(trainScheduleId) ?? new Map();
         trainScheduleIdCounts.set(zone.trackId, (trainScheduleIdCounts.get(zone.trackId) ?? 0) + 1);
         counts.set(trainScheduleId, trainScheduleIdCounts);
@@ -84,35 +97,50 @@ export function buildSplitPoints(
       tracks,
       loading,
     }) => {
-      const occupancyZones = (zones || []).map((zone) => {
-        const baseZones = zones ?? [];
-        const zonesCountByTrainScheduleId = countZonesByTrainScheduleId(baseZones);
-        const { trainId } = parseOccupancyZonePathId(zone.pathId);
+      const baseZones = zones ?? [];
+      const zonesCountByTrainScheduleId = countZonesByTrainScheduleId(baseZones);
 
-        const isHovered = hoveredTrainIdForChart === trainId;
-        const isSelected = selectedTrainId === trainId;
+      const occupancyZones = baseZones.flatMap((zone) => {
+        const isHovered = hoveredTrainIdForChart === zone.trainId;
         let totalOccurrencesOnTrack = 0;
-        if (isOccurrenceId(trainId)) {
-          const trainScheduleId = extractTrainScheduleIdFromOccurrenceId(trainId);
+        if (isOccurrenceId(zone.trainId)) {
+          const trainScheduleId = extractTrainScheduleIdFromOccurrenceId(zone.trainId);
           totalOccurrencesOnTrack =
             zonesCountByTrainScheduleId.get(trainScheduleId)?.get(zone.trackId) ?? 0;
         }
-        const path = pathsById[trainId];
-        if (!path) return zone;
-        const style = getPathStyle(hoveredItem, path, isDragging, selectedTrainId, hoveredTrainId);
-        return {
-          ...zone,
-          trailingText:
-            isHovered && totalOccurrencesOnTrack > 1
-              ? `+${Math.max(0, totalOccurrencesOnTrack - 1)}`
+
+        const path = pathsById[zone.trainId];
+        // No matching curve on the STD (e.g. a disabled occurrence): skip this zone instead of
+        // showing it in the TOD without a curveStyle.
+        if (!path) return [];
+
+        const curveStyle = getPathStyleV2(
+          {
+            chart: 'tod',
+            train: { id: zone.trainId, exceptionType: zone.exceptionType },
+            selection: selectedTrain,
+            panelMode,
+            hover: hoveredTrainIdForChart
+              ? {
+                  trainId: hoveredTrainIdForChart,
+                  from: 'tod',
+                  exceptionType: zone.exceptionType,
+                }
               : undefined,
-          curveStyle: {
-            ...zone.curveStyle,
-            color: style.color,
-            width: isSelected || isHovered ? 2 : undefined,
-            opacity: 1,
           },
-        };
+          { colors: path.colors, isSimulated: path.isSimulated }
+        );
+
+        return [
+          {
+            ...zone,
+            trailingText:
+              isHovered && totalOccurrencesOnTrack > 1
+                ? `+${Math.max(0, totalOccurrencesOnTrack - 1)}`
+                : undefined,
+            curveStyle,
+          },
+        ];
       });
 
       const waypoint = {
@@ -127,16 +155,11 @@ export function buildSplitPoints(
         onClick: handleWaypointClick,
       };
 
-      const selectedPathId = selectedTrainId
-        ? formatOccupancyZonePathId({ waypointId, trainId: selectedTrainId })
-        : undefined;
-
-      const isDraggingOccupancyZone = (zone: OccupancyZone) => {
+      const isDraggingOccupancyZone = (zone: MovableOccupancyZone) => {
         if (!isDraggingOccupancyZoneId) {
           return false;
         }
-        const { trainId } = parseOccupancyZonePathId(zone.pathId);
-        return isDraggingOccupancyZoneId(waypointId, trainId);
+        return isDraggingOccupancyZoneId(waypointId, zone.trainId);
       };
 
       return {
@@ -149,7 +172,6 @@ export function buildSplitPoints(
             tracks={tracks || []}
             occupancyZones={occupancyZones.filter((zone) => !isDraggingOccupancyZone(zone))}
             draggingOccupancyZones={occupancyZones.filter(isDraggingOccupancyZone)}
-            selectedPathId={selectedPathId}
             onClose={() => onCloseOccupancyLayer?.(waypointId)}
             onDragOver={onTrackDragOver}
             topPadding={BASE_WAYPOINT_HEIGHT}

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TRAIN_PATH_COLORS,
   TRAIN_MAIN_CATEGORY_PATH_COLORS,
 } from 'applications/operationalStudies/consts';
+import getSubCategoryColors from 'applications/operationalStudies/helpers/getSubCategoryColors';
 import type { CategoryColors } from 'applications/operationalStudies/types';
 import type { SubCategory } from 'common/api/osrdEditoastApi';
 import isMainCategory from 'modules/rollingStock/helpers/category';
@@ -59,11 +60,7 @@ const formatSpaceTimeCurves = (
           (option) => option.code === category.sub_category_code
         );
         if (currentSubCategory) {
-          colors = {
-            base: currentSubCategory.color,
-            strong: currentSubCategory.hovered_color,
-            surface: currentSubCategory.background_color,
-          };
+          colors = getSubCategoryColors(currentSubCategory);
         }
       }
     }

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
@@ -9,7 +9,7 @@ import {
   extractOccurrenceIndexFromOccurrenceId,
 } from 'utils/trainId';
 
-const EXCEPTION_SUFFIX = '≠';
+export const EXCEPTION_SUFFIX = '≠';
 
 /**
  * Turns trainSpaceTimeData (unique trains + pacedTrains) into individual train projection.

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/zones.ts
@@ -8,13 +8,14 @@ import type { TrainId } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { isTrainId } from 'utils/trainId';
 
-import type { BaseTrainProjection } from '../../../types';
+import type { BaseTrainProjection, CurveStyleExceptionType } from '../../../types';
 
-export type MovableOccupancyZone = OccupancyZone & {
+export type MovableOccupancyZone = Omit<OccupancyZone, 'curveStyle'> & {
+  curveStyle?: OccupancyZone['curveStyle'];
   dbStartTime: number;
   dbEndTime: number;
   trainId: TrainId;
-  isStartTimeException?: boolean;
+  exceptionType?: CurveStyleExceptionType;
 };
 
 export type OccupancyZoneReference = {
@@ -121,6 +122,14 @@ export function getMovableOccupancyZone(
     endDirection = 'down';
   }
 
+  let exceptionType: CurveStyleExceptionType | undefined;
+
+  if (exception?.path_and_schedule !== undefined) {
+    exceptionType = 'path_and_schedule';
+  } else if (exception?.start_time !== undefined) {
+    exceptionType = 'start_time';
+  }
+
   return {
     trackId,
     pathId: formatOccupancyZonePathId({ waypointId, trainId }),
@@ -132,6 +141,6 @@ export function getMovableOccupancyZone(
     trainName,
     dbStartTime: occupationStartTime,
     dbEndTime: occupationEndTime,
-    isStartTimeException: exception?.start_time !== undefined,
+    exceptionType,
   };
 }

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import type { OccupancyZone, Track } from '@osrd-project/ui-charts';
+import type { Track } from '@osrd-project/ui-charts';
 import type { TFunction } from 'i18next';
 import { forEach, fromPairs, isEmpty, isEqual, isFunction, keyBy, noop, uniqBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -25,6 +25,7 @@ import { mapBy } from 'utils/types';
 
 import { usePrevious } from '../../../../utils/hooks/state';
 import type { BaseTrainProjection, PathOperationalPoint, TrainSpaceTimeData } from '../../types';
+import { EXCEPTION_SUFFIX } from './helpers/makeProjectedTrains';
 import { NO_TRACK_SPECIFIED_SYMBOL, sortTracks } from './helpers/sortTracks';
 import { batchFetchTrackOccupancy } from './helpers/utils';
 import { getMovableOccupancyZone, type MovableOccupancyZone } from './helpers/zones';
@@ -38,7 +39,7 @@ export type DeployedWaypoint = {
   operationalPointId: string;
   operationalPointPosition: number;
   operationalPointName?: string;
-  zones?: OccupancyZone[];
+  zones?: MovableOccupancyZone[];
   tracks?: Track[];
   loading?: boolean;
 };
@@ -266,7 +267,7 @@ const useTrackOccupancy = ({
                 trainScheduleId,
                 occupation.exception_id
               );
-              trainName = exception.train_name?.value ?? `${train.name}/+`;
+              trainName = (exception.train_name?.value ?? `${train.name}/+`) + EXCEPTION_SUFFIX;
               startTime = new Date(exception.start_time.value);
             } else {
               trainId = formatTrainScheduleIdToIndexedOccurrenceId(
@@ -275,6 +276,7 @@ const useTrackOccupancy = ({
               );
               trainName =
                 exception?.train_name?.value ?? computeOccurrenceName(train.name, occupation.index);
+              if (exception) trainName += EXCEPTION_SUFFIX;
 
               startTime = exception?.start_time
                 ? new Date(exception.start_time.value)
@@ -486,7 +488,7 @@ const useTrackOccupancy = ({
             if (
               isOccurrenceId(zone.trainId) &&
               extractTrainScheduleIdFromOccurrenceId(zone.trainId) === draggedTrainScheduleId &&
-              !zone.isStartTimeException
+              zone.exceptionType !== 'start_time'
             ) {
               impactedPathOperationalPointIDs.add(waypointId);
               const offset = newTrainData.departureTime.getTime() - initialDepartureTime.getTime();

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -7,6 +7,7 @@ import {
   REST_BACKGROUND_COLOR,
   SELECTED_CURVE_COLOR,
   SELECTED_CURVE_OUTLINE_COLOR,
+  SELECTED_CURVE_SOFT_COLOR,
 } from 'applications/operationalStudies/consts';
 
 import getCurveStyle, { INVALID_OUTLINE } from '../getCurveStyle';
@@ -226,6 +227,113 @@ describe('getCurveStyle', () => {
       );
       const onlyHover = getCurveStyle('none', { colors, isSimulated: true }, { hovered: true });
       expect(fromHover).toEqual(onlyHover);
+    });
+  });
+
+  describe('tod', () => {
+    describe('none', () => {
+      it('should return the base color with no bar thickness nor outline', () => {
+        const style = getCurveStyle('none', { colors }, { chart: 'tod' });
+        expect(style.color).toBe(colors.base);
+        expect(style.opacity).toBe(1);
+        expect(style.thickness).toBeUndefined();
+        expect(style.outline).toBeUndefined();
+      });
+
+      it('should label with the base color and no background', () => {
+        const style = getCurveStyle('none', { colors }, { chart: 'tod' });
+        expect(style.label).toEqual({ color: colors.base, fontWeight: 400 });
+      });
+    });
+
+    // The occupancy clicked in the TOD.
+    describe('active', () => {
+      it('should return the blue selection color, a raised bar and a soft-blue outline', () => {
+        const style = getCurveStyle('active', { colors }, { chart: 'tod' });
+        expect(style.color).toBe(SELECTED_CURVE_COLOR);
+        expect(style.opacity).toBe(1);
+        expect(style.thickness).toBe(4);
+        expect(style.outline).toEqual({
+          offset: 0,
+          width: 4,
+          color: SELECTED_CURVE_SOFT_COLOR,
+          opacity: 0.25,
+        });
+      });
+
+      it('should label with the strong color, bold, with a base-colored border', () => {
+        const style = getCurveStyle('active', { colors }, { chart: 'tod' });
+        expect(style.label).toEqual({
+          color: colors.strong,
+          background: { color: colors.surface, border: colors.base },
+          fontWeight: 600,
+        });
+      });
+    });
+
+    // Belongs to the active selection but clicked elsewhere (STD or timetable).
+    describe('passivePrimary', () => {
+      it('should return the base color with a soft-colored outline and no thickness', () => {
+        const style = getCurveStyle('passivePrimary', { colors }, { chart: 'tod' });
+        expect(style.color).toBe(colors.base);
+        expect(style.thickness).toBeUndefined();
+        expect(style.outline).toEqual({
+          offset: 0,
+          width: 4,
+          color: colors.soft,
+          opacity: 0.25,
+        });
+      });
+
+      it('should label like active: strong color, bold, with a base-colored border', () => {
+        const style = getCurveStyle('passivePrimary', { colors }, { chart: 'tod' });
+        expect(style.label).toEqual({
+          color: colors.strong,
+          background: { color: colors.surface, border: colors.base },
+          fontWeight: 600,
+        });
+      });
+    });
+
+    // Sibling/exceptions related to the active selection.
+    describe('passiveSecondary', () => {
+      it('should match passivePrimary with a regular-weight label', () => {
+        const style = getCurveStyle('passiveSecondary', { colors }, { chart: 'tod' });
+        expect(style.color).toBe(colors.base);
+        expect(style.outline).toEqual({
+          offset: 0,
+          width: 4,
+          color: colors.soft,
+          opacity: 0.25,
+        });
+        expect(style.label).toEqual({
+          color: colors.strong,
+          background: { color: colors.surface, border: colors.base },
+          fontWeight: 400,
+        });
+      });
+    });
+
+    // Pointer directly over an occupancy; only a non-active one changes look.
+    describe('hover modifier', () => {
+      it('should switch a non-active curve to the strong color with a soft border and no outline', () => {
+        const style = getCurveStyle('passivePrimary', { colors }, { chart: 'tod', hovered: true });
+        expect(style.color).toBe(colors.strong);
+        expect(style.border).toEqual({ color: colors.soft, width: 1 });
+        expect(style.outline).toBeUndefined();
+        expect(style.thickness).toBeUndefined();
+        expect(style.label).toEqual({
+          color: colors.strong,
+          background: { color: colors.surface },
+          fontWeight: 400,
+        });
+      });
+
+      it('should not change the active selection on hover', () => {
+        const base = getCurveStyle('active', { colors }, { chart: 'tod' });
+        const hovered = getCurveStyle('active', { colors }, { chart: 'tod', hovered: true });
+        expect(hovered).toEqual(base);
+      });
     });
   });
 });

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -6,6 +6,7 @@ import {
   REST_BACKGROUND_COLOR,
   SELECTED_CURVE_COLOR,
   SELECTED_CURVE_OUTLINE_COLOR,
+  SELECTED_CURVE_SOFT_COLOR,
 } from 'applications/operationalStudies/consts';
 import type { CategoryColors } from 'applications/operationalStudies/types';
 import type { CurveVisualState } from 'modules/simulationResult/types';
@@ -19,6 +20,9 @@ export const INVALID_OUTLINE: CurveOutline = {
 const FONT_WEIGHT_REGULAR = 400;
 const FONT_WEIGHT_BOLD = 600;
 const OUT_OF_SELECTION_OPACITY = 0.3;
+const TOD_SELECTED_BAR_HEIGHT = 4;
+const TOD_HALO_THICKNESS = 4;
+const TOD_HALO_OPACITY = 0.25;
 const RESTING_LABEL_BACKGROUND: NonNullable<CurveStyle['label']>['background'] = {
   color: REST_BACKGROUND_COLOR,
   opacity: 0.9,
@@ -40,6 +44,8 @@ type StyleOptions = {
    * `outOfSelection` (the curve "comes back" while hovered).
    */
   hovered?: boolean;
+  /** tod switches to the TOD specific look. std (default) the space-time chart one. */
+  chart?: 'std' | 'tod';
 };
 
 const hoveredLabel = (colors: CategoryColors): NonNullable<CurveStyle['label']> => ({
@@ -154,17 +160,119 @@ const getHoveredStyle = (state: CurveVisualState, train: TrainForStyle): CurveSt
   return getBaseStyle(state, train);
 };
 
+const getTodStyle = (
+  state: CurveVisualState,
+  train: TrainForStyle,
+  hovered: boolean
+): CurveStyle => {
+  const { colors } = train;
+
+  // Primary selection (active, blue) keeps its appearance on hover; every other
+  // state switches to the hovered look.
+  if (hovered && state !== 'active') {
+    return {
+      color: colors.strong,
+      opacity: 1,
+      border: { color: colors.soft, width: 1 },
+      label: hoveredLabel(colors),
+    };
+  }
+
+  switch (state) {
+    case 'none':
+      return {
+        color: colors.base,
+        opacity: 1,
+        label: { color: colors.base, fontWeight: FONT_WEIGHT_REGULAR },
+      };
+    case 'active':
+      return {
+        color: SELECTED_CURVE_COLOR,
+        opacity: 1,
+        thickness: TOD_SELECTED_BAR_HEIGHT,
+        outline: {
+          offset: 0,
+          width: TOD_HALO_THICKNESS,
+          color: SELECTED_CURVE_SOFT_COLOR,
+          opacity: TOD_HALO_OPACITY,
+        },
+        label: {
+          color: colors.strong,
+          background: { color: colors.surface, border: colors.base },
+          fontWeight: FONT_WEIGHT_BOLD,
+        },
+      };
+    case 'passivePrimary':
+      return {
+        color: colors.base,
+        opacity: 1,
+        outline: {
+          offset: 0,
+          width: TOD_HALO_THICKNESS,
+          color: colors.soft,
+          opacity: TOD_HALO_OPACITY,
+        },
+        label: {
+          color: colors.strong,
+          background: { color: colors.surface, border: colors.base },
+          fontWeight: FONT_WEIGHT_BOLD,
+        },
+      };
+    case 'passiveSecondary':
+      return {
+        color: colors.base,
+        opacity: 1,
+        outline: {
+          offset: 0,
+          width: TOD_HALO_THICKNESS,
+          color: colors.soft,
+          opacity: TOD_HALO_OPACITY,
+        },
+        label: {
+          color: colors.strong,
+          background: { color: colors.surface, border: colors.base },
+          fontWeight: FONT_WEIGHT_REGULAR,
+        },
+      };
+    case 'drag':
+      // TODO: not reached yet, the TOD drag is still rendered by
+      // DraggingOccupancyZonesLayer with hardcoded values. Wiring the drag through
+      // curveStyle (+ a dedicated OccupancyDragStyle) will be handled in a follow up PR.
+      return {
+        color: DRAGGED_CURVE_COLOR,
+        opacity: 1,
+        level: 1,
+        thickness: 1.5,
+        outline: { offset: 0, color: DRAGGED_CURVE_OUTLINE_COLOR },
+        label: {
+          color: colors.base,
+          background: { color: colors.surface },
+          fontWeight: FONT_WEIGHT_BOLD,
+        },
+      };
+    default: {
+      // Exhaustiveness check: TS fails to compile if a state is added to the
+      // union without a case here.
+      const _exhaustive: never = state;
+      throw new Error(`Unhandled curve visual state: ${_exhaustive}`);
+    }
+  }
+};
+
 /**
  * Maps a curve visual state to its style primitives.
  *
- * `outOfSelection` and `hovered` are transverse modifiers applied on top of
- * the state. When `hovered` is set it wins over `outOfSelection`.
+ * `outOfSelection` and `hovered` are transverse modifiers applied on top of the
+ * state. When `hovered` is set it wins over `outOfSelection`. `chart: 'tod'`
+ * restyles the result for the track-occupancy diagram.
  */
 const getCurveStyle = (
   state: CurveVisualState,
   train: TrainForStyle,
-  { outOfSelection = false, hovered = false }: StyleOptions = {}
+  { outOfSelection = false, hovered = false, chart = 'std' }: StyleOptions = {}
 ): CurveStyle => {
+  // The TOD never fades occupancies out.
+  if (chart === 'tod') return getTodStyle(state, train, hovered);
   if (hovered) return getHoveredStyle(state, train);
   if (outOfSelection) {
     const { colors } = train;

--- a/front/src/modules/simulationResult/helpers/getPathStyleV2.ts
+++ b/front/src/modules/simulationResult/helpers/getPathStyleV2.ts
@@ -16,7 +16,7 @@ const getPathStyleV2 = (
   // the rest out to put the focus on the click target.
   const outOfSelection =
     state === 'none' && !!input.selection && input.selection.by !== 'timetable';
-  return getCurveStyle(state, train, { hovered, outOfSelection });
+  return getCurveStyle(state, train, { hovered, outOfSelection, chart: input.chart });
 };
 
 export default getPathStyleV2;

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/track-occupancy.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/track-occupancy.stories.tsx
@@ -9,10 +9,11 @@ import {
   useManchetteWithSpaceTimeChart,
   WaypointComponent,
   TRACK_HEIGHT_CONTAINER,
+  type CurveStyle,
   type OccupancyZone,
   type Track,
   isInteractiveWaypoint,
-  type OccupancyZonePickingElement,
+  isOccupancyPickingElement,
   isPointPickingElement,
   isSegmentPickingElement,
   BASE_WAYPOINT_HEIGHT,
@@ -33,12 +34,28 @@ import {
  * TrackOccupancyDiagram layer when selecting an operational point.
  */
 
+const SELECTED_OCCUPANCY_COLOR = '#1844ef';
+
+const getOccupancyCurveStyle = (color: string, isSelected: boolean): CurveStyle =>
+  isSelected
+    ? {
+        color: SELECTED_OCCUPANCY_COLOR,
+        opacity: 1,
+        thickness: 5,
+        outline: { offset: 0, color: SELECTED_OCCUPANCY_COLOR },
+        label: {
+          color,
+          fontWeight: 600,
+          background: { color: '#ffffff', border: color },
+        },
+      }
+    : { color, opacity: 1 };
+
 /**
  * This component shows how to use the useManchetteWithSpaceTimeChart hook with track-occupancy
  * diagrams:
  */
 const TrackOccupancyDiagramWithinSpaceTimeChartWrapper = ({ height = 561 }: { height: number }) => {
-  // TODO: Restore trains selection from GOV
   const [selectedTrain, setSelectedTrain] = useState<string>();
   const [selectedWaypoint, setSelectedWaypoint] = useState<undefined | string>(
     OPERATIONAL_POINTS[2].id
@@ -63,7 +80,7 @@ const TrackOccupancyDiagramWithinSpaceTimeChartWrapper = ({ height = 561 }: { he
         pathId: path.id,
         trackId: tracks[i % tracks.length].id, // (i.e. pick some random track)
         trainName: 'foobar',
-        color: path.color,
+        curveStyle: getOccupancyCurveStyle(path.color, path.id === selectedTrain),
       })
     );
 
@@ -77,7 +94,6 @@ const TrackOccupancyDiagramWithinSpaceTimeChartWrapper = ({ height = 561 }: { he
             position={operationalPoint.position}
             tracks={tracks}
             occupancyZones={occupancyZones}
-            selectedPathId={selectedTrain}
             onClose={() => setSelectedWaypoint(undefined)}
             topPadding={BASE_WAYPOINT_HEIGHT}
           />
@@ -98,7 +114,7 @@ const TrackOccupancyDiagramWithinSpaceTimeChartWrapper = ({ height = 561 }: { he
         ),
       },
     ];
-  }, [paths, selectedTrain, selectedWaypoint, operationalPoints]);
+  }, [paths, selectedWaypoint, operationalPoints, selectedTrain]);
 
   const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart({
     waypoints: operationalPoints.map((op) => ({
@@ -135,26 +151,18 @@ const TrackOccupancyDiagramWithinSpaceTimeChartWrapper = ({ height = 561 }: { he
             className="inset-0 absolute h-full"
             {...spaceTimeChartProps}
             onClick={({ hoveredItem }) => {
-              // Handle clicking the occupancyZone items (on the TrackOccupancyCanvas layer):
+              const element = hoveredItem?.element;
+              if (!element) return setSelectedTrain(undefined);
+              // Occupancy zones (TOD) and path items (STD) are both picked on the 'paths'
+              // layer, so they're distinguished by element type, not by layer.
               if (
-                hoveredItem?.layer === 'overlay' &&
-                hoveredItem.element.type === 'occupancyZone'
+                isOccupancyPickingElement(element) ||
+                isPointPickingElement(element) ||
+                isSegmentPickingElement(element)
               ) {
-                const newId = (hoveredItem.element as OccupancyZonePickingElement).pathId;
+                const newId = element.pathId;
                 setSelectedTrain(newId === selectedTrain ? undefined : newId);
-              }
-
-              // Handle clicking the path items (on the Path layers):
-              else if (
-                hoveredItem?.layer === 'paths' &&
-                (isPointPickingElement(hoveredItem.element) ||
-                  isSegmentPickingElement(hoveredItem.element))
-              ) {
-                const newId = hoveredItem.element.pathId;
-                setSelectedTrain(newId === selectedTrain ? undefined : newId);
-              }
-              // Handle clicking the stage:
-              else {
+              } else {
                 setSelectedTrain(undefined);
               }
             }}

--- a/front/ui/ui-charts/src/common/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/common/hooks/useCanvas.ts
@@ -95,7 +95,11 @@ export function useCanvas<T extends BaseChartContextType>(
       if (ctx) {
         const { width, height } = sizeRef.current;
         ctx.clearRect(0, 0, width, height);
-        set.forEach((fn) => fn(ctx, context));
+        set.forEach((fn) => {
+          // Reset alpha before each drawing function to prevent having the faded out-of-selection  from the STD
+          ctx.globalAlpha = 1;
+          fn(ctx, context);
+        });
       }
     });
   }, []);

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -31,6 +31,8 @@ export type CurveOutline = {
   color: string;
   /** Thickness of the outline */
   width?: number;
+  /** Opacity of the outline, e.g. the TOD halo. */
+  opacity?: number;
   /** Won't be used most of the time, color will be used */
   backgroundColor?: string;
 };
@@ -46,6 +48,10 @@ export type CurveStyle = {
   opacity: number;
   level?: PathLevel;
   outline?: CurveOutline;
+  /** TOD occupancy bar height in px. */
+  thickness?: number;
+  /** Border drawn around the TOD occupancy bar. */
+  border?: { color: string; width: number };
   label?: {
     background?: { color: string; opacity?: number; border?: string };
     color?: string;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -37,7 +37,6 @@ const TrackOccupancyCanvas = ({
   tracks,
   occupancyZones,
   draggingOccupancyZones,
-  selectedPathId,
   onClose,
   onDragOver,
   topPadding = 0,
@@ -47,7 +46,6 @@ const TrackOccupancyCanvas = ({
   tracks: Track[];
   occupancyZones: OccupancyZone[];
   draggingOccupancyZones?: OccupancyZone[];
-  selectedPathId?: string;
   onClose?: () => void;
   onDragOver?: (trackId: string | undefined) => void;
   topPadding?: number;
@@ -110,7 +108,6 @@ const TrackOccupancyCanvas = ({
         position={position}
         topPadding={topPadding}
         occupancyZones={occupancyZones}
-        selectedPathId={selectedPathId}
       />
       {draggingOccupancyZones && (
         <DraggingOccupancyZonesLayer occupancyZones={draggingOccupancyZones} />

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -77,7 +77,6 @@ const TrackOccupancyStandalone = ({
             topPadding={BASE_WAYPOINT_HEIGHT * 1.5}
             occupancyZones={occupancyZones}
             draggingOccupancyZones={draggingOccupancyZones}
-            selectedPathId={selectedPathId}
             onDragOver={handleDragOver}
             hideBorders
           />
@@ -87,15 +86,7 @@ const TrackOccupancyStandalone = ({
         ),
       },
     ],
-    [
-      height,
-      tracks,
-      occupancyZones,
-      draggingOccupancyZones,
-      selectedPathId,
-      highlightedTrackId,
-      handleDragOver,
-    ]
+    [height, tracks, occupancyZones, draggingOccupancyZones, highlightedTrackId, handleDragOver]
   );
 
   /**

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZones.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZones.ts
@@ -1,32 +1,21 @@
 import { getCrispLineCoordinate } from '../../../../common/helpers/time';
-import { PATH_COLOR_DEFAULT } from '../../../../manchette/consts';
 import type { SpaceTimeChartContextType } from '../../../../spaceTimeChart';
 import { OCCUPANCY_ZONE_Y_START, OCCUPANCY_ZONE_HEIGHT, FONTS, COLORS } from '../../../lib/consts';
 import type { OccupancyZone } from '../../../lib/types';
 import { drawOccupancyZonesTexts } from './drawOccupancyZonesTexts';
 
 const { SANS, MONO } = FONTS;
-const { REMAINING_TRAINS_BACKGROUND, WHITE_100, SELECTION_20 } = COLORS;
+const { REMAINING_TRAINS_BACKGROUND, WHITE_100 } = COLORS;
 const REMAINING_TRAINS_WIDTH = 70;
 const REMAINING_TRAINS_HEIGHT = 24;
 const REMAINING_TEXT_OFFSET = 12;
-const X_BACKGROUND_PADDING = 4;
-const X_TROUGHTRAIN_BACKGROUND_PADDING = 8;
 const BACKGROUND_HEIGHT = 40;
-const SELECTED_TRAIN_ID_GRADIANT = 2;
 const PATH_SIZE_DEFAULT = 1;
 const LABEL_OFFSET_X = 10;
 const LABEL_OFFSET_Y = 50;
-
-const drawDefaultZone = (
-  ctx: CanvasRenderingContext2D,
-  { x, y, width }: { x: number; y: number; width: number }
-) => {
-  ctx.beginPath();
-  ctx.rect(x, y, width, OCCUPANCY_ZONE_HEIGHT);
-  ctx.fill();
-  ctx.stroke();
-};
+const OCCUPANCY_OUTLINE_THICKNESS = 4;
+const OCCUPANCY_OUTLINE_X_PADDING = 3;
+const OCCUPANCY_OUTLINE_OPACITY = 0.15;
 
 const ARROW_OFFSET_X = 1;
 const ARROW_OFFSET_Y = 1.5;
@@ -95,24 +84,18 @@ export const drawOccupationZone = (
     zone,
     yOffset,
     position,
-    isSelected,
   }: {
     zone: OccupancyZone;
     yOffset: number;
     position: number;
-    isSelected?: boolean;
   }
 ) => {
-  const { color: curveColor = PATH_COLOR_DEFAULT, outline = { color: WHITE_100, width: 0.5 } } =
-    zone.curveStyle || {};
+  const { color: curveColor, outline, border, thickness } = zone.curveStyle;
 
   const curveWidth = zone.connectorStyle?.width ?? PATH_SIZE_DEFAULT;
 
   const isThroughTrain = zone.startTime === zone.endTime;
 
-  ctx.fillStyle = curveColor;
-  ctx.strokeStyle = outline.color;
-  ctx.lineWidth = outline.width ?? 0.5;
   ctx.lineJoin = 'round';
   ctx.lineCap = 'round';
   ctx.font = MONO;
@@ -124,38 +107,51 @@ export const drawOccupationZone = (
   const arrivalTimePixel = getTimePixel(zone.startTime);
   const departureTimePixel = getTimePixel(zone.endTime);
 
-  if (isSelected) {
-    const extraWidth = isThroughTrain ? X_TROUGHTRAIN_BACKGROUND_PADDING : X_BACKGROUND_PADDING;
-    const originTextLength = ctx.measureText(zone.originStation || '--').width;
-    const destinationTextLength = ctx.measureText(zone.destinationStation || '--').width;
-
-    ctx.fillStyle = SELECTION_20;
-    ctx.beginPath();
-    ctx.roundRect(
-      arrivalTimePixel - originTextLength - extraWidth,
-      y - BACKGROUND_HEIGHT / 2,
-      departureTimePixel -
-        arrivalTimePixel +
-        originTextLength +
-        destinationTextLength +
-        extraWidth * 2,
-      BACKGROUND_HEIGHT,
-      SELECTED_TRAIN_ID_GRADIANT
-    );
-    ctx.fill();
-  }
-
-  ctx.fillStyle = curveColor;
-  ctx.strokeStyle = outline.color;
-  ctx.lineWidth = outline.width ?? 0.5;
   if (isThroughTrain) {
+    ctx.fillStyle = curveColor;
+    ctx.strokeStyle = WHITE_100;
+    ctx.lineWidth = 0.5;
     drawThroughTrain(ctx, arrivalTimePixel, y);
   } else {
-    drawDefaultZone(ctx, {
-      x: arrivalTimePixel,
-      y,
-      width: departureTimePixel - arrivalTimePixel,
-    });
+    const zoneWidth = departureTimePixel - arrivalTimePixel;
+    const yCenter = y + OCCUPANCY_ZONE_HEIGHT / 2;
+    // Bar is 3px by default, raised to 5px for the active selection.
+    const barHeight = thickness ?? OCCUPANCY_ZONE_HEIGHT;
+
+    // Highlight halo behind the bar, only when selected.
+    if (outline) {
+      // Extend the occupancy by the halo thickness (outline.width) on both sides.
+      const haloHeight = barHeight + (outline.width ?? OCCUPANCY_OUTLINE_THICKNESS) * 2;
+      ctx.save();
+      ctx.globalAlpha = outline.opacity ?? OCCUPANCY_OUTLINE_OPACITY;
+      ctx.fillStyle = outline.color;
+      ctx.beginPath();
+      ctx.roundRect(
+        arrivalTimePixel - OCCUPANCY_OUTLINE_X_PADDING,
+        yCenter - haloHeight / 2,
+        zoneWidth + OCCUPANCY_OUTLINE_X_PADDING * 2,
+        haloHeight,
+        2
+      );
+      ctx.fill();
+      ctx.restore();
+    }
+
+    // Occupancy bar.
+    ctx.fillStyle = curveColor;
+    ctx.beginPath();
+    ctx.rect(arrivalTimePixel, yCenter - barHeight / 2, zoneWidth, barHeight);
+    ctx.fill();
+    if (border) {
+      // When hovering, add a border around the occupancy
+      ctx.strokeStyle = border.color;
+      ctx.lineWidth = border.width;
+      ctx.stroke();
+    } else if (!outline) {
+      ctx.strokeStyle = WHITE_100;
+      ctx.lineWidth = 0.5;
+      ctx.stroke();
+    }
   }
 
   // Draw dashed lines linking trains tracks occupancy to their paths on the SpaceTimeChart (when relevant):
@@ -183,7 +179,6 @@ export const drawOccupationZone = (
     departureTimePixel,
     isThroughTrain,
     yPosition: y,
-    isSelected,
   });
 };
 

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZonesTexts.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/helpers/drawElements/drawOccupancyZonesTexts.ts
@@ -7,19 +7,18 @@ const BREAKPOINTS = {
   small: 4,
 };
 const STROKE_WIDTH = 4;
-const X_BACKGROUND_PADDING = 4;
-const X_INITIAL_POSITION_OFFSET = 8;
+const X_BACKGROUND_PADDING = 2;
+const X_INITIAL_POSITION_OFFSET = 4;
 const X_MEDIUM_POSITION_OFFSET_BACKGROUND = 12;
-const Y_INITIAL_POSITION_OFFSET = 5;
-const Y_INITIAL_POSITION_OFFSET_BACKGROUND = 18;
-const X_SELECTED_MEDIUM_PADDING = 8;
+const Y_INITIAL_POSITION_OFFSET = 20;
+const Y_INITIAL_POSITION_OFFSET_BACKGROUND = 16;
+const Y_TEXT_CENTERING_OFFSET = 1;
 const X_THROUGHTRAIN_OFFSET = 4;
-const Y_MEDIUM_POSITION_OFFSET_BACKGROUND = 28;
-const Y_MEDIUM_POSITION_OFFSET = 14;
+const Y_MEDIUM_POSITION_OFFSET = 24;
 const ROTATE_VALUE = (-30 * Math.PI) / 180;
 
 const { SANS, MONO } = FONTS;
-const { WHITE_100, GREY_50, GREY_60, GREY_80, SELECTION_20 } = COLORS;
+const { GREY_50, GREY_60, GREY_80 } = COLORS;
 
 export const drawOccupancyZonesTexts = ({
   ctx,
@@ -28,7 +27,6 @@ export const drawOccupancyZonesTexts = ({
   departureTimePixel,
   yPosition,
   isThroughTrain,
-  isSelected,
 }: {
   ctx: CanvasRenderingContext2D;
   zone: OccupancyZone;
@@ -36,9 +34,8 @@ export const drawOccupancyZonesTexts = ({
   departureTimePixel: number;
   yPosition: number;
   isThroughTrain: boolean;
-  isSelected?: boolean;
 }) => {
-  const labelStyle = zone.curveStyle?.label;
+  const labelStyle = zone.curveStyle.label;
   const labelFontWeight = labelStyle?.fontWeight ?? 400;
 
   const zoneOccupancyLength = departureTimePixel - arrivalTimePixel - STROKE_WIDTH;
@@ -48,7 +45,7 @@ export const drawOccupancyZonesTexts = ({
 
   ctx.font = MONO;
   const originTextLength = ctx.measureText(zone.originStation || '--').width;
-  ctx.font = `${labelFontWeight} 12px IBM Plex Mono`;
+  ctx.font = `${labelFontWeight} 12px IBM Plex Sans`;
   const nameTextLength = ctx.measureText(zone.trainName).width;
 
   const { xOriginTrainName, yOriginTrainName } = isBelowBreakpoint('medium')
@@ -68,37 +65,33 @@ export const drawOccupancyZonesTexts = ({
   const xArrivalPosition = isBelowBreakpoint('small') ? 'right' : 'center';
   const xDeparturePosition = isBelowBreakpoint('small') ? 'left' : 'center';
 
+  const hasLabelBackground = !!labelStyle?.background;
   const textStroke = {
-    color: isSelected ? 'transparent' : WHITE_100,
+    color: 'transparent',
     width: STROKE_WIDTH,
   };
 
-  // train name
-  if (isSelected) {
-    const { xSelectedTrainNameBackground, ySelectedTrainNameBackground } = isBelowBreakpoint(
-      'medium'
-    )
-      ? {
-          xSelectedTrainNameBackground: xOriginTrainName - X_SELECTED_MEDIUM_PADDING,
-          ySelectedTrainNameBackground: yPosition - Y_MEDIUM_POSITION_OFFSET_BACKGROUND,
-        }
-      : {
-          xSelectedTrainNameBackground: arrivalTimePixel,
-          ySelectedTrainNameBackground: yPosition - Y_INITIAL_POSITION_OFFSET_BACKGROUND,
-        };
-
+  // train name background
+  if (hasLabelBackground) {
     ctx.save();
-    ctx.translate(xSelectedTrainNameBackground, ySelectedTrainNameBackground);
+    ctx.translate(xOriginTrainName, yOriginTrainName);
     ctx.rotate(ROTATE_VALUE);
-    ctx.fillStyle = labelStyle?.background?.color || SELECTION_20;
+    ctx.fillStyle = labelStyle!.background!.color;
     ctx.beginPath();
     ctx.roundRect(
       -X_BACKGROUND_PADDING,
-      0,
+      -Y_INITIAL_POSITION_OFFSET_BACKGROUND / 2 - Y_TEXT_CENTERING_OFFSET,
       nameTextLength + X_BACKGROUND_PADDING * 2,
-      Y_INITIAL_POSITION_OFFSET_BACKGROUND
+      Y_INITIAL_POSITION_OFFSET_BACKGROUND,
+      2
     );
     ctx.fill();
+    ctx.globalAlpha = 1;
+    if (labelStyle?.background?.border) {
+      ctx.strokeStyle = labelStyle.background.border;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
     ctx.restore();
   }
 
@@ -108,12 +101,10 @@ export const drawOccupancyZonesTexts = ({
     x: xOriginTrainName,
     y: yOriginTrainName,
     color: labelStyle?.color || GREY_50,
-    font: `${labelFontWeight} 12px IBM Plex Mono`,
+    font: `${labelFontWeight} 12px IBM Plex Sans`,
     rotateAngle: ROTATE_VALUE,
-    stroke: {
-      color: WHITE_100,
-      width: STROKE_WIDTH,
-    },
+    yPosition: 'middle',
+    stroke: textStroke,
   });
 
   // arrival minutes & departure minutes
@@ -155,7 +146,7 @@ export const drawOccupancyZonesTexts = ({
     color: GREY_60,
     xPosition: 'right',
     yPosition: 'bottom',
-    font: MONO,
+    font: `${labelFontWeight} 10px IBM Plex Mono`,
     stroke: textStroke,
   });
 
@@ -167,7 +158,7 @@ export const drawOccupancyZonesTexts = ({
     color: GREY_60,
     xPosition: 'left',
     yPosition: 'bottom',
-    font: MONO,
+    font: `${labelFontWeight} 10px IBM Plex Mono`,
     stroke: textStroke,
   });
 };

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
@@ -31,7 +31,6 @@ type RenderingInstruction =
   | {
       type: 'occupancyZone';
       zone: OccupancyZone;
-      isSelected: boolean;
       offsetY: number;
       trailingText?: string;
     }
@@ -56,13 +55,11 @@ const OccupancyZonesLayer = ({
   occupancyZones,
   position,
   topPadding,
-  selectedPathId,
 }: {
   tracks: Track[];
   occupancyZones: OccupancyZone[];
   position: number;
   topPadding: number;
-  selectedPathId?: string;
 }) => {
   const instructionsToDraw = useMemo(() => {
     const instructions: RenderingInstruction[] = [];
@@ -110,7 +107,6 @@ const OccupancyZonesLayer = ({
             type: 'occupancyZone',
             zone,
             offsetY: trackY + yPosition,
-            isSelected: zone.pathId === selectedPathId,
             trailingText: zone.trailingText,
           });
 
@@ -134,7 +130,6 @@ const OccupancyZonesLayer = ({
             type: 'occupancyZone',
             zone,
             offsetY: trackY + yPosition,
-            isSelected: zone.pathId === selectedPathId,
           });
 
           zoneCounter++;
@@ -165,9 +160,9 @@ const OccupancyZonesLayer = ({
     });
 
     return sortBy(instructions, (instruction) =>
-      instruction.type === 'occupancyZone' && instruction.isSelected ? 0 : 1
+      instruction.type === 'occupancyZone' && instruction.zone.curveStyle.outline ? 0 : 1
     );
-  }, [occupancyZones, selectedPathId, topPadding, tracks]);
+  }, [occupancyZones, topPadding, tracks]);
 
   const drawingFunction = useCallback<DrawingFunction<SpaceTimeChartContextType>>(
     (ctx, stcContext) => {
@@ -178,7 +173,6 @@ const OccupancyZonesLayer = ({
               zone: instruction.zone,
               position,
               yOffset: instruction.offsetY,
-              isSelected: instruction.isSelected,
             });
             if (instruction.trailingText) {
               drawZoneTrailingText(ctx, stcContext, {

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/lib/types.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/lib/types.ts
@@ -18,7 +18,7 @@ export type OccupancyZone = {
   startDirection?: 'up' | 'down';
   endDirection?: 'up' | 'down';
   trailingText?: string;
-  curveStyle?: CurveStyle;
+  curveStyle: CurveStyle;
   connectorStyle?: { width?: number; color?: string };
 };
 


### PR DESCRIPTION
Part of https://github.com/osrd-project/osrd-confidential/issues/677

## Description

Implements the display of selected trains in the Track Occupancy Diagram.
For each occupancy zone, the visual state (`none` / `active` / `passivePrimary` /
`passiveSecondary`) is computed through `getCurveVisualState` + `getCurveStyle`
helpers, then moved into a `curveStyle` that handles how the zone is rendered.

Depends on #17006
Depends on #16950

close #17538 


