### PR TITLE
core: add stdcm backtracking for pathfinding

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/CachedBlockMaxSpeedEnvBuilder.kt
@@ -124,16 +124,22 @@ data class CachedBlockMaxSpeedEnvBuilder(
     fun getBlockTime(
         block: BlockId,
         step: Int,
-        endOffset: Offset<Block>?,
         endSpeed: Double?,
         allowanceValue: AllowanceValue? = null,
+        endOffset: Offset<Block> = blockInfra.getBlockLength(block),
+        startOffset: Offset<Block> = Offset.zero(),
     ): Double {
-        if (endOffset?.distance == 0.meters) return 0.0
-        val actualLength = endOffset ?: blockInfra.getBlockLength(block)
-        val time =
-            getMaxSpeedEnvelope(block, step, endSpeed)
-                .interpolateArrivalAtClamp(actualLength.meters)
-        val allowanceTime = allowanceValue?.getAllowanceTime(time, actualLength.meters)
+        if (endOffset.distance == 0.meters) return 0.0
+        if (startOffset >= endOffset) return 0.0
+        val maxSpeedEnv = getMaxSpeedEnvelope(block, step, endSpeed)
+        val startTime =
+            if (startOffset.distance == 0.meters) 0.0
+            else maxSpeedEnv.interpolateArrivalAtClamp(startOffset.meters)
+        val endTime =
+            getMaxSpeedEnvelope(block, step, endSpeed).interpolateArrivalAtClamp(endOffset.meters)
+        val time = endTime - startTime
+        val length = endOffset - startOffset
+        val allowanceTime = allowanceValue?.getAllowanceTime(time, length.meters)
         return time + (allowanceTime ?: 0.0)
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -5,13 +5,14 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.utils.getBlockEntry
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
-import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.stdcm.infra_exploration.getOppositeBlockLocations
 import fr.sncf.osrd.utils.units.Offset
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -33,7 +34,8 @@ data class STDCMAStarHeuristic(
     /**
      * Defines a function that can be used as a heuristic for an A* pathfinding. It takes an edge,
      * and offset on this edge, and a step tracker as input, and returns an estimation of the
-     * remaining time needed to get to the end.
+     * remaining time needed to get to the end. // TODO: we might need to call getBlockTime with the
+     * actual offset of the backtracking locations if any.
      */
     fun invoke(edge: STDCMEdge, offset: Offset<Block>?, stepTracker: StepTracker): Double {
         val lookahead = edge.infraExplorer.getLookahead()
@@ -63,18 +65,18 @@ data class STDCMAStarHeuristic(
             maxSpeedEnvBuilder.getMaxSpeedEnvelope(lastBlock, expectedIndex, null).beginSpeed
         for (block in allBlocks.asReversed()) {
             timeUntilStartOfLastBlock +=
-                maxSpeedEnvBuilder.getBlockTime(
-                    block,
-                    expectedIndex,
-                    null,
-                    endSpeed,
-                    allowanceValue,
-                )
+                maxSpeedEnvBuilder.getBlockTime(block, expectedIndex, endSpeed, allowanceValue)
             endSpeed =
                 maxSpeedEnvBuilder.getMaxSpeedEnvelope(block, expectedIndex, endSpeed).beginSpeed
         }
         val timeSinceFirstBlock =
-            maxSpeedEnvBuilder.getBlockTime(edge.block, expectedIndex, offset, null, allowanceValue)
+            maxSpeedEnvBuilder.getBlockTime(
+                edge.block,
+                expectedIndex,
+                null,
+                allowanceValue,
+                offset ?: blockInfra.getBlockLength(edge.block),
+            )
         timeUntilStartOfLastBlock -= timeSinceFirstBlock
 
         val remainingTime = timeUntilStartOfLastBlock + timeAfterStartOfLastBlock
@@ -159,7 +161,7 @@ class STDCMHeuristicBuilder(
                 val remainingTimeSinceBlockStart =
                     remainingTimeEstimations.first()[it.edge] ?: Double.POSITIVE_INFINITY
                 val timeSinceBlockStart =
-                    maxSpeedEnvBuilder.getBlockTime(it.edge, 0, it.offset, null, allowance)
+                    maxSpeedEnvBuilder.getBlockTime(it.edge, 0, null, allowance, it.offset)
                 remainingTimeSinceBlockStart - timeSinceBlockStart
             } ?: Double.POSITIVE_INFINITY
         logger.info(
@@ -210,15 +212,68 @@ class STDCMHeuristicBuilder(
         val blocks = blockInfra.getBlocksEndingAtDetector(detector)
         val res = mutableListOf<PendingBlock>()
         for (block in blocks) {
-            val newBlock =
-                makePendingBlock(
-                    block,
-                    null,
+            val newStep =
+                getNewBlockStep(
+                    BlockLocation(block, blockInfra.getBlockLength(block)),
                     pendingBlock.stepIndex,
-                    pendingBlock.remainingTimeAtBlockStart,
-                    predecessorEndSpeed,
                 )
-            newBlock?.let { res.add(it) }
+            if (newStep == null || !steps[newStep.stepIndex].canBacktrack) {
+                // The step is unchanged or does not backtrack: the path goes through the whole
+                // block.
+                val newBlock =
+                    makePendingBlock(
+                        block,
+                        Offset.zero(),
+                        blockInfra.getBlockLength(block),
+                        newStep?.stepIndex ?: pendingBlock.stepIndex,
+                        pendingBlock.remainingTimeAtBlockStart,
+                        predecessorEndSpeed,
+                    )
+                newBlock?.let { res.add(it) }
+            } else if (newStep.stepIndex == 0) {
+                // We're at the start of the path: start offset should be the exact value.
+                val newBlock =
+                    makePendingBlock(
+                        block,
+                        newStep.blockLocation.offset,
+                        blockInfra.getBlockLength(block),
+                        0,
+                        pendingBlock.remainingTimeAtBlockStart,
+                        predecessorEndSpeed,
+                    )
+                newBlock?.let { res.add(it) }
+            } else { // The train can backtrack at this location: generate both the current block
+                // and its opposite blocks to allow backtracking.
+                val newBlock =
+                    makePendingBlock(
+                        block,
+                        // We are starting at the backtrack location: we are building an optimistic
+                        // heuristic.
+                        newStep.blockLocation.offset,
+                        blockInfra.getBlockLength(block),
+                        newStep.stepIndex,
+                        pendingBlock.remainingTimeAtBlockStart,
+                        predecessorEndSpeed,
+                    )
+                if (newBlock != null) {
+                    res.add(newBlock)
+                    // Generate the opposing blocks for the backtracking.
+                    val oppositeBlockLocations =
+                        getOppositeBlockLocations(newStep.blockLocation, blockInfra, rawInfra)
+                    for (oppositeBlock in oppositeBlockLocations) {
+                        val oppositeBlock =
+                            makePendingBlock(
+                                oppositeBlock.edge,
+                                Offset.zero(),
+                                oppositeBlock.offset,
+                                newStep.stepIndex,
+                                newBlock.remainingTimeAtBlockStart,
+                                0.0,
+                            )
+                        oppositeBlock?.let { res.add(it) }
+                    }
+                }
+            }
         }
         return res
     }
@@ -228,39 +283,71 @@ class STDCMHeuristicBuilder(
         val res = PriorityQueue<PendingBlock>()
         val stepCount = steps.size
         for (wp in steps[stepCount - 1].locations) {
-            makePendingBlock(wp.edge, wp.offset, stepCount - 1, 0.0, 0.0)?.let { res.add(it) }
+            val newStep = getNewBlockStep(wp, stepCount - 1)
+            makePendingBlock(
+                    wp.edge,
+                    Offset.zero(),
+                    wp.offset,
+                    (newStep?.stepIndex) ?: (stepCount - 1),
+                    0.0,
+                    0.0,
+                )
+                ?.let { res.add(it) }
         }
         return res
     }
 
+    data class BlockStep(val blockLocation: BlockLocation, val stepIndex: Int)
+
+    /**
+     * Find the new step (if any) corresponding to the new block. The step is on the block and is
+     * the closest one to the block's start.
+     */
+    private fun getNewBlockStep(blockLocation: BlockLocation, oldStepIndex: Int): BlockStep? {
+        var currentIndex = oldStepIndex
+        var currentLocation = blockLocation
+        while (currentIndex > 0) {
+            val step = steps[currentIndex - 1]
+            val currentLocations =
+                step.locations.filter {
+                    it.edge == currentLocation.edge && it.offset <= currentLocation.offset
+                }
+            if (currentLocations.isEmpty()) break
+            currentLocation = currentLocations.maxBy { it.offset }
+            currentIndex--
+        }
+        return if (currentIndex < oldStepIndex) BlockStep(currentLocation, currentIndex) else null
+    }
+
     /** Instantiate one pending block. */
     private fun makePendingBlock(
-        block: StaticIdx<Block>,
-        offset: Offset<Block>?,
-        currentIndex: Int,
+        block: BlockId,
+        startOffset: Offset<Block>,
+        endOffset: Offset<Block>,
+        index: Int,
         remainingTime: Double,
         endSpeed: Double?,
     ): PendingBlock? {
-        var newIndex = currentIndex
-        val actualOffset = offset ?: blockInfra.getBlockLength(block)
-        while (newIndex > 0) {
-            val step = steps[newIndex - 1]
-            if (step.locations.none { it.edge == block && it.offset <= actualOffset }) {
-                break
-            }
-            newIndex--
-        }
-        if (consistSchedule?.constraints != null && newIndex > 0 && remainingTime > 0.0) {
-            // We stop if there's any blocking constraint on the block,
-            // but only if not on the first or last block
-            // (as the constrained range may not be part of the path)
-            if (consistSchedule.constraints[newIndex].apply(block).isNotEmpty()) return null
+        if (
+            consistSchedule?.constraints != null &&
+                consistSchedule.constraints[index].apply(block).any {
+                    it.start < endOffset && it.end > startOffset
+                }
+        ) {
+            return null
         }
         return PendingBlock(
             block,
-            newIndex,
+            index,
             remainingTime +
-                maxSpeedEnvBuilder.getBlockTime(block, newIndex, offset, endSpeed, allowance),
+                maxSpeedEnvBuilder.getBlockTime(
+                    block,
+                    index,
+                    endSpeed,
+                    allowance,
+                    endOffset,
+                    startOffset,
+                ),
             endSpeed,
         )
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -18,8 +18,10 @@ import fr.sncf.osrd.stdcm.graph.engineering_allowance.EngineeringAllowanceManage
 import fr.sncf.osrd.stdcm.graph.visited_node_tracking.VisitedNodes
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
+import fr.sncf.osrd.stdcm.infra_exploration.getBacktrackingLocationInLookahead
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.stdcm.tracing.FailureExplainer
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 import java.lang.Double.isNaN
@@ -140,27 +142,31 @@ class STDCMGraph(
                 node.remainingTimeEstimation,
                 explorer = node.infraExplorer,
             )
+        val explorer = node.infraExplorer.clone()
         if (node.locationOnEdge != null) {
-            val explorer = node.infraExplorer.clone()
+            val backtrackingLocation = explorer.getBacktrackingLocationInLookahead()
             visitedNodesParameters.fingerprint =
                 VisitedNodes.Fingerprint(
                     explorer.getLastEdgeIdentifier(),
                     node.infraExplorer.getStepTracker().nStepsExcludingLookahead,
                     node.locationOnEdge.distance,
+                    backtrackingLocation,
                 )
             if (visitedNodes.isVisited(visitedNodesParameters)) return listOf()
             visitedNodes.markAsVisited(visitedNodesParameters)
             res.addAll(STDCMEdgeBuilder.fromNode(this, node, explorer).makeAllEdges())
         } else {
-            val extended = extendLookaheadUntil(node.infraExplorer.clone(), 3)
+            val extended = extendLookaheadUntil(explorer, 3)
             for (newPath in extended) {
                 if (newPath.getLookahead().isEmpty()) continue
+                val backtrackingLocation = newPath.getBacktrackingLocationInLookahead()
                 newPath.moveForward()
                 visitedNodesParameters.fingerprint =
                     VisitedNodes.Fingerprint(
                         newPath.getLastEdgeIdentifier(),
                         node.infraExplorer.getStepTracker().nStepsExcludingLookahead,
                         0.meters,
+                        backtrackingLocation,
                     )
                 visitedNodesParameters = visitedNodesParameters.copy(explorer = newPath)
                 if (visitedNodes.isVisited(visitedNodesParameters)) continue
@@ -180,11 +186,15 @@ class STDCMGraph(
      */
     fun tryMarkPending(node: STDCMNode): Boolean {
         val explorer = node.infraExplorer
+        val locationOnEdge = node.locationOnEdge ?: Offset.zero()
+        val backtrackingLocation = explorer.getBacktrackingLocationInLookahead()
+        // TODO: Look into re-using the fingerprint computed in getAdjacentEdges.
         val fingerprint =
             VisitedNodes.Fingerprint(
                 explorer.getLastEdgeIdentifier(),
                 explorer.getStepTracker().nStepsExcludingLookahead,
-                node.locationOnEdge?.distance ?: 0.meters,
+                locationOnEdge.distance,
+                backtrackingLocation,
             )
         val params =
             VisitedNodes.Parameters(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/visited_node_tracking/VisitedNodes.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm.graph.visited_node_tracking
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockLocation
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
 import fr.sncf.osrd.sim_infra.utils.getBlockEntry
 import fr.sncf.osrd.sim_infra.utils.getBlockExit
@@ -53,6 +54,8 @@ data class VisitedNodes(
         val identifier: EdgeIdentifier,
         val waypointIndex: Int,
         val startOffset: Distance,
+        val backtrackingLocation:
+            BlockLocation?, // Can be in another block, later than current edge.
     )
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -52,6 +52,7 @@ import kotlin.to
  */
 interface InfraExplorer {
     val isPathComplete: Boolean
+    val backtrackingLocations: AppendOnlyLinkedList<BlockLocation>
 
     /**
      * Get the path properties for the current edge only, starting at the given offset and for the
@@ -147,14 +148,27 @@ interface InfraExplorer {
     fun getLookaheadEndOffset(): Offset<PhysicsPath>
 }
 
-/** Returns the current block and the lookahead blocks */
+/** Returns the current block and the lookahead blocks. */
 fun InfraExplorer.getRemainingBlocks(): List<BlockId> {
     val res = mutableListOf(getCurrentBlock())
     res.addAll(getLookahead().map { it.value })
     return res
 }
 
-/** Used to identify an edge */
+/** Returns the first backtracking location in the lookahead blocks. */
+fun InfraExplorer.getBacktrackingLocationInLookahead(): BlockLocation? {
+    val lastBacktrackingLocation = this.backtrackingLocations.lastOrNull() ?: return null
+    return if (
+        this.getLookahead().any {
+            it.value == lastBacktrackingLocation.edge &&
+                it.objectEnd == lastBacktrackingLocation.offset
+        }
+    )
+        lastBacktrackingLocation
+    else null
+}
+
+/** Used to identify an edge. */
 interface EdgeIdentifier {
     override fun equals(other: Any?): Boolean
 
@@ -213,11 +227,11 @@ private class InfraExplorerImpl(
     private val rawInfra: RawInfra,
     private val blockInfra: BlockInfra,
     private val rollingStockLength: Distance,
-    // the "teleporting" part during backtracking (tail location becomes head location) is skipped
-    // so there is a spatial discontinuity in this range list
+    // The "teleporting" part during backtracking (tail location becomes head location) is skipped
+    // so there is a spatial discontinuity in this range list.
     private var blockRanges: AppendOnlyLinkedList<BlockRange>,
-    // the "teleporting" part during backtracking (tail location becomes head location) is skipped
-    // so there is a spatial discontinuity in this range list
+    // The "teleporting" part during backtracking (tail location becomes head location) is skipped
+    // so there is a spatial discontinuity in this range list.
     private var routes: AppendOnlyLinkedList<RouteRange>,
     private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
     private var lastTrack: TrackSectionId?,
@@ -227,6 +241,9 @@ private class InfraExplorerImpl(
     private var stepTracker: StepTracker,
     private var constraints: List<PathfindingConstraint>?,
     override var isPathComplete: Boolean = false,
+    // The locations where this InfraExplorer is really backtracking.
+    override var backtrackingLocations: AppendOnlyLinkedList<BlockLocation> =
+        appendOnlyLinkedListOf(),
 ) : InfraExplorer {
     override fun getCurrentEdgePathProperties(offset: Offset<Block>, length: Distance?): TrainPath {
         // We re-compute the routes of the current path since the cache may be incorrect
@@ -288,7 +305,10 @@ private class InfraExplorerImpl(
                         blockLocation,
                         possibleBacktracking.location,
                     )
-                if (extendedToBacktracking) infraExplorers.add(explorerToBacktracking)
+                if (extendedToBacktracking) {
+                    explorerToBacktracking.backtrackingLocations.add(possibleBacktracking.location)
+                    infraExplorers.add(explorerToBacktracking)
+                }
             }
         }
         return infraExplorers
@@ -375,6 +395,7 @@ private class InfraExplorerImpl(
             this.stepTracker.clone(),
             this.constraints,
             this.isPathComplete,
+            this.backtrackingLocations.shallowCopy(),
         )
     }
 
@@ -641,7 +662,7 @@ private class InfraExplorerImpl(
  * From a given block location, return all the block locations corresponding to the opposite
  * direction
  */
-private fun getOppositeBlockLocations(
+fun getOppositeBlockLocations(
     blockLocation: BlockLocation,
     blockInfra: BlockInfra,
     rawInfra: RawInfra,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
@@ -24,6 +24,7 @@ class VisitedNodesTests {
             identifier = DummyEdgeIdentifier(1),
             waypointIndex = 1,
             startOffset = 0.meters,
+            null,
         )
 
     @Test


### PR DESCRIPTION
Preliminary commit: backtrackings are not yet plugged in. If they get plugged in and are used, STDCM will fail because of spacing/routing requirements and progress logger. But this will be fixed before then.