### PR TITLE
editoast: rename `AuthorizationError::Unauthorized` to `Unauthenticated`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6349,7 +6349,7 @@ components:
         status:
           type: integer
           enum:
-          - 403
+          - 404
         type:
           type: string
           enum:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6354,7 +6354,7 @@ components:
           type: string
           enum:
           - editoast:authz:ImpersonatedUserNotFound
-    EditoastAuthorizationErrorUnauthorized:
+    EditoastAuthorizationErrorUnauthenticated:
       type: object
       required:
       - type
@@ -6363,7 +6363,7 @@ components:
       properties:
         context:
           type: object
-          title: EditoastAuthorizationErrorUnauthorizedContext
+          title: EditoastAuthorizationErrorUnauthenticatedContext
         message:
           type: string
         status:
@@ -6373,7 +6373,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:authz:Unauthorized
+          - editoast:authz:Unauthenticated
     EditoastAuthzErrorAuthorizer:
       type: object
       required:
@@ -6992,7 +6992,7 @@ components:
       - $ref: '#/components/schemas/EditoastAuthorizationErrorForbidden'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorForbiddenImpersonation'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorImpersonatedUserNotFound'
-      - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthorized'
+      - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthenticated'
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthorizer'
       - $ref: '#/components/schemas/EditoastAuthzErrorDatabase'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownIdentities'

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -116,7 +116,7 @@ impl State {
         roles: Vec<Role>,
     ) -> Result<Self, AuthorizationError> {
         match mode {
-            Mode::Unauthenticated => Err(AuthorizationError::Unauthorized),
+            Mode::Unauthenticated => Err(AuthorizationError::Unauthenticated),
             Mode::Authenticated { .. } | Mode::Impersonating { .. } => {
                 let user = user.expect("providing the request user is required when Mode::Authenticated or Mode::Impersonating");
                 Ok(State::Authenticated { user, roles })

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -503,8 +503,8 @@ pub enum AuthorizationError {
     #[error("Forbidden (403) — user must be an admin to impersonate")]
     #[editoast_error(status = 403)]
     ForbiddenImpersonation,
-    #[error("Not Found (403) — impersonated user '{identity}' not found")]
-    #[editoast_error(status = 403)]
+    #[error("Not Found (404) — impersonated user '{identity}' not found")]
+    #[editoast_error(status = 404)]
     ImpersonatedUserNotFound { identity: String },
     #[error(transparent)]
     #[editoast_error(status = 500)]

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -477,7 +477,7 @@ impl Authentication {
     ) -> Result<(), AuthorizationError> {
         match self {
             Authentication::SkipAuthorization { .. } => Ok(()),
-            Authentication::Unauthenticated => Err(AuthorizationError::Unauthorized),
+            Authentication::Unauthenticated => Err(AuthorizationError::Unauthenticated),
             Authentication::Authenticated(authorizer) => f(authorizer)
                 .await
                 .map_err(Into::into)?
@@ -494,16 +494,16 @@ pub type AuthorizerError = ::authz::Error<<PgAuthDriver as ::authz::StorageDrive
 #[derive(Debug, Error, derive_more::From, EditoastError)]
 #[editoast_error(base_id = "authz")]
 pub enum AuthorizationError {
-    #[error("Unauthorized — user must be authenticated")]
+    #[error("Unauthorized (401) — user must be authenticated")]
     #[editoast_error(status = 401)]
-    Unauthorized,
-    #[error("Forbidden — user has insufficient privileges")]
+    Unauthenticated,
+    #[error("Forbidden (403) — user has insufficient privileges")]
     #[editoast_error(status = 403)]
     Forbidden,
-    #[error("Forbidden — user must be an admin to impersonate")]
+    #[error("Forbidden (403) — user must be an admin to impersonate")]
     #[editoast_error(status = 403)]
     ForbiddenImpersonation,
-    #[error("Not Found — impersonated user '{identity}' not found")]
+    #[error("Not Found (403) — impersonated user '{identity}' not found")]
     #[editoast_error(status = 403)]
     ImpersonatedUserNotFound { identity: String },
     #[error(transparent)]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -174,7 +174,7 @@ pub(in crate::views) async fn user_groups(
         regulator, db_pool, ..
     }): State<AppState>,
 ) -> Result<Json<Vec<Group>>> {
-    let user = user.ok_or(AuthorizationError::Unauthorized)?;
+    let user = user.ok_or(AuthorizationError::Unauthenticated)?;
     let user_authorizer =
         UserAuthorizer::new(user, roles, regulator.openfga(), db_pool.get().await?);
     let user_groups = authz::v2::user_groups(user)
@@ -393,7 +393,7 @@ pub(in crate::views) async fn user_privileges(
     Json(resources_ids): Json<HashMap<ResourceType, Vec<i64>>>,
 ) -> Result<Json<HashMap<ResourceType, Vec<ResourcePrivileges>>>> {
     if matches!(authn, crate::authentication::Mode::Unauthenticated) {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Unauthenticated.into());
     }
 
     let mut result = HashMap::<_, Vec<_>>::new();
@@ -541,7 +541,7 @@ pub(in crate::views) async fn user_grants(
     Json(body): Json<HashMap<ResourceType, Vec<i64>>>,
 ) -> Result<Json<HashMap<ResourceType, Vec<UserResourceGrant>>>> {
     let Some(user) = user else {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Unauthenticated.into());
     };
     let authorizer = UserAuthorizer::new(user, roles, regulator.openfga(), db_pool.get().await?);
 
@@ -642,7 +642,7 @@ pub(in crate::views) async fn resource_granted_users(
     Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
 ) -> Result<Json<Vec<SubjectGrant>>> {
     let Some(user) = user else {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Unauthenticated.into());
     };
     let conn = db_pool.get().await?;
     let openfga = regulator.openfga();
@@ -903,7 +903,7 @@ pub(in crate::views) async fn update_grants(
                                 .await
                                 .map(Authorization::Granted),
                             Authentication::Unauthenticated => {
-                                return Err(AuthorizationError::Unauthorized.into());
+                                return Err(AuthorizationError::Unauthenticated.into());
                             }
                         }?
                         .allowed()?;

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -228,7 +228,7 @@ pub(in crate::views) async fn list(
                 }
             }
         }
-        (None, _) => return Err(AuthorizationError::Unauthorized)?,
+        (None, _) => return Err(AuthorizationError::Unauthenticated)?,
     };
     let (infras, stats) =
         Infra::list_paginated(conn, settings.order_by(move || Infra::ID.asc())).await?;

--- a/editoast/src/views/server/middlewares.rs
+++ b/editoast/src/views/server/middlewares.rs
@@ -69,7 +69,7 @@ pub(in crate::views) async fn authentication_extraction_middleware(
                 skip,
                 "invalid authentication parameters"
             );
-            AuthorizationError::Unauthorized
+            AuthorizationError::Unauthenticated
         },
     )?;
 
