### PR TITLE
editoast: de-bloat SQL queries used to build the OperationalPointCache

### DIFF
--- a/editoast/editoast_models/src/infra_objects.rs
+++ b/editoast/editoast_models/src/infra_objects.rs
@@ -340,6 +340,36 @@ impl OperationalPointModel {
     }
 }
 
+impl TrackSectionModel {
+    /// Retrieve the list of track sections that match the given (object) IDs
+    ///
+    /// Use this instead of [`TrackSectionModel::retrieve_batch_unchecked`]
+    /// when all the operational points are known to be in the same infra.
+    pub async fn retrieve_from_ids(
+        conn: &mut DbConnection,
+        infra_id: i64,
+        ids: &[String],
+    ) -> Result<Vec<Self>, database::DatabaseError> {
+        use database::tables::infra_object_track_section::dsl;
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        if ids.is_empty() {
+            // We know the result of the SQL query is going to be empty, avoid sending it.
+            return Ok(Vec::new());
+        }
+
+        Ok(dsl::infra_object_track_section
+            .filter(dsl::infra_id.eq(infra_id))
+            .filter(dsl::obj_id.eq_any(ids))
+            .load(&mut conn.write().await)
+            .await?
+            .into_iter()
+            .map(Self::from_row)
+            .collect())
+    }
+}
+
 #[cfg(test)]
 mod tests_persist {
     use super::*;

--- a/editoast/editoast_models/src/infra_objects.rs
+++ b/editoast/editoast_models/src/infra_objects.rs
@@ -310,6 +310,34 @@ impl OperationalPointModel {
             .map(Self::from_row)
             .collect())
     }
+
+    /// Retrieve the list of operational points that match the given (object) IDs
+    ///
+    /// Use this instead of [`OperationalPointModel::retrieve_batch_unchecked`]
+    /// when all the operational points are known to be in the same infra.
+    pub async fn retrieve_from_ids(
+        conn: &mut DbConnection,
+        infra_id: i64,
+        ids: &[String],
+    ) -> Result<Vec<Self>, database::DatabaseError> {
+        use database::tables::infra_object_operational_point::dsl;
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        if ids.is_empty() {
+            // We know the result of the SQL query is going to be empty, avoid sending it.
+            return Ok(Vec::new());
+        }
+
+        Ok(dsl::infra_object_operational_point
+            .filter(dsl::infra_id.eq(infra_id))
+            .filter(dsl::obj_id.eq_any(ids))
+            .load(&mut conn.write().await)
+            .await?
+            .into_iter()
+            .map(Self::from_row)
+            .collect())
+    }
 }
 
 #[cfg(test)]

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -15,7 +15,6 @@ use std::collections::HashSet;
 use crate::error::Result;
 use editoast_models::OperationalPointModel;
 use editoast_models::TrackSectionModel;
-use editoast_models::prelude::*;
 
 use super::pathfinding::PathfindingFailure;
 
@@ -74,20 +73,19 @@ impl OperationalPointCache {
             .ops
             .iter()
             .flat_map(|op| &op.parts)
-            .map(|part| (infra_id, part.track.0.clone()));
+            .map(|part| part.track.0.clone());
 
         let path_item_tracks = path_items.iter().filter_map(|item| match item.borrow() {
-            PathItemLocation::TrackOffset(TrackOffset { track, .. }) => {
-                Some((infra_id, track.0.clone()))
-            }
+            PathItemLocation::TrackOffset(TrackOffset { track, .. }) => Some(track.0.clone()),
             _ => None,
         });
 
-        let tracks = op_tracks.chain(path_item_tracks);
+        let req_track_ids = op_tracks.chain(path_item_tracks).collect::<Vec<String>>();
         let track_sections =
-            TrackSectionModel::retrieve_batch_unchecked::<_, Vec<_>>(&mut conn, tracks).await?;
+            TrackSectionModel::retrieve_from_ids(&mut conn, infra_id, &req_track_ids).await?;
 
-        let track_ids = track_sections
+        // Not all track sections may have been found.
+        let resp_track_ids = track_sections
             .iter()
             .map(|track| track.obj_id.clone())
             .collect();
@@ -100,7 +98,7 @@ impl OperationalPointCache {
             .collect();
 
         op_cache.track_ids_to_local_track_name = track_ids_to_local_track_name;
-        op_cache.track_ids = track_ids;
+        op_cache.track_ids = resp_track_ids;
         Ok(op_cache)
     }
 

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -436,9 +436,7 @@ async fn retrieve_op_from_ids(
     infra_id: i64,
     ops_id: &[String],
 ) -> Result<Vec<OperationalPointModel>> {
-    let ops_id = ops_id.iter().map(|obj_id| (infra_id, obj_id.clone()));
-    // a check for missing ids is performed later
-    OperationalPointModel::retrieve_batch_unchecked::<_, Vec<_>>(conn, ops_id)
+    OperationalPointModel::retrieve_from_ids(conn, infra_id, ops_id)
         .await
         .map_err(Into::into)
 }


### PR DESCRIPTION
Closes #17199 
Related PR: #17228 

Instead of using `retrieve_batch_unchecked` from editoast_models, use a
custom query.

The `retrieve_batch_unchecked` function would generate a query like this

    SELECT
      "infra_object_operational_point"."id",
      "infra_object_operational_point"."obj_id",
      "infra_object_operational_point"."data",
      "infra_object_operational_point"."infra_id"
    FROM "infra_object_operational_point"
    WHERE ("infra_object_operational_point"."infra_id" = $1
             AND "infra_object_operational_point"."obj_id" = $2)
       OR ("infra_object_operational_point"."infra_id" = $3
             AND "infra_object_operational_point"."obj_id" = $4)
       OR ("infra_object_operational_point"."infra_id" = $5
             AND "infra_object_operational_point"."obj_id" = $6)
       OR ("infra_object_operational_point"."infra_id" = $7
             AND "infra_object_operational_point"."obj_id" = $8)
       ...

with additional parenthesis.

To handle `/train_schedules/simulation_summary` requests, on timetables
where trains have around 200 scheduled items, the SQL queries would end
up having around 3000 bind parameters.

These queries would make postgreSQL choke (around 80% of the time spent
was in query planning), and would not use the index (well, it was using
the index, but would make an index scan for each (X AND Y) tuple).

We could implement the fix in diesel
https://github.com/diesel-rs/diesel/issues/3222
but in this case we know `infra_id` is the same for all the operational
points, so doing a custom query is still more efficient.

# How to test

With this patch

```diff
diff --git a/editoast/database/src/db_connection_pool/tracing_instrumentation.rs b/editoast/database/src/db_connection_pool/tracing_instrumentation.rs
index 4d11b703a5..fc37f2a6a5 100644
--- a/editoast/database/src/db_connection_pool/tracing_instrumentation.rs
+++ b/editoast/database/src/db_connection_pool/tracing_instrumentation.rs
@@ -60,6 +60,7 @@
                 self.connection_span = tracing::Span::none();
             }
             InstrumentationEvent::StartQuery { query, .. } => {
+                eprintln!("{query:?}");
                 let span = tracing::info_span!(
                     "query",
                     { opentelemetry_semantic_conventions::attribute::DB_QUERY_TEXT } =
```

- Open a scenario with some train schedules,
- re-send one of the `/train_schedules/simulation_summary` request using the dev tools
- notice the query in the editoast logs