### PR TITLE
front: persist nge filters

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.b2f6d97ed6bcb5f48fabd31fe42436f795378aa6",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3506,9 +3506,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.b2f6d97ed6bcb5f48fabd31fe42436f795378aa6",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.b2f6d97ed6bcb5f48fabd31fe42436f795378aa6.tgz",
-      "integrity": "sha512-dxuxEd6EWoToIaNJS45rAfbZDPZ1+lt+ki27oEy3JgRuuRa2mekdKvf9DkAF+AlQJl+lWwck6AZUmBrllIsZvg=="
+      "version": "0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c.tgz",
+      "integrity": "sha512-PY+omXJiXSiaDdyyp9QVn3fvpALuzVhQ77Xb0KSfhaWOOsmsu3e1JG3MZ4vuERuvBMpFW6LU49S54FI2VxAJ7Q=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.b2f6d97ed6bcb5f48fabd31fe42436f795378aa6",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/ngeToOsrd.ts
@@ -3,6 +3,7 @@ import type {
   NetzgrafikDto,
   NodeDto,
   LabelDto,
+  FilterSettingDto,
 } from '@osrd-project/netzgrafik-frontend';
 
 import type {
@@ -14,7 +15,7 @@ import type { AppDispatch } from 'store';
 
 import { DEFAULT_TRAIN_SCHEDULE_PAYLOAD, TRAINRUN_DIRECTIONS } from '../consts';
 import type MacroEditorState from '../MacroEditorState';
-import { getTrainCategoryFromTrainrunCategoryId } from '../utils';
+import { getTrainCategoryFromTrainrunCategoryId, localStorageFilterSettingKey } from '../utils';
 import { castNgeNode, handleNodeOperation } from './node';
 import { castNgeNoteToOsrd, handleNoteOperation } from './note';
 import {
@@ -83,6 +84,29 @@ const handleMetadataOperation = async ({
   switch (type) {
     case 'update': {
       localStorage.setItem('trafficSideNetworkGraph', netzgrafikDto.metadata.trafficSide!);
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+};
+
+const handleFilterSettingOperation = async ({
+  type,
+  filterSetting,
+  state,
+}: {
+  type: Operation['type'];
+  filterSetting: FilterSettingDto;
+  state: MacroEditorState;
+}) => {
+  switch (type) {
+    case 'update': {
+      localStorage.setItem(
+        localStorageFilterSettingKey(state.scenarioId),
+        JSON.stringify(filterSetting)
+      );
       break;
     }
     default: {
@@ -165,6 +189,13 @@ export const handleOperation = async ({
       await handleMetadataOperation({
         type,
         netzgrafikDto,
+      });
+      break;
+    case 'filterSetting':
+      await handleFilterSettingOperation({
+        type,
+        filterSetting: operation.filterSetting,
+        state,
       });
       break;
     default:

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -14,6 +14,8 @@ import {
   type TrainrunCategory,
   type FreeFloatingTextDto,
   type TrafficSide,
+  type FilterSettingDto,
+  type FilterDataDto,
 } from '@osrd-project/netzgrafik-frontend';
 import type { TFunction } from 'i18next';
 import { uniqBy } from 'lodash';
@@ -53,6 +55,7 @@ import {
   getTrainrunCategoryId,
   getTrainrunFrequencyFromTrainSchedule,
   getTrainrunTimeCategoryFromFrequency,
+  localStorageFilterSettingKey,
   storeTrainPathNodes,
 } from './utils';
 
@@ -670,6 +673,12 @@ export const getNgeDto = (
     labelIds: getNoteLabelIds(note.labels, state),
   }));
 
+  const storedFilter = localStorage.getItem(localStorageFilterSettingKey(state.scenarioId));
+  const filterSettings = storedFilter ? [JSON.parse(storedFilter) as FilterSettingDto] : [];
+  const filterData: FilterDataDto = {
+    filterSettings,
+  };
+
   return {
     ...getNgeTrainrunSectionsWithNodes(state, groupedTrainSchedules, labels),
     trainruns: getNgeTrainruns(state, groupedTrainSchedules, labels),
@@ -685,9 +694,7 @@ export const getNgeDto = (
     freeFloatingTexts,
     labels,
     labelGroups: [NODE_LABEL_GROUP, TRAINRUN_LABEL_GROUP, NOTE_LABEL_GROUP],
-    filterData: {
-      filterSettings: [],
-    },
+    filterData,
   };
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -286,3 +286,6 @@ export const fetchStationSecondaryCode = async (
   const stationOp = searchResults.find((op) => op.is_passenger_station);
   return stationOp?.secondary_code;
 };
+
+export const localStorageFilterSettingKey = (scenarioId: number) =>
+  `scenario:${scenarioId}:filterSettingNetworkGraph`;

--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
@@ -8,9 +8,11 @@ import { EMPTY_DTO } from './consts';
 type NGEElement = HTMLElement & {
   language: string;
   netzgrafikDto: NetzgrafikDto;
+  activeFilterSettingId: number;
 };
 
 type NGEProps = {
+  activeFilterSettingId?: number;
   dto?: NetzgrafikDto;
   onOperation?: (op: Operation, netzgrafikDto: NetzgrafikDto) => void;
   onLoad?: () => void;
@@ -35,7 +37,7 @@ const frameSrc = `
  * Abstracts away low-level NGE details. Doesn't contain any OSRD-specific
  * logic.
  */
-const NGE = ({ dto, onOperation, onLoad }: NGEProps) => {
+const NGE = ({ activeFilterSettingId, dto, onOperation, onLoad }: NGEProps) => {
   const { i18n } = useTranslation();
 
   const frameRef = useRef<HTMLIFrameElement>(null);
@@ -76,6 +78,13 @@ const NGE = ({ dto, onOperation, onLoad }: NGEProps) => {
       ngeRootElement.netzgrafikDto = dto;
     }
   }, [dto, ngeRootElement]);
+
+  useEffect(() => {
+    if (ngeRootElement && activeFilterSettingId !== undefined) {
+      // eslint-disable-next-line react-hooks-js/immutability
+      ngeRootElement.activeFilterSettingId = activeFilterSettingId;
+    }
+  }, [activeFilterSettingId, ngeRootElement]);
 
   useEffect(() => {
     if (ngeRootElement && onOperation) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -269,7 +269,12 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
                         childClass="scenario-loader-msg"
                       />
                     )}
-                    <NGE dto={ngeDto} onOperation={handleNGEOperation} onLoad={handleNGELoad} />
+                    <NGE
+                      activeFilterSettingId={ngeDto?.filterData.filterSettings.at(0)?.id}
+                      dto={ngeDto}
+                      onOperation={handleNGEOperation}
+                      onLoad={handleNGELoad}
+                    />
                   </div>
                 </div>
               </BoardWrapper>


### PR DESCRIPTION
This feature enables to persist the filters set in NGE, in Local Storage only.

The filters set in a scenario should not affect another scenario.

Here is an example with a scenario on which filter settings are already set, and another freshly created scenario:

https://github.com/user-attachments/assets/a73a8ae6-ddb9-4b9b-8150-ffa5c391eee1

---
Also close https://github.com/OpenRailAssociation/osrd/issues/17548#issuecomment-5058235657

Close https://github.com/OpenRailAssociation/osrd/issues/17548
