### PR TITLE
Red cross of TokenInput should be red on mouseDown

### DIFF
--- a/front/ui/ui-core/src/styles/inputs/tokenInput.css
+++ b/front/ui/ui-core/src/styles/inputs/tokenInput.css
@@ -42,6 +42,10 @@
       .token-close-btn {
         margin: 4px 4px 4px 0;
         @apply text-black-25;
+
+        :active {
+          color: var(--color-error-60);
+        }
       }
 
       &:has(.token-close-btn:active) {


### PR DESCRIPTION
This fixes a visual problem, when we hold the mouse on a TokenInput, the red cross should appear red.