### PR TITLE
core: fix parsing expected version of worker_load request

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ElectrificationRange.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ElectrificationRange.kt
@@ -27,14 +27,13 @@ class ElectrificationRange(
     sealed interface ElectrificationUsage {
         data class ElectrifiedUsage(
             val mode: String,
-            @field:Json(name = "mode_handled") val modeHandled: Boolean,
+            @Json(name = "mode_handled") val modeHandled: Boolean,
             val profile: String?,
-            @field:Json(name = "profile_handled") val profileHandled: Boolean,
+            @Json(name = "profile_handled") val profileHandled: Boolean,
         ) : ElectrificationUsage
 
-        data class NeutralUsage(
-            @field:Json(name = "lower_pantograph") val lowerPantograph: Boolean
-        ) : ElectrificationUsage
+        data class NeutralUsage(@Json(name = "lower_pantograph") val lowerPantograph: Boolean) :
+            ElectrificationUsage
 
         class NonElectrifiedUsage : ElectrificationUsage
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/WorkerLoadEndpoint.kt
@@ -44,7 +44,7 @@ class WorkerLoadEndpoint(
         /** Infra id */
         var infra: String,
         /** Infra version */
-        @field:Json(name = "expected_version") var expectedVersion: Int?,
+        @Json(name = "expected_version") var expectedVersion: Int?,
         /** Timetable ID */
         var timetable: Int?,
     )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockResponse.kt
@@ -10,7 +10,6 @@ import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.path.interfaces.JsonTrainPath
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -76,9 +75,6 @@ data class RangeValue<T>(val range: OffsetRange<TrainPath>, val value: T?) {
     }
 }
 
-class PathfindingFailed(@Json(name = "core_error") val coreError: OSRDError) :
-    PathfindingBlockResponse
-
 class NotEnoughPathItems : PathfindingBlockResponse
 
 val polymorphicPathfindingResponseAdapter: PolymorphicJsonAdapterFactory<PathfindingBlockResponse> =
@@ -89,7 +85,6 @@ val polymorphicPathfindingResponseAdapter: PolymorphicJsonAdapterFactory<Pathfin
         .withSubtype(NotFoundInTracks::class.java, "not_found_in_tracks")
         .withSubtype(IncompatibleConstraintsPathResponse::class.java, "incompatible_constraints")
         .withSubtype(NotEnoughPathItems::class.java, "not_enough_path_items")
-        .withSubtype(PathfindingFailed::class.java, "internal_error")
 
 val pathfindingResponseAdapter: JsonAdapter<PathfindingBlockResponse> =
     Moshi.Builder()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -80,11 +80,7 @@ class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take 
             pathfindingLogger.info("No path found")
             return RsJson(RsWithBody(pathfindingResponseAdapter.toJson(error.response)))
         } catch (ex: Throwable) {
-            if (ex is OSRDError && ex.osrdErrorType.isRecoverable) {
-                pathfindingLogger.info("Pathfinding failed: ${ex.message}")
-                val response = PathfindingFailed(ex)
-                return RsJson(RsWithBody(pathfindingResponseAdapter.toJson(response)))
-            }
+            pathfindingLogger.info("Pathfinding failed: ${ex.message}")
             return ExceptionHandler.handle(ex)
         }
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -11,6 +11,7 @@ import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSLoadingGaugeLimit
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.Helpers
@@ -362,10 +363,11 @@ class PathfindingTest : ApiTest() {
                 )
             )
         val response = PathfindingBlocksEndpoint(infraManager).act(RqFake(requestBody))
-        assert(response.statusCode() == 200)
-        val parsed = (pathfindingResponseAdapter.fromJson(response.body()) as? PathfindingFailed)!!
-        AssertionsForClassTypes.assertThat(parsed.coreError.type)
-            .isEqualTo("core:unknown_track_section")
+        assertEquals(response.statusCode(), 400)
+        assertEquals(
+            (OSRDError.adapter.fromJson(response.body()) as OSRDError).type,
+            "core:unknown_track_section",
+        )
     }
 
     @Test

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -12,7 +12,6 @@ use utoipa::ToSchema;
 
 use crate::AsCoreRequest;
 use crate::Json;
