### PR TITLE
editoast: disable /level_crossing_occupancy for hourly timetables

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7044,7 +7044,9 @@ components:
       - $ref: '#/components/schemas/EditoastLevelCrossingErrorDatabase'
       - $ref: '#/components/schemas/EditoastLevelCrossingErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastLevelCrossingErrorLevelCrossingBatchNotFound'
+      - $ref: '#/components/schemas/EditoastLevelCrossingErrorTimetableNotFound'
       - $ref: '#/components/schemas/EditoastLevelCrossingErrorTrainBatchNotFound'
+      - $ref: '#/components/schemas/EditoastLevelCrossingErrorUnsupportedTimetableType'
       - $ref: '#/components/schemas/EditoastLinesErrorsLineNotFound'
       - $ref: '#/components/schemas/EditoastListErrorsErrorsWrongErrorTypeProvided'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorDatabase'
@@ -7452,6 +7454,31 @@ components:
           type: string
           enum:
           - editoast:level_crossing:LevelCrossingBatchNotFound
+    EditoastLevelCrossingErrorTimetableNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastLevelCrossingErrorTimetableNotFoundContext
+          required:
+          - timetable_id
+          properties:
+            timetable_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:level_crossing:TimetableNotFound
     EditoastLevelCrossingErrorTrainBatchNotFound:
       type: object
       required:
@@ -7477,6 +7504,26 @@ components:
           type: string
           enum:
           - editoast:level_crossing:TrainBatchNotFound
+    EditoastLevelCrossingErrorUnsupportedTimetableType:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastLevelCrossingErrorUnsupportedTimetableTypeContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 422
+        type:
+          type: string
+          enum:
+          - editoast:level_crossing:UnsupportedTimetableType
     EditoastLinesErrorsLineNotFound:
       type: object
       required:

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -10,6 +10,7 @@ use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::train_simulation_ordered_batch;
 use editoast_models::Infra;
 use editoast_models::LevelCrossingModel;
+use editoast_models::Timetable;
 use editoast_models::TrainSchedule;
 use editoast_models::train_schedule::OccurrenceId;
 
@@ -33,6 +34,7 @@ use schemas::infra::LevelCrossing;
 use schemas::infra::TrackOffset;
 use schemas::primitives::Identifier;
 use schemas::primitives::TimeWindow;
