### PR TITLE
front: make DurationInput's max optional

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -363,6 +363,7 @@
     "errorMessages": {
       "error": "An error has occurred",
       "hardErrorInfra": "The infrastructure contains errors and cannot be used without first being corrected.",
+      "intervalTooHigh": "The cadence of the service must be less than 730 hours (one month)",
       "intervalTooLow": "The cadence of the service has to be at least one minute",
       "invalidInitialSpeed": "The initial speed must be rounded to the nearest tenth",
       "mandatoryField": "Required field",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -363,6 +363,7 @@
     "errorMessages": {
       "error": "Une erreur est survenue",
       "hardErrorInfra": "L'infrastructure comporte des erreurs et ne peut être utilisée sans être corrigée au préalable.",
+      "intervalTooHigh": "La cadence de la mission doit être inférieure à 730 heures (un mois)",
       "intervalTooLow": "La cadence de la mission doit être supérieure d'au moins une minute",
       "invalidInitialSpeed": "La vitesse initiale doit être arrondie au dixième",
       "mandatoryField": "Champ obligatoire",

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -381,9 +381,8 @@ const ExpandedTrainForm = ({
                     small
                     units={['m']}
                     padChar="0"
-                    max={3_600_000}
                     label={t('manageTrainSchedule.trainHeader.form.serviceCadence')}
-                    value={fields.service_cadence ?? 0}
+                    value={fields.service_cadence ?? 1_800_000} // 30m
                     onChange={(ms) => onFieldImmediateChange('service_cadence', ms)}
                   />
                 </div>

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -82,6 +82,16 @@ function computeInitialSpeedError(
   return null;
 }
 
+type ServiceCadenceError = 'TOO_LOW' | 'TOO_HIGH' | null;
+
+const ONE_MONTH_IN_MS = 2_628_000_000;
+
+function computeServiceCadenceError(serviceCadence?: number): ServiceCadenceError {
+  if (!serviceCadence) return 'TOO_LOW';
+  if (serviceCadence >= ONE_MONTH_IN_MS) return 'TOO_HIGH';
+  return null;
+}
+
 function getFieldsFromTrain(train: Train): TrainFieldsState {
   return {
     train_name: train.train_name,
@@ -110,9 +120,10 @@ function applyFieldsToTrain(
   const paced = train.paced
     ? {
         exceptions: train.paced.exceptions,
-        interval: fields.service_changed_confirmed
-          ? new Duration({ milliseconds: fields.service_cadence }).toISOString()
-          : train.paced.interval,
+        interval:
+          fields.service_changed_confirmed && !computeServiceCadenceError(fields.service_cadence)
+            ? new Duration({ milliseconds: fields.service_cadence }).toISOString()
+            : train.paced.interval,
         time_window: fields.service_changed_confirmed
           ? new Duration({ milliseconds: fields.service_window }).toISOString()
           : train.paced.time_window,
@@ -324,6 +335,11 @@ const ExpandedTrainForm = ({
     [fields.initial_speed, selectedRollingStock, computeInitialSpeedError]
   );
 
+  const serviceCadenceError = useMemo(
+    () => computeServiceCadenceError(fields.service_cadence),
+    [fields.service_cadence]
+  );
+
   const erroneousFields = useMemo(
     () => !fields.train_name || !fields.initial_speed || !!initialSpeedError,
     [fields.train_name, fields.initial_speed, initialSpeedError]
@@ -384,6 +400,17 @@ const ExpandedTrainForm = ({
                     label={t('manageTrainSchedule.trainHeader.form.serviceCadence')}
                     value={fields.service_cadence ?? 1_800_000} // 30m
                     onChange={(ms) => onFieldImmediateChange('service_cadence', ms)}
+                    statusWithMessage={
+                      serviceCadenceError
+                        ? {
+                            status: 'error',
+                            message:
+                              serviceCadenceError === 'TOO_HIGH'
+                                ? t('manageTrainSchedule.errorMessages.intervalTooHigh')
+                                : t('manageTrainSchedule.errorMessages.intervalTooLow'),
+                          }
+                        : undefined
+                    }
                   />
                 </div>
                 <div className="train-service-window">

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -6,7 +6,7 @@
   grid-template-columns: repeat(3, minmax(200px, 1fr)) 1fr [end-column];
 
   /* Useful to align some non-field element with other fields  */
-  --non-field-padding: 32px 13px 16px 16px;
+  --non-field-spacing: 32px 13px 16px 16px;
 
   :where(& > *) {
     grid-column: 1 / end-column;
@@ -45,13 +45,16 @@
     }
 
     .loose-field {
+      align-self: start;
       align-content: center;
-      padding: var(--non-field-padding);
+      margin: var(--non-field-spacing);
     }
 
     .actions {
-      place-self: end end;
-      padding: var(--non-field-padding);
+      min-height: 28px;
+      place-self: start end;
+      align-content: center;
+      margin: var(--non-field-spacing);
       grid-row: 3;
       grid-column: end-column;
     }
@@ -91,7 +94,6 @@
     color: var(--info60);
     font-weight: 600;
     margin: 16px 14px 0 16px;
-    align-self: center;
     height: 28px;
     display: flex;
     align-items: center;
@@ -121,9 +123,15 @@
       margin-bottom: unset;
     }
 
+    .train-paced-kind {
+      margin-top: 32px;
+    }
+
     .actions {
-      align-self: center;
-      padding: var(--non-field-padding);
+      align-self: start;
+      align-content: center;
+      min-height: 28px;
+      margin: var(--non-field-spacing);
     }
   }
 
@@ -146,7 +154,7 @@
 
     .actions {
       place-self: center start;
-      padding: var(--non-field-padding);
+      padding: var(--non-field-spacing);
     }
   }
 

--- a/front/ui/storybook/stories/ui-core/DurationInput.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/DurationInput.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof DurationInput> = {
     units: ['h', 'm', 's'],
     value: 0,
     padChar: '0',
+    max: undefined,
+  },
+  argTypes: {
+    max: { control: 'number', type: { name: 'number', required: false } },
   },
   title: 'Core/DurationInput',
   tags: ['autodocs'],

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -152,6 +152,15 @@ function useDurationInput({
     [focusNext]
   );
 
+  const submitChange = useCallback(() => {
+    const ms = toTotalMilliseconds(fields, formattedValues);
+    const clamped = max ? Math.min(max, ms) : ms;
+    const next = toFormattedValues(fields, clamped);
+
+    setFormattedValues(next);
+    onChange?.(toTotalMilliseconds(fields, next));
+  }, [fields, formattedValues, max, onChange]);
+
   const handleKeyDown = useCallback(
     (setting: UnitSetting, e: React.KeyboardEvent<HTMLInputElement>) => {
       const input = e.currentTarget;
@@ -172,8 +181,12 @@ function useDurationInput({
         e.preventDefault();
         focusPrevious(setting.key);
       }
+
+      if (e.key === 'Enter') {
+        submitChange();
+      }
     },
-    [focusNext, focusPrevious]
+    [focusNext, focusPrevious, submitChange]
   );
 
   const handleFocus = useCallback((setting: UnitSetting) => focusField(setting.key), [focusField]);
@@ -185,14 +198,9 @@ function useDurationInput({
         return;
       }
 
-      const ms = toTotalMilliseconds(fields, formattedValues);
-      const clamped = max ? Math.min(max, ms) : ms;
-      const next = toFormattedValues(fields, clamped);
-
-      setFormattedValues(next);
-      onChange?.(toTotalMilliseconds(fields, next));
+      submitChange();
     },
-    [fields, containerRef.current, formattedValues, max, onChange]
+    [containerRef.current, submitChange]
   );
 
   return {

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -55,13 +55,15 @@ function normalizeUnits(units: UnitProps[], padChar: string, max: number): UnitS
   });
 
   configs.sort((a, b) => b.msPerUnit - a.msPerUnit);
-  return configs.map((unit, idx) => {
+
+  return configs.map((unit, idx): UnitSetting => {
     const prev = idx > 0 ? configs[idx - 1] : null;
     const digits = prev
       ? unit.digits
       : max < Infinity
         ? String(Math.floor(max / unit.msPerUnit)).length
         : undefined;
+
     return {
       ...unit,
       digits,
@@ -74,7 +76,7 @@ function normalizeUnits(units: UnitProps[], padChar: string, max: number): UnitS
 type FormattedValues = Record<string, string>;
 
 function toUnitField(ms: number, unit: UnitSetting): [string, string] {
-  const value = Math.floor(ms / (unit.msPerUnit || 1)) % unit.max;
+  const value = Math.floor(ms / (unit.msPerUnit || 1)) % (unit.max ?? Infinity);
   return [unit.key, String(value || unit.padChar).padStart(unit.digits ?? 0, unit.padChar)];
 }
 
@@ -179,7 +181,7 @@ function useDurationInput({
       }
 
       const ms = toTotalMilliseconds(fields, formattedValues);
-      const clamped = Math.min(max ?? ms, ms);
+      const clamped = max ? Math.min(max, ms) : ms;
       const next = toFormattedValues(fields, clamped);
 
       setFormattedValues(next);

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -233,7 +233,7 @@ const UnitField = function UnitField({
         type="text"
         inputMode="numeric"
         style={{
-          width: `${digits}ch`,
+          width: digits ? `${digits ?? 2}ch` : `${value.length || 1}ch`,
         }}
         tabIndex={tabIndex}
         value={value}

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -8,7 +8,7 @@ type UnitConfig = {
   key: string;
   label: string;
   msPerUnit: number;
-  digits: number;
+  digits?: number;
 };
 
 export type UnitProps = 'h' | 'm' | 's' | 'ms' | UnitConfig;
@@ -57,9 +57,14 @@ function normalizeUnits(units: UnitProps[], padChar: string, max: number): UnitS
   configs.sort((a, b) => b.msPerUnit - a.msPerUnit);
   return configs.map((unit, idx) => {
     const prev = idx > 0 ? configs[idx - 1] : null;
+    const digits = prev
+      ? unit.digits
+      : max < Infinity
+        ? String(Math.floor(max / unit.msPerUnit)).length
+        : undefined;
     return {
       ...unit,
-      digits: prev ? unit.digits : String(Math.floor(max / unit.msPerUnit)).length,
+      digits,
       max: prev ? Math.floor(prev.msPerUnit / unit.msPerUnit) : Infinity,
       padChar,
     };
@@ -70,7 +75,7 @@ type FormattedValues = Record<string, string>;
 
 function toUnitField(ms: number, unit: UnitSetting): [string, string] {
   const value = Math.floor(ms / (unit.msPerUnit || 1)) % unit.max;
-  return [unit.key, String(value || unit.padChar).padStart(unit.digits, unit.padChar)];
+  return [unit.key, String(value || unit.padChar).padStart(unit.digits ?? 0, unit.padChar)];
 }
 
 function toFormattedValues(units: UnitSetting[], ms: number): FormattedValues {
@@ -90,9 +95,10 @@ function useDurationInput({
   value,
   onChange,
   padChar,
-  max = 99 * 3_600_000, // 99 HOURS
+  max,
   containerRef,
-}: Omit<DurationInputProps, 'id'> & {
+}: Omit<DurationInputProps, 'id' | 'max'> & {
+  max: number;
   containerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const fields = useMemo(() => normalizeUnits(units, padChar, max), [units, padChar, max]);
@@ -173,7 +179,7 @@ function useDurationInput({
       }
 
       const ms = toTotalMilliseconds(fields, formattedValues);
-      const clamped = Math.min(max, ms);
+      const clamped = Math.min(max ?? ms, ms);
       const next = toFormattedValues(fields, clamped);
 
       setFormattedValues(next);
@@ -216,7 +222,7 @@ const UnitField = function UnitField({
   tabIndex,
 }: UnitFieldProps) {
   const { label, digits, padChar } = setting;
-  const placeholder = padChar.repeat(digits);
+  const placeholder = padChar.repeat(digits ?? 2);
 
   return (
     <span className="unit-field">
@@ -255,7 +261,7 @@ const DurationInput = ({
   onChange,
   padChar = '0',
   small = false,
-  max,
+  max = Infinity,
   label,
   hint,
   ...rest

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -158,7 +158,12 @@ function useDurationInput({
 
       if (!input) return;
 
-      if (e.key === 'ArrowRight' && input.selectionStart === input.value.length) {
+      const cursorAtTheEnd = input.selectionStart === input.value.length;
+      const keyFirstLetter = setting.key.at(0)?.toLowerCase();
+      if (
+        (e.key === 'ArrowRight' || e.key === ':' || e.key.toLowerCase() === keyFirstLetter) &&
+        cursorAtTheEnd
+      ) {
         e.preventDefault();
         focusNext(setting.key);
       }

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -155,7 +155,7 @@ function useDurationInput({
 
   const submitChange = useCallback(() => {
     const ms = toTotalMilliseconds(fields, formattedValues);
-    const clamped = max ? Math.min(max, ms) : ms;
+    const clamped = Math.min(max, ms);
     const next = toFormattedValues(fields, clamped);
 
     setFormattedValues(next);

--- a/front/ui/ui-core/src/components/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import cx from 'classnames';
 
-import FieldWrapper from './FieldWrapper';
+import FieldWrapper, { type FieldWrapperProps } from './FieldWrapper';
 
 type UnitConfig = {
   key: string;
@@ -28,6 +28,7 @@ export type DurationInputProps = {
   small?: boolean;
   hint?: string;
   label?: string;
+  statusWithMessage?: FieldWrapperProps['statusWithMessage'];
 } & Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'>;
 
 const PRESETS: Record<string, Omit<UnitConfig, 'key'>> = {
@@ -279,6 +280,7 @@ const DurationInput = ({
   max = Infinity,
   label,
   hint,
+  statusWithMessage,
   ...rest
 }: DurationInputProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -300,7 +302,13 @@ const DurationInput = ({
   });
 
   return (
-    <FieldWrapper id={id} label={label} hint={hint} small={small}>
+    <FieldWrapper
+      id={id}
+      label={label}
+      hint={hint}
+      small={small}
+      statusWithMessage={statusWithMessage}
+    >
       <div
         ref={containerRef}
         className={cx('ui-duration-input', { small })}

--- a/front/ui/ui-core/src/styles/inputs/statusMessage.css
+++ b/front/ui/ui-core/src/styles/inputs/statusMessage.css
@@ -11,7 +11,7 @@
   .status-message {
     letter-spacing: 0;
     text-align: left;
-    line-height: 1.5rem;
+    line-height: 1.5;
     @apply font-semibold;
 
     &.info {


### PR DESCRIPTION
Fixes #17297.

Until now, `DurationInput` required users of that components to specify a maximum value. This was used to compute the maximum value accepted by the largest unit, sizing the whole component at the same time. It was also useful because we auto-moved the selection to the next field as soon as the user entered "enough" digits to fill that unit; that is unavailable as soon as we don't know the maximum value.

It happen that we _don't_ want to set this maximum bound most of the time; it's easier to handle big, adnormal values in other, subtle ways, and not show too many zeros in the most common cases. To workaround the missing behaviour of selecting the next field, let's add two new keyboard affordances: pressing <kbd>:</kbd> or for example <kbd>m</kbd> (i.e. the first letter of the unit) moves to the next unit field; and pressing <kbd>↵</kbd> do a blur-like behaviour of submitting the changes even if we are not in the last unit field.