### PR TITLE
editoast: expose railjson version default in openapi schema

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12687,6 +12687,7 @@ components:
         version:
           type: string
           description: The version of the RailJSON format. Defaults to the current version.
+          default: 3.5.3
       additionalProperties: false
     ReceptionSignal:
       type: string

--- a/editoast/schemas/src/infra/railjson.rs
+++ b/editoast/schemas/src/infra/railjson.rs
@@ -18,6 +18,10 @@ use super::TrackSection;
 
 pub const RAILJSON_VERSION: &str = "3.5.3";
 
+pub fn default_railjson_version() -> String {
+    RAILJSON_VERSION.to_string()
+}
+
 /// An infrastructure description in the RailJson format
 #[derive(Deserialize, Educe, Serialize, Clone, Debug, ToSchema)]
 #[educe(Default)]
@@ -25,6 +29,7 @@ pub const RAILJSON_VERSION: &str = "3.5.3";
 pub struct RailJson {
     /// The version of the RailJSON format. Defaults to the current version.
     #[educe(Default = RAILJSON_VERSION.to_string())]
+    #[schema(default = default_railjson_version)]
     pub version: String,
     /// Operational point is also known in French as "Point Remarquable" (PR). One `OperationalPoint` is a **collection** of points (`OperationalPointParts`) of interest.
     pub operational_points: Vec<OperationalPoint>,

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -6318,7 +6318,7 @@ class RailJson(BaseModel):
     """
     `TrackSection`` is a segment of rail between switches that serves as a bidirectional path for trains, and can be defined as the longest possible stretch of track within a rail infrastructure.
     """
-    version: str
+    version: str | None = "3.5.3"
     """
     The version of the RailJSON format. Defaults to the current version.
     """


### PR DESCRIPTION
The default value was not included in the `openapi.yaml`, forcing downstream consumers (`osrd_schemas_auto`) to hard-code it manually. Adding `#[schema(default = ...)]` lets the value flow through automatically and stay in sync when the version constant changes.