### PR TITLE
editoast: `POST:/authz/grants` make it possible to give rolling stock grants

### DIFF
--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -78,6 +78,13 @@ pub enum Check {
     SubjectEffectiveInfraGrantIsNot(InfraGrant, Subject, Infra),
     /// The subject must not be the last direct owner of the infra
     IsNotLastInfraOwner(Subject, Infra),
+    /// The issuer must be allowed to change the subject's rolling stock grant
+    ///
+    /// Ensures that the issuer cannot demote a more or equally privileged user, except themself.
+    /// No-op grant changes are allowed.
+    /// IMPORTANT: it is *NOT* a replacement for [`Self::HasRollingStockPrivilege`] with sharing privileges (forbids illegal promotions)
+    /// NOTE: groups grants are managed by admins exclusively so this check always rejects group subjects as admin checks are bypassed
+    CanAlterSubjectRollingStockGrant(Subject, RollingStock, RollingStockGrant),
     /// The subject must not have the specified effective rolling stock grant
     SubjectEffectiveRollingStockGrantIsNot(RollingStockGrant, Subject, RollingStock),
     /// The subject must not be the last direct owner of the rolling stock

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -140,6 +140,92 @@ pub fn rolling_stock_effective_grant(
     ))
 }
 
+/// Sets the (direct) grant a subject has on an [RollingStock].
+///
+/// No transaction is setup as OpenFGA does not support them.
+pub fn rolling_stock_set_grant(
+    subject: Subject,
+    rolling_stock: RollingStock,
+    new_grant: RollingStockGrant,
+) -> Protected<()> {
+    let prot =
+        rolling_stock_revoke_grant(subject, rolling_stock).map(move |openfga, _has_revoked| {
+            async move {
+                let mut writes = openfga.prepare_writes();
+                match (subject, new_grant) {
+                    (Subject::User(user), RollingStockGrant::Reader) => {
+                        writes.push(&RollingStock::reader().tuple(&user, &rolling_stock))
+                    }
+                    (Subject::User(user), RollingStockGrant::Writer) => {
+                        writes.push(&RollingStock::writer().tuple(&user, &rolling_stock))
+                    }
+                    (Subject::User(user), RollingStockGrant::Owner) => {
+                        writes.push(&RollingStock::owner().tuple(&user, &rolling_stock))
+                    }
+                    (Subject::Group(group), RollingStockGrant::Reader) => writes.push(
+                        &RollingStock::reader()
+                            .tuple(Group::member().userset(&group), &rolling_stock),
+                    ),
+                    (Subject::Group(group), RollingStockGrant::Writer) => writes.push(
+                        &RollingStock::writer()
+                            .tuple(Group::member().userset(&group), &rolling_stock),
+                    ),
+                    (Subject::Group(group), RollingStockGrant::Owner) => writes.push(
+                        &RollingStock::owner()
+                            .tuple(Group::member().userset(&group), &rolling_stock),
+                    ),
+                };
+                writes.execute().await?;
+                Ok(())
+            }
+            .boxed()
+        });
+
+    let share_privilege = match new_grant {
+        RollingStockGrant::Reader => RollingStockPrivilege::CanShareRead,
+        RollingStockGrant::Writer => RollingStockPrivilege::CanShareWrite,
+        RollingStockGrant::Owner => RollingStockPrivilege::CanShareOwnership,
+    };
+
+    // Set grant rules:
+    // 1. Issuer must have the correct sharing privilege [HasRollingStockPrivilege]
+    // 2. Issuer is admin (may not have any direct grant on the resource)
+    //     1. *can* demote the last owner [Authorizer admin bypass]
+    //     2. can demote or promote anyone to any grant level otherwise [Authorizer admin bypass]
+    //     3. can demote or promote any group [Authorizer admin bypass]
+    // 3. Issuer is owner
+    //     1. cannot demote the last owner (including self) [IsNotLastRollingStockOwner]
+    //     2. cannot demote another owner [CanAlterSubjectRollingStockGrant]
+    //     3. can demote or promote anyone to any grant level otherwise [CanAlterSubjectRollingStockGrant]
+    //     4. **cannot** demote or promote any group [CanAlterSubjectRollingStockGrant]
+    // 4. Issuer is anything else
+    //     1. can demote self [HasRollingStockPrivilege]
+    //     2. cannot promote self [HasRollingStockPrivilege]
+    //     3. can promote anyone up to their own grant level [CanAlterSubjectRollingStockGrant + HasRollingStockPrivilege]
+    //     4. can demote anyone with a strictly lower grant level than their own [CanAlterSubjectRollingStockGrant]
+    //     5. **cannot** demote or promote any group [CanAlterSubjectRollingStockGrant]
+    let prot = prot
+        .reset_checks() // get rid of revoking-specific checks
+        .with_check(Check::SubjectExists(subject))
+        .with_check(Check::RollingStockExists(rolling_stock))
+        .with_check(Check::HasRollingStockPrivilege(
+            Actor::Issuer,
+            share_privilege,
+            rolling_stock,
+        ))
+        .with_check(Check::CanAlterSubjectRollingStockGrant(
+            subject,
+            rolling_stock,
+            new_grant,
+        ));
+
+    if new_grant != RollingStockGrant::Owner {
+        prot.with_check(Check::IsNotLastRollingStockOwner(subject, rolling_stock))
+    } else {
+        prot
+    }
+}
+
 /// Return an operation that checks the list of subjects which have the given grant on a rolling
 /// stock.
 pub fn rolling_stock_granted_subjects(
@@ -623,7 +709,7 @@ mod tests {
     ) {
         let openfga = crate::authz_client!();
         openfga
-            .give_rolling_stock_grant(RollingStock(1), subject, grant)
+            .rolling_stock_set_grant(RollingStock(1), subject, grant)
             .await;
         assert_eq!(
             openfga

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use fga::fga;
 use fga::model::Relation as _;
 
 use crate::Group;
@@ -29,6 +28,7 @@ use crate::v2::rolling_stock_effective_grant;
 use crate::v2::rolling_stock_granted_subjects;
 use crate::v2::rolling_stock_privileges;
 use crate::v2::rolling_stock_revoke_grant;
+use crate::v2::rolling_stock_set_grant;
 use crate::v2::special_authorizers;
 use crate::v2::user_groups;
 
@@ -78,7 +78,7 @@ pub trait TestClientExt {
         grant: RollingStockGrant,
     ) -> Vec<Subject>;
     // TODO use the protected operation once authz::v2 has a proper way to give grants on rolling stocks
-    async fn give_rolling_stock_grant(
+    async fn rolling_stock_set_grant(
         &self,
         rolling_stock: RollingStock,
         subject: Subject,
@@ -255,57 +255,17 @@ impl TestClientExt for fga::Client {
             .await
             .unwrap()
     }
-    async fn give_rolling_stock_grant(
+    async fn rolling_stock_set_grant(
         &self,
         rolling_stock: RollingStock,
         subject: Subject,
         grant: RollingStockGrant,
     ) {
-        match (grant, subject) {
-            (RollingStockGrant::Reader, Subject::User(user)) => {
-                self.write_tuples(&[RollingStock::reader()
-                    .tuple(&fga!(User:user), &fga!(RollingStock:rolling_stock))])
-                    .await
-            }
-            (RollingStockGrant::Writer, Subject::User(user)) => {
-                self.write_tuples(&[RollingStock::writer()
-                    .tuple(&fga!(User:user), &fga!(RollingStock:rolling_stock))])
-                    .await
-            }
-            (RollingStockGrant::Owner, Subject::User(user)) => {
-                self.write_tuples(&[RollingStock::owner()
-                    .tuple(&fga!(User:user), &fga!(RollingStock:rolling_stock))])
-                    .await
-            }
-            (RollingStockGrant::Reader, Subject::Group(group)) => {
-                self.prepare_writes()
-                    .write(
-                        &RollingStock::reader()
-                            .tuple(Group::member().userset(&group), &rolling_stock),
-                    )
-                    .execute()
-                    .await
-            }
-            (RollingStockGrant::Writer, Subject::Group(group)) => {
-                self.prepare_writes()
-                    .write(
-                        &RollingStock::writer()
-                            .tuple(Group::member().userset(&group), &rolling_stock),
-                    )
-                    .execute()
-                    .await
-            }
-            (RollingStockGrant::Owner, Subject::Group(group)) => {
-                self.prepare_writes()
-                    .write(
-                        &RollingStock::owner()
-                            .tuple(Group::member().userset(&group), &rolling_stock),
-                    )
-                    .execute()
-                    .await
-            }
-        }
-        .unwrap()
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(rolling_stock_set_grant(subject, rolling_stock, grant))
+            .await
+            .unwrap()
     }
 
     async fn infra_list(&self, user: User, privilege: InfraPrivilege) -> ResourcesList<Infra> {

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -150,13 +150,13 @@ impl<'c> UserAuthorizer<'c> {
                 new_grant,
             ) => {
                 let issuer = self.issuer();
-                let Ok((Some(issuer_grant), current_grant)) =
+                let Ok((issuer_grant, current_grant)) =
                     authz::v2::infra_effective_grant(issuer, *infra)
                         .zip(authz::v2::infra_effective_grant(*subject, *infra))
                         .access_authorized::<Infallible>(self.openfga)
                         .access()
-                        .await?
-                else {
+                        .await?;
+                let Some(issuer_grant) = issuer_grant else {
                     // According to the authorization model, non-Admin users must have a grant to share
                     return Ok(Some(check));
                 };
@@ -190,7 +190,7 @@ impl<'c> UserAuthorizer<'c> {
                 new_grant,
             ) => {
                 let issuer = self.issuer();
-                let Ok((Some(issuer_grant), current_grant)) =
+                let Ok((issuer_grant, current_grant)) =
                     authz::v2::rolling_stock_effective_grant(issuer, *rolling_stock)
                         .zip(authz::v2::rolling_stock_effective_grant(
                             *subject,
@@ -198,8 +198,8 @@ impl<'c> UserAuthorizer<'c> {
                         ))
                         .access_authorized::<Infallible>(self.openfga)
                         .access()
-                        .await?
-                else {
+                        .await?;
+                let Some(issuer_grant) = issuer_grant else {
                     // According to the authorization model, non-Admin users must have a grant to share
                     return Ok(Some(check));
                 };

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -178,7 +178,7 @@ impl<'c> UserAuthorizer<'c> {
             }
             Check::CanAlterSubjectInfraGrant(authz::Subject::Group(_), _, _) => {
                 // The only users allowed to alter groups grants are admins who bypass this entire
-                // verification function. So if we reach here, well then... TOO BAD GAME OVER LOL
+                // verification function.
                 Some(check)
             }
 
@@ -227,7 +227,7 @@ impl<'c> UserAuthorizer<'c> {
             }
             Check::CanAlterSubjectRollingStockGrant(authz::Subject::Group(_), _, _) => {
                 // The only users allowed to alter groups grants are admins who bypass this entire
-                // verification function. So if we reach here, well then... TOO BAD GAME OVER LOL
+                // verification function.
                 Some(check)
             }
             Check::SubjectEffectiveRollingStockGrantIsNot(grant, subject, rolling_stock) => {

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -46,6 +46,7 @@ impl SystemAuthorizer<'_> {
             | Check::HasRollingStockPrivilege(..)
             | Check::CanAlterSubjectInfraGrant(..)
             | Check::SubjectEffectiveInfraGrantIsNot(..)
+            | Check::CanAlterSubjectRollingStockGrant(..)
             | Check::SubjectEffectiveRollingStockGrantIsNot(..)
             | Check::IsNotLastInfraOwner(..)
             | Check::IsNotLastRollingStockOwner(..) => None,
@@ -187,6 +188,47 @@ impl<'c> UserAuthorizer<'c> {
                     .access()
                     .await?;
                 (subject_grant == Some(*grant)).then_some(check)
+            }
+            Check::CanAlterSubjectRollingStockGrant(
+                subject @ authz::Subject::User(_),
+                rolling_stock,
+                new_grant,
+            ) => {
+                let issuer = self.issuer();
+                let Ok((Some(issuer_grant), current_grant)) =
+                    authz::v2::rolling_stock_effective_grant(issuer, *rolling_stock)
+                        .zip(authz::v2::rolling_stock_effective_grant(
+                            *subject,
+                            *rolling_stock,
+                        ))
+                        .access_authorized::<Infallible>(self.openfga)
+                        .access()
+                        .await?
+                else {
+                    // According to the authorization model, non-Admin users must have a grant to share
+                    return Ok(Some(check));
+                };
+
+                if let Some(current_grant) = current_grant {
+                    if current_grant == *new_grant {
+                        // I can do nothing (no-op);
+                        None
+                    } else if issuer == *subject {
+                        // I can also alter my own grant and self-demote;
+                        None
+                    } else {
+                        // but I cannot do the same thing to my equals
+                        (current_grant >= issuer_grant).then_some(check)
+                    }
+                } else {
+                    // Unprivileged subjects can always be shared to.
+                    None
+                }
+            }
+            Check::CanAlterSubjectRollingStockGrant(authz::Subject::Group(_), _, _) => {
+                // The only users allowed to alter groups grants are admins who bypass this entire
+                // verification function. So if we reach here, well then... TOO BAD GAME OVER LOL
+                Some(check)
             }
             Check::SubjectEffectiveRollingStockGrantIsNot(grant, subject, rolling_stock) => {
                 let Ok(subject_grant) =
@@ -500,6 +542,11 @@ mod tests {
         authz::Subject::User(authz::User(i64::MAX)),
         authz::Infra(i64::MAX)
     ))]
+    #[case::can_alter_subject_rolling_stock_grant(Check::CanAlterSubjectRollingStockGrant(
+        authz::Subject::User(authz::User(i64::MAX)),
+        authz::RollingStock(i64::MAX),
+        RollingStockGrant::Reader,
+    ))]
     #[case::subject_effective_rolling_stock_grant_is_not(
         Check::SubjectEffectiveRollingStockGrantIsNot(
             RollingStockGrant::Owner,
@@ -752,6 +799,137 @@ mod tests {
                 .unwrap();
 
             let check = Check::CanAlterSubjectInfraGrant(target, authz::Infra(1), grant);
+            let result = authorize(&user_authorizer, check).await;
+            let expected = ok.then_some(()).ok_or(check);
+            assert_eq!(result, expected);
+        }
+    }
+
+    mod can_alter_subject_rolling_stock_grant {
+        use super::*;
+
+        const ISSUER_NOTHING: authz::User = authz::User(0);
+        const ISSUER_READER: authz::User = authz::User(1);
+        const ISSUER_WRITER: authz::User = authz::User(2);
+        const ISSUER_OWNER: authz::User = authz::User(3);
+        const USER_NOTHING: authz::Subject = authz::Subject::User(authz::User(4));
+        const USER_READER: authz::Subject = authz::Subject::User(authz::User(5));
+        const USER_WRITER: authz::Subject = authz::Subject::User(authz::User(6));
+        const USER_OWNER: authz::Subject = authz::Subject::User(authz::User(7));
+        const GROUP_NOTHING: authz::Subject = authz::Subject::Group(authz::Group(8));
+        const GROUP_READER: authz::Subject = authz::Subject::Group(authz::Group(9));
+        const GROUP_WRITER: authz::Subject = authz::Subject::Group(authz::Group(10));
+        const GROUP_OWNER: authz::Subject = authz::Subject::Group(authz::Group(11));
+
+        #[rstest]
+        // a user grants another user
+        #[case::target_user_1(ISSUER_READER, USER_NOTHING, RollingStockGrant::Reader, true)]
+        #[case::target_user_2(ISSUER_READER, USER_READER, RollingStockGrant::Reader, true)]
+        #[case::target_user_3(ISSUER_READER, USER_WRITER, RollingStockGrant::Reader, false)]
+        #[case::target_user_4(ISSUER_READER, USER_OWNER, RollingStockGrant::Reader, false)]
+        #[case::target_user_5(ISSUER_WRITER, USER_NOTHING, RollingStockGrant::Writer, true)]
+        #[case::target_user_6(ISSUER_WRITER, USER_READER, RollingStockGrant::Writer, true)]
+        #[case::target_user_7(ISSUER_WRITER, USER_WRITER, RollingStockGrant::Writer, true)]
+        #[case::target_user_8(ISSUER_WRITER, USER_OWNER, RollingStockGrant::Writer, false)]
+        #[case::target_user_9(ISSUER_OWNER, USER_NOTHING, RollingStockGrant::Owner, true)]
+        #[case::target_user_10(ISSUER_OWNER, USER_READER, RollingStockGrant::Owner, true)]
+        #[case::target_user_11(ISSUER_OWNER, USER_WRITER, RollingStockGrant::Owner, true)]
+        #[case::target_user_12(ISSUER_OWNER, USER_OWNER, RollingStockGrant::Owner, true)]
+        // non-admins cannot grant groups
+        #[case::target_group_1(ISSUER_READER, GROUP_NOTHING, RollingStockGrant::Reader, false)]
+        #[case::target_group_2(ISSUER_READER, GROUP_READER, RollingStockGrant::Reader, false)]
+        #[case::target_group_3(ISSUER_READER, GROUP_WRITER, RollingStockGrant::Reader, false)]
+        #[case::target_group_4(ISSUER_READER, GROUP_OWNER, RollingStockGrant::Reader, false)]
+        #[case::target_group_5(ISSUER_WRITER, GROUP_NOTHING, RollingStockGrant::Writer, false)]
+        #[case::target_group_6(ISSUER_WRITER, GROUP_READER, RollingStockGrant::Writer, false)]
+        #[case::target_group_7(ISSUER_WRITER, GROUP_WRITER, RollingStockGrant::Writer, false)]
+        #[case::target_group_8(ISSUER_WRITER, GROUP_OWNER, RollingStockGrant::Writer, false)]
+        #[case::target_group_9(ISSUER_OWNER, GROUP_NOTHING, RollingStockGrant::Owner, false)]
+        #[case::target_group_10(ISSUER_OWNER, GROUP_READER, RollingStockGrant::Owner, false)]
+        #[case::target_group_11(ISSUER_OWNER, GROUP_WRITER, RollingStockGrant::Owner, false)]
+        #[case::target_group_12(ISSUER_OWNER, GROUP_OWNER, RollingStockGrant::Owner, false)]
+        // targeting self is allowed within privilege limits
+        #[case::target_self_1(
+            ISSUER_READER,
+            authz::Subject::User(ISSUER_READER),
+            RollingStockGrant::Reader,
+            true
+        )]
+        #[case::target_self_2(
+            ISSUER_WRITER,
+            authz::Subject::User(ISSUER_WRITER),
+            RollingStockGrant::Writer,
+            true
+        )]
+        #[case::target_self_3(
+            ISSUER_OWNER,
+            authz::Subject::User(ISSUER_OWNER),
+            RollingStockGrant::Owner,
+            true
+        )]
+        // a user with no grant do not have the privilege to share grants
+        #[case::unreachable(ISSUER_NOTHING, USER_NOTHING, RollingStockGrant::Reader, false)]
+        // noop: no changes, the issuer grant does not matter
+        #[case::noop_1(ISSUER_READER, USER_READER, RollingStockGrant::Reader, true)]
+        #[case::noop_2(ISSUER_WRITER, USER_READER, RollingStockGrant::Reader, true)]
+        #[case::noop_3(ISSUER_OWNER, USER_READER, RollingStockGrant::Reader, true)]
+        #[case::noop_4(ISSUER_READER, USER_WRITER, RollingStockGrant::Writer, true)]
+        #[case::noop_5(ISSUER_WRITER, USER_WRITER, RollingStockGrant::Writer, true)]
+        #[case::noop_6(ISSUER_OWNER, USER_WRITER, RollingStockGrant::Writer, true)]
+        #[case::noop_7(ISSUER_READER, USER_OWNER, RollingStockGrant::Owner, true)]
+        #[case::noop_8(ISSUER_WRITER, USER_OWNER, RollingStockGrant::Owner, true)]
+        #[case::noop_9(ISSUER_OWNER, USER_OWNER, RollingStockGrant::Owner, true)]
+        // -----
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn test(
+            #[case] issuer: authz::User,
+            #[case] target: authz::Subject,
+            #[case] grant: RollingStockGrant,
+            #[case] ok: bool,
+        ) {
+            let openfga = openfga().await;
+            let pool = DbConnectionPoolV2::for_tests();
+            let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+
+            openfga
+                .prepare_writes()
+                .write(
+                    &authz::RollingStock::reader().tuple(&ISSUER_READER, &authz::RollingStock(1)),
+                )
+                .write(
+                    &authz::RollingStock::writer().tuple(&ISSUER_WRITER, &authz::RollingStock(1)),
+                )
+                .write(&authz::RollingStock::owner().tuple(&ISSUER_OWNER, &authz::RollingStock(1)))
+                .write(
+                    &authz::RollingStock::reader()
+                        .tuple(&authz::User(USER_READER.id()), &authz::RollingStock(1)),
+                )
+                .write(
+                    &authz::RollingStock::writer()
+                        .tuple(&authz::User(USER_WRITER.id()), &authz::RollingStock(1)),
+                )
+                .write(
+                    &authz::RollingStock::owner()
+                        .tuple(&authz::User(USER_OWNER.id()), &authz::RollingStock(1)),
+                )
+                .write(&authz::RollingStock::reader().tuple(
+                    authz::Group::member().userset(&authz::Group(GROUP_READER.id())),
+                    &authz::RollingStock(1),
+                ))
+                .write(&authz::RollingStock::writer().tuple(
+                    authz::Group::member().userset(&authz::Group(GROUP_WRITER.id())),
+                    &authz::RollingStock(1),
+                ))
+                .write(&authz::RollingStock::owner().tuple(
+                    authz::Group::member().userset(&authz::Group(GROUP_OWNER.id())),
+                    &authz::RollingStock(1),
+                ))
+                .execute()
+                .await
+                .unwrap();
+
+            let check =
+                Check::CanAlterSubjectRollingStockGrant(target, authz::RollingStock(1), grant);
             let result = authorize(&user_authorizer, check).await;
             let expected = ok.then_some(()).ok_or(check);
             assert_eq!(result, expected);
@@ -1031,6 +1209,11 @@ mod tests {
     #[case::is_not_last_infra_owner(Check::IsNotLastInfraOwner(
         authz::Subject::user(i64::MAX),
         authz::Infra(i64::MAX)
+    ))]
+    #[case::can_alter_subject_rolling_stock_grant(Check::CanAlterSubjectRollingStockGrant(
+        authz::Subject::user(i64::MAX),
+        authz::RollingStock(i64::MAX),
+        RollingStockGrant::Reader,
     ))]
     #[case::subject_effective_rolling_stock_grant_is_not(
         Check::SubjectEffectiveRollingStockGrantIsNot(

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::ops::Not as _;
 
 use authz::v2::Access;
 use authz::v2::Actor;
@@ -160,21 +161,15 @@ impl<'c> UserAuthorizer<'c> {
                     return Ok(Some(check));
                 };
 
-                if let Some(current_grant) = current_grant {
-                    if current_grant == *new_grant {
-                        // I can do nothing (no-op);
-                        None
-                    } else if issuer == *subject {
-                        // I can also alter my own grant and self-demote;
-                        None
-                    } else {
-                        // but I cannot do the same thing to my equals
-                        (current_grant >= issuer_grant).then_some(check)
-                    }
-                } else {
-                    // Unprivileged subjects can always be shared to.
-                    None
-                }
+                current_grant.and_then(|current_grant| {
+                    let no_op = current_grant == *new_grant;
+                    let altering_self = issuer == *subject;
+                    let altering_underling = current_grant < issuer_grant;
+                    let promoting_above_me = issuer_grant < *new_grant;
+                    (!promoting_above_me && (no_op || altering_self || altering_underling))
+                        .not()
+                        .then_some(check)
+                })
             }
             Check::CanAlterSubjectInfraGrant(authz::Subject::Group(_), _, _) => {
                 // The only users allowed to alter groups grants are admins who bypass this entire
@@ -209,21 +204,15 @@ impl<'c> UserAuthorizer<'c> {
                     return Ok(Some(check));
                 };
 
-                if let Some(current_grant) = current_grant {
-                    if current_grant == *new_grant {
-                        // I can do nothing (no-op);
-                        None
-                    } else if issuer == *subject {
-                        // I can also alter my own grant and self-demote;
-                        None
-                    } else {
-                        // but I cannot do the same thing to my equals
-                        (current_grant >= issuer_grant).then_some(check)
-                    }
-                } else {
-                    // Unprivileged subjects can always be shared to.
-                    None
-                }
+                current_grant.and_then(|current_grant| {
+                    let no_op = current_grant == *new_grant;
+                    let altering_self = issuer == *subject;
+                    let altering_underling = current_grant < issuer_grant;
+                    let promoting_above_me = issuer_grant < *new_grant;
+                    (!promoting_above_me && (no_op || altering_self || altering_underling))
+                        .not()
+                        .then_some(check)
+                })
             }
             Check::CanAlterSubjectRollingStockGrant(authz::Subject::Group(_), _, _) => {
                 // The only users allowed to alter groups grants are admins who bypass this entire
@@ -746,15 +735,14 @@ mod tests {
         )]
         // a user with no grant do not have the privilege to share grants
         #[case::unreachable(ISSUER_NOTHING, USER_NOTHING, InfraGrant::Reader, false)]
