### PR TITLE
Set a higher maximum value for the service window in the train header

### DIFF
--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -269,7 +269,6 @@ const ExpandedTrainForm = ({
                     small
                     units={['h', 'm']}
                     padChar="0"
-                    max={5 * 3_600_000} // 5h00m
                     label={t('manageTrainSchedule.trainHeader.form.serviceWindow')}
                     value={fields.service_window ?? 2 * 3_600_000} // 2h00m
                     onChange={(ms) => onFieldImmediateChange('service_window', ms)}

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -24,7 +24,7 @@ export type DurationInputProps = {
   value: number;
   padChar: string;
   onChange?: (ms: number) => void;
-  max: number;
+  max?: number;
   small?: boolean;
   hint?: string;
   label?: string;
@@ -90,7 +90,7 @@ function useDurationInput({
   value,
   onChange,
   padChar,
-  max,
+  max = 99 * 3_600_000, // 99 HOURS
 }: Omit<DurationInputProps, 'id'>) {
   const fields = useMemo(() => normalizeUnits(units, padChar, max), [units, padChar, max]);
   const inputRefs = useRef<Record<string, HTMLInputElement>>({});
@@ -242,7 +242,7 @@ const DurationInput = ({
   onChange,
   padChar = '0',
   small = false,
-  max = 99 * 3_600_000, // 99 HOURS
+  max,
   label,
   hint,
   ...rest


### PR DESCRIPTION
In the train header, the service window input had an arbitral maximum value set to 5 hours, this PR sets it to 99 hours