### PR TITLE
front: add confirmation dialog on service change

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -542,6 +542,13 @@
         "trainName": "Train name"
       },
       "itinerary": "Itinerary",
+      "serviceChangeWarning": {
+        "cancel": "Cancel",
+        "confirm": "Confirm",
+        "explanations_one": "Editing the cadence or the duration of the service will reset an exception. Do you wish to continue?",
+        "explanations_other": "Editing the cadence or the duration of the service will reset {{count}} exceptions. Do you wish to continue?",
+        "header": "Service model changed"
+      },
       "serviceModelTrain": "Service model train",
       "serviceOccurrence": "Service occurrence"
     },

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -542,6 +542,13 @@
         "trainName": "Nom du train"
       },
       "itinerary": "Itinéraire",
+      "serviceChangeWarning": {
+        "cancel": "Annuler",
+        "confirm": "Confirmer",
+        "explanations_one": "Modifier la cadence ou la plage de répétition supprimera une exception. Voulez-vous continuer ?",
+        "explanations_other": "Modifier la cadence ou la plage de répétition supprimera {{count}} exceptions. Voulez-vous continuer ?",
+        "header": "Modèle de service modifié"
+      },
       "serviceModelTrain": "Train modèle de mission",
       "serviceOccurrence": "Occurrence de mission"
     },

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -35,6 +35,7 @@ import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiC
 
 import ExtraOccurrenceForm from './ExtraOccurrenceForm';
 import ExtraOccurrenceRow from './ExtraOccurrenceRow';
+import { ServiceChangeWarningDialog } from './ServiceChangeWarningDialog';
 import type { ExtraOccurrencesChanges } from './TrainHeader';
 
 // TODO: Passing `undefined` to DatePicker's selectableSlot prop should mean this
@@ -64,6 +65,7 @@ type TrainFieldsState = {
   rolling_stock_name: string;
   departure_date: Date;
   initial_speed: string | null;
+  service_changed_confirmed: boolean;
 };
 
 type initialSpeedProblem = 'INVALID_NUMBER' | 'ROUNDING' | 'TOO_HIGH' | null;
@@ -96,6 +98,7 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     departure_date: new Date(train.start_time),
     initial_speed:
       train.initial_speed === undefined ? null : String(Math.round(train.initial_speed * 36) / 10),
+    service_changed_confirmed: !train.paced || train.paced.exceptions.length === 0,
   };
 }
 
