### PR TITLE
Wire drag&drop in std with panel modes

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
@@ -2,10 +2,12 @@ import { useRef, useEffect, useCallback, useState } from 'react';
 
 import type {
   LightRollingStockWithLiveries,
+  PacedTrainException,
   TrainScheduleSimulationSummaryResult,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import formatTrainScheduleSummaries from 'modules/simulationResult/helpers/formatTrainScheduleSummaries';
+import { withPacedExceptions } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import { useAppDispatch } from 'store';
 
@@ -107,16 +109,32 @@ export default function useLazySimulateTrains({
   }, []);
 
   const updateSimulatedTrainScheduleDepartureTime = useCallback(
-    (id: number, newDeparture: Date) => {
+    (id: number, newDeparture: Date, shiftedExceptions?: PacedTrainException[]) => {
       setSimulatedTrainsById((prev) => {
         const result = prev.get(id);
         if (!result) {
           return prev;
         }
         const next = new Map(prev);
-        next.set(id, {
-          ...result,
-          startTime: newDeparture,
+        next.set(
+          id,
+          withPacedExceptions({ ...result, startTime: newDeparture }, shiftedExceptions)
+        );
+        return next;
+      });
+    },
+    []
+  );
+
+  const updateSimulatedTrainExceptions = useCallback(
+    (trainScheduleId: number, updatedExceptions: PacedTrainException[]) => {
+      setSimulatedTrainsById((prev) => {
+        const existing = prev.get(trainScheduleId);
+        if (!existing?.paced) return prev;
+        const next = new Map(prev);
+        next.set(trainScheduleId, {
+          ...existing,
+          paced: { ...existing.paced, exceptions: updatedExceptions },
         });
         return next;
       });
@@ -129,6 +147,7 @@ export default function useLazySimulateTrains({
     simulateTrainSchedules,
     removeSimulatedTrainSchedules,
     updateSimulatedTrainScheduleDepartureTime,
+    updateSimulatedTrainExceptions,
     isTrainSimulationLoading,
   };
 }

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -4,14 +4,39 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import { keyBy, sortBy } from 'lodash';
 
 import {
+  buildOccurrenceExceptionData,
+  updatePacedTrainExceptionsList,
+} from 'applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/buildPacedTrainException';
+import {
   osrdEditoastApi,
+  type PacedTrainException,
   type ScenarioWithDetails,
+  type TrainSchedule,
   type TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import { useRollingStockContext } from 'common/RollingStockContext';
+import type { PanelSelectionMode } from 'modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel';
 import useLazyProjectTrains from 'modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains';
 import { formatPacedTrainWithDetails } from 'modules/trainSchedule/helpers/formatTrainScheduleWithDetails';
+import {
+  extractOccurrenceDetailsFromPacedTrain,
+  findExceptionWithOccurrenceId,
+  getOccurrenceTrainName,
+  isPacedTrain,
+  shiftPacedExceptions,
+  withPacedExceptions,
+} from 'modules/trainSchedule/helpers/pacedTrain';
+import {
+  syncOccurrenceException,
+  updateExceptions,
+} from 'modules/trainSchedule/helpers/updateTrainScheduleHelpers';
+import type { TrainId } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
+import {
+  extractEditoastIdFromPacedTrainId,
+  extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
+} from 'utils/trainId';
 import { mapBy } from 'utils/types';
 
 import useAutoSelectTrainIds from './useAutoSelectTrainIds';
@@ -23,6 +48,14 @@ type ScenarioBroadcastMessage =
   | { type: 'upsertTrainSchedules'; trainSchedules: TrainScheduleResponse[] }
   | { type: 'removeTrainSchedules'; trainScheduleIds: number[] }
   | { type: 'setTrainScheduleDepartureTime'; trainScheduleId: number; newDeparture: Date };
+
+function upsertAndSort(
+  prev: TrainScheduleResponse[] | undefined,
+  updates: TrainScheduleResponse | TrainScheduleResponse[]
+): TrainScheduleResponse[] {
+  const arr = Array.isArray(updates) ? updates : [updates];
+  return sortBy(Object.values({ ...keyBy(prev, 'id'), ...keyBy(arr, 'id') }), 'start_time');
+}
 
 const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetableId: number) => {
   const dispatch = useAppDispatch();
@@ -64,6 +97,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
     projectTrainSchedules,
     removeProjectedTrainSchedules,
     updateProjectedTrainScheduleDepartureTime,
+    updateProjectedTrainExceptions,
   } = useLazyProjectTrains({
     infraId,
     timetableId: scenario.timetable_id,
@@ -82,6 +116,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
     isTrainSimulationLoading,
     removeSimulatedTrainSchedules,
     updateSimulatedTrainScheduleDepartureTime,
+    updateSimulatedTrainExceptions,
   } = useLazySimulateTrains({
     infraId,
     timetableId,
@@ -141,12 +176,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
   };
 
   const upsertTrainSchedules = useCallback((trainSchedulesToUpsert: TrainScheduleResponse[]) => {
-    setTrainSchedules((prev) =>
-      sortBy(
-        Object.values({ ...keyBy(prev, 'id'), ...keyBy(trainSchedulesToUpsert, 'id') }),
-        'start_time'
-      )
-    );
+    setTrainSchedules((prev) => upsertAndSort(prev, trainSchedulesToUpsert));
 
     removeSimulatedTrainSchedules(trainSchedulesToUpsert.map((trainSchedule) => trainSchedule.id));
     removeProjectedTrainSchedules(trainSchedulesToUpsert.map((trainSchedule) => trainSchedule.id));
@@ -171,46 +201,54 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
   }, []);
 
   const setTrainScheduleDepartureTime = useCallback(
-    (trainScheduleId: number, newDeparture: Date) => {
+    (trainScheduleId: number, newDeparture: Date, _panelSelectionMode?: PanelSelectionMode) => {
       setTrainSchedules((prev) => {
-        const trainSchedule = prev?.find((train) => train.id === trainScheduleId);
-        if (!trainSchedule) {
+        const prevTrainSchedule = prev?.find((train) => train.id === trainScheduleId);
+        if (!prevTrainSchedule) {
           return prev;
         }
         const updatedTrainSchedule = {
-          ...trainSchedule,
+          ...prevTrainSchedule,
           start_time: newDeparture.getTime(),
         };
-        const newTrainSchedulesById = {
-          ...keyBy(prev, 'id'),
-          ...keyBy([updatedTrainSchedule], 'id'),
-        };
-        return sortBy(Object.values(newTrainSchedulesById), 'start_time');
+        return upsertAndSort(prev, updatedTrainSchedule);
       });
 
       updateSimulatedTrainScheduleDepartureTime(trainScheduleId, newDeparture);
       updateProjectedTrainScheduleDepartureTime(trainScheduleId, newDeparture);
     },
-    []
+    [trainSchedules]
   );
 
-  /** Update only departure time of a train schedule */
+  /**
+   * Move a train (or one of its occurrences) to a new departure time, depending on the panel mode:
+   * - 'single': create / update / delete the dragged occurrence's start_time exception
+   * - 'all': shift the model and every start_time exception by the same offset
+   * - 'compliant' / non-paced: shift the model departure
+   */
   const updateTrainScheduleDepartureTime = useCallback(
-    async (trainScheduleId: number, newDeparture: Date) => {
-      const trainSchedule = trainSchedules?.find((train) => train.id === trainScheduleId);
+    async (
+      draggedTrainId: TrainId,
+      newDeparture: Date,
+      panelSelectionMode?: PanelSelectionMode
+    ) => {
+      const editoastId = extractEditoastIdFromPacedTrainId(
+        isOccurrenceId(draggedTrainId)
+          ? extractPacedTrainIdFromOccurrenceId(draggedTrainId)
+          : draggedTrainId
+      );
+      const trainSchedule = trainSchedules?.find((train) => train.id === editoastId);
       if (!trainSchedule) {
-        throw new Error(`Train schedule "${trainScheduleId}" not found`);
+        throw new Error(`Train schedule "${editoastId}" not found`);
       }
 
+      // Update the model start_time.
       await updateTrainSchedule({
         id: trainSchedule.id,
-        trainSchedule: {
-          ...trainSchedule,
-          start_time: newDeparture.getTime(),
-        },
+        trainSchedule: { ...trainSchedule, start_time: newDeparture.getTime() },
       }).unwrap();
 
-      setTrainScheduleDepartureTime(trainScheduleId, newDeparture);
+      setTrainScheduleDepartureTime(editoastId, newDeparture, panelSelectionMode);
     },
     [trainSchedules]
   );
@@ -238,11 +276,23 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
   );
 
   const updateTrainScheduleDepartureTimeWithBroadcast = useCallback(
-    async (trainScheduleId: number, newDeparture: Date) => {
-      await updateTrainScheduleDepartureTime(trainScheduleId, newDeparture);
+    async (
+      draggedTrainId: TrainId,
+      newDeparture: Date,
+      panelSelectionMode?: PanelSelectionMode
+    ) => {
+      await updateTrainScheduleDepartureTime(draggedTrainId, newDeparture, panelSelectionMode);
+      // 'single' only changes one occurrence's exception, not the model departure: nothing to
+      // broadcast as a departure-time change (other tabs reconcile via tag invalidation).
+      if (panelSelectionMode === 'single') return;
+      const editoastId = extractEditoastIdFromPacedTrainId(
+        isOccurrenceId(draggedTrainId)
+          ? extractPacedTrainIdFromOccurrenceId(draggedTrainId)
+          : draggedTrainId
+      );
       broadcastScenarioMessage({
         type: 'setTrainScheduleDepartureTime',
-        trainScheduleId,
+        trainScheduleId: editoastId,
         newDeparture,
       });
     },

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -57,6 +57,20 @@ function upsertAndSort(
   return sortBy(Object.values({ ...keyBy(prev, 'id'), ...keyBy(arr, 'id') }), 'start_time');
 }
 
+/**
+ * In 'all' mode the whole paced train moves, so every start_time exception is shifted by the same
+ * offset as the model departure. Returns undefined when there is nothing to shift.
+ */
+function computeShiftedExceptions(
+  trainSchedule: TrainScheduleResponse,
+  newDeparture: Date,
+  panelSelectionMode?: PanelSelectionMode
+): PacedTrainException[] | undefined {
+  if (panelSelectionMode !== 'all' || !trainSchedule.paced) return undefined;
+  const offset = newDeparture.getTime() - trainSchedule.start_time;
+  return shiftPacedExceptions(trainSchedule.paced.exceptions, offset);
+}
+
 const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetableId: number) => {
   const dispatch = useAppDispatch();
 
@@ -201,21 +215,28 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
   }, []);
 
   const setTrainScheduleDepartureTime = useCallback(
-    (trainScheduleId: number, newDeparture: Date, _panelSelectionMode?: PanelSelectionMode) => {
+    (trainScheduleId: number, newDeparture: Date, panelSelectionMode?: PanelSelectionMode) => {
+      const trainSchedule = trainSchedules?.find((train) => train.id === trainScheduleId);
+      const shiftedExceptions = trainSchedule
+        ? computeShiftedExceptions(trainSchedule, newDeparture, panelSelectionMode)
+        : undefined;
+
       setTrainSchedules((prev) => {
         const prevTrainSchedule = prev?.find((train) => train.id === trainScheduleId);
         if (!prevTrainSchedule) {
           return prev;
         }
-        const updatedTrainSchedule = {
-          ...prevTrainSchedule,
-          start_time: newDeparture.getTime(),
-        };
+        const updatedTrainSchedule = withPacedExceptions(
+          { ...prevTrainSchedule, start_time: newDeparture.getTime() },
+          shiftedExceptions
+        );
         return upsertAndSort(prev, updatedTrainSchedule);
       });
 
-      updateSimulatedTrainScheduleDepartureTime(trainScheduleId, newDeparture);
-      updateProjectedTrainScheduleDepartureTime(trainScheduleId, newDeparture);
+      // Pass shiftedExceptions to both so that exception occurrences (timetable + space-time chart)
+      // immediately reflect the shifted start_time without waiting for a full re-simulation.
+      updateSimulatedTrainScheduleDepartureTime(trainScheduleId, newDeparture, shiftedExceptions);
+      updateProjectedTrainScheduleDepartureTime(trainScheduleId, newDeparture, shiftedExceptions);
     },
     [trainSchedules]
   );
@@ -301,11 +322,27 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
         return;
       }
 
-      // Update the model start_time.
+      // 'all' mode: the whole paced train moves — shift every start_time exception by the same offset.
+      const shiftedExceptions = computeShiftedExceptions(
+        trainSchedule,
+        newDeparture,
+        panelSelectionMode
+      );
+
+      // Update the model start_time. The train schedule PUT ignores paced.exceptions, so shifted
+      // exceptions are persisted through their own endpoint below.
       await updateTrainSchedule({
         id: trainSchedule.id,
         trainSchedule: { ...trainSchedule, start_time: newDeparture.getTime() },
       }).unwrap();
+
+      if (shiftedExceptions) {
+        const exceptionsToShift = shiftedExceptions.filter(
+          // filter out null/undefined ids, which can happen if the exception is deleted because it was re-aligned on the model.
+          (exc) => exc.start_time && exc.id !== null && exc.id !== undefined
+        );
+        await updateExceptions(dispatch, exceptionsToShift, trainSchedule.id);
+      }
 
       setTrainScheduleDepartureTime(editoastId, newDeparture, panelSelectionMode);
     },

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -220,6 +220,24 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
     [trainSchedules]
   );
 
+  /** Update paced train exceptions in local state without re-simulating. Used after drag-created exceptions. */
+  const upsertTrainScheduleExceptions = useCallback(
+    (trainScheduleId: number, updatedExceptions: PacedTrainException[]) => {
+      setTrainSchedules((prev) => {
+        const train = prev?.find((t) => t.id === trainScheduleId);
+        if (!train?.paced) return prev;
+        const updated: TrainScheduleResponse = {
+          ...train,
+          paced: { ...train.paced, exceptions: updatedExceptions },
+        };
+        return upsertAndSort(prev, updated);
+      });
+      updateSimulatedTrainExceptions(trainScheduleId, updatedExceptions);
+      updateProjectedTrainExceptions(trainScheduleId, updatedExceptions);
+    },
+    []
+  );
+
   /**
    * Move a train (or one of its occurrences) to a new departure time, depending on the panel mode:
    * - 'single': create / update / delete the dragged occurrence's start_time exception
@@ -242,6 +260,47 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
         throw new Error(`Train schedule "${editoastId}" not found`);
       }
 
+      // 'single' mode: create / update / delete the dragged occurrence's exception. We reuse the
+      // same diff helpers as the times-stops table, so the "exception re-aligned on the model"
+      // detection (which drops the start_time override) stays consistent across the app.
+      if (
+        panelSelectionMode === 'single' &&
+        isOccurrenceId(draggedTrainId) &&
+        isPacedTrain(trainSchedule)
+      ) {
+        const existingException = findExceptionWithOccurrenceId(
+          trainSchedule.paced.exceptions,
+          draggedTrainId
+        );
+        const { paced: _paced, ...occurrenceBaseTrain } = trainSchedule;
+        const updatedOccurrence: TrainSchedule = {
+          ...extractOccurrenceDetailsFromPacedTrain(occurrenceBaseTrain, existingException),
+          train_name: getOccurrenceTrainName(trainSchedule, draggedTrainId),
+          start_time: newDeparture.getTime(),
+        };
+
+        const {
+          generatedException,
+          existingException: exceptionToSync,
+          occurrenceIndex,
+        } = buildOccurrenceExceptionData(trainSchedule, updatedOccurrence, draggedTrainId);
+        const finalException = await syncOccurrenceException(
+          dispatch,
+          generatedException,
+          exceptionToSync,
+          occurrenceIndex,
+          editoastId,
+          timetableId
+        );
+        const updatedExceptions = updatePacedTrainExceptionsList(
+          trainSchedule.paced.exceptions,
+          finalException,
+          draggedTrainId
+        );
+        upsertTrainScheduleExceptions(editoastId, updatedExceptions);
+        return;
+      }
+
       // Update the model start_time.
       await updateTrainSchedule({
         id: trainSchedule.id,
@@ -250,7 +309,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
 
       setTrainScheduleDepartureTime(editoastId, newDeparture, panelSelectionMode);
     },
-    [trainSchedules]
+    [trainSchedules, dispatch, timetableId, upsertTrainScheduleExceptions]
   );
 
   const upsertTrainSchedulesWithBroadcast = useCallback(

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -14,8 +14,9 @@ import Conflicts from 'modules/conflict/components/Conflicts';
 import useConflictsFilter from 'modules/conflict/hooks/useConflictsFilter';
 import ScenarioLoaderMessage from 'modules/scenario/components/ScenarioLoaderMessage';
 import ChronogramWrapper from 'modules/simulationResult/components/Chronogram/ChronogramWrapper';
+import type { PanelSelectionMode } from 'modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel';
 import { setFailure } from 'reducers/main';
-import type { TrainScheduleToEditData } from 'reducers/osrdconf/types';
+import type { TrainId, TrainScheduleToEditData } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import { usePrevious } from 'utils/hooks/state';
@@ -132,8 +133,12 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
   );
 
   const updateTrainScheduleDepartureTimeWithNge = useCallback(
-    async (trainScheduleId: number, newDeparture: Date) => {
-      await updateTrainScheduleDepartureTime(trainScheduleId, newDeparture);
+    async (
+      draggedTrainId: TrainId,
+      newDeparture: Date,
+      panelSelectionMode?: PanelSelectionMode
+    ) => {
+      await updateTrainScheduleDepartureTime(draggedTrainId, newDeparture, panelSelectionMode);
       refreshNge();
     },
     [updateTrainScheduleDepartureTime, refreshNge]

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -10,6 +10,7 @@ import useSimulationResults from 'applications/operationalStudies/hooks/useSimul
 import type { Board } from 'applications/operationalStudies/types';
 import { type Conflict, type TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 import SimulationWarpedMap from 'common/Map/WarpedMap/SimulationWarpedMap';
+import type { PanelSelectionMode } from 'modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel';
 import createHandleTrainDrag from 'modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag';
 import SpaceTimeChartWrapper, {
   MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT,
@@ -24,7 +25,7 @@ import TimeStopsTableWrapper from 'modules/timesStops/TimeStopsTableWrapper';
 import TrainHeader from 'modules/trainHeader/TrainHeader';
 import { findExceptionWithOccurrenceId } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
-import type { TrainScheduleToEditData } from 'reducers/osrdconf/types';
+import type { TrainId, TrainScheduleToEditData } from 'reducers/osrdconf/types';
 import { toggleDisplayOnlyPathSteps, updateSelectedTrain } from 'reducers/simulationResults';
 import {
   getDisplayOnlyPathSteps,
@@ -54,7 +55,11 @@ type SimulationResultsProps = {
   trainSchedules: TrainScheduleResponse[];
   conflicts?: Conflict[];
   activeBoards: Set<Board>;
-  updateTrainScheduleDepartureTime: (trainId: number, newDepartureTime: Date) => Promise<void>;
+  updateTrainScheduleDepartureTime: (
+    draggedTrainId: TrainId,
+    newDepartureTime: Date,
+    panelSelectionMode?: PanelSelectionMode
+  ) => Promise<void>;
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
   setDisplayTrainScheduleManagement: (type: string) => void;
   setTrainScheduleToEditData: (trainScheduleToEditData?: TrainScheduleToEditData) => void;
@@ -116,7 +121,7 @@ const SimulationResults = ({
 
   useEffect(() => {
     setTrainScheduleProjections(projectionData?.projectedTrains || []);
-  }, [projectionData]);
+  }, [projectionData?.projectedTrains]);
 
   useEffect(() => {
     if (simulationResults?.pathProperties && isScrollingToTimeStopsTable) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -687,6 +687,7 @@ const SpaceTimeChartWrapper = ({
           ref={spaceTimeChartRef}
           data-testid="space-time-chart-container"
           className="space-time-chart-container"
+          style={{ cursor: draggingState ? 'ew-resize' : undefined }}
         >
           <SpaceTimeChartToolbar
             xZoom={xZoom}

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -174,6 +174,11 @@ const buildCurveHover = (
   }
   return undefined;
 };
+function formatDragOffset(ms: number): string {
+  const sign = ms >= 0 ? '+' : '-';
+  const minutes = Math.round(Math.abs(ms) / 60_000);
+  return `${sign} ${minutes} min`;
+}
 
 const SpaceTimeChartWrapper = ({
   operationalPoints,
@@ -210,6 +215,15 @@ const SpaceTimeChartWrapper = ({
   const [draggingOccupancyZoneRef, setDraggingOccupancyZoneRef] =
     useState<OccupancyZoneReference | null>(null);
   const [dragOverTrackId, setDragOverTrackId] = useState<string | undefined>();
+  const [dragOffsetMs, setDragOffsetMs] = useState<number | null>(null);
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) =>
+      setMousePosition({ x: e.clientX, y: e.clientY + 15 });
+    document.addEventListener('mousemove', handleMouseMove);
+    return () => document.removeEventListener('mousemove', handleMouseMove);
+  }, []);
 
   const [panelSelectionMode, setPanelSelectionMode] = useState<PanelSelectionMode>('compliant');
   const [lastClickedOccurrenceId, setLastClickedOccurrenceId] = useState<OccurrenceId>();
@@ -486,6 +500,7 @@ const SpaceTimeChartWrapper = ({
       projectedTrains,
       draggingState,
       setDraggingState,
+      setDragOffsetMs,
       hoveredItem,
       previousPanning,
       setPreviousPanning,
@@ -772,6 +787,15 @@ const SpaceTimeChartWrapper = ({
           handleXZoom(Number(e.target.value));
         }}
       />
+      {draggingState &&
+        dragOffsetMs !== null &&
+        createPortal(
+          // tooltip following the cursor with the drag's time offset
+          <div className="drag-tooltip" style={{ left: mousePosition.x, top: mousePosition.y }}>
+            {formatDragOffset(dragOffsetMs)}
+          </div>,
+          document.body
+        )}
     </div>
     /* TODO use margin or absolute to align with handle */
   );

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -115,11 +115,13 @@ type SpaceTimeChartWrapperBaseProps = {
     newDepartureTime,
     initialDepartureTime,
     stopPanning,
+    panelSelectionMode,
   }: {
     draggedTrainId: TrainId;
     initialDepartureTime: Date;
     newDepartureTime: Date;
     stopPanning: boolean;
+    panelSelectionMode: PanelSelectionMode;
   }) => Promise<void>;
   height?: number;
   onTrainClick?: (trainId: TrainId) => void;
@@ -479,6 +481,8 @@ const SpaceTimeChartWrapper = ({
       spaceTimeChartOnPan: spaceTimeChartProps.onPan,
       handleTrainDrag,
       selectedTrainId,
+      selectedTrainBy,
+      panelSelectionMode,
       projectedTrains,
       draggingState,
       setDraggingState,
@@ -497,6 +501,8 @@ const SpaceTimeChartWrapper = ({
     [
       spaceTimeChartProps.onPan,
       handleTrainDrag,
+      selectedTrainBy,
+      panelSelectionMode,
       draggingState,
       hoveredItem,
       previousPanning,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/canDragHoveredTrain.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/canDragHoveredTrain.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+
+import type { PacedTrainException } from 'common/api/osrdEditoastApi';
+import type { IndividualTrainProjection } from 'modules/simulationResult/types';
+import type { OccurrenceId, PacedTrainId, TrainId } from 'reducers/osrdconf/types';
+
+import canDragHoveredTrain from '../canDragHoveredTrain';
+
+const PACED_1 = 'paced_1' as PacedTrainId;
+const PACED_2 = 'paced_2' as PacedTrainId;
+const OCC_1_0 = 'indexedoccurrence_1_0' as OccurrenceId;
+const OCC_1_1 = 'indexedoccurrence_1_1' as OccurrenceId;
+const OCC_2_0 = 'indexedoccurrence_2_0' as OccurrenceId;
+
+const train = (id: TrainId, exception?: Partial<PacedTrainException>): IndividualTrainProjection =>
+  ({ id, ...(exception ? { exception } : {}) }) as IndividualTrainProjection;
+
+describe('canDragHoveredTrain', () => {
+  it('forbids dragging when no train is selected, whatever the mode', () => {
+    for (const panelSelectionMode of ['compliant', 'single', 'all'] as const) {
+      expect(canDragHoveredTrain({ panelSelectionMode, hoveredTrain: train(OCC_1_0) })).toBe(false);
+    }
+  });
+
+  describe("'compliant' mode", () => {
+    it('allows dragging the selected non-paced train', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'compliant',
+          hoveredTrain: train(PACED_1),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(true);
+    });
+
+    it('forbids dragging a non-paced train that is not the selected one', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'compliant',
+          hoveredTrain: train(PACED_2),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(false);
+    });
+
+    it('allows dragging a conforming occurrence of the selected train', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'compliant',
+          hoveredTrain: train(OCC_1_0),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(true);
+    });
+
+    it('forbids dragging a conforming occurrence of another paced train', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'compliant',
+          hoveredTrain: train(OCC_2_0),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(false);
+    });
+
+    it('allows dragging an occurrence whose exception does not override start_time', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'compliant',
+          hoveredTrain: train(OCC_1_0, { path_and_schedule: { value: 'foo' } as never }),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(true);
+    });
+
+    it('forbids dragging an occurrence of the selected train with a start_time exception', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'compliant',
+          hoveredTrain: train(OCC_1_0, { start_time: { value: 1000 } as never }),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("'single' mode", () => {
+    it('allows dragging only the selected occurrence', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'single',
+          hoveredTrain: train(OCC_1_0),
+          selectedTrainId: OCC_1_0,
+        })
+      ).toBe(true);
+    });
+
+    it('forbids dragging a different occurrence of the same paced train', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'single',
+          hoveredTrain: train(OCC_1_1),
+          selectedTrainId: OCC_1_0,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("'all' mode", () => {
+    it('allows dragging any occurrence of the selected paced train (selected as PacedTrainId)', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'all',
+          hoveredTrain: train(OCC_1_1),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(true);
+    });
+
+    it('allows dragging when the selection is an occurrence of the same paced train', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'all',
+          hoveredTrain: train(OCC_1_1),
+          selectedTrainId: OCC_1_0,
+        })
+      ).toBe(true);
+    });
+
+    it('forbids dragging an occurrence of another paced train', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'all',
+          hoveredTrain: train(OCC_2_0),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(false);
+    });
+
+    it('forbids dragging a non-occurrence hovered train', () => {
+      expect(
+        canDragHoveredTrain({
+          panelSelectionMode: 'all',
+          hoveredTrain: train(PACED_1),
+          selectedTrainId: PACED_1,
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/canDragHoveredTrain.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/canDragHoveredTrain.ts
@@ -1,0 +1,51 @@
+import type { TrainId } from 'reducers/osrdconf/types';
+import { extractPacedTrainIdFromTrainId, isOccurrenceId } from 'utils/trainId';
+
+import type { IndividualTrainProjection } from '../../../types';
+import type { PanelSelectionMode } from '../CurveSelectionSidePanel';
+
+/**
+ * Decide whether the hovered train may start being dragged, given the active panel selection
+ * mode. The caller must already have checked that the selection is shown with blue ('std')
+ * curves — this only resolves the per-mode rule.
+ *
+ * Kept pure (no store / DOM access) so it can be unit-tested in isolation.
+ */
+export default function canDragHoveredTrain({
+  panelSelectionMode,
+  hoveredTrain,
+  selectedTrainId,
+}: {
+  panelSelectionMode: PanelSelectionMode;
+  hoveredTrain: IndividualTrainProjection;
+  selectedTrainId?: TrainId;
+}): boolean {
+  const hoveredTrainId = hoveredTrain.id;
+  if (!selectedTrainId) return false;
+
+  const belongsToSelectedTrain =
+    extractPacedTrainIdFromTrainId(hoveredTrainId) ===
+    extractPacedTrainIdFromTrainId(selectedTrainId);
+
+  switch (panelSelectionMode) {
+    case 'compliant':
+      // The hovered curve must belong to the selected train, and only a conforming occurrence
+      // (no start_time exception) — or the non-paced train itself — is draggable: dragging it
+      // shifts the model departure.
+      return (
+        belongsToSelectedTrain &&
+        !('exception' in hoveredTrain && hoveredTrain.exception?.start_time)
+      );
+
+    case 'single':
+      // only the selected occurrence (including start_time exceptions)
+      return hoveredTrainId === selectedTrainId;
+
+    case 'all':
+      // any occurrence of the selected paced train (conforming or exception)
+      return isOccurrenceId(hoveredTrainId) && belongsToSelectedTrain;
+
+    default:
+      return false;
+  }
+}

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -70,6 +70,7 @@ type ConfigureHandlePanParams = {
   projectedTrains: IndividualTrainProjection[];
   draggingState: DraggingState;
   setDraggingState: (s: DraggingState) => void;
+  setDragOffsetMs: (ms: number | null) => void;
   hoveredItem: HoveredItem | null;
   previousPanning: boolean;
   setPreviousPanning: (v: boolean) => void;
@@ -92,6 +93,7 @@ export function configureHandlePan({
   projectedTrains,
   draggingState,
   setDraggingState,
+  setDragOffsetMs,
   hoveredItem,
   previousPanning,
   setPreviousPanning,
@@ -128,9 +130,12 @@ export function configureHandlePan({
       );
       const newDepartureTime = new Date(snappedMs);
 
+      setDragOffsetMs(snappedMs - initialDepartureTime.getTime());
+
       // stop dragging if necessary
       if (!isPanning) {
         setDraggingState(undefined);
+        setDragOffsetMs(null);
       }
 
       await handleTrainDrag({

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -136,6 +136,7 @@ export function configureHandlePan({
       if (!isPanning) {
         setDraggingState(undefined);
         setDragOffsetMs(null);
+        setPreviousPanning(false);
       }
 
       await handleTrainDrag({

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -6,27 +6,53 @@ import {
   type SpaceTimeChartProps,
 } from '@osrd-project/ui-charts';
 
+import type { SimulatedException } from 'modules/trainSchedule/types';
 import type { TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrain } from 'reducers/simulationResults';
+import type { SelectionSource } from 'reducers/simulationResults/types';
 import type { AppDispatch } from 'store';
-import { Duration, subtractDurationFromDate } from 'utils/duration';
 import {
   extractEditoastIdFromPacedTrainId,
-  extractOccurrenceIndexFromOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
+  isOccurrenceId,
   isTrainId,
 } from 'utils/trainId';
 
 import type { IndividualTrainProjection, TrainSpaceTimeData } from '../../../types';
-import { isIndividualOccurrenceProjection } from './utils';
+import type { PanelSelectionMode } from '../CurveSelectionSidePanel';
+import canDragHoveredTrain from './canDragHoveredTrain';
 import { parseOccupancyZonePathId, type OccupancyZoneReference } from './zones';
+
+/** Magnetic snap radius (in pixels) used to align a dragged occurrence onto the cadence grid. */
+const SNAP_DISTANCE_PX = 8;
 
 type DraggingState =
   | {
       draggedTrain: IndividualTrainProjection;
       initialDepartureTime: Date;
+      /** Original exceptions captured at drag start — used to compute shifts without accumulation */
+      originalPacedExceptions?: SimulatedException[];
+      /** Cadence grid (model start + k × interval) a 'single'-mode occurrence snaps onto. */
+      pacedGrid?: { startTimeMs: number; intervalMs: number };
     }
   | undefined;
+
+/**
+ * Snap a candidate time onto the nearest cadence grid line (`startTimeMs + k × intervalMs`)
+ * when it is within `SNAP_DISTANCE_PX` pixels of it. `timeScale` is the chart scale in ms/px,
+ * so the snap radius stays constant on screen whatever the zoom. Returns the candidate
+ * unchanged when there is no grid or it is too far from a line.
+ */
+const snapToCadenceGrid = (
+  candidateMs: number,
+  grid: { startTimeMs: number; intervalMs: number } | undefined,
+  timeScale: number
+): number => {
+  if (!grid || grid.intervalMs <= 0) return candidateMs;
+  const k = Math.round((candidateMs - grid.startTimeMs) / grid.intervalMs);
+  const gridMs = grid.startTimeMs + k * grid.intervalMs;
+  return Math.abs(candidateMs - gridMs) <= SNAP_DISTANCE_PX * timeScale ? gridMs : candidateMs;
+};
 
 type ConfigureHandlePanParams = {
   spaceTimeChartOnPan?: SpaceTimeChartProps['onPan'];
@@ -35,8 +61,12 @@ type ConfigureHandlePanParams = {
     initialDepartureTime: Date;
     newDepartureTime: Date;
     stopPanning: boolean;
+    panelSelectionMode: PanelSelectionMode;
+    originalPacedExceptions?: SimulatedException[];
   }) => Promise<void>;
   selectedTrainId?: TrainId;
+  selectedTrainBy?: SelectionSource;
+  panelSelectionMode: PanelSelectionMode;
   projectedTrains: IndividualTrainProjection[];
   draggingState: DraggingState;
   setDraggingState: (s: DraggingState) => void;
@@ -57,6 +87,8 @@ export function configureHandlePan({
   spaceTimeChartOnPan,
   handleTrainDrag,
   selectedTrainId,
+  selectedTrainBy,
+  panelSelectionMode,
   projectedTrains,
   draggingState,
   setDraggingState,
@@ -79,33 +111,22 @@ export function configureHandlePan({
 
     // If dragging
     if (draggingState) {
-      const { draggedTrain, initialDepartureTime } = draggingState;
+      const { draggedTrain, initialDepartureTime, originalPacedExceptions, pacedGrid } =
+        draggingState;
 
-      if (draggedTrain.id !== selectedTrainId) {
+      // In 'all' mode, selectedTrainId is a PacedTrainId — don't overwrite it with the occurrence id
+      if (draggedTrain.id !== selectedTrainId && panelSelectionMode !== 'all') {
         dispatch(updateSelectedTrain({ id: draggedTrain.id, by: 'std' }));
       }
 
-      const timeDiff = payload.data.time - payload.initialData.time;
-
-      let newDepartureTime = new Date(initialDepartureTime.getTime() + timeDiff);
-
-      // if the dragged train is an occurrence, we need to update the first occurrence because the others are based on it
-      if (
-        isIndividualOccurrenceProjection(draggedTrain) &&
-        (draggedTrain.type !== 'exception' || !draggedTrain.exception.start_time)
-      ) {
-        const occurrencesIndex = extractOccurrenceIndexFromOccurrenceId(draggedTrain.id);
-        const pacedTrainId = extractEditoastIdFromPacedTrainId(
-          extractPacedTrainIdFromOccurrenceId(draggedTrain.id)
-        );
-        const pacedTrain = trainScheduleProjections.find(({ id }) => id === pacedTrainId);
-        if (pacedTrain?.paced) {
-          newDepartureTime = subtractDurationFromDate(
-            newDepartureTime,
-            new Duration({ milliseconds: occurrencesIndex * pacedTrain.paced.interval.ms })
-          );
-        }
-      }
+      // Snap onto the cadence grid (single mode) so an occurrence can be re-aligned — and made
+      // conforming — without pixel-perfect aiming.
+      const snappedMs = snapToCadenceGrid(
+        initialDepartureTime.getTime() + payload.data.time - payload.initialData.time,
+        pacedGrid,
+        payload.context.timeScale
+      );
+      const newDepartureTime = new Date(snappedMs);
 
       // stop dragging if necessary
       if (!isPanning) {
@@ -117,6 +138,8 @@ export function configureHandlePan({
         initialDepartureTime,
         newDepartureTime,
         stopPanning: !isPanning,
+        panelSelectionMode,
+        originalPacedExceptions,
       });
       return;
     }
@@ -142,14 +165,46 @@ export function configureHandlePan({
         return;
       }
 
-      // disable start time exception for now
-      const isStartTimeException = train.type === 'exception' && !!train.exception.start_time;
-      if (isStartTimeException) return;
+      // Gate: drag is only allowed when the selected train has blue curves (by === 'std')
+      if (
+        selectedTrainBy === 'std' &&
+        canDragHoveredTrain({ panelSelectionMode, hoveredTrain: train, selectedTrainId })
+      ) {
+        let initialDepartureTime = train.departureTime;
+        let originalPacedExceptions: SimulatedException[] | undefined;
+        let pacedGrid: { startTimeMs: number; intervalMs: number } | undefined;
+        if (isOccurrenceId(hoveredTrainId)) {
+          const editoastId = extractEditoastIdFromPacedTrainId(
+            extractPacedTrainIdFromOccurrenceId(hoveredTrainId)
+          );
+          const modelTrain = trainScheduleProjections.find((t) => t.id === editoastId);
+          if (modelTrain) {
+            // 'all' and 'compliant' move the whole model: anchor on the model departure so
+            // handleTrainDrag receives the model's absolute new departure (no frame accumulation).
+            if (panelSelectionMode !== 'single') {
+              initialDepartureTime = modelTrain.departureTime;
+            }
+            // 'single' and 'all' shift exceptions: capture their pre-drag values as a stable base.
+            if (panelSelectionMode !== 'compliant') {
+              originalPacedExceptions = modelTrain.paced?.exceptions;
+            }
+            // 'single' snaps the occurrence onto the model's cadence grid.
+            if (panelSelectionMode === 'single' && modelTrain.paced) {
+              pacedGrid = {
+                startTimeMs: modelTrain.departureTime.getTime(),
+                intervalMs: modelTrain.paced.interval.ms,
+              };
+            }
+          }
+        }
 
-      setDraggingState({
-        draggedTrain: train,
-        initialDepartureTime: train.departureTime,
-      });
+        setDraggingState({
+          draggedTrain: train,
+          initialDepartureTime,
+          originalPacedExceptions,
+          pacedGrid,
+        });
+      }
     }
 
     if (occupancyZoneDragAndDrop) {
@@ -173,7 +228,7 @@ export function configureHandlePan({
       }
     }
 
-    // if no hovered train, we pan normally
+    // if no hovered train (or drag not started), we pan normally
     spaceTimeChartOnPan?.(payload);
 
     if (isPanning !== previousPanning) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
@@ -99,6 +99,39 @@ async function handleSingleOccurrenceDrag({
   });
 }
 
+/** compliant mode & non-paced trains: move the model departure. */
+async function handleModelDrag({
+  setTrainScheduleProjections,
+  handleTrainDragInTrackOccupancy,
+  updateTrainScheduleDepartureTime,
+  draggedTrain,
+  replaceProjection,
+  draggedTrainId,
+  newDepartureTime,
+  initialDepartureTime,
+  stopPanning,
+}: DragContext & { draggedTrainId: TrainId }) {
+  const newTrainData: TrainSpaceTimeData = { ...draggedTrain, departureTime: newDepartureTime };
+
+  await handleTrainDragInTrackOccupancy({
+    draggedTrainId,
+    stopPanning: false,
+    initialDepartureTime,
+    newTrainData,
+  });
+  setTrainScheduleProjections(replaceProjection(newTrainData));
+
+  if (!stopPanning) return;
+
+  await updateTrainScheduleDepartureTime(draggedTrainId, newDepartureTime);
+  await handleTrainDragInTrackOccupancy({
+    draggedTrainId,
+    stopPanning: true,
+    initialDepartureTime,
+    newTrainData,
+  });
+}
+
 export default function createHandleTrainDrag({
   trainScheduleProjections,
   ...deps
@@ -140,5 +173,6 @@ export default function createHandleTrainDrag({
     if (panelSelectionMode === 'single' && isOccurrenceId(draggedTrainId)) {
       return handleSingleOccurrenceDrag({ ...context, draggedTrainId });
     }
+    return handleModelDrag({ ...context, draggedTrainId });
   };
 }

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
@@ -1,18 +1,22 @@
+import { updatePacedTrainExceptionsList } from 'applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/buildPacedTrainException';
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
-import type { TrainId } from 'reducers/osrdconf/types';
+import {
+  findExceptionWithOccurrenceId,
+  shiftPacedExceptions,
+} from 'modules/trainSchedule/helpers/pacedTrain';
+import type { SimulatedException } from 'modules/trainSchedule/types';
+import type { OccurrenceId, TrainId } from 'reducers/osrdconf/types';
 import {
   extractEditoastIdFromPacedTrainId,
+  extractOccurrenceIndexFromOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
+  isIndexedOccurrenceId,
   isOccurrenceId,
 } from 'utils/trainId';
 
-export default function createHandleTrainDrag({
-  trainScheduleProjections,
-  setTrainScheduleProjections,
-  handleTrainDragInTrackOccupancy,
-  updateTrainScheduleDepartureTime,
-}: {
-  trainScheduleProjections: TrainSpaceTimeData[];
+import type { PanelSelectionMode } from '../CurveSelectionSidePanel';
+
+type DragDeps = {
   setTrainScheduleProjections: (newProjections: TrainSpaceTimeData[]) => void;
   handleTrainDragInTrackOccupancy: (args: {
     draggedTrainId: TrainId;
@@ -21,20 +25,98 @@ export default function createHandleTrainDrag({
     stopPanning: boolean;
   }) => Promise<void>;
   updateTrainScheduleDepartureTime: (
-    trainScheduleId: number,
-    newDepartureTime: Date
+    draggedTrainId: TrainId,
+    newDepartureTime: Date,
+    panelSelectionMode?: PanelSelectionMode
   ) => Promise<void>;
-}) {
+};
+
+/** Per-drag context shared by every mode handler. */
+type DragContext = DragDeps & {
+  draggedTrain: TrainSpaceTimeData;
+  /** Returns the full projections array with the dragged train replaced by `updated`. */
+  replaceProjection: (updated: TrainSpaceTimeData) => TrainSpaceTimeData[];
+  newDepartureTime: Date;
+  initialDepartureTime: Date;
+  stopPanning: boolean;
+  /** Exceptions captured at drag start — stable base so repeated frames don't accumulate. */
+  originalPacedExceptions?: SimulatedException[];
+};
+
+/** single mode: move one occurrence through its own start_time exception. */
+async function handleSingleOccurrenceDrag({
+  setTrainScheduleProjections,
+  handleTrainDragInTrackOccupancy,
+  updateTrainScheduleDepartureTime,
+  draggedTrain,
+  replaceProjection,
+  draggedTrainId,
+  newDepartureTime,
+  stopPanning,
+  originalPacedExceptions,
+}: DragContext & { draggedTrainId: OccurrenceId }) {
+  if (!draggedTrain.paced) return;
+
+  const baseExceptions = originalPacedExceptions ?? draggedTrain.paced.exceptions;
+  const existingException = findExceptionWithOccurrenceId(baseExceptions, draggedTrainId);
+  const occurrenceIndex = isIndexedOccurrenceId(draggedTrainId)
+    ? extractOccurrenceIndexFromOccurrenceId(draggedTrainId)
+    : undefined;
+
+  // Live feedback: show the occurrence at the dragged position (keep its other overrides).
+  const previewException: SimulatedException = {
+    ...(existingException ?? { key: '', occurrence_index: occurrenceIndex }),
+    start_time: { value: newDepartureTime.getTime() },
+  };
+  const previewTrain: TrainSpaceTimeData = {
+    ...draggedTrain,
+    paced: {
+      ...draggedTrain.paced,
+      exceptions: updatePacedTrainExceptionsList(baseExceptions, previewException, draggedTrainId),
+    },
+  };
+
+  // Register the train as "being dragged" (stopPanning: false) so the trains-update effect in
+  // useTrackOccupancy skips it instead of refetching its occupancy on every frame.
+  await handleTrainDragInTrackOccupancy({
+    draggedTrainId,
+    stopPanning: false,
+    initialDepartureTime: draggedTrain.departureTime,
+    newTrainData: previewTrain,
+  });
+  setTrainScheduleProjections(replaceProjection(previewTrain));
+
+  if (!stopPanning) return;
+
+  // On drop, updateTrainScheduleDepartureTime creates/updates/deletes the occurrence exception
+  // and reconciles the local state (timetable, simulation and projection stores).
+  await updateTrainScheduleDepartureTime(draggedTrainId, newDepartureTime, 'single');
+  await handleTrainDragInTrackOccupancy({
+    draggedTrainId,
+    stopPanning: true,
+    initialDepartureTime: draggedTrain.departureTime,
+    newTrainData: previewTrain,
+  });
+}
+
+export default function createHandleTrainDrag({
+  trainScheduleProjections,
+  ...deps
+}: DragDeps & { trainScheduleProjections: TrainSpaceTimeData[] }) {
   return async function handleTrainDrag({
     draggedTrainId,
     newDepartureTime,
     initialDepartureTime,
     stopPanning,
+    panelSelectionMode,
+    originalPacedExceptions,
   }: {
     draggedTrainId: TrainId;
     newDepartureTime: Date;
     initialDepartureTime: Date;
     stopPanning: boolean;
+    panelSelectionMode: PanelSelectionMode;
+    originalPacedExceptions?: SimulatedException[];
   }) {
     const draggedItemId = extractEditoastIdFromPacedTrainId(
       isOccurrenceId(draggedTrainId)
@@ -44,35 +126,19 @@ export default function createHandleTrainDrag({
     const draggedTrain = trainScheduleProjections.find((train) => train.id === draggedItemId);
     if (!draggedTrain) return;
 
-    const newTrainData = {
-      ...draggedTrain,
-      departureTime: newDepartureTime,
+    const context: DragContext = {
+      ...deps,
+      draggedTrain,
+      replaceProjection: (updated) =>
+        trainScheduleProjections.map((train) => (train.id === draggedItemId ? updated : train)),
+      newDepartureTime,
+      initialDepartureTime,
+      stopPanning,
+      originalPacedExceptions,
     };
 
-    // Handle updating track occupancy data (with no distant update yet, so with stopPanning: false)
-    await handleTrainDragInTrackOccupancy({
-      draggedTrainId,
-      stopPanning: false,
-      initialDepartureTime,
-      newTrainData,
-    });
-
-    if (!stopPanning) {
-      // update in the state
-      setTrainScheduleProjections(
-        trainScheduleProjections.map((train) => (train.id === draggedItemId ? newTrainData : train))
-      );
-      return;
+    if (panelSelectionMode === 'single' && isOccurrenceId(draggedTrainId)) {
+      return handleSingleOccurrenceDrag({ ...context, draggedTrainId });
     }
-
-    await updateTrainScheduleDepartureTime(draggedItemId, newDepartureTime);
-
-    // Handle retrieving track occupancy data from server (so with stopPanning: true):
-    await handleTrainDragInTrackOccupancy({
-      draggedTrainId,
-      stopPanning: true,
-      initialDepartureTime,
-      newTrainData,
-    });
   };
 }

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/createHandleTrainDrag.ts
@@ -99,6 +99,51 @@ async function handleSingleOccurrenceDrag({
   });
 }
 
+/** all mode: move the model and every start_time exception by the same offset. */
+async function handleAllOccurrencesDrag({
+  setTrainScheduleProjections,
+  handleTrainDragInTrackOccupancy,
+  updateTrainScheduleDepartureTime,
+  draggedTrain,
+  replaceProjection,
+  draggedTrainId,
+  newDepartureTime,
+  initialDepartureTime,
+  stopPanning,
+  originalPacedExceptions,
+}: DragContext & { draggedTrainId: OccurrenceId }) {
+  if (!draggedTrain.paced) return;
+
+  // initialDepartureTime is the model departure at drag start, so the offset is absolute
+  // (no per-frame accumulation). The exceptions are shifted from their captured originals.
+  const offset = newDepartureTime.getTime() - initialDepartureTime.getTime();
+  const baseExceptions = originalPacedExceptions ?? draggedTrain.paced.exceptions;
+  const newTrainData: TrainSpaceTimeData = {
+    ...draggedTrain,
+    departureTime: newDepartureTime,
+    paced: { ...draggedTrain.paced, exceptions: shiftPacedExceptions(baseExceptions, offset) },
+  };
+
+  await handleTrainDragInTrackOccupancy({
+    draggedTrainId,
+    stopPanning: false,
+    initialDepartureTime,
+    newTrainData,
+  });
+  setTrainScheduleProjections(replaceProjection(newTrainData));
+
+  if (!stopPanning) return;
+
+  // updateTrainScheduleDepartureTime in 'all' mode also persists the shifted exceptions.
+  await updateTrainScheduleDepartureTime(draggedTrainId, newDepartureTime, 'all');
+  await handleTrainDragInTrackOccupancy({
+    draggedTrainId,
+    stopPanning: true,
+    initialDepartureTime,
+    newTrainData,
+  });
+}
+
 /** compliant mode & non-paced trains: move the model departure. */
 async function handleModelDrag({
   setTrainScheduleProjections,
@@ -172,6 +217,9 @@ export default function createHandleTrainDrag({
 
     if (panelSelectionMode === 'single' && isOccurrenceId(draggedTrainId)) {
       return handleSingleOccurrenceDrag({ ...context, draggedTrainId });
+    }
+    if (panelSelectionMode === 'all' && isOccurrenceId(draggedTrainId)) {
+      return handleAllOccurrencesDrag({ ...context, draggedTrainId });
     }
     return handleModelDrag({ ...context, draggedTrainId });
   };

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -10,9 +10,11 @@ import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/up
 import type {
   OperationalPointReference,
   CoreTrainPath,
+  PacedTrainException,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
+import { withPacedExceptions } from 'modules/trainSchedule/helpers/pacedTrain';
 import { getProjectionType, getIsSimulationEnabled } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 
@@ -122,30 +124,60 @@ const useLazyProjectTrains = ({
   }, []);
 
   const updateProjectedTrainScheduleDepartureTime = useCallback(
-    (id: number, newDeparture: Date) => {
+    (id: number, newDeparture: Date, shiftedExceptions?: PacedTrainException[]) => {
       setProjectedTrainsById((prev) => {
         const result = prev.get(id);
         if (!result) {
           return prev;
         }
         const next = new Map(prev);
-        next.set(id, {
-          ...result,
-          departureTime: newDeparture,
-        });
+        next.set(
+          id,
+          withPacedExceptions({ ...result, departureTime: newDeparture }, shiftedExceptions)
+        );
         return next;
       });
       // Update the train schedule in the reference map
       // This is necessary to keep the reference up-to-date for future projections
       // and to ensure that the projected trains are correctly updated
       // when the projection type changes
-      let trainSchedule = trainSchedulesByIdRef.current.get(id);
+      const trainSchedule = trainSchedulesByIdRef.current.get(id);
       if (trainSchedule) {
-        trainSchedule = {
+        trainSchedulesByIdRef.current.set(
+          id,
+          withPacedExceptions(
+            { ...trainSchedule, start_time: newDeparture.getTime() },
+            shiftedExceptions
+          )
+        );
+      }
+    },
+    []
+  );
+
+  /**
+   * Update a paced train's exceptions in the projected state (and in the reference map used for
+   * future projections) without re-projecting. Mirrors updateProjectedTrainScheduleDepartureTime
+   * for the exception-only path (single-mode occurrence drag), so a later re-seed of the chart
+   * doesn't revert the occurrence to its pre-drag position.
+   */
+  const updateProjectedTrainExceptions = useCallback(
+    (id: number, updatedExceptions: PacedTrainException[]) => {
+      setProjectedTrainsById((prev) => {
+        const result = prev.get(id);
+        if (!result?.paced) {
+          return prev;
+        }
+        const next = new Map(prev);
+        next.set(id, { ...result, paced: { ...result.paced, exceptions: updatedExceptions } });
+        return next;
+      });
+      const trainSchedule = trainSchedulesByIdRef.current.get(id);
+      if (trainSchedule?.paced) {
+        trainSchedulesByIdRef.current.set(id, {
           ...trainSchedule,
-          start_time: newDeparture.getTime(),
-        };
-        trainSchedulesByIdRef.current.set(id, trainSchedule);
+          paced: { ...trainSchedule.paced, exceptions: updatedExceptions },
+        });
       }
     },
     []
@@ -156,6 +188,7 @@ const useLazyProjectTrains = ({
     projectTrainSchedules,
     removeProjectedTrainSchedules,
     updateProjectedTrainScheduleDepartureTime,
+    updateProjectedTrainExceptions,
     allTrainsProjected,
   };
 };

--- a/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
+++ b/front/src/modules/simulationResult/styles/_manchetteWithSpaceTimeChart.scss
@@ -1,3 +1,23 @@
+.drag-tooltip {
+  position: fixed;
+  width: 83px;
+  height: 32px;
+  transform: translateX(-50%);
+  box-shadow: 0 4px 6px -2px var(--black28);
+  border-radius: 10px;
+  opacity: 0.85;
+  background-color: var(--black100);
+  color: var(--white100);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 14px;
+  font-weight: 400;
+  pointer-events: none;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .space-time-chart-container {
   position: relative;
   overflow: hidden;

--- a/front/src/modules/trainSchedule/helpers/pacedTrain.ts
+++ b/front/src/modules/trainSchedule/helpers/pacedTrain.ts
@@ -50,6 +50,26 @@ export const CHANGE_GROUP_KEYS: (keyof PacedTrainException)[] = [
 export const hasNoChangeGroups = (exception: PacedTrainException) =>
   CHANGE_GROUP_KEYS.every((key) => !(key in exception));
 
+export function shiftPacedExceptions(
+  exceptions: PacedTrainException[],
+  timeDiffMs: number
+): PacedTrainException[] {
+  return exceptions.map((exc) =>
+    exc.start_time ? { ...exc, start_time: { value: exc.start_time.value + timeDiffMs } } : exc
+  );
+}
+
+/**
+ * Return `train` with its paced exceptions replaced by `exceptions`. No-op (returns `train`
+ * unchanged) when there is nothing to apply: `exceptions` is undefined or the train is not paced.
+ */
+export const withPacedExceptions = <
+  T extends { paced?: { exceptions: PacedTrainException[] } | null },
+>(
+  train: T,
+  exceptions: PacedTrainException[] | undefined
+): T => (exceptions && train.paced ? { ...train, paced: { ...train.paced, exceptions } } : train);
+
 export const isPacedTrain = (
   trainSchedule: TrainScheduleResponse
 ): trainSchedule is PacedTrainResponseWithPaced => !!trainSchedule.paced;


### PR DESCRIPTION
closes #16720

To test:
- Verify that when you click on a curve in the GET, the panel opens correctly
- Verify that all curves move correctly when the mode is “all”
- Verify that only occurrences that are not start_time exceptions are moved when the mode is “compliant”
- Verify that moving a single occurrence in “single” mode correctly creates a start_time exception
- And finally, verify that the exception is removed if:
   - we reposition the exception within the mission’s timing (we “put it back in its place”)
   - we shift all “valid” occurrences (in “compliant” mode) to ensure the exception fits within the schedule