### PR TITLE
editoast: authz: add tests to make sure that the protected operations contain the correct checks

### DIFF
--- a/editoast/authz/src/v2/group.rs
+++ b/editoast/authz/src/v2/group.rs
@@ -102,6 +102,9 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
+    use crate::Subject;
     use crate::v2::TestClientExt as _;
     use crate::v2::special_authorizers::Authorize;
 
@@ -269,5 +272,41 @@ mod tests {
             openfga.user_groups(User(1)).await,
             HashSet::from([Group(1), Group(2)])
         );
+    }
+
+    #[rstest]
+    #[case::group_members(
+        group_members(Group(1)).checks,
+        &[Check::SubjectExists(Subject::group(1))]
+    )]
+    #[case::user_groups(
+        user_groups(User(1)).checks,
+        &[Check::SubjectExists(Subject::user(1))]
+    )]
+    #[case::add_members(
+        add_members(Group(1), HashSet::from([User(1), User(2)])).checks,
+        &[
+            Check::SubjectExists(Subject::group(1)),
+            Check::SubjectExists(Subject::user(1)),
+            Check::SubjectExists(Subject::user(2)),
+            Check::HasRole(Actor::Issuer, Role::Admin),
+        ]
+    )]
+    #[case::remove_members(
+        remove_members(Group(1), HashSet::from([User(1), User(2)])).checks,
+        &[
+            Check::SubjectExists(Subject::group(1)),
+            Check::SubjectExists(Subject::user(1)),
+            Check::SubjectExists(Subject::user(2)),
+            Check::HasRole(Actor::Issuer, Role::Admin),
+        ]
+    )]
+    fn protected_contains_expected_checks(
+        #[case] protected_checks: HashSet<Check>,
+        #[case] expected_checks: &[Check],
+    ) {
+        // Make sure that each public protected op contains its expected list of checks
+        let expected_checks = expected_checks.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(expected_checks, protected_checks);
     }
 }

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -364,6 +364,8 @@ pub fn infra_list(user: User, privilege: InfraPrivilege) -> Protected<ResourcesL
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use crate::v2::TestClientExt as _;
     use crate::v2::special_authorizers::Authorize;
 
@@ -654,7 +656,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn infra_granted_subjects() {
+    async fn infra_granted_subjects_direct_and_indirect() {
         let openfga = crate::authz_client!();
         openfga
             .prepare_writes()
@@ -685,7 +687,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn infra_list() {
+    async fn infra_list_direct_inherited_and_admin_bypass() {
         let openfga = crate::authz_client!();
         openfga
             .prepare_writes()
@@ -745,5 +747,58 @@ mod tests {
         // Only user_2 with reader grant should see the infra as being writable
         assert_eq!(infras_1, vec![]);
         assert_eq!(infras_2, vec![Infra(1)]);
+    }
+
+    #[rstest]
+    #[case::infra_direct_grant(
+        infra_direct_grant(Subject::user(1), Infra(1)).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::InfraExists(Infra(1))])
+        ]
+    #[case::infra_effective_grant(
+        infra_effective_grant(Subject::user(1), Infra(1)).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::InfraExists(Infra(1)),
+            Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1)),
+        ]
+    )]
+    #[case::infra_revoke_grant(
+        infra_revoke_grant(Subject::user(1), Infra(1)).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::InfraExists(Infra(1)),
+            Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRevoke, Infra(1)),
+            Check::IsNotLastInfraOwner(Subject::user(1), Infra(1)),
+            Check::SubjectEffectiveInfraGrantIsNot(InfraGrant::Owner, Subject::user(1), Infra(1))
+        ]
+    )]
+    #[case::infra_privileges(
+        infra_privileges(User(1), Infra(1)).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::InfraExists(Infra(1)),
+            Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1)),
+        ]
+    )]
+    #[case::infra_privileges(
+        infra_granted_subjects(Infra(1), InfraGrant::Owner).checks,
+        &[
+            Check::InfraExists(Infra(1)),
+            Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1)),
+        ]
+    )]
+    #[case::infra_list(
+        infra_list(User(1), InfraPrivilege::CanRead).checks,
+        &[Check::SubjectExists(Subject::user(1))]
+    )]
+    fn protected_contains_expected_checks(
+        #[case] protected_checks: HashSet<Check>,
+        #[case] expected_checks: &[Check],
+    ) {
+        // Make sure that each public protected op contains its expected list of checks
+        let expected_checks = expected_checks.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(expected_checks, protected_checks);
     }
 }

--- a/editoast/authz/src/v2/roles.rs
+++ b/editoast/authz/src/v2/roles.rs
@@ -86,6 +86,8 @@ pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use crate::v2::TestClientExt as _;
     use crate::v2::add_members;
     use crate::v2::special_authorizers::Authorize;