@@ -107,8 +110,12 @@ function applyFieldsToTrain(
   const paced = train.paced
     ? {
         exceptions: train.paced.exceptions,
-        interval: new Duration({ milliseconds: fields.service_cadence }).toISOString(),
-        time_window: new Duration({ milliseconds: fields.service_window }).toISOString(),
+        interval: fields.service_changed_confirmed
+          ? new Duration({ milliseconds: fields.service_cadence }).toISOString()
+          : train.paced.interval,
+        time_window: fields.service_changed_confirmed
+          ? new Duration({ milliseconds: fields.service_window }).toISOString()
+          : train.paced.time_window,
       }
     : undefined;
 
@@ -245,14 +252,14 @@ const ExpandedTrainForm = ({
 
   const constraintDistributionsOptions: { id: ConstraintDistribution; label: string }[] = useMemo(
     () => [
-    {
-      id: 'STANDARD',
-      label: t('manageTrainSchedule.allowances.distribution-linear'),
-    },
-    {
-      id: 'MARECO',
-      label: t('manageTrainSchedule.allowances.distribution-mareco'),
-    },
+      {
+        id: 'STANDARD',
+        label: t('manageTrainSchedule.allowances.distribution-linear'),
+      },
+      {
+        id: 'MARECO',
+        label: t('manageTrainSchedule.allowances.distribution-mareco'),
+      },
     ],
     [t]
   );
@@ -266,18 +273,18 @@ const ExpandedTrainForm = ({
 
   const comfortOptions: { id: Comfort; label: string }[] = useMemo(
     () => [
-    {
-      id: 'STANDARD',
-      label: t('translation:rollingStock.comfortTypes.STANDARD'),
-    },
-    {
-      id: 'AIR_CONDITIONING',
-      label: t('translation:rollingStock.comfortTypes.AIR_CONDITIONING'),
-    },
-    {
-      id: 'HEATING',
-      label: t('translation:rollingStock.comfortTypes.HEATING'),
-    },
+      {
+        id: 'STANDARD',
+        label: t('translation:rollingStock.comfortTypes.STANDARD'),
+      },
+      {
+        id: 'AIR_CONDITIONING',
+        label: t('translation:rollingStock.comfortTypes.AIR_CONDITIONING'),
+      },
+      {
+        id: 'HEATING',
+        label: t('translation:rollingStock.comfortTypes.HEATING'),
+      },
     ],
     [t]
   );
@@ -326,6 +333,26 @@ const ExpandedTrainForm = ({
       </button>
     </div>
   );
+
+  const isServiceChangeWarningDialogVisible = useMemo(
+    () =>
+      !fields.service_changed_confirmed &&
+      (fields.service_cadence?.valueOf() !== fieldsFromTrain.service_cadence?.valueOf() ||
+        fields.service_window?.valueOf() !== fieldsFromTrain.service_window?.valueOf()),
+    [train.paced, fields, fieldsFromTrain]
+  );
+
+  const revertServiceChange = useCallback(() => {
+    setFields({
+      ...fields,
+      service_cadence: fieldsFromTrain.service_cadence,
+      service_window: fieldsFromTrain.service_window,
+    });
+  }, [fields, fieldsFromTrain]);
+
+  const confirmServiceChange = useCallback(() => {
+    onFieldImmediateChange('service_changed_confirmed', true);
+  }, [onFieldImmediateChange]);
 
   return (
     <div className="train-header expanded-train-form">
@@ -601,6 +628,13 @@ const ExpandedTrainForm = ({
         </div>
       </div>
       {categoryWarning && <Banner message={categoryWarning} />}
+      {isServiceChangeWarningDialogVisible && (
+        <ServiceChangeWarningDialog
+          exceptionsCount={train.paced!.exceptions.length}
+          onCancel={revertServiceChange}
+          onConfirm={confirmServiceChange}
+        />
+      )}
     </div>
   );
 };

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -229,7 +229,7 @@ const ExpandedTrainForm = ({
         onPersistTrain(updatedTrain);
       }
     },
-    [fields, fieldsFromTrain]
+    [train, fields, fieldsFromTrain, onPersistTrain]
   );
 
   const onFieldImmediateChange = useCallback(
@@ -240,10 +240,11 @@ const ExpandedTrainForm = ({
 
       setFields(newFields);
     },
-    [fields]
+    [fields, train, onPersistTrain]
   );
 
-  const constraintDistributionsOptions: { id: ConstraintDistribution; label: string }[] = [
+  const constraintDistributionsOptions: { id: ConstraintDistribution; label: string }[] = useMemo(
+    () => [
     {
       id: 'STANDARD',
       label: t('manageTrainSchedule.allowances.distribution-linear'),
@@ -252,16 +253,19 @@ const ExpandedTrainForm = ({
       id: 'MARECO',
       label: t('manageTrainSchedule.allowances.distribution-mareco'),
     },
-  ];
+    ],
+    [t]
+  );
   const selectedConstraintDistributionOption = useMemo(
     () =>
       constraintDistributionsOptions.find(
         (constraint) => constraint.id === fields.constraint_distribution
       ),
-    [fields.constraint_distribution]
+    [fields.constraint_distribution, constraintDistributionsOptions]
   );
 
-  const comfortOptions: { id: Comfort; label: string }[] = [
+  const comfortOptions: { id: Comfort; label: string }[] = useMemo(
+    () => [
     {
       id: 'STANDARD',
       label: t('translation:rollingStock.comfortTypes.STANDARD'),
@@ -274,10 +278,12 @@ const ExpandedTrainForm = ({
       id: 'HEATING',
       label: t('translation:rollingStock.comfortTypes.HEATING'),
     },
-  ];
+    ],
+    [t]
+  );
   const selectedComfortOption = useMemo(
     () => comfortOptions.find((comfort) => comfort.id === fields.comfort),
-    [fields.comfort]
+    [comfortOptions, fields.comfort]
   );
   const selectedCategoryId = useMemo(
     () => (fields.category ? categoryOptionId(fields.category) : null),
@@ -285,7 +291,7 @@ const ExpandedTrainForm = ({
   );
   const selectedCategoryOption = useMemo(
     () => categoryOptions.find((category) => category.id === selectedCategoryId),
-    [selectedCategoryId]
+    [categoryOptions, selectedCategoryId]
   );
 
   const subCategories = useSubCategoryContext();

--- a/front/src/modules/trainHeader/ServiceChangeWarningDialog.tsx
+++ b/front/src/modules/trainHeader/ServiceChangeWarningDialog.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+
+import { Button, Dialog } from '@osrd-project/ui-core';
+import { useTranslation } from 'react-i18next';
+
+type ServiceChangeWarningDialogProps = {
+  exceptionsCount: number;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export const ServiceChangeWarningDialog = ({
+  exceptionsCount,
+  onCancel,
+  onConfirm,
+}: ServiceChangeWarningDialogProps) => {
+  const { t } = useTranslation(['operational-studies'], {
+    keyPrefix: 'manageTrainSchedule.trainHeader.serviceChangeWarning',
+  });
+  const header = useCallback(() => <h5>{t('header')}</h5>, [t]);
+  const footer = useCallback(
+    () => (
+      <div className="buttons">
+        <Button variant="Cancel" label={t('cancel')} onClick={onCancel} />
+        <Button variant="Destructive" label={t('confirm')} onClick={onConfirm} />
+      </div>
+    ),
+    [onCancel, onConfirm, t]
+  );
+
+  return (
+    <Dialog header={header()} footer={footer()}>
+      <p className="service-change-warning-explanations">
+        {t('explanations', { count: exceptionsCount })}
+      </p>
+    </Dialog>
+  );
+};

--- a/front/src/modules/trainHeader/TrainHeader.tsx
+++ b/front/src/modules/trainHeader/TrainHeader.tsx
@@ -100,7 +100,15 @@ const TrainHeader = ({
       occurrenceId,
     });
     setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.itinerary);
-  }, [train, originalPacedTrain, trainScheduleId, occurrenceId]);
+  }, [
+    train,
+    originalPacedTrain,
+    trainScheduleId,
+    occurrenceId,
+    dispatch,
+    setDisplayTrainScheduleManagement,
+    setTrainScheduleToEditData,
+  ]);
 
   if (expanded) {
     return (

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -231,3 +231,9 @@
     }
   }
 }
+
+.service-change-warning-explanations {
+  font-size: 1.1rem;
+  max-width: 500px;
+  margin-bottom: 0;
+}

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -91,7 +91,10 @@ function useDurationInput({
   onChange,
   padChar,
   max = 99 * 3_600_000, // 99 HOURS
-}: Omit<DurationInputProps, 'id'>) {
+  containerRef,
+}: Omit<DurationInputProps, 'id'> & {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}) {
   const fields = useMemo(() => normalizeUnits(units, padChar, max), [units, padChar, max]);
   const inputRefs = useRef<Record<string, HTMLInputElement>>({});
 
@@ -162,18 +165,28 @@ function useDurationInput({
 
   const handleFocus = useCallback((setting: UnitSetting) => focusField(setting.key), [focusField]);
 
-  const handleBlur = useCallback(() => {
-    const ms = toTotalMilliseconds(fields, formattedValues);
-    const clamped = Math.min(max, ms);
-    const next = toFormattedValues(fields, clamped);
-    setFormattedValues(next);
-    onChange?.(toTotalMilliseconds(fields, next));
-  }, [fields, formattedValues, max, onChange]);
+  const handleBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      const nextTarget = e.relatedTarget as Node | null;
+      if (nextTarget && containerRef.current?.contains(nextTarget)) {
+        return;
+      }
+
+      const ms = toTotalMilliseconds(fields, formattedValues);
+      const clamped = Math.min(max, ms);
+      const next = toFormattedValues(fields, clamped);
+
+      setFormattedValues(next);
+      onChange?.(toTotalMilliseconds(fields, next));
+    },
+    [fields, containerRef.current, formattedValues, max, onChange]
+  );
 
   return {
     fields,
     formattedValues,
     inputRefs,
+    containerRef,
     handleChange,
     handleFocus,
     handleBlur,
@@ -187,7 +200,7 @@ type UnitFieldProps = {
   inputRef: (el: HTMLInputElement | null) => void;
   onChange: (value: string) => void;
   onFocus: () => void;
-  onBlur: () => void;
+  onBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   tabIndex: number;
 };
@@ -247,6 +260,7 @@ const DurationInput = ({
   hint,
   ...rest
 }: DurationInputProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const {
     fields,
     formattedValues,
@@ -259,6 +273,7 @@ const DurationInput = ({
     units,
     value,
     onChange,
+    containerRef,
     padChar,
     max,
   });
@@ -266,10 +281,13 @@ const DurationInput = ({
   return (
     <FieldWrapper id={id} label={label} hint={hint} small={small}>
       <div
+        ref={containerRef}
         className={cx('ui-duration-input', { small })}
         role="group"
         aria-label="Duration Input"
-        onClick={() => inputRefs.current[fields[0].key]?.focus()}
+        onMouseDown={(e) => {
+          if (e.currentTarget === e.target) inputRefs.current[fields[0].key]?.focus();
+        }}
         {...rest}
       >
         {fields.map((setting, idx) => (
@@ -283,7 +301,7 @@ const DurationInput = ({
             tabIndex={idx === 0 ? 0 : -1}
             onChange={(val) => handleChange(setting, val)}
             onFocus={() => handleFocus(setting)}
-            onBlur={() => handleBlur()}
+            onBlur={(e) => handleBlur(e)}
             onKeyDown={(e) => handleKeyDown(setting, e)}
           />
         ))}


### PR DESCRIPTION
Fixes #16535.

This uses a way of doing this that I find elegant: we declare a new boolean field named `service_changed_confirmed` that is "checked" (i.e. set to `true`) automatically if there is no need for a confirmation. On the other hand, if there _is_ a need for confirmation (because there are exceptions) it is set automatically to `false`; as soon as we change the service window or the service cadence, we show a dialog that ask for confirmation. Confirming the dialog set this field to `true`, which "show" the change to the persist routine, hence that apply the change.

Please note that this pull request also contain a commit that adds _a lot_ of missing dependencies (and memoizationà that caused me trouble during my debug sessions… it may also explain some erratic behavior we spot before 😅 

### Acceptance criteria

- [ ] The popup is displayed after any edit made to the cadence of the train.
