### PR TITLE
core, editoast: fix duplicated path positions in simulation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/SimulationParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/SimulationParser.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.api
 
 import fr.sncf.osrd.api.standalone_sim.SimulationPowerRestrictionItem
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.api.standalone_sim.StopDetails
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
@@ -18,9 +19,10 @@ val simulationScheduleItemParserLogger = KotlinLogging.logger {}
  * Merge consecutive schedule items which are at the same location, i.e. have the same path offset.
  * Merge rules for a group of schedule items are as follows:
  * - arrival is the minimum value of all the concerned schedule items, null if they are all null.
- * - stopFor is the sum of all the stopFor values of all the schedule items, null if they are all
- *   null.
+ * - stop duration is the sum of all the stop duration values of all the schedule items, null if
+ *   they are all null.
  * - receptionSignal is the most constrained of all schedule item's receptionSignal
+ * - isBacktracking is true if at least one of the items is backtracking
  */
 fun parseRawSimulationScheduleItems(
     rawSimulationScheduleItems: List<SimulationScheduleItem>
@@ -30,8 +32,7 @@ fun parseRawSimulationScheduleItems(
     while (i < rawSimulationScheduleItems.size) {
         val pathOffset = rawSimulationScheduleItems[i].pathOffset
         var arrival = rawSimulationScheduleItems[i].arrival
-        var stopFor = rawSimulationScheduleItems[i].stopFor
-        var receptionSignal = rawSimulationScheduleItems[i].receptionSignal
+        var stopDetails = rawSimulationScheduleItems[i].stopDetails
         while (
             i < rawSimulationScheduleItems.size - 1 &&
                 rawSimulationScheduleItems[i + 1].pathOffset == pathOffset
@@ -44,21 +45,29 @@ fun parseRawSimulationScheduleItems(
                     nextArrival != null -> nextArrival
                     else -> arrival
                 }
-            val nextStopFor = rawSimulationScheduleItems[i + 1].stopFor
-            stopFor =
-                when {
-                    nextStopFor != null && stopFor != null -> stopFor + nextStopFor
-                    nextStopFor != null -> nextStopFor
-                    else -> stopFor
-                }
-            val nextReceptionSignal = rawSimulationScheduleItems[i + 1].receptionSignal
-            receptionSignal =
-                if (receptionSignal == SHORT_SLIP_STOP || nextReceptionSignal == SHORT_SLIP_STOP)
-                    SHORT_SLIP_STOP
-                else if (receptionSignal == STOP || nextReceptionSignal == STOP) STOP else OPEN
+
+            val nextStopDetails = rawSimulationScheduleItems[i + 1].stopDetails
+            if (nextStopDetails != null && stopDetails != null) {
+                var receptionSignal = stopDetails.receptionSignal
+                val nextReceptionSignal = nextStopDetails.receptionSignal
+                receptionSignal =
+                    if (
+                        receptionSignal == SHORT_SLIP_STOP || nextReceptionSignal == SHORT_SLIP_STOP
+                    )
+                        SHORT_SLIP_STOP
+                    else if (receptionSignal == STOP || nextReceptionSignal == STOP) STOP else OPEN
+                stopDetails =
+                    StopDetails(
+                        stopDetails.duration + nextStopDetails.duration,
+                        receptionSignal,
+                        stopDetails.isBacktracking || nextStopDetails.isBacktracking,
+                    )
+            } else if (nextStopDetails != null) {
+                stopDetails = nextStopDetails
+            }
             i++
         }
-        val newItem = SimulationScheduleItem(pathOffset, arrival, stopFor, receptionSignal)
+        val newItem = SimulationScheduleItem(pathOffset, arrival, stopDetails)
         if (simulationScheduleItems.lastOrNull() == newItem) {
             simulationScheduleItemParserLogger.warn { "duplicated schedule items: $newItem" }
         } else {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -51,10 +51,15 @@ class SimulationEndpoint(
             // Parse rolling stocks
             val rollingStock = parseRawRollingStock(request.physicsConsist)
 
+            val backtrackLocations =
+                request.schedule
+                    .filter { it.stopDetails != null && it.stopDetails.isBacktracking }
+                    .map { it.pathOffset }
+
             // Parse path
             val trainPath =
                 request.path.toTrainPath(
-                    request.backtrackPathItems.map { request.pathItemPositions[it] },
+                    backtrackLocations,
                     infra.rawInfra,
                     infra.blockInfra,
                     electricalProfileMap,
@@ -75,7 +80,6 @@ class SimulationEndpoint(
                     parseRawSimulationScheduleItems(request.schedule),
                     request.initialSpeed,
                     request.margins,
-                    request.pathItemPositions,
                 )
             return RsJson(RsWithBody(simulationResponseAdapter.toJson(res)))
         } catch (ex: Throwable) {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationRequest.kt
@@ -32,15 +32,13 @@ class SimulationRequest(
     val options: TrainScheduleOptions,
     @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
     @Json(name = "electrical_profile_set_id") val electricalProfileSetId: String?,
-    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<PhysicsPath>>,
-    @Json(name = "backtrack_path_items") val backtrackPathItems: List<Int>,
 ) {
     init {
-        backtrackPathItems.forEach { pathItemIndex ->
-            require(pathItemIndex > 0 && pathItemIndex < pathItemPositions.size - 1)
-            require(
-                schedule.first { it.pathOffset == pathItemPositions[pathItemIndex] }.stopFor != null
-            )
+        // Schedule should at least contain a departure and an arrival.
+        require(schedule.size >= 2)
+        // The departure and the arrival shouldn't be backtracking
+        arrayOf(schedule[0], schedule[schedule.size - 1]).forEach { scheduleItem ->
+            require(scheduleItem.stopDetails == null || !scheduleItem.stopDetails.isBacktracking)
         }
     }
 
@@ -94,8 +92,13 @@ class EffortCurve(
 class SimulationScheduleItem(
     @Json(name = "path_offset") val pathOffset: Offset<PhysicsPath>,
     val arrival: TimeDelta?,
-    @Json(name = "stop_for") val stopFor: Duration?,
+    @Json(name = "stop_details") val stopDetails: StopDetails?,
+)
+
+class StopDetails(
+    val duration: Duration,
     @Json(name = "reception_signal") val receptionSignal: RJSReceptionSignal,
+    @Json(name = "is_backtracking") val isBacktracking: Boolean,
 )
 
 sealed class MarginValue {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -280,8 +280,7 @@ class STDCMEndpoint(
                 SimulationScheduleItem(
                     path.trainPath.getLength(),
                     null,
-                    0.1.seconds,
-                    RJSTrainStop.RJSReceptionSignal.STOP,
+                    StopDetails(0.1.seconds, RJSTrainStop.RJSReceptionSignal.STOP, false),
                 )
             )
             val reportTrain =
@@ -291,7 +290,6 @@ class STDCMEndpoint(
                     infra,
                     path.rollingStocks as DistanceRangeMap<PhysicsRollingStock>,
                     scheduleItems,
-                    listOf(),
                 )
 
             // Lighter description of the same simulation result
@@ -593,7 +591,9 @@ private fun parseSimulationScheduleItems(
     return parseRawSimulationScheduleItems(
         trainStops.map {
             val duration = if (it.duration > 0.0) it.duration.seconds else null
-            SimulationScheduleItem(Offset(it.position.meters), null, duration, it.receptionSignal)
+            val stopDetails =
+                if (duration != null) StopDetails(duration, it.receptionSignal, false) else null
+            SimulationScheduleItem(Offset(it.position.meters), null, stopDetails)
         }
     )
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -38,7 +38,8 @@ fun makeSafetySpeedRanges(
     val stopsWithSafetySpeed =
         schedule
             .filter {
-                it.receptionSignal.isStopOnClosedSignal &&
+                it.stopDetails != null &&
+                    it.stopDetails.receptionSignal.isStopOnClosedSignal &&
                     // ETCS signaling system already handles Safety Approach Speed via braking
                     // curves
                     !isStopInSignalingSystemRange(it.pathOffset, signalingRanges, ETCS_LEVEL2.id)
@@ -46,7 +47,8 @@ fun makeSafetySpeedRanges(
             .map {
                 SafetySpeedStop(
                     it.pathOffset,
-                    it.receptionSignal == RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP,
+                    it.stopDetails!!.receptionSignal ==
+                        RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP,
                 )
             }
             .toMutableList()

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -54,15 +54,20 @@ fun runScheduleMetadataExtractor(
     fullInfra: FullInfra,
     rollingStocks: DistanceRangeMap<PhysicsRollingStock>,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<PhysicsPath>>,
     context: EnvelopeSimContext? = null,
 ): CompleteReportTrain {
     assert(envelope.continuous)
 
     val legacyStops =
         schedule
-            .filter { it.stopFor != null }
-            .map { TrainStop(it.pathOffset.meters, it.stopFor!!.seconds, it.receptionSignal) }
+            .filter { it.stopDetails != null }
+            .map {
+                TrainStop(
+                    it.pathOffset.meters,
+                    it.stopDetails!!.duration.seconds,
+                    it.stopDetails.receptionSignal,
+                )
+            }
 
     val rawInfra = fullInfra.rawInfra
 
@@ -84,7 +89,9 @@ fun runScheduleMetadataExtractor(
         }
 
     val pathStops =
-        schedule.filter { it.stopFor != null }.map { PathStop(it.pathOffset, it.receptionSignal) }
+        schedule
+            .filter { it.stopDetails != null }
+            .map { PathStop(it.pathOffset, it.stopDetails!!.receptionSignal) }
     val closedSignalStops = pathStops.filter { it.receptionSignal.isStopOnClosedSignal }
 
     val signalCriticalPositions =
@@ -107,8 +114,7 @@ fun runScheduleMetadataExtractor(
             zoneOccupationChangeEvents,
             rollingStocks,
         )
-    val reportTrain =
-        makeSimpleReportTrain(envelope, trainPath, rollingStocks, schedule, pathItemPositions)
+    val reportTrain = makeSimpleReportTrain(envelope, trainPath, rollingStocks, schedule)
     return CompleteReportTrain(
         reportTrain.positions,
         reportTrain.times,
@@ -210,7 +216,6 @@ fun makeSimpleReportTrain(
     trainPath: TrainPath,
     rollingStocks: DistanceRangeMap<PhysicsRollingStock>,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<PhysicsPath>>,
 ): ReportTrain {
     // Compute energy consumed
     require(arePositionsEqual(rollingStocks.upperBound().meters, envelope.endPos))
@@ -220,13 +225,21 @@ fun makeSimpleReportTrain(
     // Account for stop durations
     val stops =
         schedule
-            .filter { it.stopFor != null }
-            .map { TrainStop(it.pathOffset.meters, it.stopFor!!.seconds, it.receptionSignal) }
+            .filter { it.stopDetails != null }
+            .map {
+                TrainStop(
+                    it.pathOffset.meters,
+                    it.stopDetails!!.duration.seconds,
+                    it.stopDetails.receptionSignal,
+                )
+            }
     val envelopeStopWrapper = EnvelopeStopWrapper(envelope, stops)
 
     val pathItemTimes =
-        pathItemPositions.map { position: Offset<PhysicsPath> ->
-            TimeDelta.fromSeconds(envelopeStopWrapper.interpolateArrivalAt(position.meters))
+        schedule.map { item: SimulationScheduleItem ->
+            TimeDelta.fromSeconds(
+                envelopeStopWrapper.interpolateArrivalAt((item.pathOffset.meters))
+            )
         }
 
     // Iterate over the points and simplify the results

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -66,7 +66,6 @@ fun runStandaloneSimulation(
     schedule: List<SimulationScheduleItem>,
     initialSpeed: Double,
     margins: RangeValues<MarginValue>,
-    pathItemPositions: List<Offset<PhysicsPath>>,
     driverBehaviour: DriverBehaviour = DriverBehaviour(),
 ): SimulationSuccess {
     if (trainPath.getLength() == Offset.zero<TrainPath>()) throw OSRDError(ZeroLengthPath)
@@ -149,21 +148,9 @@ fun runStandaloneSimulation(
             )
         )
     val maxEffortResult =
-        makeSimpleReportTrain(
-            maxEffortEnvelope,
-            trainPath,
-            rollingStocks,
-            schedule,
-            pathItemPositions,
-        )
+        makeSimpleReportTrain(maxEffortEnvelope, trainPath, rollingStocks, schedule)
     val provisionalResult =
-        makeSimpleReportTrain(
-            provisionalEnvelope,
-            trainPath,
-            rollingStocks,
-            schedule,
-            pathItemPositions,
-        )
+        makeSimpleReportTrain(provisionalEnvelope, trainPath, rollingStocks, schedule)
     val finalEnvelopeResult =
         runScheduleMetadataExtractor(
             finalEnvelope,
@@ -172,7 +159,6 @@ fun runStandaloneSimulation(
             infra,
             rollingStocks,
             schedule,
-            pathItemPositions,
             context,
         )
 
@@ -284,7 +270,7 @@ fun buildFinalEnvelope(
         if (point.arrival == null) {
             // No specified arrival time,
             // we account for the stop duration and move on
-            prevFixedPointDepartureTime += point.stopFor?.seconds ?: 0.0
+            prevFixedPointDepartureTime += point.stopDetails?.duration?.seconds ?: 0.0
             continue
         }
         val sectionTime =
@@ -294,7 +280,7 @@ fun buildFinalEnvelope(
         if (abs(extraTime) < context.timeStep) {
             // The time diff is already within the margin computation tolerance,
             // adding a margin for this can increase the difference
-            prevFixedPointDepartureTime += point.stopFor?.seconds ?: 0.0
+            prevFixedPointDepartureTime += point.stopDetails?.duration?.seconds ?: 0.0
             continue
         }
         if (extraTime >= 0.0) {
@@ -308,7 +294,8 @@ fun buildFinalEnvelope(
                     point.pathOffset,
                 )
             )
-            prevFixedPointDepartureTime = arrivalTime + extraTime + (point.stopFor?.seconds ?: 0.0)
+            prevFixedPointDepartureTime =
+                arrivalTime + extraTime + (point.stopDetails?.duration?.seconds ?: 0.0)
         } else {
             // We need to *remove* time compared to the provisional envelope.
             // Ideally we would distribute the (negative) extra time following the same logic as
@@ -338,7 +325,9 @@ fun buildFinalEnvelope(
                 )
             )
             prevFixedPointDepartureTime =
-                earliestPossibleArrival + maxEffortExtraTime + (point.stopFor?.seconds ?: 0.0)
+                earliestPossibleArrival +
+                    maxEffortExtraTime +
+                    (point.stopDetails?.duration?.seconds ?: 0.0)
         }
         prevFixedPointOffset = point.pathOffset
     }
@@ -461,5 +450,7 @@ fun buildProvisionalEnvelope(
 }
 
 fun getSimStops(schedule: List<SimulationScheduleItem>): List<SimStop> {
-    return schedule.filter { it.stopFor != null }.map { SimStop(it.pathOffset, it.receptionSignal) }
+    return schedule
+        .filter { it.stopDetails != null }
+        .map { SimStop(it.pathOffset, it.stopDetails!!.receptionSignal) }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.api.SignalCriticalPosition
 import fr.sncf.osrd.api.path_properties.makePathPropResponse
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.api.standalone_sim.StopDetails
 import fr.sncf.osrd.conflicts.PathStop
 import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
@@ -631,14 +632,16 @@ class BacktrackTests {
                         SimulationScheduleItem(
                             Offset(9700.meters),
                             null,
-                            60.seconds,
-                            SHORT_SLIP_STOP,
+                            StopDetails(60.seconds, SHORT_SLIP_STOP, false),
                         ),
-                        SimulationScheduleItem(Offset(18700.meters), null, 0.seconds, OPEN),
+                        SimulationScheduleItem(
+                            Offset(18700.meters),
+                            null,
+                            StopDetails(0.seconds, OPEN, false),
+                        ),
                     ),
                 initialSpeed = 0.0,
                 margins = RangeValues(),
-                pathItemPositions = listOf(Offset(9700.meters), Offset(18700.meters)),
             )
         assertEquals(Offset(18700.meters), resp.finalOutput.positions.last())
 
@@ -757,14 +760,16 @@ class BacktrackTests {
                         SimulationScheduleItem(
                             Offset(8000.meters),
                             null,
-                            60.seconds,
-                            SHORT_SLIP_STOP,
+                            StopDetails(60.seconds, SHORT_SLIP_STOP, false),
                         ),
-                        SimulationScheduleItem(Offset(15300.meters), null, 0.seconds, OPEN),
+                        SimulationScheduleItem(
+                            Offset(15300.meters),
+                            null,
+                            StopDetails(0.seconds, OPEN, false),
+                        ),
                     ),
                 initialSpeed = 0.0,
                 margins = RangeValues(),
-                pathItemPositions = listOf(Offset(8000.meters), Offset(15300.meters)),
             )
         assertEquals(Offset(15300.meters), resp.finalOutput.positions.last())
 
@@ -866,12 +871,19 @@ class BacktrackTests {
                 timeStep = 2.0,
                 schedule =
                     listOf(
-                        SimulationScheduleItem(Offset(8400.meters), null, 60.seconds, STOP),
-                        SimulationScheduleItem(Offset(16400.meters), null, 0.seconds, OPEN),
+                        SimulationScheduleItem(
+                            Offset(8400.meters),
+                            null,
+                            StopDetails(60.seconds, STOP, false),
+                        ),
+                        SimulationScheduleItem(
+                            Offset(16400.meters),
+                            null,
+                            StopDetails(0.seconds, OPEN, false),
+                        ),
                     ),
                 initialSpeed = 0.0,
                 margins = RangeValues(),
-                pathItemPositions = listOf(Offset(8400.meters), Offset(16400.meters)),
             )
         assertEquals(Offset(16400.meters), resp.finalOutput.positions.last())
 

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/SimulationScheduleItemsParserTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/SimulationScheduleItemsParserTests.kt
@@ -3,7 +3,10 @@ package fr.sncf.osrd.standalone_sim
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import fr.sncf.osrd.api.parseRawSimulationScheduleItems
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.api.standalone_sim.StopDetails
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.STOP
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -36,40 +39,154 @@ class SimulationScheduleItemsParserTests {
             // Parser outputs minimum arrival for same path offset
             Arguments.of(
                 listOf(
-                    SimulationScheduleItem(Offset(Distance.ZERO), null, null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), TimeDelta(200), null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), TimeDelta(100), null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, null, OPEN),
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(Offset(Distance(1000)), TimeDelta(200), null),
+                    SimulationScheduleItem(Offset(Distance(1000)), TimeDelta(100), null),
+                    SimulationScheduleItem(Offset(Distance(1000)), null, null),
                 ),
                 listOf(
-                    SimulationScheduleItem(Offset(Distance.ZERO), null, null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), TimeDelta(100), null, OPEN),
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(Offset(Distance(1000)), TimeDelta(100), null),
                 ),
             ),
             // Parser outputs sum of stopFor for same path offset
             Arguments.of(
                 listOf(
-                    SimulationScheduleItem(Offset(Distance.ZERO), null, null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, TimeDelta(25), OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, TimeDelta(75), OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, null, OPEN),
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(25), OPEN, false),
+                    ),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(75), OPEN, false),
+                    ),
+                    SimulationScheduleItem(Offset(Distance(1000)), null, null),
                 ),
                 listOf(
-                    SimulationScheduleItem(Offset(Distance.ZERO), null, null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, TimeDelta(100), OPEN),
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(100), OPEN, false),
+                    ),
                 ),
             ),
             // Parser outputs the most constrained (SHORT_SLIP_STOP, then STOP, then OPEN)
             // receptionSignal for the same path offset
             Arguments.of(
                 listOf(
-                    SimulationScheduleItem(Offset(Distance.ZERO), null, null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, null, OPEN),
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, false),
+                    ),
+                    SimulationScheduleItem(Offset(Distance(1000)), null, null),
                 ),
                 listOf(
-                    SimulationScheduleItem(Offset(Distance.ZERO), null, null, OPEN),
-                    SimulationScheduleItem(Offset(Distance(1000)), null, null, OPEN),
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, false),
+                    ),
+                ),
+            ),
+            Arguments.of(
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, false),
+                    ),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), STOP, false),
+                    ),
+                ),
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), STOP, false),
+                    ),
+                ),
+            ),
+            Arguments.of(
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, false),
+                    ),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), STOP, false),
+                    ),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), SHORT_SLIP_STOP, false),
+                    ),
+                ),
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), SHORT_SLIP_STOP, false),
+                    ),
+                ),
+            ),
+            // Parser outputs isBacktracking = true if at least one of the items with the same
+            // offset is backtracking, else it outputs false
+            Arguments.of(
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, false),
+                    ),
+                ),
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, false),
+                    ),
+                ),
+            ),
+            Arguments.of(
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, false),
+                    ),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, true),
+                    ),
+                ),
+                listOf(
+                    SimulationScheduleItem(Offset(Distance.ZERO), null, null),
+                    SimulationScheduleItem(
+                        Offset(Distance(1000)),
+                        null,
+                        StopDetails(TimeDelta(0), OPEN, true),
+                    ),
                 ),
             ),
         )

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.api.standalone_sim.MarginValue
 import fr.sncf.osrd.api.standalone_sim.ReportTrain
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.api.standalone_sim.StopDetails
 import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.Percentage
