### PR TITLE
front: ensure left column in train modal is scrollable

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -254,7 +254,8 @@
   z-index: 4;
 
   .scenario-timetable-manage-train-schedule {
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     background-color: #d7d7d7aa;
     border-radius: 4px;
     animation: fadein 1s;


### PR DESCRIPTION
Fixes #17254.

This `overflow: hidden;` prevented users with very zoomed interfaces from clicking a quite important button…