### PR TITLE
front: replace OperationalPointUic by OperationalPointDomestic

### DIFF
--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -186,7 +186,8 @@ export const matchOpRefAndWaypoint = (
   }
   return (
     location.operational_point.main_code === waypoint.main_code &&
-    location.operational_point.secondary_code === waypoint.secondary_code
+    location.operational_point.secondary_code === waypoint.secondary_code &&
+    location.operational_point.country_code === waypoint.country_code
   );
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -204,23 +204,13 @@ const ItineraryModal = ({
     if (!chosenSecondaryCode) return;
     pendingStepIdRef.current = stepId;
     confirmedStepIdRef.current = stepId;
-    let opRef: OperationalPointReference;
 
-    if (suggestion.uic) {
-      opRef = { type: 'uic', uic: suggestion.uic, secondary_code: chosenSecondaryCode };
-    } else if (suggestion.mainCode) {
-      opRef = {
-        type: 'domestic',
-        main_code: suggestion.mainCode,
-        secondary_code: chosenSecondaryCode,
-        country_code: suggestion.countryCode,
-      };
-    } else {
-      const chosenOpId = suggestion.secondaryCodeList.find(
-        (c) => c.code === chosenSecondaryCode
-      )?.opId;
-      opRef = { type: 'id', operational_point: chosenOpId! };
-    }
+    const opRef: OperationalPointReference = {
+      type: 'domestic',
+      main_code: suggestion.mainCode,
+      secondary_code: chosenSecondaryCode,
+      country_code: suggestion.countryCode,
+    };
     const newLocation: PathItemLocation = {
       type: 'operational_point_part_reference',
       operational_point: opRef,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/utils.ts
@@ -34,28 +34,12 @@ export const computePathStepCoordinates = (pathStepMetadata: PathStepMetadata) =
   return [];
 };
 
-export const buildOpRef = (op: OperationalPoint): OperationalPointReference => {
-  const ch = op.secondary_code;
-  const uic = op.uic;
-  if (uic)
-    return {
-      type: 'uic',
-      uic,
-      secondary_code: ch,
-    };
-  const mainCode = op.main_code;
-  if (mainCode)
-    return {
-      type: 'domestic',
-      main_code: mainCode,
-      country_code: op.country_code,
-      secondary_code: ch,
-    };
-  return {
-    type: 'id',
-    operational_point: op.id,
-  };
-};
+export const buildOpRef = (op: OperationalPoint): OperationalPointReference => ({
+  type: 'domestic',
+  main_code: op.main_code,
+  country_code: op.country_code,
+  secondary_code: op.secondary_code,
+});
 
 export const buildOpDisplayName = (op: OperationalPoint): string => {
   const name = op.name;
@@ -67,7 +51,7 @@ export const getOpKey = (location: PathItemLocation | null): string | null => {
   if (!location || location.type === 'track_offset') return null;
   const op = location.operational_point;
   if (op.type === 'domestic') return `${op.country_code} ${op.main_code} ${op.secondary_code}`;
-  if (op.type === 'uic') return `${op.uic} ${op.secondary_code}`;
   if (op.type === 'id') return `${op.operational_point}`;
+  if (op.type === 'uic') return `${op.uic} ${op.secondary_code}`;
   return null;
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
@@ -119,13 +119,12 @@ const AddPathStepPopup = ({
         coordinates: result[0].geographic.coordinates as number[],
       });
 
-      let opRef: OperationalPointReference;
-      const uic = operationalPoint.uic;
-      if (uic) {
-        opRef = { type: 'uic', uic, secondary_code: operationalPoint.secondary_code };
-      } else {
-        opRef = { type: 'id', operational_point: operationalPoint.id };
-      }
+      const opRef: OperationalPointReference = {
+        type: 'domestic',
+        main_code: operationalPoint.main_code,
+        secondary_code: operationalPoint.secondary_code,
+        country_code: operationalPoint.country_code,
+      };
 
       setClickedOp({
         id: uuidV4(),

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -71,7 +71,8 @@ const usePathfinding = ({
 
   /**
    * Fetches operational point data for the given path steps using a search API call
-   * and updates each step with the matched operational point's name, uic, ch and coordinates (if found).
+   * and updates each step with the matched operational point's name, main code, secondary code,
+   * country code and coordinates (if found).
    *
    * This is useful when the pathfinding can not be ran or fails.
    * If pathfinding is successful, calling this function is unnecessary.
@@ -110,17 +111,18 @@ const usePathfinding = ({
         return {
           ...step,
           ...(op.name && { name: op.name }),
-          ...(op.uic && {
+          ...{
             location: {
               local_track_name: step.location.local_track_name,
               type: 'operational_point_part_reference',
               operational_point: {
-                uic: op.uic,
+                main_code: op.main_code,
                 secondary_code: op.secondary_code,
-                type: 'uic',
+                country_code: op.country_code,
+                type: 'domestic',
               },
             },
-          }),
+          },
           ...(op.geo && { coordinates: op.geo.coordinates }),
         };
       });

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -373,11 +373,6 @@ const useTimesStopsTableData = (
           const { shortSlipDistance, onStopSignal } =
             receptionSignalToSignalBooleans(receptionSignal);
 
-          // TODO: remove this error once we migrate the location to trigram/domestic
-          if (op.uic === undefined || op.uic === null) {
-            throw new Error('No valid UIC found to build operational_point_part_reference');
-          }
-
           formattedRows.push({
             ...buildTableRow({
               id: op.waypointId,
@@ -390,14 +385,13 @@ const useTimesStopsTableData = (
               computedArrival,
               shortSlipDistance,
               closedSignal: onStopSignal,
-              // Build location from OP data for creating a new PathItem if user edits this row
-              // OPs on path always have a UIC identifier
               location: {
                 type: 'operational_point_part_reference',
                 operational_point: {
-                  type: 'uic',
-                  uic: op.uic,
+                  type: 'domestic',
+                  main_code: op.main_code,
                   secondary_code: op.secondary_code ?? null,
+                  country_code: op.country_code,
                 },
               },
             }),

--- a/front/src/modules/trainSchedule/types.ts
+++ b/front/src/modules/trainSchedule/types.ts
@@ -19,7 +19,7 @@ export type SuggestedOP = {
   name: string | undefined;
   uic?: number | null;
   secondaryCode?: string | null;
-  countryCode?: string | null;
+  countryCode?: string;
   kp?: string;
   mainCode?: string;
   isPassengerStation?: boolean;


### PR DESCRIPTION
Fix: https://github.com/OpenRailAssociation/osrd/issues/17231
Depends on: https://github.com/OpenRailAssociation/osrd/pull/17195

---

Change operational_point_part_reference type: 'uic' to type: 'domestic' everywhere except for the imports, stdcm and the old itinerary modal.

---

If we don't want to change it in the tests we can drop the second commit.