### PR TITLE
front: map: use uic code to highlight OPs

### DIFF
--- a/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
@@ -29,7 +29,11 @@ function getColorByHighlighted(data: {
   if (data.highlightedOperationalPoints && data.highlightedOperationalPoints.length > 0)
     return [
       'case',
-      ['in', ['get', 'extensions_sncf_ci'], ['literal', data.highlightedOperationalPoints]],
+      [
+        'in',
+        ['to-number', ['slice', ['to-string', ['get', 'uic']], 2]],
+        ['literal', data.highlightedOperationalPoints],
+      ],
       data.inColor,
       data.outColor,
     ];
@@ -47,7 +51,11 @@ function getFilterHighlighted(
 ): FilterSpecification {
   let result: FilterSpecification = true;
   if (data.highlightedOperationalPoints && data.highlightedOperationalPoints.length > 0)
-    result = ['in', ['get', 'extensions_sncf_ci'], ['literal', data.highlightedOperationalPoints]];
+    result = [
+      'in',
+      ['to-number', ['slice', ['to-string', ['get', 'uic']], 2]],
+      ['literal', data.highlightedOperationalPoints],
+    ];
   else if (data.highlightedArea) result = ['within', data.highlightedArea];
 
   if (reverseCondition === true) {
@@ -221,7 +229,10 @@ const OperationalPointsLayer = ({
       'text-offset': [0.75, -1],
       'text-max-width': 32,
     },
-    filter: getFilterHighlighted({ highlightedArea, highlightedOperationalPoints }),
+    filter: getFilterHighlighted({
+      highlightedArea,
+      highlightedOperationalPoints,
+    }),
     paint: {
       'text-color': colors.op.textName,
       'text-halo-width': DEFAULT_HALO_WIDTH,

--- a/front/src/common/Map/Search/useSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/useSearchOperationalPoint.tsx
@@ -44,7 +44,11 @@ export default function useSearchOperationalPoint({
 
   const stdcmPerimeterOperationalpointsFilter = useMemo(() => {
     if (isStdcm && !isSuperUser && stdcmOperationalPoints) {
-      return ['or', ...stdcmOperationalPoints.map((ci) => ['=', ['ci'], ci])];
+      // CI is the last 6 digits of the UIC code (uic=87723254 => ci=723254).
+      return [
+        'or',
+        ...stdcmOperationalPoints.map((ci) => ['like', ['to_string', ['uic']], `%${ci}`]),
+      ];
     }
     return true;
   }, [stdcmOperationalPoints, isSuperUser, isStdcm]);


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/17257

The map still depend on the ci code in the sncf extension which does not exist anymore. It now uses the uic code and extracts the ci code from it