### PR TITLE
front: fix STD curve selection tooltips

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel.tsx
@@ -49,20 +49,28 @@ const CurveSelectionSidePanel = ({
 
   return (
     <div className="curve-selection-side-panel" style={{ top: position }}>
-      {formattedOccurrences.map(({ mode, value, icon, isActive }) => (
-        <button
-          key={mode}
-          className={cx('numbered-icon', { 'selected-icon': isActive })}
-          title={t(`simulationResults.curveSelection.${mode}`, {
-            count: value,
-          })}
-          onClick={() => onModeChange(mode)}
-        >
-          {icon}
-          {value > 0 && <span className="occurrences-number">{value}</span>}
-          {isActive && <div className="selection-marker" />}
-        </button>
-      ))}
+      {formattedOccurrences.map(({ mode, value, icon, isActive }) => {
+        const title = t(`simulationResults.curveSelection.${mode}`, {
+          count: value,
+        });
+
+        return (
+          <button
+            key={mode}
+            type="button"
+            className={cx('numbered-icon', { 'selected-icon': isActive })}
+            title={title}
+            aria-label={title}
+            onClick={() => onModeChange(mode)}
+          >
+            <span className="curve-selection-icon" aria-hidden>
+              {icon}
+            </span>
+            {value > 0 && <span className="occurrences-number">{value}</span>}
+            {isActive && <div className="selection-marker" />}
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/front/src/styles/scss/common/components/_manchetteWithSpaceTimeChart.scss
+++ b/front/src/styles/scss/common/components/_manchetteWithSpaceTimeChart.scss
@@ -66,6 +66,11 @@
         font-family: IBM plex sans;
         font-weight: 600;
       }
+
+      .curve-selection-icon,
+      .curve-selection-icon * {
+        pointer-events: none;
+      }
     }
 
     .selected-icon {


### PR DESCRIPTION
Closes #17299

## Summary
- Prevent STD curve selection icon SVG titles from overriding the button tooltip
- Keep the translated tooltip text on the button and expose it as an aria-label

## Testing
- oxlint . --max-warnings 0 --ignore-pattern 'ui/**'
- oxfmt on changed files --check
- tsc --noEmit --pretty false
- npm run build: fails locally on missing @osrd-project/netzgrafik-frontend dist static-copy asset, unrelated to this patch