### PR TITLE
editoast: allow rolling stock grants revoking in `POST:/authz/grants`

### DIFF
--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -78,6 +78,10 @@ pub enum Check {
     SubjectEffectiveInfraGrantIsNot(InfraGrant, Subject, Infra),
     /// The subject must not be the last direct owner of the infra
     IsNotLastInfraOwner(Subject, Infra),
+    /// The subject must not have the specified effective rolling stock grant
+    SubjectEffectiveRollingStockGrantIsNot(RollingStockGrant, Subject, RollingStock),
+    /// The subject must not be the last direct owner of the rolling stock
+    IsNotLastRollingStockOwner(Subject, RollingStock),
 
     /// The subject must exist in PostgreSQL
     SubjectExists(Subject),

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -21,6 +21,7 @@ use crate::InfraGrant;
 use crate::InfraPrivilege;
 use crate::Role;
 use crate::RollingStock;
+use crate::RollingStockGrant;
 use crate::Subject;
 use crate::User;
 use crate::model::RollingStockPrivilege;
@@ -423,6 +424,64 @@ where
         match self {
             itertools::Either::Left(l) => l.authorize(data).await,
             itertools::Either::Right(r) => r.authorize(data).await,
+        }
+    }
+}
+
+enum Grant {
+    Reader,
+    Writer,
+    Owner,
+}
+
+impl From<Grant> for RollingStockGrant {
+    fn from(grant: Grant) -> Self {
+        match grant {
+            Grant::Reader => RollingStockGrant::Reader,
+            Grant::Writer => RollingStockGrant::Writer,
+            Grant::Owner => RollingStockGrant::Owner,
+        }
+    }
+}
+
+impl From<Grant> for InfraGrant {
+    fn from(grant: Grant) -> Self {
+        match grant {
+            Grant::Reader => InfraGrant::Reader,
+            Grant::Writer => InfraGrant::Writer,
+            Grant::Owner => InfraGrant::Owner,
+        }
+    }
+}
+
+/// Given a list of the existing direct grants on a resource, either return its direct grant
+/// if there is only one or panic if multiple direct grants exist.
+// TODO PR: pass an extra `resource_type` parameter to make the panic message more explicit ?
+fn validate_direct_grant(
+    is_reader: bool,
+    is_writer: bool,
+    is_owner: bool,
+    resource_id: i64,
+    subject: Subject,
+) -> Option<Grant> {
+    match (is_reader, is_writer, is_owner) {
+        (true, false, false) => Some(Grant::Reader),
+        (false, true, false) => Some(Grant::Writer),
+        (false, false, true) => Some(Grant::Owner),
+        (false, false, false) => None,
+        _ => {
+            tracing::error!(
+                is_reader,
+                is_writer,
+                is_owner,
+                ?subject,
+                resource = ?resource_id,
+                "Subject has multiple direct grants on the same resource"
+            );
+            panic!(
+                "Subject '{subject:?}' has multiple direct grants on the same resource '{resource_id:?}', which is not supposed to happen by design. \n\
+                        Detected direct grants: reader: {is_reader}, writer: {is_writer}, owner: {is_owner}"
+            )
         }
     }
 }

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -17,6 +17,7 @@ use crate::v2::Check;
 use crate::v2::Protected;
 use crate::v2::ResourcesList;
 use crate::v2::subject_roles;
+use crate::v2::validate_direct_grant;
 
 /// Returns the *direct grant* a subject has on an [Infra], if any
 ///
@@ -30,42 +31,25 @@ pub fn infra_direct_grant(subject: Subject, infra: Infra) -> Protected<Option<In
         async move {
             let (is_reader, is_writer, is_owner) = match &subject {
                 Subject::User(user) => tokio::try_join!(
-                    openfga
-                        .tuple_exists(Infra::reader().tuple(user, &infra)),
-                    openfga
-                        .tuple_exists(Infra::writer().tuple(user, &infra)),
+                    openfga.tuple_exists(Infra::reader().tuple(user, &infra)),
+                    openfga.tuple_exists(Infra::writer().tuple(user, &infra)),
                     openfga.tuple_exists(Infra::owner().tuple(user, &infra)),
                 )?,
                 Subject::Group(group) => tokio::try_join!(
-                    openfga
-                        .tuple_exists(Infra::reader().tuple(Group::member().userset(group), &infra)),
-                    openfga
-                        .tuple_exists(Infra::writer().tuple(Group::member().userset(group), &infra)),
+                    openfga.tuple_exists(
+                        Infra::reader().tuple(Group::member().userset(group), &infra)
+                    ),
+                    openfga.tuple_exists(
+                        Infra::writer().tuple(Group::member().userset(group), &infra)
+                    ),
                     openfga
                         .tuple_exists(Infra::owner().tuple(Group::member().userset(group), &infra)),
                 )?,
             };
-
-            match (is_reader, is_writer, is_owner) {
-                (true, false, false) => Ok(Some(InfraGrant::Reader)),
-                (false, true, false) => Ok(Some(InfraGrant::Writer)),
-                (false, false, true) => Ok(Some(InfraGrant::Owner)),
-                (false, false, false) => Ok(None),
-                _ => {
-                    tracing::error!(
-                        is_reader,
-                        is_writer,
-                        is_owner,
-                        ?subject,
-                        resource = ?infra,
-                        "Subject has multiple direct grants on the same resource"
-                    );
-                    panic!(
-                        "Subject '{subject:?}' has multiple direct grants on the same resource '{infra:?}', which is not supposed to happen by design. \n\
-                        Detected direct grants: reader: {is_reader}, writer: {is_writer}, owner: {is_owner}"
-                    )
-                }
-            }
+            Ok(
+                validate_direct_grant(is_reader, is_writer, is_owner, *infra, subject)
+                    .map(Into::into),
+            )
         }
         .boxed()
     })

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -273,6 +273,65 @@ pub fn rolling_stock_direct_grant(
     .with_check(Check::SubjectExists(subject))
     .with_check(Check::RollingStockExists(rolling_stock))
 }