-use crate::RawError;
 use crate::WorkerKey;
 
 #[derive(Debug, Hash, Serialize)]
@@ -110,9 +109,6 @@ pub enum PathfindingCoreResult {
     NotEnoughPathItems,
     RollingStockNotFound {
         rolling_stock_name: String,
-    },
-    InternalError {
-        core_error: RawError,
     },
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12221,18 +12221,6 @@ components:
               enum:
               - pathfinding_not_found
         title: PathfindingFailurePathfindingNotFound
-      - type: object
-        title: PathfindingFailureInternalError
-        required:
-        - core_error
-        - failed_status
-        properties:
-          core_error:
-            $ref: '#/components/schemas/InternalError'
-          failed_status:
-            type: string
-            enum:
-            - internal_error
     PathfindingInput:
       type: object
       description: |-
@@ -14528,19 +14516,6 @@ components:
               - pathfinding_not_found
         title: SummaryResponsePathfindingNotFound
         description: Pathfinding not found
-      - type: object
-        title: SummaryResponsePathfindingFailure
-        description: An error has occurred during pathfinding
-        required:
-        - core_error
-        - status
-        properties:
-          core_error:
-            $ref: '#/components/schemas/InternalError'
-          status:
-            type: string
-            enum:
-            - pathfinding_failure
       - type: object
         title: SummaryResponseSimulationFailed
         description: An error has occurred during computing

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -33,7 +33,6 @@ use tracing::info;
 use utoipa::ToSchema;
 
 use crate::AppState;
-use crate::error::InternalError;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
 use crate::views::path::PathfindingError;
@@ -202,11 +201,6 @@ impl From<PathfindingCoreResult> for PathfindingResult {
                     PathfindingInputError::RollingStockNotFound { rolling_stock_name },
                 ))
             }
-            PathfindingCoreResult::InternalError { core_error } => {
-                PathfindingResult::Failure(PathfindingFailure::InternalError {
-                    core_error: core_error.into(),
-                })
-            }
         }
     }
 }
@@ -219,9 +213,6 @@ pub enum PathfindingFailure {
     PathfindingInputError(PathfindingInputError),
     #[educe(Default)]
     PathfindingNotFound(PathfindingNotFound),
-    InternalError {
-        core_error: InternalError,
-    },
 }
 
 /// Compute a pathfinding
@@ -373,18 +364,9 @@ async fn pathfinding_blocks_batch(
         .collect();
 
     for (path_result, hash) in computed_paths.into_iter().zip(to_compute_hashes) {
-        let result = match path_result {
-            Ok(path) => {
-                to_cache.push((hash, Box::new(path.clone().into())));
-                Arc::new(path.into())
-            }
-            // TODO: only make HTTP status code errors non-fatal
-            Err(core_error) => Arc::new(PathfindingResult::Failure(
-                PathfindingFailure::InternalError {
-                    core_error: core_error.into(),
-                },
-            )),
-        };
+        let path = path_result?;
+        to_cache.push((hash, Box::new(path.clone().into())));
+        let result: Arc<PathfindingResult> = Arc::new(path.into());
         hash_to_path_indexes[hash]
             .iter()
             .for_each(|index| pathfinding_results[*index] = result.clone());
@@ -485,13 +467,7 @@ pub(in crate::views) async fn single_pathfinding_request(
         [path] => path.data.clone(),
         _ => Err(core_client::Error::BrokenPipe),
     };
-    let result = match result {
-        Ok(path) => path.into(),
-        Err(core_error) => PathfindingResult::Failure(PathfindingFailure::InternalError {
-            core_error: core_error.into(),
-        }),
-    };
-    Ok(result)
+    Ok(result?.into())
 }
 
 #[derive(Debug, Clone)]

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -291,8 +291,6 @@ pub enum SummaryResponse {
     },
     /// Pathfinding not found
     PathfindingNotFound(PathfindingNotFound),
-    /// An error has occurred during pathfinding
-    PathfindingFailure { core_error: InternalError },
     /// An error has occurred during computing
     SimulationFailed { error_type: String },
     /// InputError
@@ -349,9 +347,6 @@ impl From<PathfindingFailure> for SummaryResponse {
             }
             PathfindingFailure::PathfindingNotFound(pathfinding_not_found) => {
                 SummaryResponse::PathfindingNotFound(pathfinding_not_found)
-            }
-            PathfindingFailure::InternalError { core_error } => {
-                SummaryResponse::PathfindingFailure { core_error }
             }
         }
     }

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -229,7 +229,6 @@
         "not_found_in_blocks": "Missing block",
         "not_found_in_routes": "Missing route",
         "not_found_in_tracks": "Missing track",