-        // noop: no changes, the issuer grant does not matter
         #[case::noop_1(ISSUER_READER, USER_READER, InfraGrant::Reader, true)]
         #[case::noop_2(ISSUER_WRITER, USER_READER, InfraGrant::Reader, true)]
         #[case::noop_3(ISSUER_OWNER, USER_READER, InfraGrant::Reader, true)]
-        #[case::noop_4(ISSUER_READER, USER_WRITER, InfraGrant::Writer, true)]
+        #[case::noop_4(ISSUER_READER, USER_WRITER, InfraGrant::Writer, false)]
         #[case::noop_5(ISSUER_WRITER, USER_WRITER, InfraGrant::Writer, true)]
         #[case::noop_6(ISSUER_OWNER, USER_WRITER, InfraGrant::Writer, true)]
-        #[case::noop_7(ISSUER_READER, USER_OWNER, InfraGrant::Owner, true)]
-        #[case::noop_8(ISSUER_WRITER, USER_OWNER, InfraGrant::Owner, true)]
+        #[case::noop_7(ISSUER_READER, USER_OWNER, InfraGrant::Owner, false)]
+        #[case::noop_8(ISSUER_WRITER, USER_OWNER, InfraGrant::Owner, false)]
         #[case::noop_9(ISSUER_OWNER, USER_OWNER, InfraGrant::Owner, true)]
         // -----
         #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -869,15 +857,14 @@ mod tests {
         )]
         // a user with no grant do not have the privilege to share grants
         #[case::unreachable(ISSUER_NOTHING, USER_NOTHING, RollingStockGrant::Reader, false)]
