### PR TITLE
front: fix useSimulationResults flaky test

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -143,6 +143,7 @@
     "start-container": "vite --host",
     "build": "npm run build --workspaces --if-present && vite build",
     "test": "npm run test --workspaces --if-present && vitest",
+    "test-debug": "npx vitest --silent=false",
     "lint": "npm run lint --workspaces --if-present && oxlint . --max-warnings 0 --ignore-pattern 'ui/**' && oxfmt . --check",
     "lint-fix": "npm run lint:fix --workspaces --if-present && oxlint . --fix --ignore-pattern 'ui/**' && oxfmt . --write",
     "generate-types": "exec scripts/generate-types.sh",

--- a/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
@@ -438,11 +438,13 @@ describe('useSimulationResults', () => {
     mockUseSelectedTrainSchedule.mockReturnValue({ ...baseTrain, id: 2 });
     rerender();
 
-    await waitFor(() => expect(result.current.results?.train.id).toBe('paced_2'));
-    expect(getTrainPath).toHaveBeenLastCalledWith({
-      id: 'paced_2',
-      infraId: INFRA_ID,
-      exceptionId: undefined,
+    await waitFor(() => {
+      expect(result.current.results?.train.id).toBe('paced_2');
+      expect(getTrainPath).toHaveBeenLastCalledWith({
+        id: 'paced_2',
+        infraId: INFRA_ID,
+        exceptionId: undefined,
+      });
     });
   });
 });


### PR DESCRIPTION
sorry for the noise about the linting

the main change is about moving `expect(getTrainPath).toHaveBeenLastCalledWith(...)` in the `await waitFor(() => ...)` block