### PR TITLE
front, ui-charts: fixes TOD freezes on updates

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -319,7 +319,10 @@ const SpaceTimeChartWrapper = ({
           .filter((train) => train.spaceTimeCurves.length > 0)
           .map((p) => +p.departureTime)
       );
-      setTimeOrigin(minTime);
+
+      if (Number.isFinite(minTime)) {
+        setTimeOrigin(minTime);
+      }
     }
   }, [selectedProjectionId, trainScheduleProjections.length]);
 

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/__tests__/utils.spec.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getTickPattern } from '../components/utils';
+import { getLabelMarks, getTickPattern } from '../components/utils';
 
 describe('getTickPattern', () => {
   const fiveMinutes = ['05', '10', '20', '25', '35', '40', '50', '55'];
@@ -54,5 +54,18 @@ describe('getTickPattern', () => {
     expect(getTickPattern('01')).not.toEqual('FIVE_MINUTES');
     expect(getTickPattern('01')).not.toEqual('QUARTER_HOUR');
     expect(getTickPattern('01')).not.toEqual('HALF_HOUR');
+  });
+});
+
+describe('getLabelMarks', () => {
+  const HOUR = 3600 * 1000;
+  const timeRanges = [HOUR];
+  const labelLevels = [1];
+
+  // Regression test for https://github.com/OpenRailAssociation/osrd/issues/12613
+  it('should return no marks for non-finite time bounds', () => {
+    expect(getLabelMarks(timeRanges, Infinity, Infinity, labelLevels)).toEqual({});
+    expect(getLabelMarks(timeRanges, -Infinity, 2 * HOUR, labelLevels)).toEqual({});
+    expect(getLabelMarks(timeRanges, NaN, NaN, labelLevels)).toEqual({});
   });
 });

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/utils.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/utils.ts
@@ -72,6 +72,8 @@ export const getLabelMarks = (
 ) => {
   const labelMarks: Record<number, { level: number; rangeIndex: number }> = {};
 
+  if (!Number.isFinite(minT) || !Number.isFinite(maxT)) return labelMarks;
+
   timeRanges.map((range, index) => {
     const labelLevel = labelLevels[index];
 


### PR DESCRIPTION
This commit fixes #12613.

Details:
- Skips the time origin update while no projection is available instead of calling `setTimeOrigin(Infinity)`
- Makes `getLabelMarks` return no marks for non-finite time bounds
- Adds a regression test covering that case