### PR TITLE
editoast: avoid sending SQL queries for empty batches

### DIFF
--- a/editoast/editoast_models/src/infra_objects.rs
+++ b/editoast/editoast_models/src/infra_objects.rs
@@ -278,6 +278,12 @@ impl OperationalPointModel {
         use diesel::prelude::*;
         use diesel::sql_types::*;
         use diesel_async::RunQueryDsl;
+
+        if uic.is_empty() {
+            // We know the result of the SQL query is going to be empty, avoid sending it.
+            return Ok(Vec::new());
+        }
+
         let uic: Vec<i64> = uic.iter().map(|&u| i64::from(u)).collect();
 
         Ok(dsl::infra_object_operational_point
@@ -300,6 +306,11 @@ impl OperationalPointModel {
         use diesel::prelude::*;
         use diesel::sql_types::*;
         use diesel_async::RunQueryDsl;
+
+        if trigrams.is_empty() {
+            // We know the result of the SQL query is going to be empty, avoid sending it.
+            return Ok(Vec::new());
+        }
 
         Ok(dsl::infra_object_operational_point
             .filter(dsl::infra_id.eq(infra_id))


### PR DESCRIPTION
Minuscule part of https://github.com/OpenRailAssociation/osrd/issues/17199

Sometimes we use the OperationalPointCache with path items that are only UIC, or only trigrams, or only ID, etc. In these cases editoast would send SQL queries that look like this:

```sql
SELECT
  "infra_object_operational_point"."id",
  "infra_object_operational_point"."obj_id",
  "infra_object_operational_point"."data",
  "infra_object_operational_point"."infra_id"
FROM "infra_object_operational_point"
WHERE (("infra_object_operational_point"."infra_id" = $1)
  AND ((data->'extensions'->'identifier'->'uic')::int = ANY($2)))
-- binds: [344, []]
```

.. which obviously return nothing.

It's not much but i figure it will help still.