### PR TITLE
Link Rolling Stock selector to train rolling stock

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -517,6 +517,7 @@
         "linear": "Linear margin",
         "mareco": "Mareco margin"
       },
+      "categoryMismatch": "This rolling stock and train category are an unusual match",
       "form": {
         "add": "Add",
         "comfort": "Comfort",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -517,6 +517,7 @@
         "linear": "Marge linéaire",
         "mareco": "Marge Mareco"
       },
+      "categoryMismatch": "L’association du matériel roulant et de la catégorie est atypique",
       "form": {
         "add": "Ajouter",
         "comfort": "Confort",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainSchedule.tsx
@@ -21,7 +21,7 @@ import Itinerary from 'modules/pathfinding/components/Itinerary';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import { RollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
-import isMainCategory from 'modules/rollingStock/helpers/category';
+import isMainCategory, { checkCategoryWarning } from 'modules/rollingStock/helpers/category';
 import { isElectric } from 'modules/rollingStock/helpers/electric';
 import TimesStopsInput from 'modules/timesStops/TimesStopsInput';
 import {
@@ -260,22 +260,7 @@ const ManageTrainSchedule = () => {
     return subCategories.find((option) => option.code === currentCategory.sub_category_code);
   }, [currentCategory, subCategories]);
 
-  const isCategoryWarning = (() => {
-    if (!rollingStock || !currentCategory) return false;
-
-    if (isMainCategory(currentCategory)) {
-      return (
-        currentCategory.main_category !== rollingStock.primary_category &&
-        !rollingStock.other_categories.includes(currentCategory.main_category)
-      );
-    }
-
-    if (currentSubCategory) {
-      return currentSubCategory.main_category !== rollingStock.primary_category;
-    }
-
-    return false;
-  })();
+  const isCategoryWarning = checkCategoryWarning(rollingStock, currentCategory, currentSubCategory);
 
   const categoryWarning = isCategoryWarning ? t('categoryMismatch') : undefined;
   return (

--- a/front/src/modules/rollingStock/helpers/category.ts
+++ b/front/src/modules/rollingStock/helpers/category.ts
@@ -1,5 +1,26 @@
-import type { TrainCategory } from 'common/api/osrdEditoastApi';
+import type { LightRollingStock, SubCategory, TrainCategory } from 'common/api/osrdEditoastApi';
 
 export default function isMainCategory(category: TrainCategory | null) {
   return category === null || 'main_category' in category;
+}
+
+export function checkCategoryWarning(
+  rollingStock: LightRollingStock | undefined,
+  currentCategory: TrainCategory | null,
+  currentSubCategory?: SubCategory
+): boolean {
+  if (!rollingStock || !currentCategory) return false;
+
+  if (isMainCategory(currentCategory)) {
+    return (
+      currentCategory.main_category !== rollingStock.primary_category &&
+      !rollingStock.other_categories.includes(currentCategory.main_category)
+    );
+  }
+
+  if (currentSubCategory) {
+    return currentSubCategory.main_category !== rollingStock.primary_category;
+  }
+
+  return false;
 }

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -1,16 +1,26 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { Button, DurationInput, Input, Select, Switch, TokenInput } from '@osrd-project/ui-core';
+import {
+  Button,
+  ComboBox,
+  DurationInput,
+  Input,
+  Select,
+  Switch,
+  TokenInput,
+  useDefaultComboBox,
+} from '@osrd-project/ui-core';
 import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
-import type { TrainCategory } from 'common/api/osrdEditoastApi';
+import type { LightRollingStockWithLiveries, TrainCategory } from 'common/api/osrdEditoastApi';
 import type { Comfort, ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import useCategoryOptions, {
   categoryOptionId,
 } from 'modules/rollingStock/hooks/useCategoryOptions';
+import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 import type { Train } from 'reducers/osrdconf/types';
 import { useDateTimeLocale } from 'utils/date';
 import { Duration } from 'utils/duration';
@@ -45,6 +55,7 @@ type TrainFieldsState = {
   use_electrical_profiles: boolean | null;
   labels: string[];
   added_exception_date: Date;
+  rolling_stock_name: string;
 };
 
 function getFieldsFromTrain(train: Train): TrainFieldsState {
@@ -59,6 +70,7 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     use_electrical_profiles: train?.options?.use_electrical_profiles ?? null,
     labels: train.labels ?? [],
     added_exception_date: new Date(train.start_time),
+    rolling_stock_name: train.rolling_stock_name,
   };
 }
 
@@ -77,6 +89,7 @@ function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
     train_name: fields.train_name || train.train_name,
     comfort: fields.comfort === null ? undefined : fields.comfort,
     category: fields.category === null ? undefined : fields.category,
+    rolling_stock_name: fields.rolling_stock_name,
     paced,
     options: {
       use_electrical_profiles:
@@ -123,6 +136,19 @@ const ExpandedTrainForm = ({
   const dateTimeLocale = useDateTimeLocale();
   const speedLimitTags = useSpeedLimitTags();
   const categoryOptions = useCategoryOptions();
+
+  const { filteredRollingStockList: rollingStocks } = useFilterRollingStock();
+
+  const getRollingStockLabel = (rs: LightRollingStockWithLiveries) => {
+    const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
+    return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
+  };
+
+  const {
+    suggestions: rollingStockSuggestions,
+    onChange: onRollingStockQueryChange,
+    resetSuggestions: resetRollingStockSuggestions,
+  } = useDefaultComboBox(rollingStocks, getRollingStockLabel);
 
   const pacedTrain = train.paced ? (train as PacedTrainWithPaced) : null;
   const occurenceId = isOccurrenceId(train.id) ? train.id : null;
@@ -224,6 +250,10 @@ const ExpandedTrainForm = ({
   const selectedCategoryOption = useMemo(
     () => categoryOptions.find((category) => category.id === selectedCategoryId),
     [selectedCategoryId]
+  );
+  const selectedRollingStock = useMemo(
+    () => rollingStocks.find((rs) => rs.name === fields.rolling_stock_name) ?? null,
+    [fields.rolling_stock_name, rollingStocks]
   );
   const erroneousFields = useMemo(() => !fields.train_name, [fields.train_name]);
 
@@ -379,12 +409,27 @@ const ExpandedTrainForm = ({
           />
         </div>
         <div className="train-rolling-stock">
-          <Input
+          <ComboBox
             id="train-header-rolling-stock-input"
-            small
             label={t('manageTrainSchedule.trainHeader.form.rollingStock')}
-            value={train.rolling_stock_name ?? ''}
-            disabled
+            small
+            autoComplete="off"
+            value={
+              selectedRollingStock
+                ? getRollingStockLabel(selectedRollingStock)
+                : fields.rolling_stock_name
+            }
+            suggestions={rollingStockSuggestions.map(getRollingStockLabel)}
+            getSuggestionLabel={(s) => s}
+            onSelectSuggestion={(label) => {
+              const rs = rollingStocks.find((r) => getRollingStockLabel(r) === label);
+              if (rs) onFieldImmediateChange('rolling_stock_name', rs.name);
+            }}
+            resetSuggestions={resetRollingStockSuggestions}
+            onChange={(e) => {
+              onRollingStockQueryChange(e);
+              onFieldChange('rolling_stock_name', e.target.value);
+            }}
           />
         </div>
         <div className="train-composition-code">

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -16,7 +16,10 @@ import { useTranslation } from 'react-i18next';
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
 import type { LightRollingStockWithLiveries, TrainCategory } from 'common/api/osrdEditoastApi';
 import type { Comfort, ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
+import Banner from 'common/Banner';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
+import { useSubCategoryContext } from 'common/SubCategoryContext';
+import isMainCategory, { checkCategoryWarning } from 'modules/rollingStock/helpers/category';
 import useCategoryOptions, {
   categoryOptionId,
 } from 'modules/rollingStock/hooks/useCategoryOptions';
@@ -252,10 +255,28 @@ const ExpandedTrainForm = ({
     [selectedCategoryId]
   );
   const selectedRollingStock = useMemo(
-    () => rollingStocks.find((rs) => rs.name === fields.rolling_stock_name) ?? null,
+    () => rollingStocks.find((rs) => rs.name === fields.rolling_stock_name),
     [fields.rolling_stock_name, rollingStocks]
   );
   const erroneousFields = useMemo(() => !fields.train_name, [fields.train_name]);
+
+  const subCategories = useSubCategoryContext();
+
+  const currentSubCategory = useMemo(() => {
+    const category = fields.category;
+    if (!category || isMainCategory(category)) return undefined;
+    return subCategories.find((option) => option.code === category.sub_category_code);
+  }, [fields.category, subCategories]);
+
+  const isCategoryWarning = checkCategoryWarning(
+    selectedRollingStock,
+    fields.category,
+    currentSubCategory
+  );
+
+  const categoryWarning = isCategoryWarning
+    ? t('manageTrainSchedule.trainHeader.categoryMismatch')
+    : undefined;
 
   const toggleBand = (
     <div className="toggle-band">
@@ -501,6 +522,7 @@ const ExpandedTrainForm = ({
           />
         </div>
       </div>
+      {categoryWarning && <Banner message={categoryWarning} />}
     </div>
   );
 };

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -206,6 +206,10 @@
       }
     }
   }
+
+  .banner {
+    margin-bottom: 0;
+  }
 }
 
 @container board-wrapper (width < 800px) {


### PR DESCRIPTION
### Description and goal

Closes https://github.com/OpenRailAssociation/osrd/issues/16538 and https://github.com/OpenRailAssociation/osrd/issues/16539
The goal is to integrate a way to change the train rolling stock directly from the table header.

The PR is splitted in two commits, one linking the selector to the rolling stock, the other integrating the display of the warning.

### Acceptance criteria

- [x] The `Select` is visually in place in the header.
- [x] Editing the input changes the rolling stock of the selected train.
- [x] Display the same `The combination of the rolling stock and the category is unusual` warning as the old train editing panel.