### PR TITLE
Link TrainHeader `DurationInput` to train service cadence and window

### DIFF
--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { Button, Checkbox, Input, Select } from '@osrd-project/ui-core';
+import { Button, Checkbox, DurationInput, Input, Select } from '@osrd-project/ui-core';
 import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
@@ -13,16 +13,13 @@ import useCategoryOptions, {
 } from 'modules/rollingStock/hooks/useCategoryOptions';
 import type { Train } from 'reducers/osrdconf/types';
 import { useDateTimeLocale } from 'utils/date';
+import { Duration } from 'utils/duration';
 import { usePrevious } from 'utils/hooks/state';
 import { findExceptionInPacedTrainByOccurenceId } from 'utils/trainExceptions';
 import { isOccurrenceId } from 'utils/trainId';
 import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
-import {
-  getServiceInterval,
-  getServiceWindow,
-  getShortDepartureDate,
-} from './utils/trainProperties';
+import { getShortDepartureDate } from './utils/trainProperties';
 
 export type ExpandedTrainFormProps = {
   train: Train;
@@ -37,6 +34,8 @@ type TrainFieldsState = {
   constraint_distribution: ConstraintDistribution;
   comfort: Comfort | null;
   category: TrainCategory | null;
+  service_cadence?: number;
+  service_window?: number;
 };
 
 function getFieldsFromTrain(train: Train): TrainFieldsState {
@@ -46,15 +45,26 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     constraint_distribution: train.constraint_distribution,
     comfort: train.comfort ?? null,
     category: train.category ?? null,
+    service_cadence: Duration.parse(train.paced?.interval ?? '0').valueOf(),
+    service_window: Duration.parse(train.paced?.time_window ?? '0').valueOf(),
   };
 }
 
 function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
+  const paced = train.paced
+    ? {
+        exceptions: train.paced.exceptions,
+        interval: new Duration({ milliseconds: fields.service_cadence }).toISOString(),
+        time_window: new Duration({ milliseconds: fields.service_window }).toISOString(),
+      }
+    : undefined;
+
   return {
     ...train,
     ...fields,
     comfort: fields.comfort === null ? undefined : fields.comfort,
     category: fields.category === null ? undefined : fields.category,
+    paced,
   };
 }
 
