### PR TITLE
front: take power restriction warning into account to compute the height

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -126,6 +126,12 @@ type TimeCellTabEntry = {
 };
 
 const HEADER_HEIGHT = 40;
+
+/**
+ * height: 47px + border-bottom: 1px (see _timesStopsTable.scss)
+ */
+const POWER_RESTRICTION_WARNING_HEIGHT = 48;
+
 const ROW_HEIGHT = 40;
 const DAY_CHANGE_BANNER_HEIGHT = 40;
 
@@ -698,12 +704,17 @@ const TimesStopsTable = ({
 
   const virtualItems = virtualizer.getVirtualItems();
 
+  let height = virtualizer.getTotalSize() + HEADER_HEIGHT;
+  if (powerRestrictionWarningCount > 0) {
+    height += POWER_RESTRICTION_WARNING_HEIGHT;
+  }
+
   return (
     <div
       className={cx('times-stops-table-new', { 'computed-data-pending': isComputedDataPending })}
       data-testid="times-stops-table-new"
       ref={virtualizedWrapperRef}
-      style={{ height: `${virtualizer.getTotalSize() + HEADER_HEIGHT}px` }}
+      style={{ height: `${height}px` }}
     >
       <table className="table-container">
         {powerRestrictionWarningCount > 0 && (


### PR DESCRIPTION
... of the time table. Otherwise, a scrollbar appears in the table when the warning is displayed.

Co-authored-by: @DucNg 

Closes #17014

# How to test

the easiest way is to import this train in a small infra scenario: 
[timetable(29).json](https://github.com/user-attachments/files/28879161/timetable.29.json). this patch makes the table large enough to fit the warning, while on dev there's an additional scrollbar.

or you can see the bug on any electric train with incompatible/invalid (idk) power restrictions, but you need to scroll down to the end of the table for the scrollbar to appear.