### PR TITLE
process-compose: make the otel agent used in `gradle run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ environment. If you are a user of `nix` package manager, you can `nix shell` to
 enter a shell where all the necessary components to develop are available.
 First, you need to set up 2 things:
 - `export OSRD_PATH="$(pwd)"`
-- download [`opentelemetry-javaagent.jar`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar) in `core/`
 
 Then, you can start the stack with the two following commands.
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -128,6 +128,10 @@ base.archivesName = "osrd"
 
 run {
     enableAssertions = true
+    doFirst {
+        def agentJar = configurations.otelAgent.files.find { it.name.contains("opentelemetry-javaagent") }
+        jvmArgs=["-javaagent:${agentJar.absolutePath}"]
+    }
 }
 
 // endregion

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -15,7 +15,6 @@ processes:
     environment:
       - "ALL_INFRA=true"
       - "CORE_EDITOAST_URL=http://localhost:8090"
-      - "JAVA_TOOL_OPTIONS=-ea -javaagent:${OSRD_PATH}/core/opentelemetry-javaagent.jar"
       - "CORE_MONITOR_TYPE=opentelemetry"
       - "OTEL_SERVICE_NAME=osrd-core"
       - "VALKEY_URL=redis://localhost"


### PR DESCRIPTION
Since the OpenTelemetry agent is now a dependency of the project, there is no need to explicitly ask people to download it. It can even be automatically used in `gradle run`.

> [!TIP]
> For `core` maintainers, this should be a no-brainer to review since it only customize the `run` task which is only used in `process-compose` to my knowledge (but maybe IntelliJ make use of it too?).