-        // noop: no changes, the issuer grant does not matter
         #[case::noop_1(ISSUER_READER, USER_READER, RollingStockGrant::Reader, true)]
         #[case::noop_2(ISSUER_WRITER, USER_READER, RollingStockGrant::Reader, true)]
         #[case::noop_3(ISSUER_OWNER, USER_READER, RollingStockGrant::Reader, true)]
-        #[case::noop_4(ISSUER_READER, USER_WRITER, RollingStockGrant::Writer, true)]
+        #[case::noop_4(ISSUER_READER, USER_WRITER, RollingStockGrant::Writer, false)]
         #[case::noop_5(ISSUER_WRITER, USER_WRITER, RollingStockGrant::Writer, true)]
         #[case::noop_6(ISSUER_OWNER, USER_WRITER, RollingStockGrant::Writer, true)]
-        #[case::noop_7(ISSUER_READER, USER_OWNER, RollingStockGrant::Owner, true)]
-        #[case::noop_8(ISSUER_WRITER, USER_OWNER, RollingStockGrant::Owner, true)]
+        #[case::noop_7(ISSUER_READER, USER_OWNER, RollingStockGrant::Owner, false)]
+        #[case::noop_8(ISSUER_WRITER, USER_OWNER, RollingStockGrant::Owner, false)]
         #[case::noop_9(ISSUER_OWNER, USER_OWNER, RollingStockGrant::Owner, true)]
         // -----
         #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -859,6 +859,10 @@ pub(in crate::views) async fn update_grants(
                     resource_id: *infra,
                 }
                 .into()),
