### PR TITLE
editoast: list rolling_stocks privileges

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -138,6 +138,7 @@ pub enum InfraGrant {
     Eq,
     Hash,
 )]
+#[cfg_attr(test, derive(PartialOrd, Ord))]
 #[fga(name = "rolling_stock")]
 pub struct RollingStock(pub i64);
 

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -14,6 +14,8 @@ use crate::RollingStockPrivilege;
 use crate::Subject;
 use crate::User;
 use crate::v2::Actor;
+use crate::v2::ResourcesList;
+use crate::v2::subject_roles;
 
 pub fn rolling_stock_privileges(
     user: User,
@@ -229,6 +231,58 @@ pub fn rolling_stock_granted_subjects(
         .with_check(Check::RollingStockExists(rolling_stock))
 }
 
+pub fn rolling_stock_list(
+    user: User,
+    privilege: RollingStockPrivilege,
+) -> Protected<ResourcesList<RollingStock>> {
+    subject_roles(Subject::user(user)).map(move |openfga, roles| {
+        async move {
+            if roles.contains(&Role::Admin) {
+                return Ok(ResourcesList::All);
+            }
+            let authorized_rolling_stocks = match privilege {
+                RollingStockPrivilege::CanRead => {
+                    openfga
+                        .list_objects(RollingStock::can_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareRead => {
+                    openfga
+                        .list_objects(RollingStock::can_share_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_share_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanDelete => {
+                    openfga
+                        .list_objects(RollingStock::can_delete().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareOwnership => {
+                    openfga
+                        .list_objects(RollingStock::can_share_ownership().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanRevoke => {
+                    openfga
+                        .list_objects(RollingStock::can_revoke().query_objects(&user))
+                        .await?
+                }
+            };
+            Ok(ResourcesList::Privileged(authorized_rolling_stocks))
+        }
+        .boxed()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -376,6 +430,79 @@ mod tests {
         assert_eq!(response, expected);
     }
 
+    #[tokio::test]
+    async fn check_rolling_stock_list_no_rights_and_admin() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(3)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .write(&User::role().tuple(&Role::Admin, &User(3)))
+            .execute()
+            .await
+            .unwrap();
+        let rolling_stocks_1 = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_2 = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_no_rights = openfga
+            .rolling_stock_list(User(4), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        let rolling_stocks_admin = openfga
+            .rolling_stock_list(User(3), RollingStockPrivilege::CanRead)
+            .await;
+        assert_eq!(
+            rolling_stocks_1.sorted().collect_vec(),
+            vec![RollingStock(1), RollingStock(3)]
+        );
+        assert_eq!(
+            rolling_stocks_2.sorted().collect_vec(),
+            vec![RollingStock(2)]
+        );
+        assert_eq!(rolling_stocks_no_rights, vec![]);
+        assert!(matches!(rolling_stocks_admin, ResourcesList::All));
+    }
+
+    #[tokio::test]
+    async fn rolling_stock_list_only_returns_resources_with_the_queried_privilege() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .execute()
+            .await
+            .unwrap();
+
+        // A reader grant grants read access and not write access
+        let reader_can_read = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_read, vec![RollingStock(1)]);
+
+        let reader_can_write = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_write, vec![]);
+
+        // A writer grant grants both read and write access
+        let writer_can_write = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(writer_can_write, vec![RollingStock(2)]);
+    }
+
     #[rstest]
     #[case::rolling_stock_privileges(
         rolling_stock_privileges(User(1), RollingStock(1)).checks,
@@ -400,6 +527,13 @@ mod tests {
         &[
            Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
            Check::RollingStockExists(RollingStock(1))
+        ]
+    )]
+    #[rstest]
+    #[case::rolling_stock_list(
+        rolling_stock_list(User(1), RollingStockPrivilege::CanRead).checks,
+        &[
+           Check::SubjectExists(Subject::user(1)),
         ]
     )]
     fn protected_contains_expected_checks(

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -63,6 +63,11 @@ pub trait TestClientExt {
         subject: Subject,
         grant: RollingStockGrant,
     );
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock>;
 }
 
 impl TestClientExt for fga::Client {
@@ -255,6 +260,20 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(crate::v2::infra::infra_list(user, privilege))
+            .await
+            .unwrap()
+    }
+
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(crate::v2::rolling_stock::rolling_stock_list(
+                user, privilege,
+            ))
             .await
             .unwrap()
     }

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,4 +1,6 @@
 use authz::RollingStockPrivilege;
+use authz::v2::Authorizer;
+use authz::v2::Check;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 use axum::extract::Json;
@@ -8,7 +10,6 @@ use axum::extract::State;
 use common::units;
 use common::units::quantities::Length;
 use database::DbConnection;
-use database::DbConnectionPoolV2;
 use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
 use editoast_models::rolling_stock::TrainMainCategory;
@@ -22,7 +23,6 @@ use schemas::rolling_stock::SupportedSignalingSystem;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 use uom::si::f64::Mass;
 use uom::si::f64::Velocity;
 use utoipa::ToSchema;
@@ -32,7 +32,9 @@ use super::RollingStockIdParam;
 use super::RollingStockKey;
 use super::RollingStockNameParam;
 use crate::AppState;
+use crate::authorizers::impossible;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -88,14 +90,48 @@ pub(in crate::views) struct LightRollingStockWithLiveriesCountList {
     )
 )]
 pub(in crate::views) async fn list(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+
+    Extension(authn_state): Extension<crate::authentication::State>,
     Query(page_settings): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<LightRollingStockWithLiveriesCountList>> {
-    let settings = page_settings
-        .into_selection_settings()
-        .order_by(|| RollingStock::ID.asc());
+    let conn = &mut db_pool.get().await?;
+    let default_settings = page_settings.into_selection_settings();
+    let settings = if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        let authorized_rolling_stocks = authorizer
+            .authorize(authz::v2::rolling_stock_list(
+                user,
+                RollingStockPrivilege::CanRead,
+            ))
+            .await?
+            .access()
+            .await?
+            .map_err(|err| match err {
+                Check::SubjectExists(_) => AuthorizationError::Forbidden,
+                check => impossible!(check),
+            })?;
+        match authorized_rolling_stocks {
+            authz::v2::ResourcesList::All => default_settings,
+            authz::v2::ResourcesList::Privileged(authorized_rolling_stocks) => default_settings
+                .filter(move || {
+                    RollingStock::ID.eq_any(
+                        authorized_rolling_stocks
+                            .iter()
+                            .map(|rolling_stock| rolling_stock.0)
+                            .collect(),
+                    )
+                }),
+        }
+    } else {
+        default_settings
+    };
+
     let (rolling_stocks, stats) =
-        RollingStock::list_paginated(&mut db_pool.get().await?, settings).await?;
+        RollingStock::list_paginated(conn, settings.order_by(move || RollingStock::ID.asc()))
+            .await?;
 
     let results = rolling_stocks.into_iter().zip(db_pool.iter_conn()).map(
         |(rolling_stock, conn)| async move {
@@ -302,6 +338,8 @@ impl From<ModeEffortCurves> for LightModeEffortCurves {
 
 #[cfg(test)]
 mod tests {
+    use authz::Role;
+    use authz::RollingStockGrant;
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -327,6 +365,57 @@ mod tests {
     async fn list_light_rolling_stock() {
         let app = test_app!().skip_authz().build();
         app.get("/light_rolling_stock").await.assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn rolling_stock_list_filters_authorized_rolling_stocks() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let rolling_stock_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_grant").await;
+        let rolling_stock_no_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_no_grant").await;
+        // Regular user with the correct roles should see only the rolling stock he is associated with:
+        let user = app
+            .user("user_identity", "user_name")
+            .with_rolling_stock_grant(rolling_stock_grant.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock")
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id]
+        );
+        // TODO: separate in two tests (admins_can_list_all_rolling_stocks and user_can_list_their_rolling_stocks)
+        // An admin should see all the rolling stocks:
+        let admin = app
+            .user("admin", "admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock/")
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id, rolling_stock_no_grant.id]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
Add a protected `list_rolling_stock` method to verify access privileges for a list of rolling stocks.


> [!CAUTION]
> THIS PR targets a feature branch ( see this [issue](https://github.com/OpenRailAssociation/osrd/issues/17264))

