### PR TITLE
core, editoast: fix more transfer of backtracking locations

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathBuilder.kt
@@ -26,12 +26,14 @@ fun buildTrainPathFromBlock(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     blockId: BlockId,
+    backtrackLocations: List<Offset<Block>>,
     beginOffset: Offset<Block> = Offset(0.meters),
     endOffset: Offset<Block> = blockInfra.getBlockLength(blockId),
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
 ): TrainPath {
+    backtrackLocations.forEach { assert(it == beginOffset || it == endOffset) }
     val blockList =
         listOf(
             BlockRange(
@@ -47,6 +49,7 @@ fun buildTrainPathFromBlock(
         rawInfra,
         blockInfra,
         blockList,
+        backtrackLocations.map { Offset(it.distance) },
         routes,
         routeNames,
         electricalProfileMapping,
@@ -58,6 +61,7 @@ fun buildTrainPathFromBlocks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     blocks: List<BlockId>,
+    backtrackLocations: List<Offset<PhysicsPath>>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
@@ -82,6 +86,7 @@ fun buildTrainPathFromBlocks(
         rawInfra,
         blockInfra,
         blockRanges,
+        backtrackLocations,
         routes,
         routeNames,
         electricalProfileMapping,
@@ -93,11 +98,11 @@ fun buildTrainPathFromBlockRanges(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     blockRanges: List<BlockRange>,
+    backtrackLocations: List<Offset<PhysicsPath>>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
     haveApproximateBlocks: Boolean = false,
-    backtrackLocations: List<Offset<PhysicsPath>> = listOf(),
 ): TrainPath {
     require(routes == null || routeNames == null)
     val chunks = generateTrackChunks(rawInfra, blockInfra, blockRanges)
@@ -123,6 +128,7 @@ fun buildTrainPathFromChunks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     chunkRanges: List<DirChunkRange>,
+    backtrackLocations: List<Offset<PhysicsPath>>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
@@ -132,6 +138,7 @@ fun buildTrainPathFromChunks(
         rawInfra,
         blockInfra,
         blockRanges,
+        backtrackLocations,
         routes,
         routeNames,
         electricalProfileMapping,
@@ -147,6 +154,7 @@ fun buildTrainPathFromTracks(
     rawInfra: RawInfra,
     blockInfra: BlockInfra,
     trackRanges: List<DirTrackRange>,
+    backtrackLocations: List<Offset<PhysicsPath>>,
     routes: List<RouteId>? = null,
     routeNames: List<String>? = null,
     electricalProfileMapping: ElectricalProfileMapping? = null,
@@ -170,6 +178,7 @@ fun buildTrainPathFromTracks(
         rawInfra,
         blockInfra,
         chunkRanges,
+        backtrackLocations,
         routes,
         routeNames,
         electricalProfileMapping,

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/JsonTrainPath.kt
@@ -39,6 +39,7 @@ data class JsonTrainPath(
     }
 
     fun toTrainPath(
+        backtrackLocations: List<Offset<PhysicsPath>>,
         rawInfra: RawInfra,
         blockInfra: BlockInfra,
         electricalProfileMapping: ElectricalProfileMapping?,
@@ -54,6 +55,7 @@ data class JsonTrainPath(
             rawInfra,
             blockInfra,
             blockRanges = blockRanges,
+            backtrackLocations = backtrackLocations,
             routeNames = routes.map { it.id },
             electricalProfileMapping = electricalProfileMapping,
         )

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -88,7 +88,13 @@ class TestBALtoBAL {
                 blockInfra.getBlocksStartingAtDetector(detV.decreasing).first(),
             )
         val trainPath =
-            buildTrainPathFromBlocks(infra, blockInfra, blocks, routeNames = listOf("U-Z"))
+            buildTrainPathFromBlocks(
+                infra,
+                blockInfra,
+                blocks,
+                listOf(),
+                routeNames = listOf("U-Z"),
+            )
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.CLEAR)
         val res =
             simulator.evaluate(
@@ -190,6 +196,7 @@ class TestBALtoBAL {
                 infra,
                 blockInfra,
                 blockRanges,
+                listOf(),
                 routeNames = listOf("U-Z"),
             )
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.CLEAR)

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
@@ -95,7 +95,13 @@ class TestBAPRtoBAL {
             )
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.INCOMPATIBLE)
         val trainPath =
-            buildTrainPathFromBlocks(infra, blockInfra, blocks, routeNames = listOf("W-Z"))
+            buildTrainPathFromBlocks(
+                infra,
+                blockInfra,
+                blocks,
+                listOf(),
+                routeNames = listOf("W-Z"),
+            )
         val res =
             simulator.evaluate(
                 infra,

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
@@ -76,7 +76,13 @@ class TestTVM300toBAL {
             )
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.INCOMPATIBLE)
         val trainPath =
-            buildTrainPathFromBlocks(infra, blockInfra, blocks, routeNames = listOf("W-Z"))
+            buildTrainPathFromBlocks(
+                infra,
+                blockInfra,
+                blocks,
+                listOf(),
+                routeNames = listOf("W-Z"),
+            )
         val res =
             simulator.evaluate(
                 infra,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -60,7 +60,12 @@ class ETCSBrakingCurvesEndpoint(
 
             // Parse path.
             val trainPath =
-                request.path.toTrainPath(infra.rawInfra, infra.blockInfra, electricalProfileMap)
+                request.path.toTrainPath(
+                    listOf(),
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    electricalProfileMap,
+                )
             val powerRestrictions = parsePowerRestrictions(request.powerRestrictions)
             val electrificationMap =
                 trainPath.getElectrificationMap(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
@@ -14,10 +14,12 @@ import fr.sncf.osrd.cli.Take
 import fr.sncf.osrd.path.implementations.PartialDirTrackRange
 import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromTracks
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.reporting.exceptions.OSRDError.newUnknownTrackSectionError
 import fr.sncf.osrd.sim_infra.api.DirTrackSectionId
 import fr.sncf.osrd.toDirection
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Offset.Companion.max
 import fr.sncf.osrd.utils.units.Offset.Companion.min
 import fr.sncf.osrd.utils.units.forceDirected
@@ -34,7 +36,12 @@ class PathPropEndpoint(private val infraManager: InfraProvider) : Take {
             // Load infra
             val infra = infraManager.getInfra(request.infra, request.expectedVersion)
 
-            val trainPath = buildTrainPath(infra, request.trackSectionRanges)
+            val trainPath =
+                buildTrainPath(
+                    infra,
+                    request.trackSectionRanges,
+                    listOf(), // TODO: convey (then use) backtrackLocations in the request
+                )
             val res = makePathPropResponse(trainPath, infra.rawInfra)
 
             RsJson(RsWithBody(pathPropResponseAdapter.toJson(res)))
@@ -47,6 +54,7 @@ class PathPropEndpoint(private val infraManager: InfraProvider) : Take {
     private fun buildTrainPath(
         infra: FullInfra,
         trackRanges: List<DirectionalTrackRange>,
+        backtrackLocations: List<Offset<PhysicsPath>>,
     ): TrainPath {
         val partialTrackRanges =
             trackRanges.map {
@@ -65,6 +73,11 @@ class PathPropEndpoint(private val infraManager: InfraProvider) : Take {
                 )
             }
         val trackRanges = buildRangeList(partialTrackRanges)
-        return buildTrainPathFromTracks(infra.rawInfra, infra.blockInfra, trackRanges)
+        return buildTrainPathFromTracks(
+            infra.rawInfra,
+            infra.blockInfra,
+            trackRanges,
+            backtrackLocations,
+        )
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingPostProcessing.kt
@@ -46,13 +46,16 @@ private fun validatePathfindingResponse(
     // TODO path migrations: some of those checks won't be true anymore with backtracks
     if (res !is PathfindingBlockSuccess) return
 
-    val trainPath = res.path.toTrainPath(infra.rawInfra, infra.blockInfra, null)
+    val backtrackLocations = res.backtrackPathItems.map { res.pathItemPositions[it] }
+
+    val trainPath = res.path.toTrainPath(backtrackLocations, infra.rawInfra, infra.blockInfra, null)
     val blocks = trainPath.getBlocks()
     for ((i, blockRange) in blocks.withIndex()) {
         val block = blockRange.value
         val stopAtBufferStop = infra.blockInfra.blockStopAtBufferStop(block)
         val isLastBlock = i == blocks.size - 1
-        if (stopAtBufferStop && !isLastBlock) {
+        val endsBacktracking = blockRange.pathEnd in backtrackLocations
+        if (stopAtBufferStop && !(isLastBlock || endsBacktracking)) {
             val zonePath = infra.blockInfra.getBlockZonePaths(block).last()
             val detector = infra.rawInfra.getZonePathExit(zonePath)
             val detectorName = infra.rawInfra.getDetectorName(detector.value)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
@@ -25,6 +25,7 @@ class SignalProjectionEndpoint(private val infraManager: InfraProvider) : Take {
             // Parse path
             val trainPath =
                 request.path.toTrainPath(
+                    listOf(), // TODO: convey (then use) backtrackLocations in the request
                     infra.rawInfra,
                     infra.blockInfra,
                     electricalProfileMapping = null,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -10,7 +10,6 @@ import fr.sncf.osrd.cli.RsWithStatus
 import fr.sncf.osrd.cli.Take
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.standalone_sim.runStandaloneSimulation
-import fr.sncf.osrd.utils.*
 import io.opentelemetry.api.trace.Span
 import java.io.File
 import java.time.LocalDateTime
@@ -54,7 +53,12 @@ class SimulationEndpoint(
 
             // Parse path
             val trainPath =
-                request.path.toTrainPath(infra.rawInfra, infra.blockInfra, electricalProfileMap)
+                request.path.toTrainPath(
+                    request.backtrackPathItems.map { request.pathItemPositions[it] },
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    electricalProfileMap,
+                )
 
             val res =
                 runStandaloneSimulation(

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -101,7 +101,7 @@ data class SpacingResourceGenerator(
     private val blockRanges = ArrayDeque<BlockRange>()
     private val routeRanges = ArrayDeque<RouteRange>()
     private val zoneRanges = ArrayDeque<ZonePathRange>()
-    private val stops = ArrayDeque<PathStop>()
+    private val closedSignalStops = ArrayDeque<PathStop>()
     private val pendingSignals = ArrayDeque<PendingSignalData>()
     // It's tempting to use zone id instead of zone path ids here,
     // but data for the same zone in different directions can't be merged
@@ -156,7 +156,7 @@ data class SpacingResourceGenerator(
         blockRanges.addLinearObjects(newBlockRanges)
         routeRanges.addLinearObjects(newRouteRanges)
         zoneRanges.addLinearObjects(newZoneRanges)
-        stops.addAll(newStops.filter { it.receptionSignal.isStopOnClosedSignal })
+        closedSignalStops.addAll(newStops.filter { it.receptionSignal.isStopOnClosedSignal })
         for ((signal, pathOffset) in signals) {
             if (pendingSignals.lastOrNull()?.signal == signal)
                 continue // block transition signals are listed on either block
@@ -226,7 +226,7 @@ data class SpacingResourceGenerator(
         res.blockRanges.addAll(blockRanges)
         res.routeRanges.addAll(routeRanges)
         res.zoneRanges.addAll(zoneRanges)
-        res.stops.addAll(stops)
+        res.closedSignalStops.addAll(closedSignalStops)
         res.pendingSignals.addAll(pendingSignals)
         res.isPathComplete = isPathComplete
         res.reachedFirstSignal = reachedFirstSignal
@@ -317,7 +317,8 @@ data class SpacingResourceGenerator(
         val zonePathsToRemove = mutableListOf<ZonePathId>()
         for ((zonePath, ongoingRequirementData) in ongoingZoneRequirements) {
             val zoneId = rawInfra.getZonePathZone(zonePath)
-            val requirement = ongoingRequirementData.generateRequirement(zoneId, callbacks, stops)
+            val requirement =
+                ongoingRequirementData.generateRequirement(zoneId, callbacks, closedSignalStops)
             if (requirement != null) {
                 res.add(requirement)
                 if (requirement.isComplete) zonePathsToRemove.add(zonePath)
@@ -326,7 +327,10 @@ data class SpacingResourceGenerator(
         for (zonePath in zonePathsToRemove) { // Avoid modifying while iterating
             ongoingZoneRequirements.remove(zonePath)
         }
-        stops.removeWhile { it.pathOffset < callbacks.currentPathOffset }
+        // `currentPathOffset` is at least some blocks before the end of the path to be explored.
+        // And so signals (and protected zones) after `currentPathOffset` that could be impacted by
+        // a simulated closed-signal stop are already taken care of.
+        closedSignalStops.removeWhile { it.pathOffset < callbacks.currentPathOffset }
         return res
     }
 
@@ -529,18 +533,18 @@ data class SpacingResourceGenerator(
         fun generateRequirement(
             zoneId: ZoneId,
             callbacks: IncrementalRequirementCallbacks,
-            stops: List<PathStop>,
+            closedSignalStops: List<PathStop>,
         ): SpacingRequirement? {
             if (minRequiredOffset > callbacks.currentPathOffset) return null
             var beginTime = callbacks.arrivalTimeInRange(minRequiredOffset, Offset(Distance.MAX))
             val simCurrentTime = callbacks.currentTime
             require(beginTime <= simCurrentTime)
 
-            val lastPreviousStopOffset =
-                stops.lastOrNull { it.pathOffset < zoneEntryOffset }?.pathOffset
-            if (lastPreviousStopOffset != null) {
-                val departureTime = callbacks.departureFromStop(lastPreviousStopOffset)
-                val minRequirementTime = departureTime - CLOSED_SIGNAL_RESERVATION_MARGIN
+            val lastClosedStopBeforeEntryOffset =
+                closedSignalStops.lastOrNull { it.pathOffset < zoneEntryOffset }?.pathOffset
+            if (lastClosedStopBeforeEntryOffset != null) {
+                val stopDepartureTime = callbacks.departureFromStop(lastClosedStopBeforeEntryOffset)
+                val minRequirementTime = stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN
                 beginTime = max(minRequirementTime, beginTime)
                 if (beginTime > simCurrentTime) return null // after a stop not departed from yet
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/ElectrificationConstraints.kt
@@ -20,7 +20,7 @@ data class ElectrificationConstraints(
     val compatibleElectrification: Collection<String>,
 ) : PathfindingConstraint {
     override fun apply(edge: BlockId): Collection<OffsetRange<Block>> {
-        val path = buildTrainPathFromBlock(rawInfra, blockInfra, edge)
+        val path = buildTrainPathFromBlock(rawInfra, blockInfra, edge, listOf())
         return getBlockedRanges(path, compatibleElectrification)
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraints.kt
@@ -15,7 +15,7 @@ data class LoadingGaugeConstraints(
 ) : PathfindingConstraint {
     override fun apply(edge: BlockId): Collection<OffsetRange<Block>> {
         val res = HashSet<OffsetRange<Block>>()
-        val path = buildTrainPathFromBlock(infra, blockInfra, edge)
+        val path = buildTrainPathFromBlock(infra, blockInfra, edge, listOf())
         res.addAll(getBlockedRanges(loadingGaugeType, path))
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/TrackSectionConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/TrackSectionConstraints.kt
@@ -17,7 +17,7 @@ data class TrackSectionConstraints(
 ) : PathfindingConstraint {
     override fun apply(edge: BlockId): Collection<OffsetRange<Block>> {
         val res = HashSet<OffsetRange<Block>>()
-        val path = buildTrainPathFromBlock(infra, blockInfra, edge)
+        val path = buildTrainPathFromBlock(infra, blockInfra, edge, listOf())
         res.addAll(getBlockedRanges(allowedTrackSections, path))
 
         return res

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
@@ -87,7 +87,13 @@ data class CachedBlockMaxSpeedEnvBuilder(
             mrspEnvCache.computeIfAbsent(cacheKey) {
                 // TODO: change input to infra explorers, and fetch last route there
                 val pathProps =
-                    buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
+                    buildTrainPathFromBlock(
+                        rawInfra,
+                        blockInfra,
+                        block,
+                        listOf(),
+                        routes = listOf(),
+                    )
                 val rollingStock = consistSchedule.rollingStocks[step]
                 val context = build(rollingStock, pathProps, timeStep, comfort)
                 val mrsp =

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -45,11 +45,15 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         val lastExplorer = edges.last().infraExplorer
         val blockRanges = lastExplorer.getAllBlocks().toList()
         val routes = lastExplorer.getExploredRoutes()
+        val seenSteps = lastExplorer.getStepTracker().getSeenSteps().toList()
         val trainPath =
             buildTrainPathFromBlockRanges(
                 infra.rawInfra,
                 infra.blockInfra,
                 blockRanges,
+                seenSteps.mapNotNull { step ->
+                    if (step.isBacktracking) step.travelledPathOffset else null
+                },
                 routes = routes,
             )
 
@@ -73,7 +77,6 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 stops,
                 updatedTimeData,
             )
-        val seenSteps = lastExplorer.getStepTracker().getSeenSteps().toList()
         val res =
             STDCMResult(
                 withAllowance.envelope,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -141,6 +141,15 @@ interface InfraExplorer {
     ): List<PathStop>
 
     /**
+     * Returns the backtrack locations in the given interval, going up to the path start/end if
+     * unspecified
+     */
+    fun getBacktrackLocationsInRange(
+        from: Offset<PhysicsPath>? = null,
+        to: Offset<PhysicsPath>? = null,
+    ): List<Offset<PhysicsPath>>
+
+    /**
      * Returns the end of the lookahead as a train path offset. Can also be seen as the total length
      * of the currently known path.
      */
@@ -169,6 +178,8 @@ data class ExplorerStep(
     val plannedTimingData: PlannedTimingData? = null,
 )
 
+data class TrainPathCacheKey(val blockId: BlockId, val backtrackLocation: Offset<Block>?)
+
 /**
  * Init all InfraExplorers starting at the given location. The last of `stops` are used to identify
  * when the incremental path is complete. `constraints` are used to determine if a block can be
@@ -185,8 +196,8 @@ fun initInfraExplorers(
     require(constraints == null || targets.isEmpty() || constraints.size == targets.size)
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
-    val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block)
-    val blockToPathProperties = mutableMapOf(block to pathProps)
+    val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, listOf())
+    val blockToPathProperties = mutableMapOf(TrainPathCacheKey(block, null) to pathProps)
     val routes = blockInfra.routesOnBlock(rawInfra, block)
 
     routes.forEach { route ->
@@ -221,7 +232,7 @@ private class InfraExplorerImpl(
     private var routes: AppendOnlyLinkedList<RouteRange>,
     private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
     private var lastTrack: TrackSectionId?,
-    private var trainPathCache: MutableMap<BlockId, TrainPath>,
+    private var trainPathCache: MutableMap<TrainPathCacheKey, TrainPath>,
     private var currentIndex: Int = 0, // /!\ currentBlockRange should be updated simultaneously /!\
     private var currentBlockRange: BlockRange? = null,
     private var stepTracker: StepTracker,
@@ -234,10 +245,26 @@ private class InfraExplorerImpl(
         // We also can't set a first route for sure in initInfraExplorer, but we set the first cache
         // entry.
         // So we have to correct that here now that we now which route we're on.
+        val blockRange = getCurrentBlockRange()
+        val blockBacktrackLocations =
+            getBacktrackLocationsInRange(blockRange.pathBegin, blockRange.pathEnd).map {
+                Offset<Block>(it.distance - blockRange.objectAbsolutePathStart.distance)
+            }
+
+        assert(blockBacktrackLocations.size <= 1)
+        val trainPathCacheKey =
+            TrainPathCacheKey(getCurrentBlock(), blockBacktrackLocations.firstOrNull())
+
         val path =
-            trainPathCache.getOrElse(getCurrentBlock()) {
-                val res = buildTrainPathFromBlock(rawInfra, blockInfra, getCurrentBlock())
-                trainPathCache[getCurrentBlock()] = res
+            trainPathCache.getOrElse(trainPathCacheKey) {
+                val res =
+                    buildTrainPathFromBlock(
+                        rawInfra,
+                        blockInfra,
+                        getCurrentBlock(),
+                        blockBacktrackLocations,
+                    )
+                trainPathCache[trainPathCacheKey] = res
                 res
             }
         val route = blockRoutes[getCurrentBlock()]!!
@@ -396,9 +423,18 @@ private class InfraExplorerImpl(
             rawInfra,
             blockInfra,
             blocks,
+            getSeenBacktrackLocations(),
             getExploredRoutes(),
             electricalProfileMapping = electricalProfileMapping,
         )
+    }
+
+    private fun getSeenBacktrackLocations(): List<Offset<PhysicsPath>> {
+        return stepTracker
+            .iterateSeenStepsBackwards()
+            .mapNotNull { if (it.isBacktracking) it.travelledPathOffset else null }
+            .toList()
+            .asReversed()
     }
 
     private fun <T, U> getSubRanges(
@@ -436,9 +472,30 @@ private class InfraExplorerImpl(
         return getStepTracker()
             .iterateSeenStepsBackwards()
             .takeWhile { it.travelledPathOffset >= from }
-            .filter { it.originalStep.stop && it.travelledPathOffset <= to }
-            .map {
-                PathStop(it.travelledPathOffset, RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP)
+            .mapNotNull {
+                if (it.originalStep.stop && it.travelledPathOffset <= to)
+                    PathStop(
+                        it.travelledPathOffset,
+                        RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP,
+                    )
+                else null
+            }
+            .toList()
+            .asReversed()
+    }
+
+    override fun getBacktrackLocationsInRange(
+        from: Offset<PhysicsPath>?,
+        to: Offset<PhysicsPath>?,
+    ): List<Offset<PhysicsPath>> {
+        val from = from ?: Offset.zero()
+        val to = to ?: getLookaheadEndOffset()
+        return getStepTracker()
+            .iterateSeenStepsBackwards()
+            .takeWhile { it.travelledPathOffset >= from }
+            .mapNotNull {
+                if (it.isBacktracking && it.travelledPathOffset <= to) it.travelledPathOffset
+                else null
             }
             .toList()
             .asReversed()

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -55,7 +55,8 @@ data class CachedBlockMRSPBuilder(
     fun getMRSP(block: BlockId): Envelope {
         return mrspCache.computeIfAbsent(block) {
             // TODO: change input to infra explorers, and fetch last route there
-            val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, routes = listOf())
+            val pathProps =
+                buildTrainPathFromBlock(rawInfra, blockInfra, block, listOf(), routes = listOf())
             computeMRSP(
                 pathProps,
                 rsMaxSpeed,

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
@@ -50,9 +50,11 @@ class CSVLogger(filename: String, private val keys: List<String>) {
 /** Return the geo coordinates of a node. */
 fun STDCMNode.toGeoPoint(rawInfra: RawInfra, blockInfra: BlockInfra): Point {
     val blockRange = infraExplorer.getCurrentBlockRange()
-    val geo = buildTrainPathFromBlock(rawInfra, blockInfra, blockRange.value).getGeo()
+    val geo = buildTrainPathFromBlock(rawInfra, blockInfra, blockRange.value, listOf()).getGeo()
     val blockLength = blockInfra.getBlockLength(blockRange.value)
     val blockOffset = blockRange.offsetFromTrainPath(infraExplorer.getSimulatedLength())
+    // TODO interpolate at the track-section level, as the geo length is not guaranteed equal to
+    //   the topo length for all track-sections
     var p = geo.interpolateNormalized(blockOffset.meters / blockLength.meters)
     if (p.lat.isNaN() || p.lon.isNaN()) p = geo.getPoints().first()
     return p

--- a/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/DriverBehaviourTest.kt
@@ -22,7 +22,7 @@ class DriverBehaviourTest {
                 infra.addBlock("b", "c", 100.meters, 10.0),
                 infra.addBlock("c", "d", 100.meters, 20.0),
             )
-        val path = buildTrainPathFromBlocks(infra, infra, blocks, routes = listOf())
+        val path = buildTrainPathFromBlocks(infra, infra, blocks, listOf(), routes = listOf())
         val testRollingStock = TestTrains.VERY_SHORT_FAST_TRAIN
         val driverBehaviour = DriverBehaviour(2.0, 3.0)
         var mrsp = computeMRSP(path, testRollingStock, true, null, null)

--- a/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/backtracks/BacktrackTests.kt
@@ -166,9 +166,9 @@ class BacktrackTests {
             infra.rawInfra,
             infra.blockInfra,
             buildRangeList(blockRanges),
+            listOf(backtrackLocation),
             routeNames =
                 listOf("rt.bf.a->det.a3", "rt.det.a3->bf.c", "rt.bf.c->det.c1", "rt.det.c1->bf.b"),
-            backtrackLocations = listOf(backtrackLocation),
         )
     }
 
@@ -236,8 +236,8 @@ class BacktrackTests {
             infra.rawInfra,
             infra.blockInfra,
             buildRangeList(blockRanges),
+            listOf(backtrackLocation),
             routeNames = listOf("rt.bf.a->det.a3", "rt.det.a3->bf.c", "rt.det.c1->bf.b"),
-            backtrackLocations = listOf(backtrackLocation),
         )
     }
 
@@ -315,9 +315,9 @@ class BacktrackTests {
             infra.rawInfra,
             infra.blockInfra,
             buildRangeList(blockRanges),
+            listOf(backtrackLocation),
             routeNames =
                 listOf("rt.bf.a->det.a3", "rt.det.a3->bf.c", "rt.bf.c->det.c1", "rt.det.c1->bf.b"),
-            backtrackLocations = listOf(backtrackLocation),
         )
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
@@ -151,13 +151,21 @@ class MRSPTest {
         // Compute paths
         val infra = fullInfraFromRJS(rjsInfra, InfraMetadata("modified_small_infra"))
         val blockInfra = infra.blockInfra
-        path = buildTrainPathFromBlock(infra.rawInfra, blockInfra, BlockId(0U), routes = listOf())
+        path =
+            buildTrainPathFromBlock(
+                infra.rawInfra,
+                blockInfra,
+                BlockId(0U),
+                listOf(),
+                routes = listOf(),
+            )
         val block30 = Helpers.getBlocksOnRoutes(infra, listOf(route1.id))[0]
         path30 =
             buildTrainPathFromBlock(
                 infra.rawInfra,
                 blockInfra,
                 block30,
+                listOf(),
                 routeNames = listOf(route1.id),
             )
         val block60 = Helpers.getBlocksOnRoutes(infra, listOf(route2.id))[0]
@@ -166,6 +174,7 @@ class MRSPTest {
                 infra.rawInfra,
                 blockInfra,
                 block60,
+                listOf(),
                 routeNames = listOf(route2.id),
             )
     }
@@ -186,6 +195,7 @@ class MRSPTest {
                     infra.rawInfra,
                     infra.blockInfra,
                     block,
+                    listOf(),
                     routeNames = listOf(route),
                 )
             val pathLen = routeLen(route)
@@ -209,7 +219,13 @@ class MRSPTest {
         val block = Helpers.getBlocksOnRoutes(infra, listOf(ROUTES[0])).last()
         pathTo1NoRoutes =
             TestPath(
-                buildTrainPathFromBlock(infra.rawInfra, infra.blockInfra, block, routes = listOf()),
+                buildTrainPathFromBlock(
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    block,
+                    listOf(),
+                    routes = listOf(),
+                ),
                 Envelope.make(
                     EnvelopeTestUtils.makeFlatPart(
                         LimitKind.SPEED_LIMIT,

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -31,7 +31,13 @@ class RemainingDistanceEstimatorTest {
     fun setUp() {
         smallInfra = Helpers.smallInfra
         block = Helpers.getBlocksOnRoutes(smallInfra!!, listOf("rt.DA2->DA5"))[0]
-        path = buildTrainPathFromBlock(smallInfra!!.rawInfra, smallInfra!!.blockInfra, block!!)
+        path =
+            buildTrainPathFromBlock(
+                smallInfra!!.rawInfra,
+                smallInfra!!.blockInfra,
+                block!!,
+                listOf(),
+            )
     }
 
     @ParameterizedTest

--- a/core/src/test/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionTest.kt
@@ -150,7 +150,7 @@ class SignalProjectionTests {
             )
 
         val jsonTrainPath = JsonTrainPath(blocks, routes, trackSectionRanges)
-        val trainPath = jsonTrainPath.toTrainPath(infra.rawInfra, infra.blockInfra, null)
+        val trainPath = jsonTrainPath.toTrainPath(listOf(), infra.rawInfra, infra.blockInfra, null)
 
         val signalProjections =
             projectSignals(

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -566,6 +566,7 @@ class PathPropertiesTests {
                 infra.rawInfra,
                 infra.blockInfra,
                 BlockId(0U),
+                listOf(),
                 routes = listOf(),
             )
         val speedLimits = path.getSpeedLimitProperties("trainTag", null)
@@ -613,6 +614,7 @@ class PathPropertiesTests {
                 infra.rawInfra,
                 infra.blockInfra,
                 blocks.last(),
+                listOf(),
                 routeNames = listOf("rt.DH2->buffer_stop.7"),
             )
 

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -51,7 +51,7 @@ class StandaloneSimulationTest {
             .map { infra.blockInfra.getBlockFromName("block.${md5(it)}")!! }
 
     private val trainPath =
-        buildTrainPathFromBlocks(infra.rawInfra, infra.blockInfra, blocks, routes)
+        buildTrainPathFromBlocks(infra.rawInfra, infra.blockInfra, blocks, listOf(), routes)
     private val pathLength = trainPath.getLength()
 
     // Build a reference max speed envelope

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -457,7 +457,7 @@ fun makeRequirementsFromPath(
         )
             as PathfindingBlockSuccess
 
-    val trainPath = path.path.toTrainPath(infra.rawInfra, infra.blockInfra, null)
+    val trainPath = path.path.toTrainPath(listOf(), infra.rawInfra, infra.blockInfra, null)
     val sim =
         runStandaloneSimulation(
             infra,

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.path.implementations.PartialDirTrackRange
 import fr.sncf.osrd.path.implementations.buildRangeList
 import fr.sncf.osrd.path.implementations.buildTrainPathFromTracks
+import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.path.interfaces.subRange
 import fr.sncf.osrd.path.legacy_objects.ElectricalProfileMapping
@@ -21,6 +22,7 @@ fun pathFromTracks(
     dir: Direction,
     start: Distance,
     end: Distance,
+    backtrackLocations: List<Offset<PhysicsPath>>,
     electricalProfileMapping: ElectricalProfileMapping? = null,
     routeNames: List<String>? = null,
 ): TrainPath {
@@ -42,6 +44,7 @@ fun pathFromTracks(
         rawInfra,
         blockInfra,
         trackRanges.subRange(Offset(start), Offset(end)),
+        backtrackLocations,
         electricalProfileMapping = electricalProfileMapping,
         routeNames = routeNames,
     )
@@ -53,6 +56,7 @@ fun pathFromTracks(
     dir: Direction,
     start: Distance,
     end: Distance,
+    backtrackLocations: List<Offset<PhysicsPath>> = listOf(),
     electricalProfileMapping: ElectricalProfileMapping? = null,
     routeNames: List<String>? = null,
 ): TrainPath {
@@ -63,6 +67,7 @@ fun pathFromTracks(
         dir,
         start,
         end,
+        backtrackLocations,
         electricalProfileMapping = electricalProfileMapping,
         routeNames = routeNames,
     )

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -502,12 +502,13 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
             train_schedule,
             consist,
         } = train_schedule_with_consist;
-        let (path, path_item_positions) = match pathfinding.as_ref() {
+        let (path, path_item_positions, backtrack_path_items) = match pathfinding.as_ref() {
             PathfindingResult::Success(PathfindingResultSuccess {
                 path,
                 path_item_positions,
+                backtrack_path_items,
                 ..
-            }) => (path, path_item_positions),
+            }) => (path, path_item_positions, backtrack_path_items),
             PathfindingResult::Failure(pathfinding_failed) => {
                 simulation_results[index] =
                     Some(Arc::new(simulation::Response::PathfindingFailed {
@@ -522,6 +523,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
             infra,
             train_schedule,
             path_item_positions,
+            backtrack_path_items.as_ref(),
             path,
             electrical_profile_set_id,
             PhysicsConsist::from(consist.clone()),
@@ -748,6 +750,7 @@ fn build_simulation_request<T: TrainScheduleLike>(
     infra: &Infra,
     train_schedule: &T,
     path_item_positions: &[u64],
+    backtrack_path_items: Option<&Vec<usize>>,
     path: &TrainPath,
     electrical_profile_set_id: Option<i64>,
     physics_consist: PhysicsConsist,
@@ -775,7 +778,7 @@ fn build_simulation_request<T: TrainScheduleLike>(
         physics_consist,
         electrical_profile_set_id,
         path_item_positions: path_item_positions.to_vec(),
-        backtrack_path_items: Some(vec![]),
+        backtrack_path_items: backtrack_path_items.cloned(),
     }
 }
 


### PR DESCRIPTION
also minor renaming in core

🔍 The major challenge here is to check if we must have the backtracking locations, or if it's OK to go with an empty list, given the usage.

### Motivation

While hand-testing (tinckering code a bit) some under-development feature (for operational studies: spacing/routing requirements, pathfinding), the stack was removing some backtracking information.
So I went for a removal of default values in core and a check one-by-one.
I chose to not impact core's API (and add `TODO`s) as some upcoming features are going to push for those modifications, but it's not required for current hand-testing.

### Tests

No tests added as the whole feature only can be integration-tested for now (editoast part).
The under-development feature (spacing requirement) will be tested in the dedicated PR.

Hand-testing requires tinckering core code to have any intermediate stop being `canBacktrack` and check the routing (and spacing later) requirements of a backtracking train (superpose exact trains and observe conflicts). Tinckering front to filter routing/spacing can be necessary, too.