+                Err(Check::RollingStockExists(rolling_stock)) => Err(AuthzError::UnknownResource {
+                    resource_id: *rolling_stock,
+                }
+                .into()),
                 Err(Check::SubjectExists(subject)) => Err(AuthzError::UnknownSubject {
                     subject_id: subject.id(),
                 }
@@ -871,7 +875,16 @@ pub(in crate::views) async fn update_grants(
                         | InfraPrivilege::CanShareOwnership,
                         _,
                     )
+                    | Check::HasRollingStockPrivilege(
+                        Actor::Issuer,
+                        RollingStockPrivilege::CanShareRead
+                        | RollingStockPrivilege::CanShareWrite
+                        | RollingStockPrivilege::CanShareOwnership,
+                        _,
+                    )
                     | Check::CanAlterSubjectInfraGrant(..)
+                    | Check::CanAlterSubjectRollingStockGrant(..)
+                    | Check::IsNotLastRollingStockOwner(..)
                     | Check::IsNotLastInfraOwner(..),
                 ) => Err(AuthorizationError::Forbidden.into()),
                 Err(check) => impossible!(check),
@@ -930,9 +943,7 @@ impl GrantBody {
                 authz::v2::infra_set_grant(*subject, resource_id.into(), grant.into())
             }
             ResourceType::RollingStock => {
-                unreachable!(
-                    "not implemented yet, requires implementing rolling stock grants in OpenFGA and exposing them in the authorizer"
-                )
+                authz::v2::rolling_stock_set_grant(*subject, resource_id.into(), grant.into())
             }
         })
     }