@@ -357,5 +359,33 @@ mod tests {
             openfga.subject_roles(&Subject::user(2)).await,
             HashSet::from_iter([Role::Stdcm])
         );
+    }
+
+    #[rstest]
+    #[case::subject_roles(
+        subject_roles(Subject::user(1)).checks,
+        &[Check::SubjectExists(Subject::user(1))]
+    )]
+    #[case::add_roles(
+        add_roles(Subject::user(1), HashSet::from([Role::Admin, Role::Stdcm])).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::HasRole(Actor::Issuer, Role::Admin)
+        ]
+    )]
+    #[case::remove_roles(
+        remove_roles(Subject::user(1), HashSet::from([Role::Admin, Role::Stdcm])).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::HasRole(Actor::Issuer, Role::Admin)
+        ]
+    )]
+    fn protected_contains_expected_checks(
+        #[case] protected_checks: HashSet<Check>,
+        #[case] expected_checks: &[Check],
+    ) {
+        // Make sure that each public protected op contains its expected list of checks
+        let expected_checks = expected_checks.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(expected_checks, protected_checks);
     }
 }

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -231,6 +231,8 @@ pub fn rolling_stock_granted_subjects(
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use crate::User;
     use crate::v2::TestClientExt as _;
     use crate::v2::special_authorizers::Authorize;
@@ -342,7 +344,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rolling_stock_granted_subjects() {
+    async fn rolling_stock_granted_subjects_direct_and_indirect() {
         let openfga = crate::authz_client!();
         openfga
             .prepare_writes()
@@ -372,5 +374,40 @@ mod tests {
         expected.sort();
         response.sort();
         assert_eq!(response, expected);
+    }
+
+    #[rstest]
+    #[case::rolling_stock_privileges(
+        rolling_stock_privileges(User(1), RollingStock(1)).checks,
+        &[
+           Check::SubjectExists(Subject::user(1)),
+           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
+           Check::RollingStockExists(RollingStock(1))
+        ]
+    )]
+    #[rstest]
+    #[case::rolling_stock_effective_grant(
+        rolling_stock_effective_grant(Subject::user(1), RollingStock(1)).checks,
+        &[
+           Check::SubjectExists(Subject::user(1)),
+           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
+           Check::RollingStockExists(RollingStock(1))
+        ]
+    )]
+    #[rstest]
+    #[case::rolling_stock_granted_subjects(
+        rolling_stock_granted_subjects(RollingStock(1), RollingStockGrant::Writer).checks,
+        &[
+           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
+           Check::RollingStockExists(RollingStock(1))
+        ]
+    )]
+    fn protected_contains_expected_checks(
+        #[case] protected_checks: HashSet<Check>,
+        #[case] expected_checks: &[Check],
+    ) {
+        // Make sure that each public protected op contains its expected list of checks
+        let expected_checks = expected_checks.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(expected_checks, protected_checks);
     }
 }


### PR DESCRIPTION
Context: the `Protected` methods in `authz` are responsible of setting up a number of relevant checks according to what they do: if they are related to a user, that the user exists (`Check::IssuerExists`), if the action needs a specific role, that the given user has that role (`Check::HasRole`), etc.

The issue: we never test which checks are present on which protected op. If the implementation of a method returning a `Protected` moves, some checks might disappear or be added. When it happens, it will silently alter the behavior of authorization for those protected ops in the authorizers and in the endpoint handlers using them (which could trigger unexpected and possibly untested panics in the endpoint handlers for example). It could become problematic as we are starting to compose protected ops from other protected ops, which makes it easier to miss that some checks were added or removed.

Example: `POST:/authz/me/grants` handler calls the protected op `v2::rolling_stock::rolling_stock_effective_grant` and either skips authorization failures on the `Check` variants it expects `rolling_stock_effective_grant` to return, or panics on an unknown variant. If we add a new check to `rolling_stock_effective_grant` (knowingly or not: it could come from another protected op that we composed with), it will compile just fine but the endpoint will panic when the check fails instead of handling it correctly. Two things can then happen:
- We are lucky: there is already a test covering the situation leading to that check being triggered _and_ it makes the test fail. => We update the endpoint handler so that it takes into account that new possible variant.
- No luck, the handler tests still pass => Testsuite is green. If the developer / reviewers don't notice that the protected op has a new check (which could have been implicitly added), it gets merged and breaks the endpoint.

The goal of this PR is to test in `authz` that our protected methods have exactly the list of `Checks` that we expect and that a test will fail and need to be updated whenever that checks list moves. It should make it more obvious when it happens that the callers of that protected op also need to be updated in the PR.

> [!NOTE] 
a better solution would be to somehow crash at compile time when a handler matches against situations that cannot happen in the protected ops it uses;  however that sounds like a big refactorization of the way authorization works vs adding a 5 lines test in `authz` for every protected op)