### PR TITLE
front: moves waypoint groups fold logic to parent

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -56,6 +56,14 @@ const IntermediateWaypointsPanel = ({
     [pathProperties, pathSteps, positionByStepId]
   );
 
+  const [collapsedStepIds, setCollapsedStepIds] = useState<Set<string>>(new Set());
+  const toggleGroup = (stepId: string) =>
+    setCollapsedStepIds((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(stepId)) next.add(stepId);
+      return next;
+    });
+
   return (
     <aside
       className="intermediate-waypoints-panel"
@@ -74,6 +82,8 @@ const IntermediateWaypointsPanel = ({
               group={group}
               requestedLabel={getRequestedLabel(group.requestedStep)}
               onAdd={(op) => onAddWaypoint(op, group.requestedStep.id)}
+              expanded={!collapsedStepIds.has(group.requestedStep.id)}
+              onToggle={() => toggleGroup(group.requestedStep.id)}
             />
           ))}
         </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { ChevronDown, ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
@@ -12,19 +10,20 @@ type WaypointGroupProps = {
   group: WaypointGroupType;
   requestedLabel: string;
   onAdd: (op: CoreOperationalPointOnPath) => void;
-  defaultExpanded?: boolean;
+  expanded: boolean;
+  onToggle: () => void;
 };
 
 const WaypointGroup = ({
   group,
   requestedLabel,
   onAdd,
-  defaultExpanded = true,
+  expanded,
+  onToggle,
 }: WaypointGroupProps) => {
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTrainSchedule.itineraryModal.intermediateWaypointsPanel',
   });
-  const [expanded, setExpanded] = useState(defaultExpanded);
 
   const hasIntermediates = group.intermediates.length > 0;
 
@@ -35,7 +34,7 @@ const WaypointGroup = ({
           <button
             type="button"
             className="intermediate-waypoints-panel__group-toggle"
-            onClick={() => setExpanded((v) => !v)}
+            onClick={onToggle}
             aria-expanded={expanded}
             aria-label={expanded ? t('collapseGroup') : t('expandGroup')}
           >


### PR DESCRIPTION
This allows preserving the collapsed groups state during new simulations, as long as the panel remains opened.

This fixes #17318.