@@ -1366,25 +1377,42 @@ mod tests {
         }
     }
 
-    // TODO update this test with rolling stock grants once both revoking and granting are
-    // implemented
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn grants_test() {
-        // This test starts with a user that is the owner of an infra.
-        // Then it creates a new user and adds it as a writer to the infra.
-        // Finally, it removes the new user from the infra.
-        let app = test_app!().build();
-        let db_pool = app.db_pool();
-        let openfga = app.openfga();
-        let infra = authz::Infra(create_small_infra(&mut db_pool.get_ok()).await.id);
-        let owner = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
             .user("owner", "Owner")
             .with_roles([Role::OperationalStudies])
-            .with_infra_grant(*infra, InfraGrant::Owner)
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
             .create()
-            .await;
+            .await
+        )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(resource_id, InfraGrant::Owner)
+            .create()
+            .await
+        )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn grants_test(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+    ) {
+        // This test starts with a user that is the owner of resource.
+        // Then it creates a new user and adds it as a writer to the resource.
+        // Finally, it removes the new user from the resource.
+        let openfga = app.openfga();
 
-        // Create a new user and add it as a writer to the infra with the grant API
+        // Create a new user and add it as a writer to the resource with the grant API
         let writer = authz::User::from(app.user("writer", "Writer").create().await);
         app.post("/authz/grants")
             .by_user(owner.as_ref())
@@ -1392,9 +1420,9 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": *writer,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": *infra,
-                        "grant": InfraGrant::Writer
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Writer
                     }
                 ]
             }))
@@ -1402,28 +1430,56 @@ mod tests {
             .assert_status(StatusCode::CREATED);
 
         // Check that the new user has the good grant
-        assert_eq!(
-            openfga.infra_direct_grant(writer, infra).await,
-            Some(InfraGrant::Writer)
-        );
+        match resource_type {
+            ResourceType::Infra => assert_eq!(
+                openfga
+                    .infra_direct_grant(authz::Subject::user(writer), authz::Infra(resource_id))
+                    .await,
+                Some(InfraGrant::Writer)
+            ),
+            ResourceType::RollingStock => assert_eq!(
+                openfga
+                    .rolling_stock_direct_grant(
+                        authz::Subject::user(writer),
+                        authz::RollingStock(resource_id)
+                    )
+                    .await,
+                Some(RollingStockGrant::Writer)
+            ),
+        }
 
-        // Remove the user from the API
+        // Remove the user grant from the API
         app.post("/authz/grants")
             .by_user(owner.as_ref())
             .json(&json!({
                 "revoke": [
                     {
                         "subject_id": *writer,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": *infra
+                        "resource_type": resource_type,
+                        "resource_id": resource_id
                     }
                 ]
             }))
             .await
             .assert_status_no_content();
 
-        // Check that the new user has the good grant
-        assert_eq!(openfga.infra_direct_grant(writer, infra).await, None);
+        match resource_type {
+            ResourceType::Infra => assert_eq!(
+                openfga
+                    .infra_direct_grant(authz::Subject::user(writer), authz::Infra(resource_id))
+                    .await,
+                None
+            ),
+            ResourceType::RollingStock => assert_eq!(
+                openfga
+                    .rolling_stock_direct_grant(
+                        authz::Subject::user(writer),
+                        authz::RollingStock(resource_id)
+                    )
+                    .await,
+                None
+            ),
+        }
     }
 
     #[rstest]
@@ -1670,18 +1726,37 @@ mod tests {
         };
     }
 
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
+            .user("owner", "Owner")
+            .with_infra_grant(resource_id, InfraGrant::Owner)
+            .create()
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("owner", "Owner")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn admin_can_demote_last_infra_owner() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
+    async fn admin_can_demote_last_resource_owner(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+    ) {
         let admin = app
             .user("admin", "Admin")
             .with_roles([Role::Admin])
-            .create()
-            .await;
-        let owner = app
-            .user("owner", "Owner")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
             .create()
             .await;
 
@@ -1689,34 +1764,71 @@ mod tests {
             .json(&json!({
                 "grant": [{
                     "subject_id": owner.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Writer
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Writer
                 }]
             }))
             .by_user(admin.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
-        app.assert_infra_grant(infra.id, owner.id, Some(InfraGrant::Writer));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, owner.id, Some(InfraGrant::Writer));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    owner.id,
+                    Some(RollingStockGrant::Writer),
+                )
+                .await;
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn admin_can_promote_and_demote_anyone_infra_grant() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let admin = app
-            .user("admin", "Admin")
-            .with_roles([Role::Admin])
-            .create()
-            .await;
-        let alice = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("alice", "Alice")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-        let bob = app
+            .await,
+        app
             .user("bob", "Bob")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_infra_grant(resource_id, InfraGrant::Reader)
+            .create()
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("alice", "Alice")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+        app
+            .user("bob", "Bob")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Reader)
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn admin_can_promote_and_demote_anyone_resource_grant(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] alice: authz::identity::User,
+        #[case] bob: authz::identity::User,
+    ) {
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
             .create()
             .await;
 
@@ -1724,268 +1836,570 @@ mod tests {
             .json(&json!({
                 "grant": [{
                     "subject_id": bob.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Owner
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Owner
                 }]
             }))
             .by_user(admin.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
-        app.assert_infra_grant(infra.id, bob.id, Some(InfraGrant::Owner));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, bob.id, Some(InfraGrant::Owner))
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, bob.id, Some(RollingStockGrant::Owner))
+                    .await
+            }
+        }
 
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": bob.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Writer
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Writer
                 }]
             }))
             .by_user(admin.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
-        app.assert_infra_grant(infra.id, alice.id, Some(InfraGrant::Owner));
-        app.assert_infra_grant(infra.id, bob.id, Some(InfraGrant::Writer));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, alice.id, Some(InfraGrant::Owner));
+                app.assert_infra_grant(resource_id, bob.id, Some(InfraGrant::Writer));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    alice.id,
+                    Some(RollingStockGrant::Owner),
+                )
+                .await;
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    bob.id,
+                    Some(RollingStockGrant::Writer),
+                )
+                .await;
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn last_owner_cannot_demote_itself() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let owner = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("owner", "Owner")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("owner", "Owner")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn last_owner_cannot_demote_itself(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": owner.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Writer
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Writer
                 }]
             }))
             .by_user(owner.as_ref())
             .await
             .assert_status_forbidden();
