### PR TITLE
front: make project, scenario and study forms submittable by hitting ENTER

### DIFF
--- a/front/src/applications/operationalStudies/components/Study/AddOrEditStudyModal.tsx
+++ b/front/src/applications/operationalStudies/components/Study/AddOrEditStudyModal.tsx
@@ -84,7 +84,7 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
 
   const initialValuesRef = useRef<StudyForm | null>(null);
 
-  const modalRef = useRef<HTMLDivElement | null>(null);
+  const modalRef = useRef<HTMLFormElement | null>(null);
 
   const { clickedOutside, setHasChanges, resetClickedOutside } = useModalOutsideClick(modalRef);
 
@@ -106,7 +106,8 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
   const invalidFields = checkStudyFields(currentStudy);
   const hasErrors = Object.values(invalidFields).some((field) => field);
 
-  const createStudy = () => {
+  const createStudy = (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (hasErrors) {
       setDisplayErrors(true);
     } else {
@@ -211,7 +212,12 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
   }
 
   return (
-    <div data-testid="study-edition-modal" className="study-edition-modal" ref={modalRef}>
+    <form
+      data-testid="study-edition-modal"
+      className="study-edition-modal"
+      ref={modalRef}
+      onSubmit={createStudy}
+    >
       {clickedOutside && (
         <div className="confirm-modal">
           <div className="confirm-modal-content">
@@ -498,8 +504,7 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
             <button
               data-testid="create-study"
               className="btn btn-primary"
-              type="button"
-              onClick={createStudy}
+              type="submit"
               disabled={!isExpectedEndDateValid || !isActualEndDateValid}
             >
               <span className="mr-2">
@@ -510,7 +515,7 @@ const AddOrEditStudyModal = ({ editionMode, study, scenarios }: AddOrEditStudyMo
           )}
         </div>
       </ModalFooterSNCF>
-    </div>
+    </form>
   );
 };
 

--- a/front/src/common/BootstrapSNCF/ChipsSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/ChipsSNCF.tsx
@@ -67,6 +67,7 @@ export default function ChipsSNCF({
     if (e.key === 'Enter' && e.target) {
       if (!tags.includes(e.target.value)) addTag(e.target.value);
       setChipInputValue('');
+      e.preventDefault();
     }
   };
 

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -84,7 +84,7 @@ export default function AddOrEditProjectModal({
 
   const initialValuesRef = useRef<ProjectForm | null>(null);
 
-  const modalRef = useRef<HTMLDivElement | null>(null);
+  const modalRef = useRef<HTMLFormElement | null>(null);
 
   const { clickedOutside, setHasChanges, resetClickedOutside } = useModalOutsideClick(modalRef);
 
@@ -126,7 +126,8 @@ export default function AddOrEditProjectModal({
   const invalidFields = checkProjectFields(currentProject);
   const hasError = Object.values(invalidFields).some((fieldIsInvalid) => fieldIsInvalid);
 
-  const createProject = async () => {
+  const createProject = async (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (hasError) {
       setDisplayErrors(true);
     } else {
@@ -256,7 +257,7 @@ export default function AddOrEditProjectModal({
   useModalFocusTrap(modalRef, closeModal);
 
   return (
-    <div className="project-edition-modal" ref={modalRef}>
+    <form className="project-edition-modal" ref={modalRef} onSubmit={createProject}>
       {clickedOutside && (
         <div className="confirm-modal">
           <div className="confirm-modal-content">
@@ -464,12 +465,7 @@ export default function AddOrEditProjectModal({
               {t('project.projectModifyButton')}
             </button>
           ) : (
-            <button
-              data-testid="create-project"
-              className="btn btn-primary"
-              type="button"
-              onClick={createProject}
-            >
+            <button data-testid="create-project" className="btn btn-primary" type="submit">
               <span className="mr-2">
                 <FaPlus />
               </span>
@@ -478,6 +474,6 @@ export default function AddOrEditProjectModal({
           )}
         </div>
       </ModalFooterSNCF>
-    </div>
+    </form>
   );
 }

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -121,7 +121,7 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
 
   const initialValuesRef = useRef<ScenarioForm | null>(null);
 
-  const modalRef = useRef<HTMLDivElement | null>(null);
+  const modalRef = useRef<HTMLFormElement | null>(null);
 
   const { clickedOutside, setHasChanges, resetClickedOutside } = useModalOutsideClick(modalRef);
 
@@ -147,7 +147,8 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
   const invalidFields = checkScenarioFields(currentScenario);
   const hasErrors = Object.values(invalidFields).some((field) => field);
 
-  const createScenario = async () => {
+  const createScenario = async (event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (!currentScenario.infra_id || hasErrors) {
       setDisplayErrors(true);
     } else if (projectId && studyId && currentScenario && currentScenario.name) {
@@ -255,7 +256,12 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
   useModalFocusTrap(modalRef, closeModal);
 
   return (
-    <div data-testid="scenario-edition-modal" className="scenario-edition-modal" ref={modalRef}>
+    <form
+      data-testid="scenario-edition-modal"
+      className="scenario-edition-modal"
+      ref={modalRef}
+      onSubmit={createScenario}
+    >
       {clickedOutside && (
         <div className="confirm-modal">
           <div className="confirm-modal-content">
@@ -399,12 +405,7 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
               {t('main.scenarioModifyButton')}
             </button>
           ) : (
-            <button
-              data-testid="create-scenario"
-              className="btn btn-sm btn-primary"
-              type="button"
-              onClick={createScenario}
-            >
+            <button data-testid="create-scenario" className="btn btn-sm btn-primary" type="submit">
               <span className="mr-2">
                 <FaPlus />
               </span>
@@ -413,7 +414,7 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
           )}
         </div>
       </ModalFooterSNCF>
-    </div>
+    </form>
   );
 };
 

--- a/front/src/utils/hooks/useModalFocusTrap.ts
+++ b/front/src/utils/hooks/useModalFocusTrap.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
  * + expose input mode (keyboard vs pointer) via documentElement dataset
  */
 export default function useModalFocusTrap(
-  modalRef: React.RefObject<HTMLDivElement | HTMLDialogElement | null>,
+  modalRef: React.RefObject<HTMLElement | null>,
   closeModal: () => void,
   { focusOnFirstElement = false } = {}
 ) {


### PR DESCRIPTION
Changed the `type="button"` to `type="submit"` and made the modals forms instead of plain divs.

Closes nothing, idk if this is tracked somewhere but it was bugging me for a long time.