@@ -72,7 +82,6 @@ function extractChangesInFields(
   current?: TrainFieldsState
 ): Partial<TrainFieldsState> {
   const changedValues: Partial<TrainFieldsState> = {};
-
   for (const fieldName of Object.keys(before) as (keyof TrainFieldsState)[]) {
     if (
       after[fieldName] !== before[fieldName] &&
@@ -131,7 +140,6 @@ const ExpandedTrainForm = ({
   const onFieldBlur = useCallback(
     (_fieldName: keyof TrainFieldsState) => {
       const changes = extractChangesInFields(fieldsFromTrain, fields);
-
       if (Object.keys(changes).length) {
         const updatedTrain = applyFieldsToTrain(fields, train);
         onPersistTrain(updatedTrain);
@@ -223,21 +231,27 @@ const ExpandedTrainForm = ({
                 {t('manageTrainSchedule.trainHeader.serviceModelTrain')}
               </div>
               <div className="train-service-cadence">
-                <Input
+                <DurationInput
                   id="train-header-service-cadence-input"
                   small
+                  units={['m']}
+                  padChar="0"
+                  max={3_600_000}
                   label={t('manageTrainSchedule.trainHeader.form.serviceCadence')}
-                  value={`${getServiceInterval(pacedTrain) ?? 0} min`}
-                  disabled
+                  value={fields.service_cadence ?? 0}
+                  onChange={(ms) => onFieldImmediateChange('service_cadence', ms)}
                 />
               </div>
               <div className="train-service-window">
-                <Input
+                <DurationInput
                   id="train-header-service-window-input"
                   small
+                  units={['h', 'm']}
+                  padChar="0"
+                  max={5 * 3_600_000} // 5h00m
                   label={t('manageTrainSchedule.trainHeader.form.serviceWindow')}
-                  value={`${getServiceWindow(pacedTrain) ?? 0} min`}
-                  disabled
+                  value={fields.service_window ?? 2 * 3_600_000} // 2h00m
+                  onChange={(ms) => onFieldImmediateChange('service_window', ms)}
                 />
               </div>
               <div className="actions">

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -61,6 +61,13 @@
     :where(& > *) {
       grid-column: 1 / end-column;
     }
+
+    .train-service-cadence,
+    .train-service-window {
+      .ui-duration-input {
+        width: 100%;
+      }
+    }
   }
 
   .train-paced-kind {

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -28,7 +28,7 @@ export type DurationInputProps = {
   small?: boolean;
   hint?: string;
   label?: string;
-} & React.ComponentPropsWithoutRef<'div'>;
+} & Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'>;
 
 const PRESETS: Record<string, Omit<UnitConfig, 'key'>> = {
   h: { label: 'h', digits: 2, msPerUnit: 3_600_000 },
@@ -93,7 +93,6 @@ function useDurationInput({
   max,
 }: Omit<DurationInputProps, 'id'>) {
   const fields = useMemo(() => normalizeUnits(units, padChar, max), [units, padChar, max]);
-
   const inputRefs = useRef<Record<string, HTMLInputElement>>({});
 
   const [initialValue, setInitialValue] = useState(value);
@@ -129,13 +128,6 @@ function useDurationInput({
       if (previous) focusField(previous.key);
     },
     [fields, focusField]
-  );
-
-  const emit = useCallback(
-    (nextValues: FormattedValues) => {
-      onChange?.(toTotalMilliseconds(fields, nextValues));
-    },
-    [fields, onChange]
   );
 
   const handleChange = useCallback(
@@ -175,8 +167,8 @@ function useDurationInput({
     const clamped = Math.min(max, ms);
     const next = toFormattedValues(fields, clamped);
     setFormattedValues(next);
-    emit(next);
-  }, [fields, formattedValues, max, emit]);
+    onChange?.(toTotalMilliseconds(fields, next));
+  }, [fields, formattedValues, max, onChange]);
 
   return {
     fields,
@@ -195,7 +187,6 @@ type UnitFieldProps = {
   inputRef: (el: HTMLInputElement | null) => void;
   onChange: (value: string) => void;
   onFocus: () => void;
-  onBlur: () => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   tabIndex: number;
 };
@@ -206,7 +197,6 @@ const UnitField = function UnitField({
   inputRef,
   onChange,
   onFocus,
-  onBlur,
   onKeyDown,
   tabIndex,
 }: UnitFieldProps) {
@@ -228,7 +218,6 @@ const UnitField = function UnitField({
         aria-label={label}
         onChange={(e) => onChange(e.target.value)}
         onFocus={onFocus}
-        onBlur={onBlur}
         onKeyDown={onKeyDown}
       />
       <span aria-hidden onClick={onFocus}>
@@ -255,21 +244,14 @@ const DurationInput = ({
   hint,
   ...rest
 }: DurationInputProps) => {
-  const {
-    fields,
-    formattedValues,
-    inputRefs,
-    handleChange,
-    handleFocus,
-    handleBlur,
-    handleKeyDown,
-  } = useDurationInput({
-    units,
-    value,
-    onChange,
-    padChar,
-    max,
-  });
+  const { fields, formattedValues, inputRefs, handleChange, handleFocus, handleKeyDown } =
+    useDurationInput({
+      units,
+      value,
+      onChange,
+      padChar,
+      max,
+    });
 
   return (
     <FieldWrapper id={id} label={label} hint={hint} small={small}>
@@ -277,6 +259,7 @@ const DurationInput = ({
         className={cx('ui-duration-input', { small })}
         role="group"
         aria-label="Duration Input"
+        onClick={() => inputRefs.current[fields[0].key]?.focus()}
         {...rest}
       >
         {fields.map((setting, idx) => (
@@ -290,7 +273,6 @@ const DurationInput = ({
             tabIndex={idx === 0 ? 0 : -1}
             onChange={(val) => handleChange(setting, val)}
             onFocus={() => handleFocus(setting)}
-            onBlur={() => handleBlur()}
             onKeyDown={(e) => handleKeyDown(setting, e)}
           />
         ))}

--- a/front/ui/ui-core/src/styles/inputs/duration-input.css
+++ b/front/ui/ui-core/src/styles/inputs/duration-input.css
@@ -26,6 +26,8 @@
   line-height: 1.25rem;
   font-size: 0.875rem;
 
+  cursor: text;
+
   .unit-field {
     line-height: 20px;
     letter-spacing: 0;


### PR DESCRIPTION
### Description and goal

This is the second part of #16534. The goal is to integrate a way to edit the service window duration directly from the table header.

### Acceptance criteria


- [x] The component is visually in place in the header.
- [x] using the component changes the corresponding info of the selected train.