-        app.assert_infra_grant(infra.id, owner.id, Some(InfraGrant::Owner));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, owner.id, Some(InfraGrant::Owner))
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    owner.id,
+                    Some(RollingStockGrant::Owner),
+                )
+                .await
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn owner_cannot_demote_another_owner() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let tom = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("tom", "Tom")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-        let jerry = app
+            .await,
+        app
             .user("jerry", "Jerry")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("tom", "Tom")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+        app
+            .user("jerry", "Jerry")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn owner_cannot_demote_another_owner(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] tom: authz::identity::User,
+        #[case] jerry: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": jerry.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Writer
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Writer
                 }]
             }))
             .by_user(tom.as_ref())
             .await
             .assert_status_forbidden();
-        app.assert_infra_grant(infra.id, jerry.id, Some(InfraGrant::Owner));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, jerry.id, Some(InfraGrant::Owner))
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    jerry.id,
+                    Some(RollingStockGrant::Owner),
+                )
+                .await
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn owner_can_promote_and_demote_anyone_infra_grant() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let owner = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("owner", "Owner")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-        let target = app
+            .await,
+        app
             .user("target", "Target")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_infra_grant(resource_id, InfraGrant::Reader)
             .create()
-            .await;
-
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("owner", "Owner")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+        app
+            .user("target", "Target")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Reader)
+            .create()
+            .await,
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn owner_can_promote_and_demote_anyone_infra_grant(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+        #[case] target: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": target.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Writer
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Writer
                 }]
             }))
             .by_user(owner.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
-        app.assert_infra_grant(infra.id, target.id, Some(InfraGrant::Writer));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, target.id, Some(InfraGrant::Writer));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    target.id,
+                    Some(RollingStockGrant::Writer),
+                )
+                .await;
+            }
+        }
 
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": target.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Reader
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Reader
                 }]
             }))
             .by_user(owner.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
-        app.assert_infra_grant(infra.id, target.id, Some(InfraGrant::Reader));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, target.id, Some(InfraGrant::Reader));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    target.id,
+                    Some(RollingStockGrant::Reader),
+                )
+                .await
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn writer_can_demote_self_infra_grant() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let writer = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("writer", "Writer")
-            .with_infra_grant(infra.id, InfraGrant::Writer)
+            .with_infra_grant(resource_id, InfraGrant::Writer)
             .create()
-            .await;
-
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn writer_can_demote_self_resource_grant(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] writer: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": writer.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Reader
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Reader
                 }]
             }))
             .by_user(writer.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
-        app.assert_infra_grant(infra.id, writer.id, Some(InfraGrant::Reader));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, writer.id, Some(InfraGrant::Reader));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    writer.id,
+                    Some(RollingStockGrant::Reader),
+                )
+                .await;
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn writer_cannot_promote_self_infra_grant() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let writer = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("writer", "Writer")
-            .with_infra_grant(infra.id, InfraGrant::Writer)
+            .with_infra_grant(resource_id, InfraGrant::Writer)
             .create()
-            .await;
-
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn writer_cannot_promote_self_resource_grant(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] writer: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": writer.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Owner
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Owner
                 }]
             }))
             .by_user(writer.as_ref())
             .await
             .assert_status_forbidden();
-        app.assert_infra_grant(infra.id, writer.id, Some(InfraGrant::Writer));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, writer.id, Some(InfraGrant::Writer));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    writer.id,
+                    Some(RollingStockGrant::Writer),
+                )
+                .await;
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn writer_can_promote_another_subject_up_to_writer_infra_grant() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let writer = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("writer", "Writer")
-            .with_infra_grant(infra.id, InfraGrant::Writer)
+            .with_infra_grant(resource_id, InfraGrant::Writer)
             .create()
-            .await;
-        let reader = app
+            .await,
+        app
             .user("reader", "Reader")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_infra_grant(resource_id, InfraGrant::Reader)
             .create()
-            .await;
-
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await,
+        app
+            .user("reader", "Reader")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Reader)
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn writer_can_promote_another_subject_up_to_writer_infra_grant(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] writer: authz::identity::User,
+        #[case] reader: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": reader.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Writer
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Writer
                 }]
             }))
             .by_user(writer.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
-        app.assert_infra_grant(infra.id, reader.id, Some(InfraGrant::Writer));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, reader.id, Some(InfraGrant::Writer));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    reader.id,
+                    Some(RollingStockGrant::Writer),
+                )
+                .await;
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn writer_cannot_promote_above_writer_infra_grant() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let writer = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("writer", "Writer")
-            .with_infra_grant(infra.id, InfraGrant::Writer)
+            .with_infra_grant(resource_id, InfraGrant::Writer)
             .create()
-            .await;
-        let reader = app
+            .await,
+        app
             .user("reader", "Reader")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_infra_grant(resource_id, InfraGrant::Reader)
             .create()
-            .await;
-
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await,
+        app
+            .user("reader", "Reader")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Reader)
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn writer_cannot_promote_above_writer_rolling_stock_grant(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] writer: authz::identity::User,
+        #[case] reader: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": reader.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Owner
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Owner
                 }]
             }))
             .by_user(writer.as_ref())
             .await
             .assert_status_forbidden();
-        app.assert_infra_grant(infra.id, reader.id, Some(InfraGrant::Reader));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, reader.id, Some(InfraGrant::Reader));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    reader.id,
+                    Some(RollingStockGrant::Reader),
+                )
+                .await;
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn writer_cannot_demote_equal_or_higher_infra_grant_target() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let writer = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("writer", "Writer")
-            .with_infra_grant(infra.id, InfraGrant::Writer)
+            .with_infra_grant(resource_id, InfraGrant::Writer)
             .create()
-            .await;
-        let equal = app
+            .await,
+        app
             .user("equal", "Equal")
-            .with_infra_grant(infra.id, InfraGrant::Writer)
+            .with_infra_grant(resource_id, InfraGrant::Writer)
             .create()
-            .await;
-        let higher = app
+            .await,
+        app
             .user("higher", "Higher")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-
