### PR TITLE
front: bump nge (new feature + fixes)

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.ccf5793a0a935514168c0c35e7bbf7ea3f1def23",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3602,9 +3602,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9.tgz",
-      "integrity": "sha512-a/G6ojtXHoQYoWtv9C78EsD8edvZohhNLDQuNNRWX+Ey2HRAhVETx9xmLVIAl7/txBhFbvnrAGlLb2Kjk3yA0w=="
+      "version": "0.0.0-snapshot.ccf5793a0a935514168c0c35e7bbf7ea3f1def23",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.ccf5793a0a935514168c0c35e7bbf7ea3f1def23.tgz",
+      "integrity": "sha512-Tebqr37IRs07lcqSydr80+7Jp9PmQglxRF6QEwTgXH/eYVBNFeQbL/xRmZEHfzzi2yJ5VwZQBho1qyFgd1/gtg=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.8de5c4ccf4d281f5e88fee6269421c20ed230cb9",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.ccf5793a0a935514168c0c35e7bbf7ea3f1def23",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",


### PR DESCRIPTION
Embed upstream commits from "docs: add security policy" to
"feat(view): enable full name display instead of short name in perlenkette".

Small fixes and one feature (commit messages starting by "feat(view): enable full name display instead of short name in...") are added.

Commits can be found here: https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commits/main/