### PR TITLE
editoast, cli: show expected roles on failed parse

### DIFF
--- a/editoast/src/client/roles.rs
+++ b/editoast/src/client/roles.rs
@@ -174,7 +174,8 @@ fn parse_role_case_insensitive(tag: &str) -> anyhow::Result<Role> {
             return Ok(role);
         }
     }
-    bail!("Invalid role tag '{tag}'");
+    let expected: Vec<String> = Role::iter().map(|role| role.to_string()).collect();
+    bail!("Invalid role tag '{tag}', expected one of {expected:?}");
 }
 
 pub async fn add_roles(


### PR DESCRIPTION
in the cli when typing a role that doesn't exist, show the expected values to avoid having to look them up in the sources.

e.g.

    editoast roles add mock/mocked operationalstudy
      2026-06-17T13:16:41.532367Z  INFO editoast::client::openfga_config: connecting to OpenFGA, url: http://localhost:8091/
        at src/client/openfga_config.rs

      2026-06-17T13:16:41.635384Z ERROR editoast: ❌ Invalid role tag 'operationalstudy', expected one of ["Admin", "Stdcm", "OperationalStudies"]
        at src/main.rs