+            .await
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await,
+        app
+            .user("equal", "Equal")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await,
+        app
+            .user("higher", "Higher")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn writer_cannot_demote_equal_or_higher_infra_grant_target(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] writer: authz::identity::User,
+        #[case] equal: authz::identity::User,
+        #[case] higher: authz::identity::User,
+    ) {
         app.post("/authz/grants")
             .json(&json!({
                 "grant": [{
                     "subject_id": equal.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Reader
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Reader
                 }]
             }))
             .by_user(writer.as_ref())
@@ -1995,33 +2409,76 @@ mod tests {
             .json(&json!({
                 "grant": [{
                     "subject_id": higher.id,
-                    "resource_type": ResourceType::Infra,
-                    "resource_id": infra.id,
-                    "grant": InfraGrant::Writer
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                    "grant": StandardGrant::Writer
                 }]
             }))
             .by_user(writer.as_ref())
             .await
             .assert_status_forbidden();
 
-        app.assert_infra_grant(infra.id, writer.id, Some(InfraGrant::Writer));
-        app.assert_infra_grant(infra.id, equal.id, Some(InfraGrant::Writer));
-        app.assert_infra_grant(infra.id, higher.id, Some(InfraGrant::Owner));
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, writer.id, Some(InfraGrant::Writer));
+                app.assert_infra_grant(resource_id, equal.id, Some(InfraGrant::Writer));
+                app.assert_infra_grant(resource_id, higher.id, Some(InfraGrant::Owner));
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    writer.id,
+                    Some(RollingStockGrant::Writer),
+                )
+                .await;
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    equal.id,
+                    Some(RollingStockGrant::Writer),
+                )
+                .await;
+                app.assert_rolling_stock_grant(
+                    resource_id,
+                    higher.id,
+                    Some(RollingStockGrant::Owner),
+                )
+                .await;
+            }
+        }
     }
 
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
+            .user("alice", "Alice")
+            .with_infra_grant(resource_id, InfraGrant::Owner)
+            .create()
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("alice", "Alice")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn admin_can_give_grants_to_groups() {
-        let app = test_app!().build();
+    async fn admin_can_give_grants_to_groups(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] alice: authz::identity::User,
+    ) {
         let openfga = app.openfga();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
         let admin = app
             .user("admin", "Admin")
             .with_roles([Role::Admin])
-            .create()
-            .await;
-        let alice = app
-            .user("alice", "Alice")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
             .create()
             .await;
         let bob = app.user("bob", "Bob").create().await;
@@ -2030,7 +2487,6 @@ mod tests {
             .with_members([&alice, &bob])
             .create()
             .await;
-        let infra = authz::Infra(infra.id);
         let alice_info = alice.clone();
         let alice = authz::User::from(alice);
         let bob = authz::User::from(bob);
@@ -2042,36 +2498,68 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": *alice_and_bob,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": *infra,
-                        "grant": InfraGrant::Writer
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Writer
                     },
                     {
                         "subject_id": *bob,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": *infra,
-                        "grant": InfraGrant::Reader
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Reader
                     }
                 ]
             }))
             .await
             .assert_status(StatusCode::CREATED);
 
-        assert_eq!(
-            openfga.infra_direct_grant(alice, infra).await,
-            Some(InfraGrant::Owner)
-        ); // still owner
-        assert_eq!(
-            openfga.infra_direct_grant(alice_and_bob, infra).await,
-            Some(InfraGrant::Writer)
-        ); // direct group grant
-        assert_eq!(
-            openfga.infra_direct_grant(bob, infra).await,
-            Some(InfraGrant::Reader)
-        ); // direct user grant
-
-        app.assert_infra_grant(*infra, *bob, Some(InfraGrant::Writer)); // inherited group grant
-        app.assert_infra_grant(*infra, *alice, Some(InfraGrant::Owner)); // inherited group grant superseded by direct user grant
+        match resource_type {
+            ResourceType::Infra => {
+                let infra = authz::Infra(resource_id);
+                assert_eq!(
+                    openfga.infra_direct_grant(alice, infra).await,
+                    Some(InfraGrant::Owner)
+                ); // still owner
+                assert_eq!(
+                    openfga.infra_direct_grant(alice_and_bob, infra).await,
+                    Some(InfraGrant::Writer)
+                ); // direct group grant
+                assert_eq!(
+                    openfga.infra_direct_grant(bob, infra).await,
+                    Some(InfraGrant::Reader)
+                ); // direct user grant
+                app.assert_infra_grant(resource_id, *bob, Some(InfraGrant::Writer)); // inherited group grant
+                app.assert_infra_grant(resource_id, *alice, Some(InfraGrant::Owner)); // inherited group grant superseded by direct user grant
+            }
+            ResourceType::RollingStock => {
+                let rolling_stock = authz::RollingStock(resource_id);
+                assert_eq!(
+                    openfga
+                        .rolling_stock_direct_grant(authz::Subject::user(alice), rolling_stock)
+                        .await,
+                    Some(RollingStockGrant::Owner)
+                ); // still owner
+                assert_eq!(
+                    openfga
+                        .rolling_stock_direct_grant(
+                            authz::Subject::group(alice_and_bob),
+                            rolling_stock
+                        )
+                        .await,
+                    Some(RollingStockGrant::Writer)
+                ); // direct group grant
+                assert_eq!(
+                    openfga
+                        .rolling_stock_direct_grant(authz::Subject::user(bob), rolling_stock)
+                        .await,
+                    Some(RollingStockGrant::Reader)
+                ); // direct user grant
+                app.assert_rolling_stock_grant(resource_id, *bob, Some(RollingStockGrant::Writer))
+                    .await; // inherited group grant
+                app.assert_rolling_stock_grant(resource_id, *alice, Some(RollingStockGrant::Owner))
+                    .await; // inherited group grant superseded by direct user grant
+            }
+        }
 
         app.post("/authz/grants")
             .by_user(alice_info.as_ref())
@@ -2079,30 +2567,72 @@ mod tests {
                 "revoke": [
                     {
                         "subject_id": *alice_and_bob,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": *infra
+                        "resource_type": resource_type,
+                        "resource_id": resource_id
                     }
                 ]
             }))
             .await
             .assert_status_no_content();
 
-        assert_eq!(openfga.infra_direct_grant(alice_and_bob, infra).await, None); // group grant removed
-        assert_eq!(
-            openfga.infra_direct_grant(bob, infra).await,
-            Some(InfraGrant::Reader)
-        ); // bob's direct grant is still there
+        match resource_type {
+            ResourceType::Infra => {
+                let infra = authz::Infra(resource_id);
+                assert_eq!(openfga.infra_direct_grant(alice_and_bob, infra).await, None); // group grant removed
+                assert_eq!(
+                    openfga.infra_direct_grant(bob, infra).await,
+                    Some(InfraGrant::Reader)
+                ); // bob's direct grant is still there
+            }
+            ResourceType::RollingStock => {
+                let rolling_stock = authz::RollingStock(resource_id);
+                assert_eq!(
+                    openfga
+                        .rolling_stock_direct_grant(
+                            authz::Subject::group(alice_and_bob),
+                            rolling_stock
+                        )
+                        .await,
+                    None
+                ); // group grant removed
+                assert_eq!(
+                    openfga
+                        .rolling_stock_direct_grant(authz::Subject::user(bob), rolling_stock)
+                        .await,
+                    Some(RollingStockGrant::Reader)
+                ); // bob's direct grant is still there
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn non_admin_forbidden_to_give_groups_any_grant() {
-        let app = test_app!().build();
-        let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let owner = app
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
             .user("owner", "Owner")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("owner", "Owner")
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn non_admin_forbidden_to_give_groups_any_grant(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+    ) {
         let bob = app.user("bob", "Bob").create().await;
         let group = app.group("Group").with_members([&bob]).create().await;
 
@@ -2112,31 +2642,85 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": group.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id,
-                        "grant": InfraGrant::Reader
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Reader
                     }
                 ]
             }))
             .await
             .assert_status_forbidden();
 