+
+/// Revokes the (direct) grant a subject has on a [RollingStock], if any
+///
+/// Returns `true` if a grant was revoked, `false` otherwise, making the operation idempotent.
+/// No transaction is setup as OpenFGA does not support them.
+pub fn rolling_stock_revoke_grant(
+    subject: Subject,
+    rolling_stock: RollingStock,
+) -> Protected<bool> {
+    let prot = rolling_stock_direct_grant(subject, rolling_stock).map(move |openfga, grant| {
+        async move {
+            let Some(grant) = grant else {
+                return Ok(false);
+            };
+
+            let mut delete = openfga.prepare_deletes();
+            match (subject, grant) {
+                (Subject::User(user), RollingStockGrant::Reader) => {
+                    delete.push(&RollingStock::reader().tuple(&user, &rolling_stock))
+                }
+                (Subject::User(user), RollingStockGrant::Writer) => {
+                    delete.push(&RollingStock::writer().tuple(&user, &rolling_stock))
+                }
+                (Subject::User(user), RollingStockGrant::Owner) => {
+                    delete.push(&RollingStock::owner().tuple(&user, &rolling_stock))
+                }
+                (Subject::Group(group), RollingStockGrant::Reader) => delete.push(
+                    &RollingStock::reader().tuple(Group::member().userset(&group), &rolling_stock),
+                ),
+                (Subject::Group(group), RollingStockGrant::Writer) => delete.push(
+                    &RollingStock::writer().tuple(Group::member().userset(&group), &rolling_stock),
+                ),
+                (Subject::Group(group), RollingStockGrant::Owner) => delete.push(
+                    &RollingStock::owner().tuple(Group::member().userset(&group), &rolling_stock),
+                ),
+            };
+            delete.execute().await?;
+            Ok(true)
+        }
+        .boxed()
+    });
+
+    // Revoking rules:
+    // 1. Only owners (and admins) can fully revoke grants
+    // 2. The last owner of a resource cannot be revoked (admins can)
+    // 3. An owner cannot revoke another owner
+    prot.with_check(Check::HasRollingStockPrivilege(
+        Actor::Issuer,
+        RollingStockPrivilege::CanRevoke,
+        rolling_stock,
+    ))
+    .with_check(Check::SubjectEffectiveRollingStockGrantIsNot(
+        RollingStockGrant::Owner,
+        subject,
+        rolling_stock,
+    ))
+    .with_check(Check::IsNotLastRollingStockOwner(subject, rolling_stock))
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -567,6 +626,99 @@ mod tests {
             .unwrap()
             .unwrap_authorized()
             .await;
+    }
+
+    #[rstest::rstest]
+    #[case::user_reader(Subject::user(1), RollingStockGrant::Reader)]
+    #[case::user_writer(Subject::user(1), RollingStockGrant::Writer)]
+    #[case::user_owner(Subject::user(1), RollingStockGrant::Owner)]
+    #[case::group_reader(Subject::group(1), RollingStockGrant::Reader)]
+    #[case::group_writer(Subject::group(1), RollingStockGrant::Writer)]
+    #[case::group_owner(Subject::group(1), RollingStockGrant::Owner)]
+    #[tokio::test]
+    async fn revoke_rolling_stock_grant_ok(
+        #[case] subject: Subject,
+        #[case] grant: RollingStockGrant,
+    ) {
+        let openfga = crate::authz_client!();
+        openfga
+            .give_rolling_stock_grant(RollingStock(1), subject, grant)
+            .await;
+        assert_eq!(
+            openfga
+                .rolling_stock_direct_grant(subject, RollingStock(1))
+                .await,
+            Some(grant)
+        );
+        assert!(
+            openfga
+                .rolling_stock_revoke_grant(subject, RollingStock(1))
+                .await
+        );
+        assert_eq!(
+            openfga
+                .rolling_stock_direct_grant(subject, RollingStock(1))
+                .await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_rolling_stock_grant_noop() {
+        let openfga = crate::authz_client!();
+        assert!(
+            !openfga
+                .rolling_stock_revoke_grant(Subject::user(1), RollingStock(1))
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_rolling_stock_grant_with_inherited() {
+        let openfga = crate::authz_client!();
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(10)))
+            .write(
+                &RollingStock::writer()
+                    .tuple(Group::member().userset(&Group(10)), &RollingStock(1)),
+            ) // inherited
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1))) // direct
+            .write(&RollingStock::owner().tuple(&User(1), &RollingStock(2))) // unrelated
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            openfga
+                .rolling_stock_direct_grant(Subject::user(1), RollingStock(1))
+                .await,
+            Some(RollingStockGrant::Reader)
+        );
+        assert!(
+            openfga
+                .rolling_stock_revoke_grant(Subject::user(1), RollingStock(1))
+                .await
+        );
+        assert_eq!(
+            openfga
+                .rolling_stock_direct_grant(Subject::user(1), RollingStock(1))
+                .await,
+            None
+        );
+        assert_eq!(
+            openfga
+                .rolling_stock_effective_grant(Subject::user(1), RollingStock(1))
+                .await,
+            Some(RollingStockGrant::Writer)
+        );
+        assert_eq!(
+            openfga
+                .rolling_stock_direct_grant(Subject::user(1), RollingStock(2))
+                .await,
+            Some(RollingStockGrant::Owner)
+        );
     }
 
     #[rstest]

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -14,6 +14,7 @@ use crate::RollingStockPrivilege;
 use crate::Subject;
 use crate::User;
 use crate::v2::Actor;