-        "pathfinding_failure": "Pathfinding failed",
         "pathfinding_not_found": "Pathfinding not found",
         "rolling_stock_not_found": "RS not found",
         "simulation_failed": "Simulation failed",
@@ -480,8 +479,6 @@
     "pathfindingDone": "Pathfinding done.",
     "pathfindingError": "An error occurred in pathfinding: {{errorMessage}}.",
     "pathfindingErrors": {
-      "incompatible_constraints": "Incompatible constraints",
-      "invalid_path_items": "Waypoint not found",
       "not_enough_path_items": "Missing parameters for pathfinding: Departure, Arrival, Rolling stock",
       "not_found_in_blocks": "Missing block",
       "not_found_in_routes": "Missing route",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -229,7 +229,6 @@
         "not_found_in_blocks": "Canton manquant",
         "not_found_in_routes": "Itinéraire manquant",
         "not_found_in_tracks": "Voie manquante",
-        "pathfinding_failure": "Calcul non abouti",
         "pathfinding_not_found": "Chemin introuvable",
         "rolling_stock_not_found": "MR non trouvé",
         "simulation_failed": "Simulation impossible",
@@ -480,8 +479,6 @@
     "pathfindingDone": "Recherche d'itinéraire terminée.",
     "pathfindingError": "Erreur dans la recherche d’itinéraire : {{errorMessage}}.",
     "pathfindingErrors": {
-      "incompatible_constraints": "Contraintes incompatibles",
-      "invalid_path_items": "Point de passage non trouvé",
       "not_enough_path_items": "Éléments manquants pour la recherche : Origine, Destination, Matériel roulant",
       "not_found_in_blocks": "Canton manquant",
       "not_found_in_routes": "Itinéraire manquant",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3748,25 +3748,13 @@ export type CorePathfindingNotFound =
       incompatible_constraints: CoreIncompatibleConstraints;
       relaxed_constraints_path: CorePathfindingResultSuccess;
     };
-export type InternalError = {
-  context: {
-    [key: string]: unknown;
-  };
-  message: string;
-  status?: number;
-  type: string;
-};
 export type PathfindingFailure =
   | (CorePathfindingInputError & {
       failed_status: 'pathfinding_input_error';
     })
   | (CorePathfindingNotFound & {
       failed_status: 'pathfinding_not_found';
-    })
-  | {
-      core_error: InternalError;
-      failed_status: 'internal_error';
-    };
+    });
 export type PathfindingResult =
   | (CorePathfindingResultSuccess & {
       status: 'success';
@@ -4748,6 +4736,14 @@ export type StdcmProgressionEvent = {
   best_travel_time: number;
   point: GeoJsonPoint;
 };
+export type InternalError = {
+  context: {
+    [key: string]: unknown;
+  };
+  message: string;
+  status?: number;
+  type: string;
+};
 export type SimulationResponse =
   | (SimulationResponseSuccess & {
       status: 'success';
@@ -5110,10 +5106,6 @@ export type SimulationSummaryResult =
   | (CorePathfindingNotFound & {
       status: 'pathfinding_not_found';
     })
-  | {
-      core_error: InternalError;
-      status: 'pathfinding_failure';
-    }
   | {
       error_type: string;
       status: 'simulation_failed';

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -322,18 +322,7 @@ const usePathfinding = ({
           return;
         }
 
-        let error: string;
-        if (pathfindingResult.failed_status === 'internal_error') {
-          const translationKey = pathfindingResult.core_error.type.startsWith('core:')
-            ? pathfindingResult.core_error.type.replace('core:', '')
-            : pathfindingResult.core_error.type;
-          error = t(`coreErrors.${translationKey}`, {
-            defaultValue: pathfindingResult.core_error.message,
-          });
-        } else {
-          error = t(`pathfindingErrors.${pathfindingResult.error_type}`);
-        }
-        setError(error);
+        setError(t(`pathfindingErrors.${pathfindingResult.error_type}`));
       } catch (e) {
         if (isObject(e)) {
           let error;

--- a/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfindingV2.ts
@@ -127,18 +127,7 @@ const usePathfindingV2 = () => {
         return;
       }
 
-      let error: string;
-      if (pathfindingResult.failed_status === 'internal_error') {
-        const translationKey = pathfindingResult.core_error.type.startsWith('core:')
-          ? pathfindingResult.core_error.type.replace('core:', '')
-          : pathfindingResult.core_error.type;
-        error = t(`coreErrors.${translationKey}`, {
-          defaultValue: pathfindingResult.core_error.message,
-        });
-      } else {
-        error = t(`pathfindingErrors.${pathfindingResult.error_type}`);
-      }
-      setPathfindingError(error);
+      setPathfindingError(t(`pathfindingErrors.${pathfindingResult.error_type}`));
       setPathProperties(undefined);
     },
     [infraId]

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -2837,11 +2837,6 @@ class Zones(BaseModel):
     """
 
 
-class PathfindingFailureInternalError(BaseModel):
-    core_error: InternalError
-    failed_status: Literal["internal_error"]
-
-
 class PathfindingOutput(BaseModel):
     detectors: list[Identifier]
     switches_directions: dict[str, str]
@@ -3418,15 +3413,6 @@ class SummaryResponseSuccess(BaseModel):
     """
     Travel time in ms
     """
-
-
-class SummaryResponsePathfindingFailure(BaseModel):
-    """
-    An error has occurred during pathfinding
-    """
-
-    core_error: InternalError
-    status: Literal["pathfinding_failure"]
 
 
 class SummaryResponseSimulationFailed(BaseModel):
@@ -6379,9 +6365,7 @@ class SimDebugData(BaseModel):
 
 class ResponsePathfindingFailed(BaseModel):
     pathfinding_failed: (
-        PathfindingFailurePathfindingInputError
-        | PathfindingFailurePathfindingNotFound
-        | PathfindingFailureInternalError
+        PathfindingFailurePathfindingInputError | PathfindingFailurePathfindingNotFound
     )
     status: Literal["pathfinding_failed"]
 
@@ -6433,7 +6417,6 @@ class TrainScheduleSimulationSummaryResult(BaseModel):
         str,
         SummaryResponseSuccess
         | SummaryResponsePathfindingNotFound
-        | SummaryResponsePathfindingFailure
         | SummaryResponseSimulationFailed
         | SummaryResponsePathfindingInputError,
     ]
@@ -6443,7 +6426,6 @@ class TrainScheduleSimulationSummaryResult(BaseModel):
     train_schedule: (
         SummaryResponseSuccess
         | SummaryResponsePathfindingNotFound
-        | SummaryResponsePathfindingFailure
         | SummaryResponseSimulationFailed
         | SummaryResponsePathfindingInputError
     )


### PR DESCRIPTION
close #17188 close #14335

This fixes infra loading when edition is performed.

Core:
- Fix parsing `infra_version`. It was ignored and always `null` :upside_down_face: 
- Cleanup and fix InternalError, they're now considered as Errors on both editoast and core.