-        app.assert_infra_grant(infra.id, bob.id, None);
-        app.assert_infra_grant(infra.id, group.id, None);
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, bob.id, None);
+                app.assert_infra_grant(resource_id, group.id, None);
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, bob.id, None)
+                    .await;
+                app.assert_rolling_stock_grant(resource_id, group.id, None)
+                    .await;
+            }
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn adding_a_grant_that_already_exists() {
-        let app = test_app!().build();
-        let db_pool = app.db_pool();
-        let infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let owner = app
-            .user("tom", "Tom")
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+        app
+            .user("owner", "Owner")
             .with_roles([Role::OperationalStudies])
-            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .with_infra_grant(resource_id, InfraGrant::Owner)
             .create()
-            .await;
-
+            .await,
+        app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(resource_id, InfraGrant::Writer)
+            .create()
+            .await,
+        app
+            .user("spike", "Spike")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(resource_id, InfraGrant::Writer)
+            .create()
+            .await,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+        app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+        app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await,
+        app
+            .user("spike", "Spike")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(resource_id, RollingStockGrant::Writer)
+            .create()
+            .await,
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn adding_a_grant_that_already_exists(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+        #[case] owner: authz::identity::User,
+        #[case] writer: authz::identity::User,
+        #[case] other_writer: authz::identity::User,
+    ) {
         // owner self-reassigns their own grant
         app.post("/authz/grants")
             .by_user(owner.as_ref())
@@ -2144,21 +2728,14 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": owner.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id,
-                        "grant": InfraGrant::Owner
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Owner
                     }
                 ]
             }))
             .await
             .assert_status(StatusCode::CREATED);
-
-        let writer = app
-            .user("jerry", "Jerry")
-            .with_roles([Role::OperationalStudies])
-            .with_infra_grant(infra.id, InfraGrant::Writer)
-            .create()
-            .await;
 
         // owner can reassign writer's grant
         app.post("/authz/grants")
@@ -2167,9 +2744,9 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": writer.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id,
-                        "grant": InfraGrant::Writer
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Writer
                     }
                 ]
             }))
@@ -2183,21 +2760,14 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": writer.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id,
-                        "grant": InfraGrant::Writer
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Writer
                     }
                 ]
             }))
             .await
             .assert_status(StatusCode::CREATED);
-
-        let other_writer = app
-            .user("spike", "Spike")
-            .with_roles([Role::OperationalStudies])
-            .with_infra_grant(infra.id, InfraGrant::Writer)
-            .create()
-            .await;
 
         // writer can reassign another writer's grant if it is a no-op
         app.post("/authz/grants")
@@ -2206,9 +2776,9 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": other_writer.id,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": infra.id,
-                        "grant": InfraGrant::Writer
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Writer
                     }
                 ]
             }))
@@ -2216,33 +2786,69 @@ mod tests {
             .assert_status(StatusCode::CREATED);
     }
 
+    #[rstest]
+    #[case::infra(
+        test_app!().build(),
+        create_small_infra(&mut app.db_pool().get_ok()).await.id,
+        ResourceType::Infra,
+    )]
+    #[case::rolling_stock(
+        test_app!().build(),
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
+        ResourceType::RollingStock,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn skipped_authz_can_set_grants() {
-        let app = test_app!().build();
-        let openfga = app.openfga();
-        let db_pool = app.db_pool();
-        let infra = authz::Infra(create_small_infra(&mut db_pool.get_ok()).await.id);
+    async fn skipped_authz_can_set_grants(
+        #[case] app: TestApp,
+        #[case] resource_id: i64,
+        #[case] resource_type: ResourceType,
+    ) {
         let user = authz::User::from(app.user("user", "User").create().await);
-        app.assert_infra_grant(infra.0, user.0, None);
+        match resource_type {
+            ResourceType::Infra => {
+                app.assert_infra_grant(resource_id, user.0, None);
+            }
+            ResourceType::RollingStock => {
+                app.assert_rolling_stock_grant(resource_id, user.0, None)
+                    .await;
+            }
+        }
         app.post("/authz/grants")
             .skip_authz()
             .json(&json!({
                 "grant": [
                     {
                         "subject_id": *user,
-                        "resource_type": ResourceType::Infra,
-                        "resource_id": *infra,
-                        "grant": InfraGrant::Owner
+                        "resource_type": resource_type,
+                        "resource_id": resource_id,
+                        "grant": StandardGrant::Owner
                     }
                 ]
             }))
             .await
             .assert_status(StatusCode::CREATED);
 
-        assert_eq!(
-            openfga.infra_direct_grant(user, infra).await,
-            Some(InfraGrant::Owner)
-        );
+        match resource_type {
+            ResourceType::Infra => {
+                assert_eq!(
+                    app.openfga()
+                        .infra_direct_grant(user, authz::Infra(resource_id))
+                        .await,
+                    Some(InfraGrant::Owner)
+                );
+            }
+            ResourceType::RollingStock => {
+                assert_eq!(
+                    app.openfga()
+                        .rolling_stock_direct_grant(
+                            authz::Subject::User(user),
+                            authz::RollingStock(resource_id)
+                        )
+                        .await,
+                    Some(RollingStockGrant::Owner)
+                );
+            }
+        }
     }
 
     #[rstest]

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -560,7 +560,7 @@ impl<'a> UserBuilder<'a> {
             }
             for (rolling_stock_id, grant) in rolling_stock_grants.into_iter() {
                 app.openfga()
-                    .give_rolling_stock_grant(
+                    .rolling_stock_set_grant(
                         RollingStock(rolling_stock_id),
                         authz::Subject::User(authz::User(user.id)),
                         grant,
@@ -675,7 +675,7 @@ impl<'a> GroupBuilder<'a> {
             }
             for (rolling_stock_id, grant) in rolling_stock_grants.into_iter() {
                 app.openfga()
-                    .give_rolling_stock_grant(RollingStock(rolling_stock_id), subject, grant)
+                    .rolling_stock_set_grant(RollingStock(rolling_stock_id), subject, grant)
                     .await;
             }
         }


### PR DESCRIPTION
Context: https://github.com/osrd-project/osrd-confidential/issues/1064

>[!NOTE]
The change in itself isn't that big: most of the lines diff come from an update of existing tests in `views/authz.rs` so that they can manage both infras and rolling stock resource.

Make it possible to give rolling stock grants in `POST:/authz/grants`.

The same rules apply (admin bypass, demoting owners, etc) when giving rolling stock grants compared to infra grants.