+use crate::v2::validate_direct_grant;
 
 pub fn rolling_stock_privileges(
     user: User,
@@ -229,6 +230,49 @@ pub fn rolling_stock_granted_subjects(
         .with_check(Check::RollingStockExists(rolling_stock))
 }
 
+/// Returns the *direct grant* a subject has on a [RollingStock], if any
+///
+/// A user can have *indirect grants* on a resource through group membership.
+/// For those, use [`rolling_stock_effective_grant`].
+///
+/// A subject can have at most one direct grant on any resource. Should this
+/// invariant be violated, the protected operation will panic.
+pub fn rolling_stock_direct_grant(
+    subject: Subject,
+    rolling_stock: RollingStock,
+) -> Protected<Option<RollingStockGrant>> {
+    Protected::new(move |openfga| {
+        async move {
+            let (is_reader, is_writer, is_owner) = match &subject {
+                Subject::User(user) => tokio::try_join!(
+                    openfga.tuple_exists(RollingStock::reader().tuple(user, &rolling_stock)),
+                    openfga.tuple_exists(RollingStock::writer().tuple(user, &rolling_stock)),
+                    openfga.tuple_exists(RollingStock::owner().tuple(user, &rolling_stock)),
+                )?,
+                Subject::Group(group) => tokio::try_join!(
+                    openfga.tuple_exists(
+                        RollingStock::reader()
+                            .tuple(Group::member().userset(group), &rolling_stock)
+                    ),
+                    openfga.tuple_exists(
+                        RollingStock::writer()
+                            .tuple(Group::member().userset(group), &rolling_stock)
+                    ),
+                    openfga.tuple_exists(
+                        RollingStock::owner().tuple(Group::member().userset(group), &rolling_stock)
+                    ),
+                )?,
+            };
+            Ok(
+                validate_direct_grant(is_reader, is_writer, is_owner, *rolling_stock, subject)
+                    .map(Into::into),
+            )
+        }
+        .boxed()
+    })
+    .with_check(Check::SubjectExists(subject))
+    .with_check(Check::RollingStockExists(rolling_stock))
+}
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -374,6 +418,155 @@ mod tests {
         expected.sort();
         response.sort();
         assert_eq!(response, expected);
+    }
+
+    #[tokio::test]
+    async fn user_rolling_stock_direct_grant() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        let rolling_stock_grant = async |user_id: i64| {
+            rolling_stock_direct_grant(Subject::user(user_id), RollingStock(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+
+        assert_eq!(rolling_stock_grant(1).await, None);
+
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(1)))
+            .write(&RollingStock::owner().tuple(&User(3), &RollingStock(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            rolling_stock_grant(1).await,
+            Some(RollingStockGrant::Reader)
+        );
+        assert_eq!(
+            rolling_stock_grant(2).await,
+            Some(RollingStockGrant::Writer)
+        );
+        assert_eq!(rolling_stock_grant(3).await, Some(RollingStockGrant::Owner));
+    }
+
+    #[tokio::test]
+    async fn group_rolling_stock_direct_grant() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        let rolling_stock_grant = async |group_id: i64| {
+            rolling_stock_direct_grant(Subject::group(group_id), RollingStock(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+
+        assert_eq!(rolling_stock_grant(1).await, None);
+
+        openfga
+            .prepare_writes()
+            .write(
+                &RollingStock::reader().tuple(Group::member().userset(&Group(1)), &RollingStock(1)),
+            )
+            .write(
+                &RollingStock::writer().tuple(Group::member().userset(&Group(2)), &RollingStock(1)),
+            )
+            .write(
+                &RollingStock::owner().tuple(Group::member().userset(&Group(3)), &RollingStock(1)),
+            )
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            rolling_stock_grant(1).await,
+            Some(RollingStockGrant::Reader)
+        );
+        assert_eq!(
+            rolling_stock_grant(2).await,
+            Some(RollingStockGrant::Writer)
+        );
+        assert_eq!(rolling_stock_grant(3).await, Some(RollingStockGrant::Owner));
+    }
+
+    #[tokio::test]
+    async fn no_inference_rolling_stock_direct_grant() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(&Group::member().tuple(&User(2), &Group(2)))
+            .write(&Group::member().tuple(&User(3), &Group(3)))
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(
+                &RollingStock::writer().tuple(Group::member().userset(&Group(2)), &RollingStock(1)),
+            )
+            .write(&RollingStock::owner().tuple(&User(3), &RollingStock(1)))
+            .write(
+                &RollingStock::reader().tuple(Group::member().userset(&Group(3)), &RollingStock(1)),
+            )
+            .execute()
+            .await
+            .unwrap();
+
+        let user_direct_grant = async |user_id: i64| {
+            rolling_stock_direct_grant(Subject::user(user_id), RollingStock(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+        let group_direct_grant = async |group_id: i64| {
+            rolling_stock_direct_grant(Subject::group(group_id), RollingStock(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+
+        assert_eq!(user_direct_grant(1).await, Some(RollingStockGrant::Reader));
+        assert_eq!(group_direct_grant(1).await, None);
+
+        assert_eq!(user_direct_grant(2).await, None);
+        assert_eq!(group_direct_grant(2).await, Some(RollingStockGrant::Writer));
+
+        assert_eq!(user_direct_grant(3).await, Some(RollingStockGrant::Owner));
+        assert_eq!(group_direct_grant(3).await, Some(RollingStockGrant::Reader));
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn rolling_stock_direct_grant_inconsistent_state_panics() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::writer().tuple(&User(1), &RollingStock(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        rolling_stock_direct_grant(Subject::user(1), RollingStock(1))
+            .authorize(&authorize)
+            .await
+            .unwrap()
+            .unwrap_authorized()
+            .await;
     }
 
     #[rstest]

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -20,6 +20,7 @@ use crate::v2::infra_granted_subjects;
 use crate::v2::infra_privileges;
 use crate::v2::infra_revoke_grant;
 use crate::v2::infra_set_grant;
+use crate::v2::rolling_stock_direct_grant;
 use crate::v2::rolling_stock_effective_grant;
 use crate::v2::rolling_stock_granted_subjects;
 use crate::v2::rolling_stock_privileges;
@@ -48,6 +49,11 @@ pub trait TestClientExt {
         rolling_stock: RollingStock,
     ) -> HashSet<RollingStockPrivilege>;
     async fn rolling_stock_effective_grant(
+        &self,
+        subject: Subject,
+        rolling_stock: RollingStock,
+    ) -> Option<RollingStockGrant>;
+    async fn rolling_stock_direct_grant(
         &self,
         subject: Subject,
         rolling_stock: RollingStock,
@@ -100,6 +106,18 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(infra_effective_grant(subject, infra))
+            .await
+            .unwrap()
+    }
+
+    async fn rolling_stock_direct_grant(
+        &self,
+        subject: Subject,
+        rolling_stock: RollingStock,
+    ) -> Option<RollingStockGrant> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(rolling_stock_direct_grant(subject, rolling_stock))
             .await
             .unwrap()
     }

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -24,6 +24,7 @@ use crate::v2::rolling_stock_direct_grant;
 use crate::v2::rolling_stock_effective_grant;
 use crate::v2::rolling_stock_granted_subjects;
 use crate::v2::rolling_stock_privileges;
+use crate::v2::rolling_stock_revoke_grant;
 use crate::v2::special_authorizers;
 use crate::v2::user_groups;
 
@@ -43,6 +44,11 @@ pub trait TestClientExt {
     async fn infra_privileges(&self, user: User, infra: Infra) -> HashSet<InfraPrivilege>;
     async fn infra_granted_subjects(&self, infra: Infra, grant: InfraGrant) -> Vec<Subject>;
     async fn infra_list(&self, user: User, privilege: InfraPrivilege) -> ResourcesList<Infra>;
+    async fn rolling_stock_revoke_grant(
+        &self,
+        subject: Subject,
+        rolling_stock: RollingStock,
+    ) -> bool;
     async fn rolling_stock_privileges(
         &self,
         user: User,
@@ -196,6 +202,17 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(rolling_stock_granted_subjects(rolling_stock, grant))
+            .await
+            .unwrap()
+    }
+    async fn rolling_stock_revoke_grant(
+        &self,
+        subject: Subject,
+        rolling_stock: RollingStock,
+    ) -> bool {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(rolling_stock_revoke_grant(subject, rolling_stock))
             .await
             .unwrap()
     }

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -280,6 +280,7 @@ mod tests {
     use authz::InfraPrivilege;
     use authz::Role;
     use authz::RollingStockGrant;
+    use authz::RollingStockPrivilege;
     use authz::v2::Actor;
     use authz::v2::Check;
     use authz::v2::Protected;
@@ -436,6 +437,48 @@ mod tests {
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn existing_rolling_stock() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let user = create_user(&pool, "user").await;
+        let rolling_stock = authz::RollingStock(
+            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
+                .await
+                .id,
+        );
+        let system = SystemAuthorizer {
+            openfga: &openfga,
+            conn: pool.get_ok(),
+        };
+        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
+
+        assert_eq!(
+            authorize(&system, Check::RollingStockExists(rolling_stock)).await,
+            Ok(())
+        );
+        assert_eq!(
+            authorize(&user_authorizer, Check::RollingStockExists(rolling_stock)).await,
+            Ok(())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn missing_rolling_stock() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let user = create_user(&pool, "user").await;
+        let system = SystemAuthorizer {
+            openfga: &openfga,
+            conn: pool.get_ok(),
+        };
+        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
+
+        let check = Check::RollingStockExists(authz::RollingStock(i64::MAX));
+        assert_eq!(authorize(&system, check).await, Err(check));
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
+    }
+
     #[rstest]
     #[case::has_role(Check::HasRole(Actor::Issuer, Role::Admin))]
     #[case::has_infra_privilege(Check::HasInfraPrivilege(
@@ -540,35 +583,36 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn user_authorizer_subject_effective_rolling_stock_grant_is_not() {
+    async fn user_authorizer_issuer_rolling_stock_privilege() {
         let openfga = openfga().await;
         let pool = DbConnectionPoolV2::for_tests();
-        let issuer = create_user(&pool, "issuer").await;
-        let target = create_user(&pool, "target").await;
+        let owner = create_user(&pool, "owner").await;
+        let no_grant = create_user(&pool, "no-grant").await;
         let rolling_stock = authz::RollingStock(
             create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
                 .await
                 .id,
         );
         openfga
-            .write_tuples(&[authz::RollingStock::owner().tuple(&target, &rolling_stock)])
+            .write_tuples(&[authz::RollingStock::owner().tuple(&owner, &rolling_stock)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
 
-        let check = Check::SubjectEffectiveRollingStockGrantIsNot(
-            RollingStockGrant::Owner,
-            authz::Subject::User(target),
-            rolling_stock,
-        );
-        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
-
-        let check = Check::SubjectEffectiveRollingStockGrantIsNot(
-            RollingStockGrant::Writer,
-            authz::Subject::User(target),
+        let user_authorizer = UserAuthorizer::new(owner, vec![], &openfga, pool.get_ok());
+        let check = Check::HasRollingStockPrivilege(
+            Actor::Issuer,
+            RollingStockPrivilege::CanDelete,
             rolling_stock,
         );
         assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
+
+        let user_authorizer = UserAuthorizer::new(no_grant, vec![], &openfga, pool.get_ok());
+        let check = Check::HasRollingStockPrivilege(
+            Actor::Issuer,
+            RollingStockPrivilege::CanShareRead,
+            rolling_stock,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -712,6 +756,38 @@ mod tests {
             let expected = ok.then_some(()).ok_or(check);
             assert_eq!(result, expected);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_authorizer_user_rolling_stock_privilege() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let issuer = create_user(&pool, "issuer").await;
+        let target = create_user(&pool, "target").await;
+        let rolling_stock = authz::RollingStock(
+            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
+                .await
+                .id,
+        );
+        openfga
+            .write_tuples(&[authz::RollingStock::writer().tuple(&target, &rolling_stock)])
+            .await
+            .unwrap();
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+
+        let check = Check::HasRollingStockPrivilege(
+            Actor::User(target),
+            RollingStockPrivilege::CanWrite,
+            rolling_stock,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
+
+        let check = Check::HasRollingStockPrivilege(
+            Actor::User(target),
+            RollingStockPrivilege::CanDelete,
+            rolling_stock,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -46,7 +46,9 @@ impl SystemAuthorizer<'_> {
             | Check::HasRollingStockPrivilege(..)
             | Check::CanAlterSubjectInfraGrant(..)
             | Check::SubjectEffectiveInfraGrantIsNot(..)
-            | Check::IsNotLastInfraOwner(..) => None,
+            | Check::SubjectEffectiveRollingStockGrantIsNot(..)
+            | Check::IsNotLastInfraOwner(..)
+            | Check::IsNotLastRollingStockOwner(..) => None,
         })
     }
 }
@@ -186,12 +188,30 @@ impl<'c> UserAuthorizer<'c> {
                     .await?;
                 (subject_grant == Some(*grant)).then_some(check)
             }
+            Check::SubjectEffectiveRollingStockGrantIsNot(grant, subject, rolling_stock) => {
+                let Ok(subject_grant) =
+                    authz::v2::rolling_stock_effective_grant(*subject, *rolling_stock)
+                        .access_authorized::<Infallible>(self.openfga)
+                        .access()
+                        .await?;
+                (subject_grant == Some(*grant)).then_some(check)
+            }
             Check::IsNotLastInfraOwner(subject, infra) => {
                 let Ok(owners) =
                     authz::v2::infra_granted_subjects(*infra, authz::InfraGrant::Owner)
                         .access_authorized::<Infallible>(self.openfga)
                         .access()
                         .await?;
+                (owners.len() == 1 && owners.contains(subject)).then_some(check)
+            }
+            Check::IsNotLastRollingStockOwner(subject, rolling_stock) => {
+                let Ok(owners) = authz::v2::rolling_stock_granted_subjects(
+                    *rolling_stock,
+                    authz::RollingStockGrant::Owner,
+                )
+                .access_authorized::<Infallible>(self.openfga)
+                .access()
+                .await?;
                 (owners.len() == 1 && owners.contains(subject)).then_some(check)
             }
             // checked by SystemAuthorizer
@@ -259,6 +279,7 @@ mod tests {
     use authz::InfraGrant;
     use authz::InfraPrivilege;
     use authz::Role;
+    use authz::RollingStockGrant;
     use authz::v2::Actor;
     use authz::v2::Check;
     use authz::v2::Protected;
@@ -268,6 +289,7 @@ mod tests {
 
     use super::*;
     use crate::fixtures::create_empty_infra;
+    use crate::fixtures::create_fast_rolling_stock;
 
     async fn openfga() -> fga::Client {
         let openfga = fga::test_client!("authz@");
@@ -435,6 +457,17 @@ mod tests {
         authz::Subject::User(authz::User(i64::MAX)),
         authz::Infra(i64::MAX)
     ))]
+    #[case::subject_effective_rolling_stock_grant_is_not(
+        Check::SubjectEffectiveRollingStockGrantIsNot(
+            RollingStockGrant::Owner,
+            authz::Subject::User(authz::User(i64::MAX)),
+            authz::RollingStock(i64::MAX)
+        )
+    )]
+    #[case::is_not_last_rolling_stock_owner(Check::IsNotLastRollingStockOwner(
+        authz::Subject::User(authz::User(i64::MAX)),
+        authz::RollingStock(i64::MAX)
+    ))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn system_authorizer_ignores_non_sanity_checks(#[case] check: Check) {
         let openfga = openfga().await;
@@ -504,6 +537,38 @@ mod tests {
         let user_authorizer = UserAuthorizer::new(no_grant, vec![], &openfga, pool.get_ok());
         let check = Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanShareRead, infra);
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_authorizer_subject_effective_rolling_stock_grant_is_not() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let issuer = create_user(&pool, "issuer").await;
+        let target = create_user(&pool, "target").await;
+        let rolling_stock = authz::RollingStock(
+            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
+                .await
+                .id,
+        );
+        openfga
+            .write_tuples(&[authz::RollingStock::owner().tuple(&target, &rolling_stock)])
+            .await
+            .unwrap();
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+
+        let check = Check::SubjectEffectiveRollingStockGrantIsNot(
+            RollingStockGrant::Owner,
+            authz::Subject::User(target),
+            rolling_stock,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
+
+        let check = Check::SubjectEffectiveRollingStockGrantIsNot(
+            RollingStockGrant::Writer,
+            authz::Subject::User(target),
+            rolling_stock,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -678,6 +743,38 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_authorizer_subject_effective_rolling_stock_grant_is_not() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let issuer = create_user(&pool, "issuer").await;
+        let target = create_user(&pool, "target").await;
+        let rolling_stock = authz::RollingStock(
+            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
+                .await
+                .id,
+        );
+        openfga
+            .write_tuples(&[authz::RollingStock::owner().tuple(&target, &rolling_stock)])
+            .await
+            .unwrap();
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+
+        let check = Check::SubjectEffectiveRollingStockGrantIsNot(
+            RollingStockGrant::Owner,
+            authz::Subject::User(target),
+            rolling_stock,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
+
+        let check = Check::SubjectEffectiveRollingStockGrantIsNot(
+            RollingStockGrant::Writer,
+            authz::Subject::User(target),
+            rolling_stock,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_authorizer_subject_effective_infra_grant_is_not_checks_inherited_grant() {
         let openfga = openfga().await;
         let pool = DbConnectionPoolV2::for_tests();
@@ -698,6 +795,38 @@ mod tests {
             InfraGrant::Owner,
             authz::Subject::User(target),
             infra,
+        );
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_authorizer_subject_effective_rolling_stock_grant_is_not_checks_inherited_grant() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let issuer = create_user(&pool, "issuer").await;
+        let target = create_user(&pool, "target").await;
+        let group = create_group(&pool, "owners").await;
+        let rolling_stock = authz::RollingStock(
+            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
+                .await
+                .id,
+        );
+        openfga
+            .prepare_writes()
+            .write(&authz::Group::member().tuple(&target, &group))
+            .write(
+                &authz::RollingStock::owner()
+                    .tuple(authz::Group::member().userset(&group), &rolling_stock),
+            )
+            .execute()
+            .await
+            .unwrap();
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+
+        let check = Check::SubjectEffectiveRollingStockGrantIsNot(
+            RollingStockGrant::Owner,
+            authz::Subject::User(target),
+            rolling_stock,
         );
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
     }
@@ -732,6 +861,40 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_authorizer_is_not_last_rolling_stock_owner_user() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let issuer = create_user(&pool, "issuer").await;
+        let owner = create_user(&pool, "owner").await;
+        let other_owner = create_user(&pool, "other-owner").await;
+        let no_grant = create_user(&pool, "no-grant").await;
+        let rolling_stock = authz::RollingStock(
+            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
+                .await
+                .id,
+        );
+        openfga
+            .write_tuples(&[authz::RollingStock::owner().tuple(&owner, &rolling_stock)])
+            .await
+            .unwrap();
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+
+        let check = Check::IsNotLastRollingStockOwner(authz::Subject::User(owner), rolling_stock);
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
+
+        let check =
+            Check::IsNotLastRollingStockOwner(authz::Subject::User(no_grant), rolling_stock);
+        assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
+
+        openfga
+            .write_tuples(&[authz::RollingStock::owner().tuple(&other_owner, &rolling_stock)])
+            .await
+            .unwrap();
+        let check = Check::IsNotLastRollingStockOwner(authz::Subject::User(owner), rolling_stock);
+        assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_authorizer_is_not_last_infra_owner_group() {
         let openfga = openfga().await;
         let pool = DbConnectionPoolV2::for_tests();
@@ -747,6 +910,28 @@ mod tests {
         let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
 
         let check = Check::IsNotLastInfraOwner(authz::Subject::Group(group), infra);
+        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_authorizer_is_not_last_rolling_stock_owner_group() {
+        let openfga = openfga().await;
+        let pool = DbConnectionPoolV2::for_tests();
+        let issuer = create_user(&pool, "issuer").await;
+        let group = create_group(&pool, "group").await;
+        let rolling_stock = authz::RollingStock(
+            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
+                .await
+                .id,
+        );
+        openfga
+            .write_tuples(&[authz::RollingStock::owner()
+                .tuple(authz::Group::member().userset(&group), &rolling_stock)])
+            .await
+            .unwrap();
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+
+        let check = Check::IsNotLastRollingStockOwner(authz::Subject::Group(group), rolling_stock);
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
     }
 
@@ -770,6 +955,17 @@ mod tests {
     #[case::is_not_last_infra_owner(Check::IsNotLastInfraOwner(
         authz::Subject::user(i64::MAX),
         authz::Infra(i64::MAX)
+    ))]
+    #[case::subject_effective_rolling_stock_grant_is_not(
+        Check::SubjectEffectiveRollingStockGrantIsNot(
+            RollingStockGrant::Owner,
+            authz::Subject::user(i64::MAX),
+            authz::RollingStock(i64::MAX)
+        )
+    )]
+    #[case::is_not_last_infra_owner(Check::IsNotLastRollingStockOwner(
+        authz::Subject::user(i64::MAX),
+        authz::RollingStock(i64::MAX)
     ))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn user_authorizer_admin_bypass(#[case] check: Check) {

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -896,7 +896,14 @@ pub(in crate::views) async fn update_grants(
                 Err(
                     Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRevoke, _)
                     | Check::SubjectEffectiveInfraGrantIsNot(..)
-                    | Check::IsNotLastInfraOwner(..),
+                    | Check::IsNotLastInfraOwner(..)
+                    | Check::HasRollingStockPrivilege(
+                        Actor::Issuer,
+                        RollingStockPrivilege::CanRevoke,
+                        _,
+                    )
+                    | Check::SubjectEffectiveRollingStockGrantIsNot(..)
+                    | Check::IsNotLastRollingStockOwner(..),
                 ) => Err(AuthorizationError::Forbidden.into()),
                 Err(check) => impossible!(check),
             }
@@ -947,7 +954,7 @@ impl RevokeBody {
         Ok(match resource_type {
             ResourceType::Infra => authz::v2::infra_revoke_grant(*subject, resource_id.into()),
             ResourceType::RollingStock => {
-                unreachable!("not implemented yet")
+                authz::v2::rolling_stock_revoke_grant(*subject, resource_id.into())
             }
         })
     }
@@ -980,6 +987,7 @@ mod tests {
     use authz::v2::TestClientExt as _;
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
     use serde_json::json;
     use std::collections::HashSet;
     use strum::IntoEnumIterator;
@@ -988,6 +996,7 @@ mod tests {
     use crate::fixtures::create_empty_infra;
     use crate::fixtures::create_fast_rolling_stock;
     use crate::fixtures::create_small_infra;
+    use crate::views::test_app::TestApp;
     use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::test_app;
 
@@ -1357,6 +1366,8 @@ mod tests {
         }
     }
 
+    // TODO update this test with rolling stock grants once both revoking and granting are
+    // implemented
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn grants_test() {
         // This test starts with a user that is the owner of an infra.
@@ -1415,132 +1426,248 @@ mod tests {
         assert_eq!(openfga.infra_direct_grant(writer, infra).await, None);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn only_owners_can_revoke_infra_grants() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let writer = app
-            .user("writer", "Writer")
-            .with_infra_grant(infra.id, InfraGrant::Writer)
-            .create()
-            .await;
-        let reader = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("reader", "Reader")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_infra_grant(resource_id, InfraGrant::Reader)
             .create()
-            .await;
-
+            .await,
+        app
+            .user("writer", "Writer")
+            .with_infra_grant(resource_id, InfraGrant::Writer)
+            .create()
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("reader", "Reader")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Reader)
+            .create()
+            .await,
+        app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await,
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn only_owners_can_revoke_grants(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] reader: authz::identity::User,
+        #[case] writer: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .by_user(writer.as_ref())
             .json(&json!({
                 "revoke": [
                     {
                         "subject_id": reader.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id
-                    }
+                        "resource_type": resource_type,
+                        "resource_id": resource_id
+                    },
                 ]
             }))
             .await
             .assert_status_forbidden();
 
-        app.assert_infra_grant(infra.id, reader.id, Some(InfraGrant::Reader));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, reader.id, Some(InfraGrant::Reader))
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    reader.id,
+                    Some(RollingStockGrant::Reader),
+                )
+                .await
+            }
+        }
     }
 
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
+            .user("reader", "Reader")
+            .with_infra_grant(resource_id, InfraGrant::Reader)
+            .create()
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("reader", "Reader")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Reader)
+            .create()
+            .await,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn admins_can_revoke_infra_grants() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
+    async fn admins_can_revoke_grants(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] reader: authz::identity::User,
+    ) {
         let admin = app
             .user("admin", "Admin")
             .with_roles([Role::Admin])
             .create()
             .await;
-        let reader = app
-            .user("reader", "Reader")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
-            .create()
-            .await;
-
         app.post("/authz/grants")
             .by_user(admin.as_ref())
             .json(&json!({
                 "revoke": [
                     {
                         "subject_id": reader.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id
-                    }
+                        "resource_type": resource_type,
+                        "resource_id": resource_id
+                    },
                 ]
             }))
             .await
             .assert_status_no_content();
 
-        app.assert_infra_grant(infra.id, reader.id, None);
+        match resource_type {
+            ResourceType::Infra => app.assert_infra_grant(resource_id, reader.id, None),
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, reader.id, None)
+                    .await
+            }
+        };
     }
 
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
+            .user("owner", "Owner")
+            .with_infra_grant(resource_id, InfraGrant::Owner)
+            .create()
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("owner", "Owner")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn last_infra_owner_can_be_revoked_by_admin() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
+    async fn last_resource_owner_can_be_revoked_by_admin(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+    ) {
         let admin = app
             .user("admin", "Admin")
             .with_roles([Role::Admin])
             .create()
             .await;
-        let owner = app
-            .user("owner", "Owner")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
-            .create()
-            .await;
-
         app.post("/authz/grants")
             .by_user(admin.as_ref())
             .json(&json!({
                 "revoke": [
                     {
                         "subject_id": owner.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id
-                    }
+                        "resource_type": resource_type,
+                        "resource_id": resource_id
+                    },
                 ]
             }))
             .await
             .assert_status_no_content();
 
-        app.assert_infra_grant(infra.id, owner.id, None);
+        match resource_type {
+            ResourceType::Infra => app.assert_infra_grant(resource_id, owner.id, None),
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, owner.id, None)
+                    .await
+            }
+        };
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn owner_cannot_revoke_another_infra_owner() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let alice = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("alice", "Alice")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-        let bob = app
+            .await,
+        app
             .user("bob", "Bob")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("alice", "Alice")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+        app
+            .user("bob", "Bob")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn owner_cannot_revoke_another_resource_owner(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] alice: authz::identity::User,
+        #[case] bob: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .by_user(alice.as_ref())
             .json(&json!({
                 "revoke": [
                     {
                         "subject_id": bob.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id
+                        "resource_type": resource_type,
+                        "resource_id": resource_id
                     }
                 ]
             }))
             .await
             .assert_status_forbidden();
 
-        app.assert_infra_grant(infra.id, bob.id, Some(InfraGrant::Owner));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, bob.id, Some(InfraGrant::Owner))
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, bob.id, Some(RollingStockGrant::Owner))
+                    .await
+            }
+        };
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -2090,19 +2217,13 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn skipped_authz_can_set_and_remove_grants() {
+    async fn skipped_authz_can_set_grants() {
         let app = test_app!().build();
         let openfga = app.openfga();
         let db_pool = app.db_pool();
         let infra = authz::Infra(create_small_infra(&mut db_pool.get_ok()).await.id);
-        let user = authz::User::from(
-            app.user("authz", "Authz")
-                .with_infra_grant(*infra, InfraGrant::Owner)
-                .create()
-                .await,
-        );
-
-        // Adding OWNER on the same user/infra
+        let user = authz::User::from(app.user("user", "User").create().await);
+        app.assert_infra_grant(infra.0, user.0, None);
         app.post("/authz/grants")
             .skip_authz()
             .json(&json!({
@@ -2122,49 +2243,111 @@ mod tests {
             openfga.infra_direct_grant(user, infra).await,
             Some(InfraGrant::Owner)
         );
+    }
 
-        // Remove the grant
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        authz::User::from(
+            app.user("user", "User")
+                .with_infra_grant(resource_id, InfraGrant::Owner)
+                .create()
+                .await,
+        ),
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        authz::User::from(
+            app.user("user", "User")
+                .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+                .create()
+                .await,
+        ),
+
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn skipped_authz_can_remove_grants(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] user: authz::User,
+    ) {
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, user.0, Some(InfraGrant::Owner))
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, user.0, Some(RollingStockGrant::Owner))
+                    .await
+            }
+        };
         app.post("/authz/grants")
             .skip_authz()
             .json(&json!({
                 "revoke": [
                     {
                         "subject_id": *user,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": *infra
-                    }
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                    },
                 ]
             }))
             .await
             .assert_status_no_content();
 
