### PR TITLE
editoast: adapt conflicts for hourly timetables

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/TimetableProvider.kt
@@ -169,12 +169,7 @@ class TimetableDownloader(
             val trainRequirementsById = fetchTrainRequirements(infraId, timetableId)
             trainRequirementsById.collect { trainRequirementById ->
                 for (rjsRequirement in trainRequirementById.spacingRequirements) {
-                    val requirement =
-                        SpacingRequirement.fromRJSWithAddedTime(
-                            rjsRequirement,
-                            infra,
-                            trainRequirementById.startTime.seconds,
-                        )
+                    val requirement = SpacingRequirement.fromRJS(rjsRequirement, infra)
                     val set = zoneUses.computeIfAbsent(requirement.zone) { TreeRangeSet.create() }
                     set.add(Range.closedOpen(requirement.beginTime, requirement.endTime))
                     detailedRequirements

--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -199,12 +199,7 @@ class JSONTimetableReader(val jsonTimetablePath: String) : TimetableProvider {
         while (jsonReader.hasNext()) {
             val train = adapter.fromJson(jsonReader)!!
             for (rjsSpacingReq in train.spacingRequirements) {
-                val spacingReq =
-                    SpacingRequirement.fromRJSWithAddedTime(
-                        rjsSpacingReq,
-                        infra,
-                        train.startTime.seconds,
-                    )
+                val spacingReq = SpacingRequirement.fromRJS(rjsSpacingReq, infra)
                 val set = zoneUses.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
                 set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
                 detailedRequirements

--- a/core/src/main/kotlin/fr/sncf/osrd/api/RequirementsParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/RequirementsParser.kt
@@ -1,14 +1,10 @@
 package fr.sncf.osrd.api
 
 import fr.sncf.osrd.api.conflicts.TrainRequirementsRequest
-import fr.sncf.osrd.api.conflicts.WorkSchedulesRequest
 import fr.sncf.osrd.conflicts.*
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
 import fr.sncf.osrd.utils.LogAggregator
-import fr.sncf.osrd.utils.units.Duration
-import fr.sncf.osrd.utils.units.TimeDelta
-import fr.sncf.osrd.utils.units.seconds
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.slf4j.Logger
@@ -20,15 +16,13 @@ val requirementsParserLogger: Logger = LoggerFactory.getLogger("RequirementsPars
 fun parseTrainsRequirements(
     infra: RawInfra,
     trainsRequirements: Map<String, TrainRequirementsRequest>,
-    referenceTime: TimeDelta,
 ): List<Requirements> {
     val res = mutableListOf<Requirements>()
     for ((id, trainRequirements) in trainsRequirements) {
-        val delta = trainRequirements.startTime - referenceTime
         val spacingRequirements =
-            parseSpacingRequirements(infra, trainRequirements.spacingRequirements, delta)
+            parseSpacingRequirements(infra, trainRequirements.spacingRequirements)
         val routingRequirements =
-            parseRoutingRequirements(infra, trainRequirements.routingRequirements, delta)
+            parseRoutingRequirements(infra, trainRequirements.routingRequirements)
         res.add(
             Requirements(
                 RequirementId(id, RequirementType.TRAIN),
@@ -43,7 +37,6 @@ fun parseTrainsRequirements(
 fun parseSpacingRequirements(
     infra: RawInfra,
     spacingRequirements: Collection<RJSSpacingRequirement>,
-    timeToAdd: TimeDelta = Duration.ZERO,
 ): List<SpacingRequirement> {
     val res = mutableListOf<SpacingRequirement>()
     for (spacingRequirement in spacingRequirements) {
@@ -51,8 +44,8 @@ fun parseSpacingRequirements(
             SpacingRequirement.fromRJS(
                 RJSSpacingRequirement(
                     spacingRequirement.zone,
-                    spacingRequirement.beginTime + timeToAdd,
-                    spacingRequirement.endTime + timeToAdd,
+                    spacingRequirement.beginTime,
+                    spacingRequirement.endTime,
                 ),
                 infra,
             )
@@ -64,7 +57,6 @@ fun parseSpacingRequirements(
 fun parseRoutingRequirements(
     infra: RawSignalingInfra,
     routingRequirements: Collection<RJSRoutingRequirement>,
-    timeToAdd: TimeDelta = Duration.ZERO,
 ): List<RoutingRequirement> {
     val res = mutableListOf<RoutingRequirement>()
     for (routingRequirement in routingRequirements) {
@@ -72,14 +64,14 @@ fun parseRoutingRequirements(
             RoutingRequirement.fromRJS(
                 RJSRoutingRequirement(
                     routingRequirement.route,
-                    routingRequirement.beginTime + timeToAdd,
+                    routingRequirement.beginTime,
                     routingRequirement.zones.map {
                         RJSRoutingZoneRequirement(
                             it.zone,
                             it.entryDetector,
                             it.exitDetector,
                             it.switches,
-                            it.endTime + timeToAdd,
+                            it.endTime,
                         )
                     },
                 ),
@@ -90,15 +82,6 @@ fun parseRoutingRequirements(
     return res
 }
 
-fun parseWorkSchedulesRequest(
-    infra: RawSignalingInfra,
-    workSchedulesRequest: WorkSchedulesRequest,
-    referenceTime: TimeDelta,
-): Collection<Requirements> {
-    val delta = workSchedulesRequest.startTime - referenceTime
-    return convertWorkScheduleMap(infra, workSchedulesRequest.workScheduleRequirements, delta)
-}
-
 /**
  * Convert work schedules into timetable spacing requirements, taking work schedule ids into
  * account.
@@ -106,15 +89,12 @@ fun parseWorkSchedulesRequest(
 fun convertWorkScheduleMap(
     rawInfra: RawSignalingInfra,
     workSchedules: Map<String, WorkSchedule>,
-    timeToAdd: TimeDelta = 0.seconds,
 ): Collection<Requirements> {
     val res = mutableListOf<Requirements>()
     val logAggregator = LogAggregator({ requirementsParserLogger.warn(it) })
     for (entry in workSchedules) {
         val workScheduleRequirements = mutableListOf<RJSSpacingRequirement>()
-        workScheduleRequirements.addAll(
-            convertWorkSchedule(rawInfra, entry.value, timeToAdd, logAggregator)
-        )
+        workScheduleRequirements.addAll(convertWorkSchedule(rawInfra, entry.value, logAggregator))
         res.add(
             Requirements(
                 RequirementId(entry.key, RequirementType.WORK_SCHEDULE),
@@ -131,13 +111,12 @@ fun convertWorkScheduleMap(
 fun convertWorkScheduleCollection(
     rawInfra: RawSignalingInfra,
     workSchedules: Collection<WorkSchedule>,
-    timeToAdd: TimeDelta = 0.seconds,
 ): List<Requirements> {
     val logAggregator = LogAggregator({ requirementsParserLogger.warn(it) })
     val res = mutableListOf<Requirements>()
     for (workSchedule in workSchedules) {
         val workSchedulesRequirements =
-            convertWorkSchedule(rawInfra, workSchedule, timeToAdd, logAggregator).map {
+            convertWorkSchedule(rawInfra, workSchedule, logAggregator).map {
                 SpacingRequirement.fromRJS(it, rawInfra)
             }
         res.add(
@@ -154,7 +133,6 @@ fun convertWorkScheduleCollection(
 private fun convertWorkSchedule(
     rawInfra: RawSignalingInfra,
     workSchedule: WorkSchedule,
-    timeToAdd: TimeDelta = 0.seconds,
     logAggregator: LogAggregator,
 ): Collection<RJSSpacingRequirement> {
     val res = mutableListOf<RJSSpacingRequirement>()
@@ -181,8 +159,8 @@ private fun convertWorkSchedule(
             res.add(
                 RJSSpacingRequirement(
                     rawInfra.getZoneName(zone),
-                    workSchedule.startTime + timeToAdd,
-                    workSchedule.endTime + timeToAdd,
+                    workSchedule.startTime,
+                    workSchedule.endTime,
                 )
             )
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
@@ -2,8 +2,8 @@ package fr.sncf.osrd.api.conflicts
 
 import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.InfraProvider
+import fr.sncf.osrd.api.convertWorkScheduleMap
 import fr.sncf.osrd.api.parseTrainsRequirements
-import fr.sncf.osrd.api.parseWorkSchedulesRequest
 import fr.sncf.osrd.cli.Request
 import fr.sncf.osrd.cli.Response
 import fr.sncf.osrd.cli.RsJson
@@ -15,7 +15,6 @@ import fr.sncf.osrd.conflicts.Conflict
 import fr.sncf.osrd.conflicts.Requirements
 import fr.sncf.osrd.conflicts.detectConflicts
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
-import fr.sncf.osrd.utils.units.TimeDelta
 import fr.sncf.osrd.utils.units.seconds
 
 class ConflictDetectionEndpoint(private val infraManager: InfraProvider) : Take {
@@ -34,19 +33,20 @@ class ConflictDetectionEndpoint(private val infraManager: InfraProvider) : Take 
 
             val infra = infraManager.getInfra(request.infra, request.expectedVersion)
 
-            var minStartTime = request.trainsRequirements.values.minBy { it.startTime }.startTime
             val requirements = mutableListOf<Requirements>()
             if (request.workSchedules != null) {
-                minStartTime = minOf(minStartTime, request.workSchedules.startTime)
                 val convertedWorkSchedules =
-                    parseWorkSchedulesRequest(infra.rawInfra, request.workSchedules, minStartTime)
+                    convertWorkScheduleMap(
+                        infra.rawInfra,
+                        request.workSchedules.workScheduleRequirements,
+                    )
                 requirements.addAll(convertedWorkSchedules)
             }
             val trainRequirements =
-                parseTrainsRequirements(infra.rawInfra, request.trainsRequirements, minStartTime)
+                parseTrainsRequirements(infra.rawInfra, request.trainsRequirements)
             requirements.addAll(trainRequirements)
             val conflicts = detectConflicts(requirements)
-            val res = makeConflictDetectionResponse(infra.rawInfra, conflicts, minStartTime)
+            val res = makeConflictDetectionResponse(infra.rawInfra, conflicts)
 
             RsJson(RsWithBody(conflictResponseAdapter.toJson(res)))
         } catch (ex: Throwable) {
@@ -58,20 +58,19 @@ class ConflictDetectionEndpoint(private val infraManager: InfraProvider) : Take 
 private fun makeConflictDetectionResponse(
     infra: RawSignalingInfra,
     conflicts: Collection<Conflict>,
-    referenceTime: TimeDelta,
 ): ConflictDetectionResponse {
     return ConflictDetectionResponse(
         conflicts.map {
             ConflictResponse(
                 it.trainIds,
                 it.workScheduleIds,
-                referenceTime + it.startTime.seconds,
+                it.startTime.seconds,
                 (it.endTime - it.startTime).seconds,
                 it.conflictType,
                 it.requirements.map { requirement ->
                     ConflictRequirement(
                         infra.getZoneName(requirement.zone),
-                        referenceTime + requirement.startTime.seconds,
+                        requirement.startTime.seconds,
                         (requirement.endTime - requirement.startTime).seconds,
                     )
                 },

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionRequest.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.api.RJSRoutingRequirement
 import fr.sncf.osrd.api.RJSSpacingRequirement
 import fr.sncf.osrd.api.WorkSchedule
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
-import fr.sncf.osrd.utils.units.TimeDelta
 
 class ConflictDetectionRequest(
     /** Infra ID. */
@@ -28,16 +27,6 @@ class ConflictDetectionRequest(
 /** Describes the requirements needed for a given train to run without any delay. */
 open class TrainRequirementsRequest(
     /**
-     * Start time for the given train: elapsed ms since an implicit 'request base time'.
-     * `start_time` acts as a reference point for all time values in the spacing and routing
-     * requirements for this train (values expressed as time delta).
-     *
-     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
-     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
-     * the timetable start for hourly timetables.
-     */
-    @Json(name = "start_time") val startTime: TimeDelta,
-    /**
      * Spacing requirements for the given train (i.e. which zones need to be free in which time
      * ranges).
      */
@@ -54,35 +43,15 @@ open class TrainRequirementsRequest(
 class TrainRequirementsById(
     @Json(name = "train_id") val trainId: String,
     @Json(name = "train_name") val trainName: String?,
-    /**
-     * Start time for the given train: elapsed ms since an implicit 'request base time'.
-     * `start_time` acts as a reference point for all time values in the spacing and routing
-     * requirements for this train (values expressed as time delta).
-     *
-     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
-     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
-     * the timetable start for hourly timetables.
-     */
-    @Json(name = "start_time") startTime: TimeDelta,
     @Json(name = "spacing_requirements") spacingRequirements: Collection<RJSSpacingRequirement>,
     @Json(name = "routing_requirements") routingRequirements: Collection<RJSRoutingRequirement>,
-) : TrainRequirementsRequest(startTime, spacingRequirements, routingRequirements)
+) : TrainRequirementsRequest(spacingRequirements, routingRequirements)
 
 /** Describes the set of work schedules in the given timetable. */
 class WorkSchedulesRequest(
-    /**
-     * Start time for the work schedules: elapsed ms since the implicit 'request base time'.
-     * `start_time` acts as a reference point for all time values in the work schedule requirements
-     * (values expressed as time delta).
-     *
-     * The implicit 'request base time' is the same over the whole request (`trains_requirements`
-     * and `work_schedules`) and response. Example: `1970-01-01T00:00:00Z` for calendar timetables;
-     * the timetable start for hourly timetables.
-     */
-    @Json(name = "start_time") val startTime: TimeDelta,
     /** Map of work schedule id -> work schedule data. */
     @Json(name = "work_schedule_requirements")
-    val workScheduleRequirements: Map<String, WorkSchedule>,
+    val workScheduleRequirements: Map<String, WorkSchedule>
 )
 
 val conflictRequestAdapter: JsonAdapter<ConflictDetectionRequest> =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -500,31 +500,29 @@ fun getRequirements(
 ): RequirementsWithMetadata {
     val requirements = mutableMapOf<ZoneId, TreeRangeSet<Double>>()
     val metadata = mutableMapOf<ZoneId, MutableList<STDCMTimetableData.DetailedRequirement>>()
-    for (convertedWorkSchedule in
-        convertWorkScheduleCollection(infra.rawInfra, request.workSchedules)) {
-        for (spacingReq in convertedWorkSchedule.spacingRequirements) {
-            val set = requirements.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
-            set.add(Range.closedOpen(spacingReq.beginTime, spacingReq.endTime))
-            metadata
-                .computeIfAbsent(spacingReq.zone) { mutableListOf() }
-                .add(
-                    STDCMTimetableData.DetailedRequirement(
-                        spacingReq.beginTime,
-                        spacingReq.endTime,
-                        convertedWorkSchedule.id,
-                    )
-                )
-        }
-    }
 
-    val trainRequirements = runBlocking { timetableCacheManager.get(infra, request.timetableId) }
-    // Cached requirements are relative to EPOCH. Add time diff with request start time
-    // to these requirements.
+    // Train and work schedule requirements are both relative to EPOCH.
+    // Shift them into the search window.
     val searchWindowBeginEpoch = request.startTime.durationSinceEpoch()
     val searchWindowEndEpoch =
         searchWindowBeginEpoch +
             request.maximumDepartureDelay!!.seconds +
             request.maximumRunTime.seconds
+
+    for (convertedWorkSchedule in
+        convertWorkScheduleCollection(infra.rawInfra, request.workSchedules)) {
+        for (spacingReq in convertedWorkSchedule.spacingRequirements) {
+            val begin = spacingReq.beginTime - searchWindowBeginEpoch
+            val end = spacingReq.endTime - searchWindowBeginEpoch
+            val set = requirements.computeIfAbsent(spacingReq.zone) { TreeRangeSet.create() }
+            set.add(Range.closedOpen(begin, end))
+            metadata
+                .computeIfAbsent(spacingReq.zone) { mutableListOf() }
+                .add(STDCMTimetableData.DetailedRequirement(begin, end, convertedWorkSchedule.id))
+        }
+    }
+
+    val trainRequirements = runBlocking { timetableCacheManager.get(infra, request.timetableId) }
     for ((zoneId, rangeSet) in trainRequirements.zoneUses) {
         val setBuilder = requirements.computeIfAbsent(zoneId) { TreeRangeSet.create() }
         for (range in rangeSet.asRanges()) {

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/RequirementTypes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/RequirementTypes.kt
@@ -31,19 +31,6 @@ data class SpacingRequirement(
                 true,
             )
         }
-
-        fun fromRJSWithAddedTime(
-            input: RJSSpacingRequirement,
-            infra: RawInfra,
-            addedTime: Double,
-        ): SpacingRequirement {
-            return SpacingRequirement(
-                infra.getZoneFromName(input.zone),
-                input.beginTime.seconds + addedTime,
-                input.endTime.seconds + addedTime,
-                true,
-            )
-        }
     }
 }
 

--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -26,16 +26,6 @@ pub struct ConflictDetectionRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrainRequirements {
-    /// Start time for the given train: elapsed ms since an implicit 'request base time'.
-    /// `start_time` acts as a reference point for all time values in the spacing and routing
-    /// requirements for this train (values expressed as time delta).
-    ///
-    /// The implicit 'request base time' is the same over the whole request
-    /// (`trains_requirements` and `work_schedules`) and response.
-    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
-    /// timetables.
-    #[serde(with = "common::units::millisecond::i64")]
-    pub start_time: Offset,
     pub spacing_requirements: Vec<SpacingRequirement>,
     pub routing_requirements: Vec<RoutingRequirement>,
 }
@@ -47,33 +37,12 @@ pub struct TrainRequirementsById {
     pub train_id: String,
     /// ID that can be used to find the train in tools other than OSRD. Used in debug traces.
     pub train_name: String,
-    /// Start time for the given train: elapsed ms since an implicit 'request base time'.
-    /// `start_time` acts as a reference point for all time values in the spacing and routing
-    /// requirements for this train (values expressed as an offset).
-    ///
-    /// The implicit 'request base time' is the same over the whole request
-    /// (`trains_requirements` and `work_schedules`) and response.
-    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
-    /// timetables.
-    #[serde(with = "common::units::millisecond::i64")]
-    #[schema(value_type = i64)]
-    pub start_time: Offset,
     pub spacing_requirements: Vec<SpacingRequirement>,
     pub routing_requirements: Vec<RoutingRequirement>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct WorkSchedulesRequest {
-    /// Start time for the work schedules: elapsed ms since the implicit 'request base time'.
-    /// `start_time` acts as a reference point for all time values in the work schedule
-    /// requirements (values expressed as an offset).
-    ///
-    /// The implicit 'request base time' is the same over the whole request
-    /// (`trains_requirements` and `work_schedules`) and response.
-    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
-    /// timetables.
-    #[serde(with = "common::units::millisecond::i64")]
-    pub start_time: Offset,
     pub work_schedule_requirements: HashMap<String, WorkSchedule>,
 }
 

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -190,9 +190,14 @@ pub struct SignalCriticalPosition {
 #[schema(as = CoreSpacingRequirement)]
 pub struct SpacingRequirement {
     pub zone: String,
-    // Time in ms
+    /// Time in ms since a reference point that depends on which struct embeds this one:
+    /// - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+    ///   requirements): a request-wide origin shared by all trains, `work_schedules` and the
+    ///   response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+    ///   hourly ones);
+    /// - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
     pub begin_time: u64,
-    // Time in ms
+    /// Time in ms: see begin_time
     pub end_time: u64,
 }
 
@@ -200,7 +205,12 @@ pub struct SpacingRequirement {
 #[schema(as = CoreRoutingRequirement)]
 pub struct RoutingRequirement {
     pub route: String,
-    /// Time in ms
+    /// Time in ms since a reference point that depends on which struct embeds this one:
+    /// - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+    ///   requirements): a request-wide origin shared by all trains, `work_schedules` and the
+    ///   response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+    ///   hourly ones);
+    /// - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
     pub begin_time: u64,
     pub zones: Vec<RoutingZoneRequirement>,
 }
@@ -212,7 +222,12 @@ pub struct RoutingZoneRequirement {
     pub entry_detector: String,
     pub exit_detector: String,
     pub switches: HashMap<String, String>,
-    /// Time in ms
+    /// Time in ms since a reference point that depends on which struct embeds this one:
+    /// - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+    ///   requirements): a request-wide origin shared by all trains, `work_schedules` and the
+    ///   response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+    ///   hourly ones);
+    /// - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
     pub end_time: u64,
 }
 

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -91,9 +91,12 @@ pub struct StepTimingData {
 pub struct WorkSchedule {
     /// Unique identifier for the work schedule
     pub obj_id: String,
-    /// Start time as a time delta from the stdcm start time in ms
+    /// Time in ms since a request-wide origin (`1970-01-01T00:00:00Z` for calendar timetables,
+    /// the timetable start for hourly ones). This origin is shared by :
+    /// - the `start_time` in STDCM `Request`(all since `1970-01-01T00:00:00Z`)
+    /// - all train requirements and work schedules in conflicts detection
     pub start_time: u64,
-    /// End time as a time delta from the stdcm start time in ms
+    /// Time in ms: see start_time.
     pub end_time: u64,
     /// List of unavailable track ranges
     pub track_ranges: Vec<UndirectedTrackRange>,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5780,7 +5780,13 @@ components:
         begin_time:
           type: integer
           format: int64
-          description: Time in ms
+          description: |-
+            Time in ms since a reference point that depends on which struct embeds this one:
+            - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+              requirements): a request-wide origin shared by all trains, `work_schedules` and the
+              response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+              hourly ones);
+            - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
           minimum: 0
         route:
           type: string
@@ -5800,7 +5806,13 @@ components:
         end_time:
           type: integer
           format: int64
-          description: Time in ms
+          description: |-
+            Time in ms since a reference point that depends on which struct embeds this one:
+            - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+              requirements): a request-wide origin shared by all trains, `work_schedules` and the
+              response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+              hourly ones);
+            - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
           minimum: 0
         entry_detector:
           type: string
@@ -5929,10 +5941,18 @@ components:
         begin_time:
           type: integer
           format: int64
+          description: |-
+            Time in ms since a reference point that depends on which struct embeds this one:
+            - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+              requirements): a request-wide origin shared by all trains, `work_schedules` and the
+              response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+              hourly ones);
+            - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
           minimum: 0
         end_time:
           type: integer
           format: int64
+          description: 'Time in ms: see begin_time'
           minimum: 0
         zone:
           type: string
@@ -5996,7 +6016,6 @@ components:
       required:
       - train_id
       - train_name
-      - start_time
       - spacing_requirements
       - routing_requirements
       properties:
@@ -6008,18 +6027,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CoreSpacingRequirement'
-        start_time:
-          type: integer
-          format: int64
-          description: |-
-            Start time for the given train: elapsed ms since an implicit 'request base time'.
-            `start_time` acts as a reference point for all time values in the spacing and routing
-            requirements for this train (values expressed as an offset).
-
-            The implicit 'request base time' is the same over the whole request
-            (`trains_requirements` and `work_schedules`) and response.
-            Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
-            timetables.
         train_id:
           type: string
         train_name:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7121,6 +7121,7 @@ components:
       - $ref: '#/components/schemas/EditoastTemporarySpeedLimitErrorNameAlreadyUsed'
       - $ref: '#/components/schemas/EditoastTimetableErrorDatabase'
       - $ref: '#/components/schemas/EditoastTimetableErrorInfraNotFound'
+      - $ref: '#/components/schemas/EditoastTimetableErrorInvalidPeriod'
       - $ref: '#/components/schemas/EditoastTimetableErrorNotFound'
       - $ref: '#/components/schemas/EditoastTimetableErrorParseError'
       - $ref: '#/components/schemas/EditoastTimetableErrorTimeout'
@@ -9251,6 +9252,31 @@ components:
           type: string
           enum:
           - editoast:timetable:InfraNotFound
+    EditoastTimetableErrorInvalidPeriod:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastTimetableErrorInvalidPeriodContext
+          required:
+          - timetable_period
+          properties:
+            timetable_period:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 422
+        type:
+          type: string
+          enum:
+          - editoast:timetable:InvalidPeriod
     EditoastTimetableErrorNotFound:
       type: object
       required:

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -53,6 +53,17 @@ pub async fn create_timetable_with_train_schedule_set(
     (timetable, train_schedule_set)
 }
 
+/// Returns a tuple of (timetable, train_schedule_set) for an hourly timetable
+pub async fn create_hourly_timetable_with_train_schedule_set(
+    conn: &mut DbConnection,
+) -> (Timetable, TrainScheduleSet) {
+    // The train schedule set type must match the timetable type (DB constraint).
+    let timetable = create_hourly_timetable(conn).await;
+    let train_schedule_set = create_hourly_train_schedule_set(conn).await;
+    let _ = link_train_schedule_set_to_timetable(conn, train_schedule_set.id, timetable.id).await;
+    (timetable, train_schedule_set)
+}
+
 pub async fn create_timetable_with_simple_paced_train(
     conn: &mut DbConnection,
 ) -> (Timetable, editoast_models::TrainSchedule) {
@@ -75,6 +86,27 @@ pub async fn create_train_schedule_set(conn: &mut DbConnection) -> TrainSchedule
         .create(conn)
         .await
         .expect("Failed to create train schedule set")
+}
+
+pub async fn create_hourly_timetable(conn: &mut DbConnection) -> Timetable {
+    Timetable::changeset()
+        .timetable_type(editoast_models::timetable_type::TimetableType(
+            schemas::timetable_type::TimetableType::Hourly,
+        ))
+        .create(conn)
+        .await
+        .expect("Failed to create hourly timetable")
+}
+
+pub async fn create_hourly_train_schedule_set(conn: &mut DbConnection) -> TrainScheduleSet {
+    TrainScheduleSet::changeset()
+        .timetable_type(editoast_models::timetable_type::TimetableType(
+            schemas::timetable_type::TimetableType::Hourly,
+        ))
+        .name(None)
+        .create(conn)
+        .await
+        .expect("Failed to create hourly train schedule set")
 }
 
 pub async fn create_catalog_entry_with_name(conn: &mut DbConnection, name: &str) -> CatalogEntry {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -21,6 +21,7 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use common::units::millisecond;
 use common::units::quantities::Acceleration;
 use common::units::quantities::Length;
 use common::units::quantities::Mass;
@@ -31,6 +32,8 @@ use core_client::conflict_detection::TrainRequirements;
 use core_client::conflict_detection::TrainRequirementsById;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::PhysicsConsist;
+use core_client::simulation::RoutingRequirement;
+use core_client::simulation::SpacingRequirement;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use editoast_models::TrainScheduleException;
@@ -373,11 +376,11 @@ pub(in crate::views) async fn conflicts(
             }
             Some((
                 train_id,
-                TrainRequirements {
-                    start_time: train_schedule.start_time(),
-                    spacing_requirements: simulation.final_output.spacing_requirements.clone(),
-                    routing_requirements: simulation.final_output.routing_requirements.clone(),
-                },
+                make_requirements_absolute(
+                    train_schedule.start_time(),
+                    simulation.final_output.spacing_requirements.clone(),
+                    simulation.final_output.routing_requirements.clone(),
+                ),
             ))
         });
 
@@ -522,15 +525,48 @@ fn build_trains_requirements(
                 }) => Some(final_output),
                 _ => None,
             }?;
+            let train_requirements = make_requirements_absolute(
+                start_time,
+                spacing_requirements.clone(),
+                routing_requirements.clone(),
+            );
             Some(TrainRequirementsById {
                 train_id: train_id.to_string(),
-                start_time,
-                spacing_requirements,
-                routing_requirements,
+                spacing_requirements: train_requirements.spacing_requirements,
+                routing_requirements: train_requirements.routing_requirements,
                 train_name,
             })
         },
     )
+}
+
+/// Add the start_time of the occurrence into every requirement time
+fn make_requirements_absolute(
+    start_time: Offset,
+    spacing_requirements: Vec<SpacingRequirement>,
+    routing_requirements: Vec<RoutingRequirement>,
+) -> TrainRequirements {
+    let start_ms = millisecond::i64::from(start_time) as u64;
+    TrainRequirements {
+        spacing_requirements: spacing_requirements
+            .into_iter()
+            .map(|mut requirement| {
+                requirement.begin_time += start_ms;
+                requirement.end_time += start_ms;
+                requirement
+            })
+            .collect(),
+        routing_requirements: routing_requirements
+            .into_iter()
+            .map(|mut requirement| {
+                requirement.begin_time += start_ms;
+                for zone in &mut requirement.zones {
+                    zone.end_time += start_ms;
+                }
+                requirement
+            })
+            .collect(),
+    }
 }
 
 #[derive(Deserialize, ToSchema, Eq, PartialEq)]
@@ -1028,6 +1064,7 @@ mod tests {
     use axum::http::StatusCode;
     use chrono::Duration;
     use common::units;
+    use core_client::simulation::RoutingZoneRequirement;
     use editoast_models::train_schedule::TrainScheduleChangeset;
     use pretty_assertions::assert_eq;
     use schemas::fixtures::simple_rolling_stock;
@@ -1215,6 +1252,47 @@ mod tests {
             .assert_status_not_found()
             .json();
         assert_eq!(&response.error_type, "editoast:timetable:NotFound")
+    }
+
+    #[test]
+    fn test_make_requirements_absolute() {
+        let start_time = millisecond::i64::new(30_000);
+
+        let spacing_requirement = SpacingRequirement {
+            zone: "ZONE_1".to_string(),
+            begin_time: 0,
+            end_time: 7,
+        };
+        let routing_requirement = RoutingRequirement {
+            route: "ZONE_2".to_string(),
+            begin_time: 12,
+            zones: vec![RoutingZoneRequirement {
+                zone: "ZONE_3".to_string(),
+                entry_detector: "D_1".to_string(),
+                exit_detector: "D_2".to_string(),
+                switches: {
+                    let mut map = HashMap::new();
+                    map.insert("S_1".to_string(), "S_2".to_string());
+                    map
+                },
+                end_time: 15,
+            }],
+        };
+
+        let result = make_requirements_absolute(
+            start_time,
+            vec![spacing_requirement],
+            vec![routing_requirement],
+        );
+
+        // Every time is shifted by 30_000 ms (30s).
+        let spacing = &result.spacing_requirements[0];
+        assert_eq!(spacing.begin_time, 30_000);
+        assert_eq!(spacing.end_time, 30_007);
+
+        let routing = &result.routing_requirements[0];
+        assert_eq!(routing.begin_time, 30_012);
+        assert_eq!(routing.zones[0].end_time, 30_015);
     }
 
     fn create_physics_consist() -> PhysicsConsistParameters {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -11,7 +11,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Duration;
 
 use authz;
 use axum::Extension;
@@ -21,6 +20,7 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use chrono::Duration;
 use common::units::millisecond;
 use common::units::quantities::Acceleration;
 use common::units::quantities::Length;
@@ -71,6 +71,9 @@ use crate::views::AuthenticationExt;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::timetable::conflicts::Conflict;
 use crate::views::timetable::conflicts::build_conflict_core_request;
+use crate::views::timetable::conflicts::build_cyclic_occurrence_requirements;
+use crate::views::timetable::conflicts::compute_hourly_pattern_period;
+use crate::views::timetable::conflicts::populate_timetable;
 use crate::views::timetable::conflicts::retrieve_trains;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use editoast_models::Infra;
@@ -100,6 +103,9 @@ enum TimetableError {
     #[error("Request timed out")]
     #[editoast_error(status = 504)]
     Timeout,
+    #[error("Hourly timetable period is '{timetable_period}' h but should be under 24h")]
+    #[editoast_error(status = 422)]
+    InvalidPeriod { timetable_period: i64 },
 }
 
 /// Creation result for a Timetable
@@ -315,8 +321,23 @@ pub(in crate::views) async fn conflicts(
     })
     .await?;
 
-    let trains = retrieve_trains(conn.clone(), timetable_id).await?;
-    let train_schedules_ids = trains.iter().map(|t| t.id).collect::<Vec<_>>();
+    let (timetable_type, trains) = retrieve_trains(conn.clone(), timetable_id).await?;
+
+    let timetable_period = match timetable_type {
+        TimetableType::Calendar => None,
+        TimetableType::Hourly => compute_hourly_pattern_period(&trains),
+    };
+    // Reject a timetable period longer than 24h: an hourly timetable is not meant to span more than a day
+    if let Some(timetable_period) = timetable_period
+        && timetable_period > Duration::hours(24)
+    {
+        return Err(TimetableError::InvalidPeriod {
+            timetable_period: timetable_period.num_hours(),
+        }
+        .into());
+    }
+
+    let train_schedules_ids = trains.iter().map(|t| t.id).collect_vec();
 
     let mut exceptions =
         editoast_models::TrainScheduleException::retrieve_exceptions_by_train_schedules(
@@ -343,7 +364,21 @@ pub(in crate::views) async fn conflicts(
     // Flatten paced trains occurrences
     let (occurrence_ids, occurrence_trains): (Vec<_>, Vec<_>) = train_schedules_with_exceptions
         .iter()
-        .flat_map(|(ts, exceptions)| ts.iter_occurrences(exceptions))
+        .flat_map(|(ts, exceptions)| {
+            let single_period_occurrences = ts.iter_occurrences(exceptions).collect();
+            match timetable_period {
+                None => single_period_occurrences,
+                Some(period) => {
+                    // For hourly timetable, occurrences must be duplicated to cover the timetable period (ex: a 1h mission within a 2h period)
+                    let time_window_ms = ts
+                        .time_window
+                        .expect("all time_window are defined when timetable_period exists")
+                        .num_milliseconds();
+                    let repetition = (period.num_milliseconds() / time_window_ms) as usize;
+                    populate_timetable(single_period_occurrences, repetition, time_window_ms)
+                }
+            }
+        })
         .unzip();
 
     let occurrence_simulations: Vec<_> = train_simulation_ordered_batch(
@@ -382,6 +417,15 @@ pub(in crate::views) async fn conflicts(
                     simulation.final_output.routing_requirements.clone(),
                 ),
             ))
+        })
+        .flat_map(|(train_id, train_requirements)| match timetable_period {
+            None => vec![(train_id, train_requirements)],
+            Some(period) => build_cyclic_occurrence_requirements(
+                train_id,
+                train_requirements.spacing_requirements,
+                train_requirements.routing_requirements,
+                period,
+            ),
         });
 
     let (trains_ids_map, conflict_detection_request) =
@@ -615,7 +659,7 @@ pub(in crate::views) async fn get_local_track_names(
     })
     .await?;
 
-    timeout(Duration::from_secs(240), async move {
+    timeout(std::time::Duration::from_secs(240), async move {
         let conn = &mut db_pool.get().await?;
 
         Timetable::exists_or_fail(conn, timetable_id, || TimetableError::NotFound {
@@ -1076,6 +1120,7 @@ mod tests {
 
     use super::*;
     use crate::error::InternalError;
+    use crate::fixtures::create_hourly_timetable_with_train_schedule_set;
     use crate::fixtures::create_small_infra;
     use crate::fixtures::create_timetable;
     use crate::fixtures::create_timetable_with_simple_paced_train;
@@ -1293,6 +1338,43 @@ mod tests {
         let routing = &result.routing_requirements[0];
         assert_eq!(routing.begin_time, 30_012);
         assert_eq!(routing.zones[0].end_time, 30_015);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn conflicts_hourly_rejects_period_over_24h() {
+        let app = test_app!().skip_authz().build();
+        let pool = app.db_pool();
+
+        let infra = create_small_infra(&mut pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_hourly_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
+
+        // Period = 5 * 7 = 35h.
+        for time_window in [5, 7] {
+            let mut base = simple_paced_train_base();
+            base.train_occurrence.start_time = units::millisecond::i64::new(0);
+            base.paced.as_mut().unwrap().time_window =
+                Duration::hours(time_window).try_into().unwrap();
+            base.paced.as_mut().unwrap().interval = Duration::hours(1).try_into().unwrap();
+            TrainScheduleChangeset::from(base)
+                .train_schedule_set_id(train_schedule_set.id)
+                .create(&mut pool.get_ok())
+                .await
+                .expect("Failed to create paced train");
+        }
+
+        let response: InternalError = app
+            .get(
+                format!(
+                    "/timetable/{}/conflicts?infra_id={}",
+                    timetable.id, infra.id
+                )
+                .as_str(),
+            )
+            .await
+            .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
+            .json();
+        assert_eq!(response.error_type, "editoast:timetable:InvalidPeriod");
     }
 
     fn create_physics_consist() -> PhysicsConsistParameters {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,3 +1,4 @@
+pub mod conflicts;
 mod occupancy_blocks;
 pub mod similar_trains;
 pub mod simulation;
@@ -26,21 +27,15 @@ use common::units::quantities::Mass;
 use common::units::quantities::Offset;
 use common::units::quantities::Velocity;
 use core_client::AsCoreRequest;
-use core_client::conflict_detection::Conflict as CoreConflict;
-use core_client::conflict_detection::ConflictDetectionRequest;
-use core_client::conflict_detection::ConflictRequirement;
-use core_client::conflict_detection::ConflictType;
 use core_client::conflict_detection::TrainRequirements;
 use core_client::conflict_detection::TrainRequirementsById;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::PhysicsConsist;
-use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use editoast_models::TrainScheduleException;
 use editoast_models::prelude::*;
 use editoast_models::timetable::Timetable;
-use editoast_models::timetable::TimetableWithTrains;
 use itertools::Itertools;
 use itertools::izip;
 use schemas::RollingStock;
@@ -61,7 +56,6 @@ use tokio::time::timeout;
 use train_schedule::TrainScheduleResponse;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 use super::infra::InfraIdQueryParam;
 use super::pagination::PaginatedList;
@@ -72,6 +66,9 @@ use crate::AppState;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
 use crate::views::path::operational_point_cache::OperationalPointCache;
+use crate::views::timetable::conflicts::Conflict;
+use crate::views::timetable::conflicts::build_conflict_core_request;
+use crate::views::timetable::conflicts::retrieve_trains;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use editoast_models::Infra;
 use editoast_models::TrainScheduleSet;
@@ -271,70 +268,6 @@ pub struct ElectricalProfileSetIdQueryParam {
     electrical_profile_set_id: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
-pub struct Conflict {
-    /// List of trains involved in the conflict.
-    #[schema(inline)]
-    train_ids: Vec<OccurrenceId>,
-    /// List of work schedule ids involved in the conflict
-    pub work_schedule_ids: Vec<i64>,
-    /// Start of the conflict time range: elapsed ms since an implicit 'request base time'.
-    /// This is the *union* of all the conflicting time ranges.
-    ///
-    /// The implicit 'request base time' is the same as the train schedules' `start_time`
-    /// frame in this timetable.
-    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
-    /// timetables.
-    #[serde(with = "common::units::millisecond::i64")]
-    #[schema(value_type = i64)]
-    pub start_time: Offset,
-    /// Duration of the conflict in ms.
-    pub duration: u64,
-    /// Type of the conflict
-    pub conflict_type: ConflictType,
-    /// List of requirements causing the conflict
-    pub requirements: Vec<ConflictRequirement>,
-}
-
-impl Conflict {
-    /// This function processes train ids from Core Response
-    ///  and maps them to either a `train_schedule_id` or a `paced_train_occurrence_id` based on the provided key mapping.
-    fn from_core_response(
-        conflict: CoreConflict,
-        trains_map: &HashMap<Uuid, OccurrenceId>,
-    ) -> Result<Self> {
-        let train_ids: Vec<_> = conflict
-            .train_ids
-            .into_iter()
-            .map(|train_uuid| {
-                trains_map
-                    .get(&train_uuid)
-                    .expect("Unreachable case encountered while parsing train IDs")
-            })
-            .cloned()
-            .collect();
-
-        let work_schedule_ids = conflict
-            .work_schedule_ids
-            .into_iter()
-            .map(|id| {
-                id.parse::<i64>().map_err(|_| TimetableError::ParseError {
-                    train_id: id.clone(),
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(Self {
-            train_ids,
-            work_schedule_ids,
-            start_time: conflict.start_time,
-            duration: conflict.duration,
-            conflict_type: conflict.conflict_type,
-            requirements: conflict.requirements,
-        })
-    }
-}
-
 /// Retrieve the list of conflicts of the timetable
 ///
 /// The following trains are **excluded** from the result:
@@ -459,51 +392,6 @@ pub(in crate::views) async fn conflicts(
         .map(|response| Conflict::from_core_response(response, &trains_ids_map))
         .collect();
     Ok(Json(conflicts_response?))
-}
-
-async fn retrieve_trains(
-    mut conn: DbConnection,
-    timetable_id: i64,
-) -> Result<Vec<editoast_models::TrainSchedule>> {
-    let timetable_trains =
-        TimetableWithTrains::retrieve_or_fail(conn.clone(), timetable_id, || {
-            TimetableError::NotFound { timetable_id }
-        })
-        .await?;
-    let trains = editoast_models::TrainSchedule::retrieve_batch_unchecked(
-        &mut conn,
-        timetable_trains.paced_train_ids,
-    )
-    .await?;
-
-    Ok(trains)
-}
-
-/// Build the core conflict detection request
-fn build_conflict_core_request(
-    infra: Infra,
-    items: impl Iterator<Item = (OccurrenceId, TrainRequirements)>,
-) -> (HashMap<Uuid, OccurrenceId>, ConflictDetectionRequest) {
-    let mut trains_map: HashMap<Uuid, OccurrenceId> = HashMap::new();
-
-    let trains_requirements: HashMap<Uuid, TrainRequirements> = items
-        .map(|(train_id, train_requirements)| {
-            let train_id_for_core = Uuid::new_v4();
-            trains_map.insert(train_id_for_core, train_id);
-
-            (train_id_for_core, train_requirements)
-        })
-        .collect();
-
-    (
-        trains_map,
-        ConflictDetectionRequest {
-            infra: infra.id,
-            expected_version: infra.version,
-            trains_requirements,
-            work_schedules: None,
-        },
-    )
 }
 
 /// Retrieve the list of requirements of the timetable (invalid trains are ignored)
@@ -1140,12 +1028,8 @@ mod tests {
     use axum::http::StatusCode;
     use chrono::Duration;
     use common::units;
-    use core_client::simulation::RoutingRequirement;
-    use core_client::simulation::RoutingZoneRequirement;
-    use core_client::simulation::SpacingRequirement;
     use editoast_models::train_schedule::TrainScheduleChangeset;
     use pretty_assertions::assert_eq;
-    use schemas::fixtures::ms_since_epoch;
     use schemas::fixtures::simple_rolling_stock;
     use schemas::fixtures::towed_rolling_stock;
     use schemas::rolling_stock::RollingResistanceRaw;
@@ -1331,151 +1215,6 @@ mod tests {
             .assert_status_not_found()
             .json();
         assert_eq!(&response.error_type, "editoast:timetable:NotFound")
-    }
-
-    // Build one train schedule and one paced train with 2 occurrences
-    // then check that the function 'build_conflict_core_request'
-    // produce something coherent
-    #[test]
-    fn build_coherent_conflict_core_request() {
-        // Given
-        let infra = Infra::default();
-        let ts_id = 13;
-        let ts_start_time = ms_since_epoch("2025-01-01T08:00:00Z");
-
-        let spacing_requirement = SpacingRequirement {
-            zone: "ZONE_1".to_string(),
-            begin_time: 0,
-            end_time: 7,
-        };
-        let routing_requirement = RoutingRequirement {
-            route: "ZONE_2".to_string(),
-            begin_time: 12,
-            zones: vec![RoutingZoneRequirement {
-                zone: "ZONE_3".to_string(),
-                entry_detector: "D_1".to_string(),
-                exit_detector: "D_2".to_string(),
-                switches: {
-                    let mut map = HashMap::new();
-                    map.insert("S_1".to_string(), "S_2".to_string());
-                    map
-                },
-                end_time: 15,
-            }],
-        };
-        let paced_train_id = 42;
-        let paced_start_time = ms_since_epoch("2025-01-01T09:00:00Z");
-        let paced_interval = units::second::new(3600.0);
-
-        let train_ids = vec![
-            OccurrenceId::new_base(paced_train_id, 0),
-            OccurrenceId::new_base(paced_train_id, 1),
-            OccurrenceId::new_base(ts_id, 0),
-        ];
-
-        let requirements = vec![
-            TrainRequirements {
-                start_time: paced_start_time,
-                spacing_requirements: vec![spacing_requirement.clone()],
-                routing_requirements: vec![routing_requirement.clone()],
-            },
-            TrainRequirements {
-                start_time: paced_start_time + paced_interval,
-                spacing_requirements: vec![spacing_requirement.clone()],
-                routing_requirements: vec![routing_requirement.clone()],
-            },
-            TrainRequirements {
-                start_time: ts_start_time,
-                spacing_requirements: vec![spacing_requirement.clone()],
-                routing_requirements: vec![routing_requirement.clone()],
-            },
-        ];
-
-        // When
-        let (trains_ids_map, conflict_core_request) =
-            build_conflict_core_request(infra, train_ids.into_iter().zip(requirements));
-
-        // Then (assert the train schedule)
-        assert_eq!(conflict_core_request.trains_requirements.len(), 3);
-
-        let simple_ts_train_core_id = trains_ids_map
-            .iter()
-            .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base {
-                    train_schedule_id, ..
-                } if *train_schedule_id == ts_id => Some(core_id),
-                _ => None,
-            })
-            .unwrap();
-
-        let simple_requirements = conflict_core_request
-            .trains_requirements
-            .get(simple_ts_train_core_id)
-            .unwrap();
-        assert_eq!(simple_requirements.start_time, ts_start_time);
-        assert_eq!(
-            simple_requirements.spacing_requirements,
-            vec![spacing_requirement.clone()]
-        );
-        assert_eq!(
-            simple_requirements.routing_requirements,
-            vec![routing_requirement.clone()]
-        );
-
-        // Then (assert the paced train, first occurrence)
-        let paced_0_train_core_id = trains_ids_map
-            .iter()
-            .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base {
-                    train_schedule_id,
-                    index,
-                    ..
-                } if *train_schedule_id == paced_train_id && *index == 0 => Some(core_id),
-                _ => None,
-            })
-            .unwrap();
-        let paced_0_requirements = conflict_core_request
-            .trains_requirements
-            .get(paced_0_train_core_id)
-            .unwrap();
-        assert_eq!(paced_0_requirements.start_time, paced_start_time);
-        assert_eq!(
-            paced_0_requirements.spacing_requirements,
-            vec![spacing_requirement.clone()]
-        );
-        assert_eq!(
-            paced_0_requirements.routing_requirements,
-            vec![routing_requirement.clone()]
-        );
-
-        // Then (assert the paced train, second occurrence)
-        let paced_1_train_core_id = trains_ids_map
-            .iter()
-            .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base {
-                    train_schedule_id,
-                    index,
-                    ..
-                } if *train_schedule_id == paced_train_id && *index == 1 => Some(core_id),
-                _ => None,
-            })
-            .unwrap();
-        let paced_1_requirements = conflict_core_request
-            .trains_requirements
-            .get(paced_1_train_core_id)
-            .unwrap();
-        assert_eq!(
-            paced_1_requirements.start_time,
-            paced_start_time + paced_interval
-        );
-        assert_eq!(
-            paced_1_requirements.spacing_requirements,
-            vec![spacing_requirement]
-        );
-        assert_eq!(
-            paced_1_requirements.routing_requirements,
-            vec![routing_requirement]
-        );
     }
 
     fn create_physics_consist() -> PhysicsConsistParameters {

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -1,0 +1,285 @@
+use std::collections::HashMap;
+
+use common::units::quantities::Offset;
+use editoast_models::prelude::*;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::error::Result;
+use crate::views::timetable::TimetableError;
+use core_client::conflict_detection::Conflict as CoreConflict;
+use core_client::conflict_detection::ConflictDetectionRequest;
+use core_client::conflict_detection::ConflictRequirement;
+use core_client::conflict_detection::ConflictType;
+use core_client::conflict_detection::TrainRequirements;
+use database::DbConnection;
+use editoast_models::Infra;
+use editoast_models::timetable::TimetableWithTrains;
+use editoast_models::train_schedule::OccurrenceId;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct Conflict {
+    /// List of trains involved in the conflict.
+    #[schema(inline)]
+    train_ids: Vec<OccurrenceId>,
+    /// List of work schedule ids involved in the conflict
+    pub work_schedule_ids: Vec<i64>,
+    /// Start of the conflict time range: elapsed ms since an implicit 'request base time'.
+    /// This is the *union* of all the conflicting time ranges.
+    ///
+    /// The implicit 'request base time' is the same as the train schedules' `start_time`
+    /// frame in this timetable.
+    /// Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
+    /// timetables.
+    #[serde(with = "common::units::millisecond::i64")]
+    #[schema(value_type = i64)]
+    pub start_time: Offset,
+    /// Duration of the conflict in ms.
+    pub duration: u64,
+    /// Type of the conflict
+    pub conflict_type: ConflictType,
+    /// List of requirements causing the conflict
+    pub requirements: Vec<ConflictRequirement>,
+}
+
+impl Conflict {
+    /// This function processes train ids from Core Response
+    ///  and maps them to either a `train_schedule_id` or a `paced_train_occurrence_id` based on the provided key mapping.
+    pub(super) fn from_core_response(
+        conflict: CoreConflict,
+        trains_map: &HashMap<Uuid, OccurrenceId>,
+    ) -> Result<Self> {
+        let train_ids: Vec<_> = conflict
+            .train_ids
+            .into_iter()
+            .map(|train_uuid| {
+                trains_map
+                    .get(&train_uuid)
+                    .expect("Unreachable case encountered while parsing train IDs")
+            })
+            .cloned()
+            .collect();
+
+        let work_schedule_ids = conflict
+            .work_schedule_ids
+            .into_iter()
+            .map(|id| {
+                id.parse::<i64>().map_err(|_| TimetableError::ParseError {
+                    train_id: id.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            train_ids,
+            work_schedule_ids,
+            start_time: conflict.start_time,
+            duration: conflict.duration,
+            conflict_type: conflict.conflict_type,
+            requirements: conflict.requirements,
+        })
+    }
+}
+
+pub(super) async fn retrieve_trains(
+    mut conn: DbConnection,
+    timetable_id: i64,
+) -> Result<Vec<editoast_models::TrainSchedule>> {
+    let timetable_trains =
+        TimetableWithTrains::retrieve_or_fail(conn.clone(), timetable_id, || {
+            TimetableError::NotFound { timetable_id }
+        })
+        .await?;
+    let trains = editoast_models::TrainSchedule::retrieve_batch_unchecked(
+        &mut conn,
+        timetable_trains.paced_train_ids,
+    )
+    .await?;
+
+    Ok(trains)
+}
+
+/// Build the core conflict detection request
+pub(super) fn build_conflict_core_request(
+    infra: Infra,
+    items: impl Iterator<Item = (OccurrenceId, TrainRequirements)>,
+) -> (HashMap<Uuid, OccurrenceId>, ConflictDetectionRequest) {
+    let mut trains_map: HashMap<Uuid, OccurrenceId> = HashMap::new();
+
+    let trains_requirements: HashMap<Uuid, TrainRequirements> = items
+        .map(|(train_id, train_requirements)| {
+            let train_id_for_core = Uuid::new_v4();
+            trains_map.insert(train_id_for_core, train_id);
+
+            (train_id_for_core, train_requirements)
+        })
+        .collect();
+
+    (
+        trains_map,
+        ConflictDetectionRequest {
+            infra: infra.id,
+            expected_version: infra.version,
+            trains_requirements,
+            work_schedules: None,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::units;
+    use core_client::simulation::RoutingRequirement;
+    use core_client::simulation::RoutingZoneRequirement;
+    use core_client::simulation::SpacingRequirement;
+    use pretty_assertions::assert_eq;
+    use schemas::fixtures::ms_since_epoch;
+
+    // Build one train schedule and one paced train with 2 occurrences
+    // then check that the function 'build_conflict_core_request'
+    // produce something coherent
+    #[test]
+    fn build_coherent_conflict_core_request() {
+        // Given
+        let infra = Infra::default();
+        let ts_id = 13;
+        let ts_start_time = ms_since_epoch("2025-01-01T08:00:00Z");
+
+        let spacing_requirement = SpacingRequirement {
+            zone: "ZONE_1".to_string(),
+            begin_time: 0,
+            end_time: 7,
+        };
+        let routing_requirement = RoutingRequirement {
+            route: "ZONE_2".to_string(),
+            begin_time: 12,
+            zones: vec![RoutingZoneRequirement {
+                zone: "ZONE_3".to_string(),
+                entry_detector: "D_1".to_string(),
+                exit_detector: "D_2".to_string(),
+                switches: {
+                    let mut map = HashMap::new();
+                    map.insert("S_1".to_string(), "S_2".to_string());
+                    map
+                },
+                end_time: 15,
+            }],
+        };
+        let paced_train_id = 42;
+        let paced_start_time = ms_since_epoch("2025-01-01T09:00:00Z");
+        let paced_interval = units::second::new(3600.0);
+
+        let train_ids = vec![
+            OccurrenceId::new_base(paced_train_id, 0),
+            OccurrenceId::new_base(paced_train_id, 1),
+            OccurrenceId::new_base(ts_id, 0),
+        ];
+
+        let requirements = vec![
+            TrainRequirements {
+                start_time: paced_start_time,
+                spacing_requirements: vec![spacing_requirement.clone()],
+                routing_requirements: vec![routing_requirement.clone()],
+            },
+            TrainRequirements {
+                start_time: paced_start_time + paced_interval,
+                spacing_requirements: vec![spacing_requirement.clone()],
+                routing_requirements: vec![routing_requirement.clone()],
+            },
+            TrainRequirements {
+                start_time: ts_start_time,
+                spacing_requirements: vec![spacing_requirement.clone()],
+                routing_requirements: vec![routing_requirement.clone()],
+            },
+        ];
+
+        // When
+        let (trains_ids_map, conflict_core_request) =
+            build_conflict_core_request(infra, train_ids.into_iter().zip(requirements));
+
+        // Then (assert the train schedule)
+        assert_eq!(conflict_core_request.trains_requirements.len(), 3);
+
+        let simple_ts_train_core_id = trains_ids_map
+            .iter()
+            .find_map(|(core_id, train_id)| match train_id {
+                OccurrenceId::Base {
+                    train_schedule_id, ..
+                } if *train_schedule_id == ts_id => Some(core_id),
+                _ => None,
+            })
+            .unwrap();
+
+        let simple_requirements = conflict_core_request
+            .trains_requirements
+            .get(simple_ts_train_core_id)
+            .unwrap();
+        assert_eq!(simple_requirements.start_time, ts_start_time);
+        assert_eq!(
+            simple_requirements.spacing_requirements,
+            vec![spacing_requirement.clone()]
+        );
+        assert_eq!(
+            simple_requirements.routing_requirements,
+            vec![routing_requirement.clone()]
+        );
+
+        // Then (assert the paced train, first occurrence)
+        let paced_0_train_core_id = trains_ids_map
+            .iter()
+            .find_map(|(core_id, train_id)| match train_id {
+                OccurrenceId::Base {
+                    train_schedule_id,
+                    index,
+                    ..
+                } if *train_schedule_id == paced_train_id && *index == 0 => Some(core_id),
+                _ => None,
+            })
+            .unwrap();
+        let paced_0_requirements = conflict_core_request
+            .trains_requirements
+            .get(paced_0_train_core_id)
+            .unwrap();
+        assert_eq!(paced_0_requirements.start_time, paced_start_time);
+        assert_eq!(
+            paced_0_requirements.spacing_requirements,
+            vec![spacing_requirement.clone()]
+        );
+        assert_eq!(
+            paced_0_requirements.routing_requirements,
+            vec![routing_requirement.clone()]
+        );
+
+        // Then (assert the paced train, second occurrence)
+        let paced_1_train_core_id = trains_ids_map
+            .iter()
+            .find_map(|(core_id, train_id)| match train_id {
+                OccurrenceId::Base {
+                    train_schedule_id,
+                    index,
+                    ..
+                } if *train_schedule_id == paced_train_id && *index == 1 => Some(core_id),
+                _ => None,
+            })
+            .unwrap();
+        let paced_1_requirements = conflict_core_request
+            .trains_requirements
+            .get(paced_1_train_core_id)
+            .unwrap();
+        assert_eq!(
+            paced_1_requirements.start_time,
+            paced_start_time + paced_interval
+        );
+        assert_eq!(
+            paced_1_requirements.spacing_requirements,
+            vec![spacing_requirement]
+        );
+        assert_eq!(
+            paced_1_requirements.routing_requirements,
+            vec![routing_requirement]
+        );
+    }
+}

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -131,155 +131,91 @@ pub(super) fn build_conflict_core_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::units;
     use core_client::simulation::RoutingRequirement;
     use core_client::simulation::RoutingZoneRequirement;
     use core_client::simulation::SpacingRequirement;
-    use pretty_assertions::assert_eq;
-    use schemas::fixtures::ms_since_epoch;
+
+    fn spacing(zone: &str, begin_time: u64, end_time: u64) -> SpacingRequirement {
+        SpacingRequirement {
+            zone: zone.to_string(),
+            begin_time,
+            end_time,
+        }
+    }
+
+    fn routing(route: &str, begin_time: u64, end_time: u64) -> RoutingRequirement {
+        RoutingRequirement {
+            route: route.to_string(),
+            begin_time,
+            zones: vec![RoutingZoneRequirement {
+                zone: format!("{route}_ZONE"),
+                entry_detector: "D_1".to_string(),
+                exit_detector: "D_2".to_string(),
+                switches: HashMap::new(),
+                end_time,
+            }],
+        }
+    }
 
     // Build one train schedule and one paced train with 2 occurrences
     // then check that the function 'build_conflict_core_request'
     // produce something coherent
     #[test]
     fn build_coherent_conflict_core_request() {
-        // Given
         let infra = Infra::default();
         let ts_id = 13;
-        let ts_start_time = ms_since_epoch("2025-01-01T08:00:00Z");
-
-        let spacing_requirement = SpacingRequirement {
-            zone: "ZONE_1".to_string(),
-            begin_time: 0,
-            end_time: 7,
-        };
-        let routing_requirement = RoutingRequirement {
-            route: "ZONE_2".to_string(),
-            begin_time: 12,
-            zones: vec![RoutingZoneRequirement {
-                zone: "ZONE_3".to_string(),
-                entry_detector: "D_1".to_string(),
-                exit_detector: "D_2".to_string(),
-                switches: {
-                    let mut map = HashMap::new();
-                    map.insert("S_1".to_string(), "S_2".to_string());
-                    map
-                },
-                end_time: 15,
-            }],
-        };
         let paced_train_id = 42;
-        let paced_start_time = ms_since_epoch("2025-01-01T09:00:00Z");
-        let paced_interval = units::second::new(3600.0);
 
-        let train_ids = vec![
-            OccurrenceId::new_base(paced_train_id, 0),
-            OccurrenceId::new_base(paced_train_id, 1),
-            OccurrenceId::new_base(ts_id, 0),
+        let train_schedule = OccurrenceId::new_base(ts_id, 0);
+        let paced_occurrence_0 = OccurrenceId::new_base(paced_train_id, 0);
+        let paced_occurrence_1 = OccurrenceId::new_base(paced_train_id, 1);
+
+        let train_schedule_requirements = TrainRequirements {
+            spacing_requirements: vec![spacing("TS_ZONE", 0, 7)],
+            routing_requirements: vec![routing("TS_ROUTE", 12, 15)],
+        };
+        let paced_occurrence_0_requirements = TrainRequirements {
+            spacing_requirements: vec![spacing("PACED_ZONE", 0, 7)],
+            routing_requirements: vec![routing("PACED_ROUTE", 12, 15)],
+        };
+        // Same mission as occurrence 0, one period later.
+        let paced_occurrence_1_requirements = TrainRequirements {
+            spacing_requirements: vec![spacing("PACED_ZONE", 3_600_000, 3_600_007)],
+            routing_requirements: vec![routing("PACED_ROUTE", 3_600_012, 3_600_015)],
+        };
+
+        let items = vec![
+            (
+                paced_occurrence_0.clone(),
+                paced_occurrence_0_requirements.clone(),
+            ),
+            (
+                paced_occurrence_1.clone(),
+                paced_occurrence_1_requirements.clone(),
+            ),
+            (train_schedule.clone(), train_schedule_requirements.clone()),
         ];
 
-        let requirements = vec![
-            TrainRequirements {
-                start_time: paced_start_time,
-                spacing_requirements: vec![spacing_requirement.clone()],
-                routing_requirements: vec![routing_requirement.clone()],
-            },
-            TrainRequirements {
-                start_time: paced_start_time + paced_interval,
-                spacing_requirements: vec![spacing_requirement.clone()],
-                routing_requirements: vec![routing_requirement.clone()],
-            },
-            TrainRequirements {
-                start_time: ts_start_time,
-                spacing_requirements: vec![spacing_requirement.clone()],
-                routing_requirements: vec![routing_requirement.clone()],
-            },
-        ];
-
-        // When
         let (trains_ids_map, conflict_core_request) =
-            build_conflict_core_request(infra, train_ids.into_iter().zip(requirements));
+            build_conflict_core_request(infra, items.into_iter());
 
-        // Then (assert the train schedule)
         assert_eq!(conflict_core_request.trains_requirements.len(), 3);
 
-        let simple_ts_train_core_id = trains_ids_map
-            .iter()
-            .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base {
-                    train_schedule_id, ..
-                } if *train_schedule_id == ts_id => Some(core_id),
-                _ => None,
-            })
-            .unwrap();
+        let assert_requirements = |occurrence: &OccurrenceId, expected: &TrainRequirements| {
+            let core_id = trains_ids_map
+                .iter()
+                .find_map(|(core_id, mapped)| (mapped == occurrence).then_some(core_id))
+                .expect("occurrence should be mapped to a core id");
+            let actual = conflict_core_request
+                .trains_requirements
+                .get(core_id)
+                .expect("core id should carry requirements");
+            assert_eq!(actual.spacing_requirements, expected.spacing_requirements);
+            assert_eq!(actual.routing_requirements, expected.routing_requirements);
+        };
 
-        let simple_requirements = conflict_core_request
-            .trains_requirements
-            .get(simple_ts_train_core_id)
-            .unwrap();
-        assert_eq!(simple_requirements.start_time, ts_start_time);
-        assert_eq!(
-            simple_requirements.spacing_requirements,
-            vec![spacing_requirement.clone()]
-        );
-        assert_eq!(
-            simple_requirements.routing_requirements,
-            vec![routing_requirement.clone()]
-        );
-
-        // Then (assert the paced train, first occurrence)
-        let paced_0_train_core_id = trains_ids_map
-            .iter()
-            .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base {
-                    train_schedule_id,
-                    index,
-                    ..
-                } if *train_schedule_id == paced_train_id && *index == 0 => Some(core_id),
-                _ => None,
-            })
-            .unwrap();
-        let paced_0_requirements = conflict_core_request
-            .trains_requirements
-            .get(paced_0_train_core_id)
-            .unwrap();
-        assert_eq!(paced_0_requirements.start_time, paced_start_time);
-        assert_eq!(
-            paced_0_requirements.spacing_requirements,
-            vec![spacing_requirement.clone()]
-        );
-        assert_eq!(
-            paced_0_requirements.routing_requirements,
-            vec![routing_requirement.clone()]
-        );
-
-        // Then (assert the paced train, second occurrence)
-        let paced_1_train_core_id = trains_ids_map
-            .iter()
-            .find_map(|(core_id, train_id)| match train_id {
-                OccurrenceId::Base {
-                    train_schedule_id,
-                    index,
-                    ..
-                } if *train_schedule_id == paced_train_id && *index == 1 => Some(core_id),
-                _ => None,
-            })
-            .unwrap();
-        let paced_1_requirements = conflict_core_request
-            .trains_requirements
-            .get(paced_1_train_core_id)
-            .unwrap();
-        assert_eq!(
-            paced_1_requirements.start_time,
-            paced_start_time + paced_interval
-        );
-        assert_eq!(
-            paced_1_requirements.spacing_requirements,
-            vec![spacing_requirement]
-        );
-        assert_eq!(
-            paced_1_requirements.routing_requirements,
-            vec![routing_requirement]
-        );
+        assert_requirements(&train_schedule, &train_schedule_requirements);
+        assert_requirements(&paced_occurrence_0, &paced_occurrence_0_requirements);
+        assert_requirements(&paced_occurrence_1, &paced_occurrence_1_requirements);
     }
 }

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
+use chrono::Duration;
+use common::units::millisecond;
 use common::units::quantities::Offset;
 use editoast_models::prelude::*;
+use schemas::timetable_type::TimetableType;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -13,10 +16,14 @@ use core_client::conflict_detection::ConflictDetectionRequest;
 use core_client::conflict_detection::ConflictRequirement;
 use core_client::conflict_detection::ConflictType;
 use core_client::conflict_detection::TrainRequirements;
+use core_client::simulation::RoutingRequirement;
+use core_client::simulation::RoutingZoneRequirement;
+use core_client::simulation::SpacingRequirement;
 use database::DbConnection;
 use editoast_models::Infra;
 use editoast_models::timetable::TimetableWithTrains;
 use editoast_models::train_schedule::OccurrenceId;
+use schemas::TrainOccurrence;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
@@ -83,10 +90,12 @@ impl Conflict {
     }
 }
 
+type Interval = (u64, u64);
+
 pub(super) async fn retrieve_trains(
     mut conn: DbConnection,
     timetable_id: i64,
-) -> Result<Vec<editoast_models::TrainSchedule>> {
+) -> Result<(TimetableType, Vec<editoast_models::TrainSchedule>)> {
     let timetable_trains =
         TimetableWithTrains::retrieve_or_fail(conn.clone(), timetable_id, || {
             TimetableError::NotFound { timetable_id }
@@ -98,7 +107,7 @@ pub(super) async fn retrieve_trains(
     )
     .await?;
 
-    Ok(trains)
+    Ok((timetable_trains.timetable_type.0, trains))
 }
 
 /// Build the core conflict detection request
@@ -128,12 +137,145 @@ pub(super) fn build_conflict_core_request(
     )
 }
 
+pub(super) fn compute_hourly_pattern_period(
+    paced_trains: &[editoast_models::TrainSchedule],
+) -> Option<Duration> {
+    let paced_train_lcm = paced_trains
+        .iter()
+        .map(|paced_train| {
+            paced_train
+                .time_window
+                .expect("a paced_train should have a time_window")
+                .num_milliseconds()
+        })
+        .reduce(lcm)?;
+    Some(Duration::milliseconds(paced_train_lcm))
+}
+
+fn gcd(a: i64, b: i64) -> i64 {
+    if b == 0 { a } else { gcd(b, a % b) }
+}
+
+fn lcm(a: i64, b: i64) -> i64 {
+    (a / gcd(a, b)).saturating_mul(b)
+}
+
+pub(super) fn populate_timetable(
+    period_occurrences: Vec<(OccurrenceId, TrainOccurrence)>,
+    repetition: usize,
+    time_window_ms: i64,
+) -> Vec<(OccurrenceId, TrainOccurrence)> {
+    let mut occurrences = Vec::with_capacity(period_occurrences.len() * repetition);
+    for period in 0..repetition {
+        for (id, occurrence) in &period_occurrences {
+            let mut new_occurrence = occurrence.clone();
+            new_occurrence.start_time += millisecond::i64::new(time_window_ms * period as i64);
+            let new_id = id.clone();
+            occurrences.push((new_id, new_occurrence));
+        }
+    }
+    occurrences
+}
+
+/// An hourly timetable is cyclic, so we need to get back each requirement onto [0, timetable_period[.
+/// To do so, each requirement is wrapped modulo the period, splitting it if it crosses the period boundary.
+pub(super) fn build_cyclic_occurrence_requirements(
+    train_id: OccurrenceId,
+    spacing_requirements: Vec<SpacingRequirement>,
+    routing_requirements: Vec<RoutingRequirement>,
+    timetable_period: Duration,
+) -> Vec<(OccurrenceId, TrainRequirements)> {
+    let period_ms = timetable_period.num_milliseconds() as u64;
+
+    vec![(
+        train_id.clone(),
+        TrainRequirements {
+            spacing_requirements: split_spacing(period_ms, &spacing_requirements),
+            routing_requirements: split_routing(period_ms, &routing_requirements),
+        },
+    )]
+}
+
+/// Wraps an interval [begin, end[ into [0, period[, splitting it if it crosses the period boundary
+fn split_interval(begin: u64, end: u64, period: u64) -> Vec<Interval> {
+    let duration = end - begin;
+    if duration >= period {
+        // Occupied the whole period
+        return vec![(0, period)];
+    }
+    let period_begin = begin % period;
+
+    if period_begin + duration <= period {
+        vec![(period_begin, period_begin + duration)]
+    } else {
+        vec![
+            (period_begin, period),
+            (0, period_begin + duration - period),
+        ]
+    }
+}
+
+/// Wraps the spacing requirements into [0, period[, splitting it if it crosses the period boundary
+fn split_spacing(period: u64, requirements: &[SpacingRequirement]) -> Vec<SpacingRequirement> {
+    let mut split_requirements = Vec::new();
+    for requirement in requirements {
+        let split_requirement =
+            split_interval(requirement.begin_time, requirement.end_time, period);
+        split_requirements.extend(split_requirement.into_iter().map(|(begin_time, end_time)| {
+            SpacingRequirement {
+                zone: requirement.zone.clone(),
+                begin_time,
+                end_time,
+            }
+        }));
+    }
+    split_requirements
+}
+
+/// Wraps the routing requirements into [0, period[, splitting it if it crosses the period boundary
+fn split_routing(period: u64, requirements: &[RoutingRequirement]) -> Vec<RoutingRequirement> {
+    let mut split_requirements = Vec::new();
+    for requirement in requirements {
+        // All zones share a begin_time
+        // The split requirement can have two possible begins: the route's position in the period (period_begin) and the origin (0)
+        let period_begin = requirement.begin_time % period;
+        let mut unwrapped_zones = Vec::new(); // begin = period_begin
+        let mut wrapped_zones = Vec::new(); // begin = 0
+        for zone in &requirement.zones {
+            let split_requirement = split_interval(requirement.begin_time, zone.end_time, period);
+            for (begin_time, end_time) in split_requirement {
+                let zone = RoutingZoneRequirement {
+                    end_time,
+                    ..zone.clone()
+                };
+                if begin_time == 0 {
+                    wrapped_zones.push(zone);
+                } else {
+                    unwrapped_zones.push(zone);
+                }
+            }
+        }
+        for (begin_time, zones) in [(0, wrapped_zones), (period_begin, unwrapped_zones)] {
+            if !zones.is_empty() {
+                split_requirements.push(RoutingRequirement {
+                    route: requirement.route.clone(),
+                    begin_time,
+                    zones,
+                });
+            }
+        }
+    }
+    split_requirements
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use common::units;
     use core_client::simulation::RoutingRequirement;
     use core_client::simulation::RoutingZoneRequirement;
     use core_client::simulation::SpacingRequirement;
+    use rstest::rstest;
 
     fn spacing(zone: &str, begin_time: u64, end_time: u64) -> SpacingRequirement {
         SpacingRequirement {
@@ -155,6 +297,117 @@ mod tests {
                 end_time,
             }],
         }
+    }
+
+    #[rstest]
+    // Entirely inside the period, no boundary crossing.
+    #[case::no_wrap(100, 300, 1000, vec![(100, 300)])]
+    // Crosses the period boundary: split in two (up to the boundary, then from 0).
+    #[case::wrap_first_period(900, 1100, 1000, vec![(900, 1000), (0, 100)])]
+    // Lasts a whole period or more: saturates to the entire period.
+    #[case::duration_exceeds_period(100, 1500, 1000, vec![(0, 1000)])]
+    // Starts in a later period, no crossing: a single wrapped part.
+    #[case::beyond_first_period_no_wrap(1200, 1300, 1000, vec![(200, 300)])]
+    // Starts in a later period and crosses the boundary: two parts.
+    #[case::beyond_first_period_wrap(1500, 2100, 1000, vec![(500, 1000), (0, 100)])]
+    fn split_interval_cases(
+        #[case] begin: u64,
+        #[case] end: u64,
+        #[case] period: u64,
+        #[case] expected: Vec<Interval>,
+    ) {
+        assert_eq!(split_interval(begin, end, period), expected);
+    }
+
+    fn routing_zone(name: &str, end_time: u64) -> RoutingZoneRequirement {
+        RoutingZoneRequirement {
+            zone: name.to_string(),
+            entry_detector: "D1".to_string(),
+            exit_detector: "D2".to_string(),
+            switches: HashMap::new(),
+            end_time,
+        }
+    }
+
+    fn routing_req(begin_time: u64, zones: Vec<RoutingZoneRequirement>) -> RoutingRequirement {
+        RoutingRequirement {
+            route: "R".to_string(),
+            begin_time,
+            zones,
+        }
+    }
+
+    #[rstest]
+    // One zone whose reservation crosses the boundary: wrapped part from 0, then unwrapped part
+    // at period_begin.
+    #[case::wrap_first_period(
+        vec![routing_req(800, vec![routing_zone("Z1", 1200)])],
+        vec![
+            routing_req(0, vec![routing_zone("Z1", 200)]),
+            routing_req(800, vec![routing_zone("Z1", 1000)]),
+        ],
+    )]
+    // begin_time beyond the period, no crossing: a single requirement at period_begin.
+    #[case::begin_beyond_period(
+        vec![routing_req(1700, vec![routing_zone("Z1", 1800), routing_zone("Z2", 1900)])],
+        vec![routing_req(700, vec![routing_zone("Z1", 800), routing_zone("Z2", 900)])],
+    )]
+    // begin_time beyond the period and the zone crosses the boundary: wrapped + unwrapped groups.
+    #[case::begin_beyond_period_wrap(
+        vec![routing_req(1700, vec![routing_zone("Z", 2600)])],
+        vec![
+            routing_req(0, vec![routing_zone("Z", 600)]),
+            routing_req(700, vec![routing_zone("Z", 1000)]),
+        ],
+    )]
+    fn split_routing_cases(
+        #[case] reqs: Vec<RoutingRequirement>,
+        #[case] expected: Vec<RoutingRequirement>,
+    ) {
+        let period = 1000;
+        assert_eq!(split_routing(period, &reqs), expected);
+    }
+
+    #[test]
+    fn populate_timetable_duplicates_occurrences() {
+        // A 1h mission with two occurrences (at 0 and 30min), duplicated 3 times to fill a 3h period.
+        let occurrences = [0, 1_800_000]
+            .into_iter()
+            .enumerate()
+            .map(|(index, start_ms)| {
+                (
+                    OccurrenceId::new_base(1, index),
+                    TrainOccurrence {
+                        start_time: units::millisecond::i64::new(start_ms),
+                        ..TrainOccurrence::fake()
+                    },
+                )
+            })
+            .collect();
+
+        let result = populate_timetable(occurrences, 3, 3_600_000);
+
+        let starts: Vec<i64> = result
+            .iter()
+            .map(|(_, occurrence)| units::millisecond::i64::from(occurrence.start_time))
+            .collect();
+        assert_eq!(
+            starts,
+            vec![0, 1_800_000, 3_600_000, 5_400_000, 7_200_000, 9_000_000]
+        );
+
+        let ids: Vec<_> = result.into_iter().map(|(id, _)| id).collect();
+        assert_eq!(
+            ids,
+            vec![
+                OccurrenceId::new_base(1, 0),
+                OccurrenceId::new_base(1, 1),
+                OccurrenceId::new_base(1, 0),
+                OccurrenceId::new_base(1, 1),
+                OccurrenceId::new_base(1, 0),
+                OccurrenceId::new_base(1, 1),
+            ]
+        );
     }
 
     // Build one train schedule and one paced train with 2 occurrences

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -41,7 +41,6 @@ use schemas::train_schedule::ScheduleItem;
 use schemas::train_schedule::TrainOccurrence;
 use serde::Deserialize;
 use serde::Serialize;
-use std::cmp::max;
 use std::collections::HashSet;
 use std::pin::pin;
 use std::sync::Arc;
@@ -543,21 +542,16 @@ pub fn as_core_work_schedule(
     earliest_departure_time: DateTime<Utc>,
     latest_simulation_end: DateTime<Utc>,
 ) -> Option<core_client::stdcm::WorkSchedule> {
-    let search_window_duration =
-        (latest_simulation_end - earliest_departure_time).num_milliseconds() as u64;
-
-    let start_time =
-        elapsed_time_since_ms(&work_schedule.start_date_time, &earliest_departure_time);
-    let end_time = elapsed_time_since_ms(&work_schedule.end_date_time, &earliest_departure_time);
-
-    if end_time == 0 || start_time >= search_window_duration {
+    if work_schedule.end_date_time <= earliest_departure_time
+        || work_schedule.start_date_time >= latest_simulation_end
+    {
         return None;
     }
 
     Some(core_client::stdcm::WorkSchedule {
         obj_id: work_schedule.obj_id.clone(),
-        start_time,
-        end_time,
+        start_time: work_schedule.start_date_time.timestamp_millis() as u64,
+        end_time: work_schedule.end_date_time.timestamp_millis() as u64,
         track_ranges: work_schedule
             .track_ranges
             .iter()
@@ -568,10 +562,6 @@ pub fn as_core_work_schedule(
             })
             .collect(),
     })
-}
-
-fn elapsed_time_since_ms(time: &DateTime<Utc>, since: &DateTime<Utc>) -> u64 {
-    max(0, (*time - since).num_milliseconds()) as u64
 }
 
 #[cfg(test)]

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -269,6 +269,7 @@
       "Database": "Internal error (database)",
       "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
       "InfraNotLoaded": "Infrastructure '{{infra_id}}' is not loaded",
+      "InvalidPeriod": "Hourly timetable period should be under 24h",
       "NotFound": "Timetable '{{timetable_id}}' could not be found",
       "ParseError": "Failed to parse train_id: '{{train_id}}'",
       "Timeout": "Request timed out",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -269,6 +269,7 @@
       "Database": "Erreur interne (base de données)",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "InfraNotLoaded": "L'infrastructure '{{infra_id}}' n'est pas chargée",
+      "InvalidPeriod": "La période d'une trame doit être inférieure à 24h",
       "NotFound": "Grille horaire '{{timetable_id}}' non trouvée",
       "ParseError": "Impossible de parser train_id : '{{train_id}}'",
       "Timeout": "Le serveur n'a pas répondu à temps",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4445,7 +4445,12 @@ export type CoreReportTrain = {
   times: number[];
 };
 export type CoreRoutingZoneRequirement = {
-  /** Time in ms */
+  /** Time in ms since a reference point that depends on which struct embeds this one:
+    - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+      requirements): a request-wide origin shared by all trains, `work_schedules` and the
+      response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+      hourly ones);
+    - in `CompleteReportTrain` (simulation results): the train's own `start_time`. */
   end_time: number;
   entry_detector: string;
   exit_detector: string;
@@ -4455,7 +4460,12 @@ export type CoreRoutingZoneRequirement = {
   zone: string;
 };
 export type CoreRoutingRequirement = {
-  /** Time in ms */
+  /** Time in ms since a reference point that depends on which struct embeds this one:
+    - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+      requirements): a request-wide origin shared by all trains, `work_schedules` and the
+      response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+      hourly ones);
+    - in `CompleteReportTrain` (simulation results): the train's own `start_time`. */
   begin_time: number;
   route: string;
   zones: CoreRoutingZoneRequirement[];
@@ -4469,7 +4479,14 @@ export type CoreSignalCriticalPosition = {
   time: number;
 };
 export type CoreSpacingRequirement = {
+  /** Time in ms since a reference point that depends on which struct embeds this one:
+    - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+      requirements): a request-wide origin shared by all trains, `work_schedules` and the
+      response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+      hourly ones);
+    - in `CompleteReportTrain` (simulation results): the train's own `start_time`. */
   begin_time: number;
+  /** Time in ms: see begin_time */
   end_time: number;
   zone: string;
 };
@@ -4741,15 +4758,6 @@ export type Conflict = {
 export type CoreTrainRequirementsById = {
   routing_requirements: CoreRoutingRequirement[];
   spacing_requirements: CoreSpacingRequirement[];
-  /** Start time for the given train: elapsed ms since an implicit 'request base time'.
-    `start_time` acts as a reference point for all time values in the spacing and routing
-    requirements for this train (values expressed as an offset).
-    
-    The implicit 'request base time' is the same over the whole request
-    (`trains_requirements` and `work_schedules`) and response.
-    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
-    timetables. */
-  start_time: number;
   train_id: string;
   /** ID that can be used to find the train in tools other than OSRD. Used in debug traces. */
   train_name: string;

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -271,7 +271,12 @@ class CoreReportTrain(BaseModel):
 class CoreRoutingZoneRequirement(BaseModel):
     end_time: Annotated[int, Field(ge=0)]
     """
-    Time in ms
+    Time in ms since a reference point that depends on which struct embeds this one:
+    - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+      requirements): a request-wide origin shared by all trains, `work_schedules` and the
+      response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+      hourly ones);
+    - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
     """
     entry_detector: str
     exit_detector: str
@@ -355,7 +360,18 @@ class CoreSimpleEnvelope(BaseModel):
 
 class CoreSpacingRequirement(BaseModel):
     begin_time: Annotated[int, Field(ge=0)]
+    """
+    Time in ms since a reference point that depends on which struct embeds this one:
+    - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+      requirements): a request-wide origin shared by all trains, `work_schedules` and the
+      response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+      hourly ones);
+    - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
+    """
     end_time: Annotated[int, Field(ge=0)]
+    """
+    Time in ms: see begin_time
+    """
     zone: str
 
 
@@ -4323,7 +4339,12 @@ class CoreIncompatibleOffsetRangeWithValue(BaseModel):
 class CoreRoutingRequirement(BaseModel):
     begin_time: Annotated[int, Field(ge=0)]
     """
-    Time in ms
+    Time in ms since a reference point that depends on which struct embeds this one:
+    - in `TrainRequirements` & `TrainRequirementsById` (conflict detection & timetable
+      requirements): a request-wide origin shared by all trains, `work_schedules` and the
+      response (`1970-01-01T00:00:00Z` for calendar timetables, the timetable start for
+      hourly ones);
+    - in `CompleteReportTrain` (simulation results): the train's own `start_time`.
     """
     route: str
     zones: list[CoreRoutingZoneRequirement]
@@ -4376,17 +4397,6 @@ class CoreTrainPath(BaseModel):
 class CoreTrainRequirementsById(BaseModel):
     routing_requirements: list[CoreRoutingRequirement]
     spacing_requirements: list[CoreSpacingRequirement]
-    start_time: int
-    """
-    Start time for the given train: elapsed ms since an implicit 'request base time'.
-    `start_time` acts as a reference point for all time values in the spacing and routing
-    requirements for this train (values expressed as an offset).
-
-    The implicit 'request base time' is the same over the whole request
-    (`trains_requirements` and `work_schedules`) and response.
-    Example: `1970-01-01T00:00:00Z` for calendar timetables; the timetable start for hourly
-    timetables.
-    """
     train_id: str
     train_name: str
     """

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -1966,6 +1966,20 @@ class EditoastTimetableErrorInfraNotFound(BaseModel):
     type: Literal["editoast:timetable:InfraNotFound"]
 
 
+class EditoastTimetableErrorInvalidPeriodContext(BaseModel):
+    timetable_period: int
+
+
+class EditoastTimetableErrorInvalidPeriod(BaseModel):
+    context: Annotated[
+        EditoastTimetableErrorInvalidPeriodContext | None,
+        Field(title="EditoastTimetableErrorInvalidPeriodContext"),
+    ] = None
+    message: str
+    status: Literal[422]
+    type: Literal["editoast:timetable:InvalidPeriod"]
+
+
 class EditoastTimetableErrorNotFoundContext(BaseModel):
     timetable_id: int
 
@@ -4540,6 +4554,7 @@ class EditoastError(
         | EditoastTemporarySpeedLimitErrorNameAlreadyUsed
         | EditoastTimetableErrorDatabase
         | EditoastTimetableErrorInfraNotFound
+        | EditoastTimetableErrorInvalidPeriod
         | EditoastTimetableErrorNotFound
         | EditoastTimetableErrorParseError
         | EditoastTimetableErrorTimeout
@@ -4703,6 +4718,7 @@ class EditoastError(
         | EditoastTemporarySpeedLimitErrorNameAlreadyUsed
         | EditoastTimetableErrorDatabase
         | EditoastTimetableErrorInfraNotFound
+        | EditoastTimetableErrorInvalidPeriod
         | EditoastTimetableErrorNotFound
         | EditoastTimetableErrorParseError
         | EditoastTimetableErrorTimeout


### PR DESCRIPTION
Hourly timetables are cyclic and repeat on a period. They need their requirements folded back onto a single cycle before being send to core.
This PR first refactor the conflicts code structuration creating a new module (first commit), then refactor the `TrainRequirements` and `WorkScheduleRequest` format to use absolute times and adapt core accordingly (second commit) and then implements the logic needed for conflict in hourly timetables (last commit). It is better to review  it commit by commit.

For hourly timetables, the conflicts endpoint now:
- computes the timetable period as the LCM of its missions `time_window`
- rejects any period longer than 24h since hourly timetable is not meant to span more than a day
- duplicates each mission's occurrences to cover the whole period, keeping the same OccurenceId for each copy
- splits every spacing and routing requirement to have all of them onto [0, period[. A requirement crossing the period boundary is split into several requirements.

The calendar timetable behaviour remains unchanged.