### PR TITLE
front: fix similar train secondary code resolution

### DIFF
--- a/front/src/applications/stdcm/utils/__tests__/addSecondaryCodesToSimilarTrains.spec.ts
+++ b/front/src/applications/stdcm/utils/__tests__/addSecondaryCodesToSimilarTrains.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PostSimilarTrainsApiResponse } from 'common/api/osrdEditoastApi';
+import type { PathOperationalPoint } from 'modules/simulationResult/types';
+
+import { addSecondaryCodesToSimilarTrains } from '../addSecondaryCodesToSimilarTrains';
+
+const makePathOP = (
+  opId: string,
+  name: string,
+  secondaryCode: string | null
+): PathOperationalPoint =>
+  ({
+    opId,
+    waypointId: `${opId}-${secondaryCode ?? 'no-code'}`,
+    name,
+    secondary_code: secondaryCode,
+  }) as PathOperationalPoint;
+
+const makeSimilarTrainSegment = (
+  begin: string,
+  end: string
+): PostSimilarTrainsApiResponse['similar_trains'][number] => ({
+  begin,
+  end,
+  train: {
+    train_name: 'train 1',
+    start_time: '2026-06-17T10:00:00Z',
+  },
+});
+
+describe('addSecondaryCodesToSimilarTrains', () => {
+  it('uses the first matching path occurrence for a repeated begin operational point', () => {
+    const result = addSecondaryCodesToSimilarTrains(
+      [makeSimilarTrainSegment('same-op', 'next-op')],
+      [
+        makePathOP('same-op', 'Same OP', 'FI'),
+        makePathOP('next-op', 'Next OP', 'NO'),
+        makePathOP('same-op', 'Same OP', 'WRONG'),
+      ]
+    );
+
+    expect(result[0].begin).toEqual({
+      name: 'Same OP',
+      secondary_code: 'FI',
+    });
+  });
+
+  it('resolves a merged segment end after the resolved begin occurrence', () => {
+    const result = addSecondaryCodesToSimilarTrains(
+      [makeSimilarTrainSegment('same-op', 'same-op')],
+      [
+        makePathOP('same-op', 'Same OP', 'FI'),
+        makePathOP('middle-op', 'Middle OP', 'MI'),
+        makePathOP('same-op', 'Same OP', 'LA'),
+      ]
+    );
+
+    expect(result[0].begin).toEqual({
+      name: 'Same OP',
+      secondary_code: 'FI',
+    });
+    expect(result[0].end).toEqual({
+      name: 'Same OP',
+      secondary_code: 'LA',
+    });
+  });
+
+  it('falls back to the segment id and dash code when the path operational point is missing', () => {
+    const result = addSecondaryCodesToSimilarTrains(
+      [makeSimilarTrainSegment('missing-begin', 'missing-end')],
+      [makePathOP('known-op', 'Known OP', 'KO')]
+    );
+
+    expect(result[0].begin).toEqual({
+      name: 'missing-begin',
+      secondary_code: '—',
+    });
+    expect(result[0].end).toEqual({
+      name: 'missing-end',
+      secondary_code: '—',
+    });
+  });
+});

--- a/front/src/applications/stdcm/utils/addSecondaryCodesToSimilarTrains.ts
+++ b/front/src/applications/stdcm/utils/addSecondaryCodesToSimilarTrains.ts
@@ -3,29 +3,55 @@ import type { PathOperationalPoint } from 'modules/simulationResult/types';
 
 import type { SimilarTrainWithSecondaryCode } from '../types';
 
+type OperationalPointMatch = {
+  op: PathOperationalPoint;
+  index: number;
+};
+
 export const addSecondaryCodesToSimilarTrains = (
   similarTrains: PostSimilarTrainsApiResponse['similar_trains'],
   pathOP?: PathOperationalPoint[]
 ): SimilarTrainWithSecondaryCode[] => {
+  const orderedPathOP = pathOP ?? [];
   const opById = new Map<string, PathOperationalPoint>();
-  pathOP?.forEach((op) => {
+  orderedPathOP.forEach((op) => {
     if (op.opId) {
       opById.set(op.opId, op);
     }
   });
 
-  const getOpInfo = (id: string) => {
-    const op = opById.get(id);
+  const findOpFromIndex = (id: string, startIndex: number): OperationalPointMatch | undefined => {
+    for (let index = startIndex; index < orderedPathOP.length; index += 1) {
+      const op = orderedPathOP[index];
+      if (op.opId === id) {
+        return { op, index };
+      }
+    }
+
+    return undefined;
+  };
+
+  const getOpInfo = (id: string, match?: OperationalPointMatch) => {
+    const op = match?.op ?? opById.get(id);
     return {
       name: op?.name ?? id,
       secondary_code: op?.secondary_code ?? '—',
     };
   };
 
-  return similarTrains.map((similarTrain) => ({
-    train_name: similarTrain.train?.train_name ?? null,
-    start_time: similarTrain.train ? new Date(similarTrain.train.start_time) : undefined,
-    begin: getOpInfo(similarTrain.begin),
-    end: getOpInfo(similarTrain.end),
-  }));
+  let cursor = 0;
+
+  return similarTrains.map((similarTrain) => {
+    const beginMatch = findOpFromIndex(similarTrain.begin, cursor);
+    const endMatch = findOpFromIndex(similarTrain.end, beginMatch ? beginMatch.index + 1 : cursor);
+
+    cursor = endMatch?.index ?? beginMatch?.index ?? cursor;
+
+    return {
+      train_name: similarTrain.train?.train_name ?? null,
+      start_time: similarTrain.train ? new Date(similarTrain.train.start_time) : undefined,
+      begin: getOpInfo(similarTrain.begin, beginMatch),
+      end: getOpInfo(similarTrain.end, endMatch),
+    };
+  });
 };


### PR DESCRIPTION
Fixes #17263

## Summary

When enriching STDCM similar-train segments for the simulation sheet, repeated operational point ids could resolve to the wrong path occurrence and display the wrong secondary code.

This changes the resolver to walk path operational points in order, preserving the correct occurrence for segment begin/end values.

## Tests

  - npm exec vitest -- run src/applications/stdcm/utils/__tests__/addSecondaryCodesToSimilarTrains.spec.ts src/applications/stdcm/utils/__tests__/mergeSimilarTrainSegments.spec.ts
  - npm run build-ui
  - npm run lint