@@ -217,7 +217,7 @@ pub(in crate::views) async fn authentication_validation_middleware(
         }
         crate::authentication::Mode::Skip { .. } => (None, ::authz::v2::Protected::default()),
         crate::authentication::Mode::Unauthenticated => {
-            return Err(AuthorizationError::Unauthorized.into());
+            return Err(AuthorizationError::Unauthenticated.into());
         }
     };
 

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -35,7 +35,7 @@
       "GrantsApiMisuse": "Improper API usage",
       "ImpersonatedUserNotFound": "Unknown impersonated user",
       "NoSuchUser": "Unknown user",
-      "Unauthorized": "Unauthenticated user",
+      "Unauthenticated": "Unauthenticated user",
       "UnknownIdentities": "Unknown identities '{{identities}}'",
       "UnknownResource": "Unknown resource",
       "UnknownResourceType": "Unknown resource type",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -35,7 +35,7 @@
       "GrantsApiMisuse": "Mauvaise utilisation de l'API d'autorisation",
       "ImpersonatedUserNotFound": "Utilisateur usurpé inconnu",
       "NoSuchUser": "Utilisateur inconnu",
-      "Unauthorized": "Utilisateur non authentifié",
+      "Unauthenticated": "Utilisateur non authentifié",
       "UnknownIdentities": "Identités inconnues '{{identities}}'",
       "UnknownResource": "Ressource inconnue",
       "UnknownResourceType": "Type de ressource inconnu",

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -512,14 +512,14 @@ class EditoastAuthorizationErrorImpersonatedUserNotFound(BaseModel):
     type: Literal["EditoastAuthorizationErrorImpersonatedUserNotFound"]
 
 
-class EditoastAuthorizationErrorUnauthorized(BaseModel):
+class EditoastAuthorizationErrorUnauthenticated(BaseModel):
     context: Annotated[
         dict[str, Any] | None,
-        Field(title="EditoastAuthorizationErrorUnauthorizedContext"),
+        Field(title="EditoastAuthorizationErrorUnauthenticatedContext"),
     ] = None
     message: str
     status: Literal[401]
-    type: Literal["EditoastAuthorizationErrorUnauthorized"]
+    type: Literal["EditoastAuthorizationErrorUnauthenticated"]
 
 
 class EditoastAuthzErrorAuthorizer(BaseModel):
@@ -4313,7 +4313,7 @@ class EditoastError(
         | EditoastAuthorizationErrorForbidden
         | EditoastAuthorizationErrorForbiddenImpersonation
         | EditoastAuthorizationErrorImpersonatedUserNotFound
-        | EditoastAuthorizationErrorUnauthorized
+        | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorAuthorizer
         | EditoastAuthzErrorDatabase
         | EditoastAuthzErrorUnknownIdentities
@@ -4476,7 +4476,7 @@ class EditoastError(
         | EditoastAuthorizationErrorForbidden
         | EditoastAuthorizationErrorForbiddenImpersonation
         | EditoastAuthorizationErrorImpersonatedUserNotFound
-        | EditoastAuthorizationErrorUnauthorized
+        | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorAuthorizer
         | EditoastAuthzErrorDatabase
         | EditoastAuthzErrorUnknownIdentities

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -508,7 +508,7 @@ class EditoastAuthorizationErrorImpersonatedUserNotFound(BaseModel):
         Field(title="EditoastAuthorizationErrorImpersonatedUserNotFoundContext"),
     ] = None
     message: str
-    status: Literal[403]
+    status: Literal[404]
     type: Literal["EditoastAuthorizationErrorImpersonatedUserNotFound"]
 
 


### PR DESCRIPTION
follow-up of https://github.com/OpenRailAssociation/osrd/pull/17135#discussion_r3382085001

That's what a 401 means. The name more in tune with the naming we use
everywhere else in editoast.

`Forbidden` (403) wasn't changed because it's already close enough to
"unauthorized".

