### PR TITLE
Display train header warning message when train name is left empty

### DIFF
--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -74,6 +74,7 @@ function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
   return {
     ...train,
     ...fields,
+    train_name: fields.train_name || train.train_name,
     comfort: fields.comfort === null ? undefined : fields.comfort,
     category: fields.category === null ? undefined : fields.category,
     paced,
@@ -224,10 +225,11 @@ const ExpandedTrainForm = ({
     () => categoryOptions.find((category) => category.id === selectedCategoryId),
     [selectedCategoryId]
   );
+  const erroneousFields = useMemo(() => !fields.train_name, [fields.train_name]);
 
   const toggleBand = (
     <div className="toggle-band">
-      <button className="header-toggle" onClick={() => onCollapse()}>
+      <button className="header-toggle" onClick={() => onCollapse()} disabled={erroneousFields}>
         <ChevronUp />
       </button>
     </div>
@@ -334,6 +336,14 @@ const ExpandedTrainForm = ({
             value={fields.train_name}
             onChange={(event) => onFieldChange('train_name', event.target.value)}
             onBlur={() => onFieldBlur('train_name')}
+            statusWithMessage={
+              !fields.train_name
+                ? {
+                    status: 'error',
+                    message: t('manageTrainSchedule.errorMessages.requiredField'),
+                  }
+                : undefined
+            }
           />
         </div>
         <div className="train-departure-date">

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -18,6 +18,16 @@
     padding-top: 3px;
     margin-right: 8px;
     margin-bottom: -28px;
+
+    .header-toggle:disabled {
+      opacity: 0.5;
+      pointer-events: none;
+
+      &:hover,
+      &:focus {
+        box-shadow: none;
+      }
+    }
   }
 
   .train-form {


### PR DESCRIPTION
### Description

Closes #16527 

### Acceptance Criterias

- [x] If the name field is emptied: because it's not allowed by our backend to have an anonymous train, we show an error popup around the field (like we do in the itinerary modal) with a "Name requested" text in English, "Nom obligatoire" in French
- [x] If any field in the header is erroneous (only this name field for now), we should not allow users to collapse the header or open the itinerary modal, and highlight the error on click on those buttons