+use schemas::timetable_type::TimetableType;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -48,9 +50,15 @@ enum LevelCrossingError {
     #[error("{count} train(s) could not be found")]
     #[editoast_error(status = 404)]
     TrainBatchNotFound { count: usize },
-    #[error("Infra '{infra_id}', could not be found")]
+    #[error("Infra '{infra_id}' could not be found")]
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
+    #[error("Timetable '{timetable_id}' could not be found")]
+    #[editoast_error(status = 404)]
+    TimetableNotFound { timetable_id: i64 },
+    #[error("Hourly timetables are not supported")]
+    #[editoast_error(status = 422)]
+    UnsupportedTimetableType,
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::Error),
@@ -111,6 +119,15 @@ pub(in crate::views) async fn occupancy(
     .await?;
 
     let conn = &mut db_pool.get().await?;
+
+    // Check timetable type
+    let timetable = Timetable::retrieve_or_fail(conn.clone(), timetable_id, || {
+        LevelCrossingError::TimetableNotFound { timetable_id }
+    })
+    .await?;
+    if timetable.timetable_type.0 == TimetableType::Hourly {
+        return Err(LevelCrossingError::UnsupportedTimetableType.into());
+    }
 
     // Load infra + level_crossings + trains
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || {
@@ -358,6 +375,7 @@ fn find_pedal_position(
 mod tests {
     use super::*;
     use crate::fixtures::create_fast_rolling_stock;
+    use crate::fixtures::create_hourly_timetable_with_train_schedule_set;
     use crate::fixtures::create_small_infra;
     use crate::fixtures::create_timetable_with_train_schedule_set;
     use crate::views::test_app::test_app;
@@ -637,5 +655,30 @@ mod tests {
                 .unwrap_or(0),
             0
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_level_crossing_occupancy_rejects_hourly_timetable() {
+        let app = test_app!()
+            .skip_authz()
+            .core_client(MockingClient::new().into())
+            .build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let (timetable, _train_schedule_set) =
+            create_hourly_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+
+        let response = app
+            .post("/level_crossing_occupancy")
+            .json(&LevelCrossingOccupancyForm {
+                train_ids: vec![],
+                level_crossing_ids: vec![],
+                infra_id: small_infra.id,
+                timetable_id: timetable.id,
+                electrical_profile_set_id: None,
+            })
+            .await;
+
+        response.assert_status_unprocessable_entity();
     }
 }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -125,7 +125,9 @@
       "Database": "Internal error (database)",
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found.",
       "LevelCrossingBatchNotFound": "'{{count}}' level crossing(s) could not be found.",
-      "TrainBatchNotFound": "'{{count}}' paced train(s) could not be found."
+      "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found.",
+      "TrainBatchNotFound": "'{{count}}' paced train(s) could not be found.",
+      "UnsupportedTimetableType": "Hourly timetables are not supported."
     },
     "macro_node": {
       "Database": "Internal error",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -125,7 +125,9 @@
       "Database": "Erreur interne (base de données)",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée.",
       "LevelCrossingBatchNotFound": "'{{count}}' passage(s) à niveau introuvable(s).",
-      "TrainBatchNotFound": "'{{count}}' mission(s) introuvable(s)."
+      "TimetableNotFound": "Grille horaire '{{timetable_id}}' introuvable.",
+      "TrainBatchNotFound": "'{{count}}' mission(s) introuvable(s).",
+      "UnsupportedTimetableType": "Les trames ne sont pas gérées."
     },
     "macro_node": {
       "Database": "Erreur interne",

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -1012,6 +1012,20 @@ class EditoastLevelCrossingErrorLevelCrossingBatchNotFound(BaseModel):
     type: Literal["editoast:level_crossing:LevelCrossingBatchNotFound"]
 
 
+class EditoastLevelCrossingErrorTimetableNotFoundContext(BaseModel):
+    timetable_id: int
+
+
+class EditoastLevelCrossingErrorTimetableNotFound(BaseModel):
+    context: Annotated[
+        EditoastLevelCrossingErrorTimetableNotFoundContext | None,
+        Field(title="EditoastLevelCrossingErrorTimetableNotFoundContext"),
+    ] = None
+    message: str
+    status: Literal[404]
+    type: Literal["editoast:level_crossing:TimetableNotFound"]
+
+
 class EditoastLevelCrossingErrorTrainBatchNotFoundContext(BaseModel):
     count: int
 
@@ -1024,6 +1038,16 @@ class EditoastLevelCrossingErrorTrainBatchNotFound(BaseModel):
     message: str
     status: Literal[404]
     type: Literal["editoast:level_crossing:TrainBatchNotFound"]
+
+
+class EditoastLevelCrossingErrorUnsupportedTimetableType(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None,
+        Field(title="EditoastLevelCrossingErrorUnsupportedTimetableTypeContext"),
+    ] = None
+    message: str
+    status: Literal[422]
+    type: Literal["editoast:level_crossing:UnsupportedTimetableType"]
 
 
 class EditoastLinesErrorsLineNotFoundContext(BaseModel):
@@ -4477,7 +4501,9 @@ class EditoastError(
         | EditoastLevelCrossingErrorDatabase
         | EditoastLevelCrossingErrorInfraNotFound
         | EditoastLevelCrossingErrorLevelCrossingBatchNotFound
+        | EditoastLevelCrossingErrorTimetableNotFound
         | EditoastLevelCrossingErrorTrainBatchNotFound
+        | EditoastLevelCrossingErrorUnsupportedTimetableType
         | EditoastLinesErrorsLineNotFound
         | EditoastListErrorsErrorsWrongErrorTypeProvided
         | EditoastMacroNodeErrorDatabase
@@ -4641,7 +4667,9 @@ class EditoastError(
         | EditoastLevelCrossingErrorDatabase
         | EditoastLevelCrossingErrorInfraNotFound
         | EditoastLevelCrossingErrorLevelCrossingBatchNotFound
+        | EditoastLevelCrossingErrorTimetableNotFound
         | EditoastLevelCrossingErrorTrainBatchNotFound
+        | EditoastLevelCrossingErrorUnsupportedTimetableType
         | EditoastLinesErrorsLineNotFound
         | EditoastListErrorsErrorsWrongErrorTypeProvided
         | EditoastMacroNodeErrorDatabase


### PR DESCRIPTION
We don't want to adapt in `/level_crossing_occupancy` endpoint to hourly timetables for now so we disable it to avoid inconsistancy.