@@ -88,7 +89,6 @@ class StandaloneSimulationTest {
                 listOf(),
                 0.0,
                 RangeValues(listOf(), listOf()),
-                listOf(),
             )
         println(res)
     }
@@ -118,21 +118,22 @@ class StandaloneSimulationTest {
                     maxEffortEnvelope.interpolateDepartureFrom(thirdDistance.meters).seconds +
                         60.seconds,
                     null,
-                    OPEN,
                 ),
                 SimulationScheduleItem(
                     halfDistance,
                     maxEffortEnvelope.interpolateDepartureFrom(halfDistance.meters).seconds +
                         120.seconds,
-                    15.seconds,
-                    OPEN,
+                    StopDetails(15.seconds, OPEN, false),
                 ),
-                SimulationScheduleItem(twoThirdDistance, null, 30.seconds, OPEN),
+                SimulationScheduleItem(
+                    twoThirdDistance,
+                    null,
+                    StopDetails(30.seconds, OPEN, false),
+                ),
                 SimulationScheduleItem(
                     pathLength,
                     maxEffortEnvelope.totalTime.seconds + 300.seconds,
-                    0.seconds,
-                    OPEN,
+                    StopDetails(0.seconds, OPEN, false),
                 ),
             )
 
@@ -226,7 +227,6 @@ class StandaloneSimulationTest {
                 testCase.schedule,
                 testCase.startSpeed,
                 testCase.margins,
-                listOf(),
                 DriverBehaviour(0.0, 0.0),
             )
 