-        assert_eq!(openfga.infra_direct_grant(user, infra).await, None);
+        match resource_type {
+            ResourceType::Infra => app.assert_infra_grant(resource_id, user.0, None),
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, user.0, None)
+                    .await
+            }
+        };
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn remove_a_grant_that_doesnt_exists() {
-        let app = test_app!().build();
-        let db_pool = app.db_pool();
-        let infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let owner = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("owner", "Owner")
             .with_roles([Role::OperationalStudies])
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn remove_a_grant_that_doesnt_exist(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+    ) {
         let other = app.user("other", "Other").create().await;
-
-        // Remove the READER grant should not fail
         app.post("/authz/grants")
             .by_user(owner.as_ref())
             .json(&json!({
                 "revoke": [
                     {
                         "subject_id": other.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id,
-                    }
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                    },
                 ]
             }))
             .await

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -432,6 +432,24 @@ impl TestApp {
         )
     }
 
+    pub async fn assert_rolling_stock_grant(
+        &self,
+        rolling_stock_id: i64,
+        subject_id: i64,
+        expected_grant: Option<RollingStockGrant>,
+    ) {
+        let subject = self.authz_subject(subject_id);
+        let actual_grant = self
+            .openfga()
+            .rolling_stock_effective_grant(subject, authz::RollingStock(rolling_stock_id))
+            .await;
+        pretty_assertions::assert_eq!(
+            actual_grant,
+            expected_grant,
+            "Rolling stock grant for subject '{subject_id}' on rolling stock '{rolling_stock_id}' does not match"
+        );
+    }
+
     #[track_caller]
     pub fn assert_infra_grant(
         &self,


### PR DESCRIPTION
Context: https://github.com/osrd-project/osrd-confidential/issues/1064

It copies the authorization infra resources revoking behavior when revoking rolling stock grants:
- The last owner of a rolling stock resource cannot be revoked.
- Owners of a resource cannot revoke its other owners.
- Admins can revoke anyone.

Question for reviewers: is there a difference in which we intend to handle rolling stock resources revoking at the moment compared to infras ?