@@ -249,7 +249,11 @@ class StandaloneSimulationTest {
             if (scheduledPoint.arrival != null) {
                 assertEquals(scheduledPoint.arrival.seconds, arrival, 2.0)
             }
-            assertEquals(scheduledPoint.stopFor?.seconds ?: 0.0, departure - arrival, 2.0)
+            assertEquals(
+                scheduledPoint.stopDetails?.duration?.seconds ?: 0.0,
+                departure - arrival,
+                2.0,
+            )
         }
 
         // Test margin values
@@ -294,11 +298,23 @@ class StandaloneSimulationTest {
         val schedule =
             listOf(
                 // Start of path, check that it doesn't extend beyond the start
-                SimulationScheduleItem(Offset(42.meters), 42.seconds, 42.seconds, SHORT_SLIP_STOP),
+                SimulationScheduleItem(
+                    Offset(42.meters),
+                    42.seconds,
+                    StopDetails(42.seconds, SHORT_SLIP_STOP, false),
+                ),
                 // OPEN, check that this is ignored
-                SimulationScheduleItem(Offset(10_000.meters), 42.seconds, 42.seconds, OPEN),
+                SimulationScheduleItem(
+                    Offset(10_000.meters),
+                    42.seconds,
+                    StopDetails(42.seconds, OPEN, false),
+                ),
                 // STOP before the last buffer stop
-                SimulationScheduleItem(Offset(10_300.meters), 42.seconds, 42.seconds, STOP),
+                SimulationScheduleItem(
+                    Offset(10_300.meters),
+                    42.seconds,
+                    StopDetails(42.seconds, STOP, false),
+                ),
             )
 
         val signalingRanges = buildSignalingRanges(infra, trainPath)
@@ -327,16 +343,23 @@ class StandaloneSimulationTest {
         // switch or buffer-stop is under ETCS or not doesn't matter)
         val schedule =
             listOf(
-                SimulationScheduleItem(Offset(42.meters), 42.seconds, 42.seconds, STOP),
+                SimulationScheduleItem(
+                    Offset(42.meters),
+                    42.seconds,
+                    StopDetails(42.seconds, STOP, false),
+                ),
                 // Stop associated to the 10150m signal
                 SimulationScheduleItem(
                     Offset(10_000.meters),
                     42.seconds,
-                    42.seconds,
-                    SHORT_SLIP_STOP,
+                    StopDetails(42.seconds, SHORT_SLIP_STOP, false),
                 ),
                 // Stop associated to the last buffer stop
-                SimulationScheduleItem(Offset(10_300.meters), 42.seconds, 42.seconds, STOP),
+                SimulationScheduleItem(
+                    Offset(10_300.meters),
+                    42.seconds,
+                    StopDetails(42.seconds, STOP, false),
+                ),
             )
 
         val signalingRangesBAL = buildSignalingRanges(infra, trainPath)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -473,7 +473,6 @@ fun makeRequirementsFromPath(
             listOf(),
             0.0,
             RangeValues(),
-            listOf(),
         )
 
     return sim.finalOutput.spacingRequirements.map {

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -116,10 +116,18 @@ pub struct SimulationScheduleItem {
     pub path_offset: u64,
     /// Time in ms since the departure of the train
     pub arrival: Option<u64>,
-    /// Duration of the stop in ms
-    pub stop_for: Option<u64>,
+    /// Stop details if this is a stop
+    pub stop_details: Option<StopDetails>,
+}
+
+#[derive(Debug, Serialize, Hash, PartialEq)]
+pub struct StopDetails {
+    /// Stop duration in ms
+    pub duration: u64,
     /// Whether the next signal is expected to be blocking while stopping
     pub reception_signal: ReceptionSignal,
+    /// Whether this stop is followed by a backtracking
+    pub is_backtracking: bool,
 }
 
 #[derive(Debug, Serialize, Hash, PartialEq)]
@@ -280,11 +288,6 @@ pub struct Request {
     pub options: TrainScheduleOptions,
     pub physics_consist: PhysicsConsist,
     pub electrical_profile_set_id: Option<i64>,
-    /// The path offsets in mm of each path item given as input of the pathfinding
-    pub path_item_positions: Vec<u64>,
-    /// The indexes of the path items where the train backtracks
-    // TODO: Remove Option once front is fully connected
-    pub backtrack_path_items: Option<Vec<usize>>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -80,11 +80,18 @@ pub(super) fn build_request(
     ) in params.schedule_items().iter().enumerate()
     {
         let position = path_item_positions[i];
+        let stop_details = stop_for.map(|duration| core_client::simulation::StopDetails {
+            duration,
+            reception_signal: *reception_signal,
+            is_backtracking: match backtrack_path_items {
+                None => false,
+                Some(ref items) => items.contains(&i),
+            },
+        });
         schedule.push(core_client::simulation::SimulationScheduleItem {
             path_offset: position,
             arrival: *arrival_at,
-            stop_for: *stop_for,
-            reception_signal: *reception_signal,
+            stop_details,
         });
     }
 
@@ -116,8 +123,6 @@ pub(super) fn build_request(
         options: params.options().clone(),
         physics_consist: sim_consist.0.clone(),
         path,
-        path_item_positions,
-        backtrack_path_items,
     })
 }
 
@@ -229,14 +234,16 @@ mod tests {
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 0,
                     arrival: None,
-                    stop_for: None,
-                    reception_signal: Default::default(),
+                    stop_details: None,
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 10,
                     arrival: Some(300),
-                    stop_for: Some(0),
-                    reception_signal: Default::default(),
+                    stop_details: Some(core_client::simulation::StopDetails {
+                        duration: 0,
+                        reception_signal: Default::default(),
+                        is_backtracking: false,
+                    }),
                 },
             ],
             margins: core_client::simulation::SimulationMargins {
@@ -252,8 +259,6 @@ mod tests {
             options: Default::default(),
             physics_consist: sim_consist.0,
             path,
-            path_item_positions,
-            backtrack_path_items: Some(vec![]),
         };
 
         assert_eq!(request, expected);
@@ -338,32 +343,47 @@ mod tests {
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 0,
                     arrival: None,
-                    stop_for: Some(0),
-                    reception_signal: Default::default(),
+                    stop_details: Some(core_client::simulation::StopDetails {
+                        duration: 0,
+                        reception_signal: Default::default(),
+                        is_backtracking: false,
+                    }),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 10,
                     arrival: Some(100),
-                    stop_for: Some(0),
-                    reception_signal: Default::default(),
+                    stop_details: Some(core_client::simulation::StopDetails {
+                        duration: 0,
+                        reception_signal: Default::default(),
+                        is_backtracking: false,
+                    }),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 20,
                     arrival: Some(200),
-                    stop_for: Some(0),
-                    reception_signal: Default::default(),
+                    stop_details: Some(core_client::simulation::StopDetails {
+                        duration: 0,
+                        reception_signal: Default::default(),
+                        is_backtracking: false,
+                    }),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 30,
                     arrival: Some(300),
-                    stop_for: Some(0),
-                    reception_signal: Default::default(),
+                    stop_details: Some(core_client::simulation::StopDetails {
+                        duration: 0,
+                        reception_signal: Default::default(),
+                        is_backtracking: false,
+                    }),
                 },
                 core_client::simulation::SimulationScheduleItem {
                     path_offset: 40,
                     arrival: Some(400),
-                    stop_for: Some(0),
-                    reception_signal: Default::default(),
+                    stop_details: Some(core_client::simulation::StopDetails {
+                        duration: 0,
+                        reception_signal: Default::default(),
+                        is_backtracking: false,
+                    }),
                 },
             ],
             margins: core_client::simulation::SimulationMargins {
@@ -398,8 +418,6 @@ mod tests {
             options: Default::default(),
             physics_consist: sim_consist.0,
             path,
-            path_item_positions,
-            backtrack_path_items: Some(vec![]),
         };
 
         assert_eq!(request, expected);

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -13,6 +13,7 @@ use core_client::simulation::SimulationPowerRestrictionItem;
 use core_client::simulation::SimulationScheduleItem;
 use core_client::simulation::SimulationSuccess;
 use core_client::simulation::SpeedLimitProperties;
+use core_client::simulation::StopDetails;
 use core_task::PathfindingConsist;
 use core_task::SimulationConsist;
 use core_task::SimulationTrain;
@@ -752,7 +753,12 @@ fn build_simulation_request<T: TrainScheduleLike>(
 ) -> core_client::simulation::Request {
     let path_items_to_position =
         build_path_items_to_position(train_schedule.path(), path_item_positions);
-    let schedule = build_sim_schedule_items(train_schedule.schedule(), &path_items_to_position);
+    let schedule = build_sim_schedule_items(
+        train_schedule.schedule(),
+        &path_items_to_position,
+        train_schedule.path(),
+        backtrack_path_items,
+    );
     let margins = build_sim_margins(train_schedule.margins(), &path_items_to_position);
     let power_restrictions = build_sim_power_restriction_items(
         train_schedule.power_restrictions(),
@@ -772,8 +778,6 @@ fn build_simulation_request<T: TrainScheduleLike>(
         options: train_schedule.options().clone(),
         physics_consist,
         electrical_profile_set_id,
-        path_item_positions: path_item_positions.to_vec(),
-        backtrack_path_items: backtrack_path_items.cloned(),
     }
 }
 
@@ -794,21 +798,45 @@ pub fn build_path_items_to_position<'t>(
 pub fn build_sim_schedule_items(
     schedule_items: &[ScheduleItem],
     path_items_to_position: &HashMap<&schemas::primitives::NonBlankString, u64>,
+    path_items: &[PathItem],
+    backtrack_path_items: Option<&Vec<usize>>,
 ) -> Vec<SimulationScheduleItem> {
-    schedule_items
+    let schedule_items: HashMap<_, _> = schedule_items
         .iter()
-        .map(|schedule_item| SimulationScheduleItem {
-            path_offset: path_items_to_position[&schedule_item.at],
-            arrival: schedule_item
-                .arrival
-                .as_ref()
-                .map(|t| t.num_milliseconds() as u64),
-            stop_for: schedule_item
-                .stop_for
-                .as_ref()
-                .map(|t| t.num_milliseconds() as u64),
-            reception_signal: schedule_item.reception_signal,
-        })
+        .map(|schedule_item| (&schedule_item.at, schedule_item))
+        .collect();
+    let mut is_backtracking = vec![false; path_items.len()];
+    backtrack_path_items
+        .unwrap_or(&vec![])
+        .iter()
+        .for_each(|index| is_backtracking[*index] = true);
+    path_items
+        .iter()
+        .zip(is_backtracking)
+        .map(
+            |(path_item, is_backtracking)| match schedule_items.get(&path_item.id) {
+                None => match is_backtracking {
+                    true => unreachable!(),
+                    _ => SimulationScheduleItem {
+                        path_offset: path_items_to_position[&path_item.id],
+                        arrival: None,
+                        stop_details: None,
+                    },
+                },
+                Some(schedule_item) => SimulationScheduleItem {
+                    path_offset: path_items_to_position[&schedule_item.at],
+                    arrival: schedule_item
+                        .arrival
+                        .as_ref()
+                        .map(|t| t.num_milliseconds() as u64),
+                    stop_details: schedule_item.stop_for.as_ref().map(|t| StopDetails {
+                        duration: t.num_milliseconds() as u64,
+                        reception_signal: schedule_item.reception_signal,
+                        is_backtracking,
+                    }),
+                },
+            },
+        )
         .collect()
 }
 
@@ -857,6 +885,7 @@ fn compute_train_simulation_hash_with_versioning(
 mod tests {
     use super::*;
     use schemas::TrainOccurrence;
+    use schemas::train_schedule::ReceptionSignal;
 
     // Test data
     // The simulation responses contain just enough data to compute
@@ -1038,5 +1067,38 @@ mod tests {
         let respect: Vec<bool> =
             path_item_respect_times(&sim.final_output.report_train.path_item_times, &schedule);
         assert_eq!(*respect, [true, false, true]);
+    }
+
+    #[test]
+    fn test_build_simulation_schedule() {
+        let train_schedule = train_schedule_honored();
+        let path_item_positions: [u64; 2] = [0, 3000];
+        let path_items_to_position =
+            build_path_items_to_position(train_schedule.path(), &path_item_positions);
+        let simulation_schedule_items = build_sim_schedule_items(
+            &train_schedule.schedule,
+            &path_items_to_position,
+            train_schedule.path(),
+            None,
+        );
+        assert_eq!(
+            simulation_schedule_items,
+            [
+                SimulationScheduleItem {
+                    path_offset: 0,
+                    arrival: None,
+                    stop_details: None
+                },
+                SimulationScheduleItem {
+                    path_offset: 3000,
+                    arrival: None,
+                    stop_details: Some(StopDetails {
+                        duration: 0,
+                        reception_signal: ReceptionSignal::Open,
+                        is_backtracking: false,
+                    })
+                }
+            ]
+        );
     }
 }

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -808,7 +808,7 @@ pub(in crate::views) async fn etcs_braking_curves(
                 .into();
             train_schedule.apply_train_schedule_exception(&exception)
         }
-        None => train_schedule.into_train_occurrence(),
+        None => train_schedule.clone().into_train_occurrence(),
     };
 
     // Compute simulation of a train schedule
@@ -858,7 +858,12 @@ pub(in crate::views) async fn etcs_braking_curves(
         &train_occurrence.path,
         &pathfinding_response.path_item_positions,
     );
-    let schedule = build_sim_schedule_items(&train_occurrence.schedule, &path_items_to_position);
+    let schedule = build_sim_schedule_items(
+        &train_occurrence.schedule,
+        &path_items_to_position,
+        &train_schedule.path,
+        None,
+    );
     let power_restrictions = build_sim_power_restriction_items(
         &train_occurrence.power_restrictions,
         &path_items_to_position,


### PR DESCRIPTION
Remove `path_item_positions` and `backtrack_path_items` parameters in the simulation/ core endpoint. The parameter `schedule` already contains `path_item_positions` data and I modified it to include `backtrack_path_items` data as well.

Adapt editoast to these new parameters.

Fix https://github.com/OpenRailAssociation/osrd/issues/16688