### PR TITLE
front, test: improve and test useDefaultComboBox

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   ComboBox,
@@ -62,10 +62,10 @@ const ItineraryModalFormHeader = ({
   const { rollingStock } = useStoreDataForRollingStockSelector({
     rollingStockId: modalFormState.rollingStockId,
   });
-  const getRollingStockLabel = (rs: LightRollingStockWithLiveries) => {
+  const getRollingStockLabel = useCallback((rs: LightRollingStockWithLiveries) => {
     const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
     return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
-  };
+  }, []);
 
   const { filteredRollingStockList: fullRollingStockList } = useFilterRollingStock();
 

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { Input, ComboBox, useDefaultComboBox, Select } from '@osrd-project/ui-core';
 import { skipToken } from '@reduxjs/toolkit/query';
@@ -151,15 +151,16 @@ const StdcmConsist = ({
     isDebugMode,
   });
 
-  const getLabel = (rs: LightRollingStockWithLiveries) => {
+  const getLabel = useCallback((rs: LightRollingStockWithLiveries) => {
     const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
     return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
-  };
+  }, []);
 
   const rollingStockComboBoxDefaultProps = useDefaultComboBox(rollingStocks, getLabel);
+  const getTowedRollingStockName = useCallback((trs: TowedRollingStock) => trs.name, []);
   const towedRollingStockComboBoxDefaultProps = useDefaultComboBox(
     towedRollingStocks,
-    (trs: TowedRollingStock) => trs.name
+    getTowedRollingStockName
   );
 
   const handleRollingStockSelect = (option?: LightRollingStockWithLiveries) => {

--- a/front/src/common/NavBar/UserSettings.tsx
+++ b/front/src/common/NavBar/UserSettings.tsx
@@ -56,7 +56,8 @@ const UserSettings = () => {
     if (!impersonatedUser) getUserList(inputValue);
   }, [inputValue, impersonatedUser]);
 
-  const userComboBoxDefaultProps = useDefaultComboBox(userList, (subject) => subject.name);
+  const getSubjectName = useCallback((subject: SearchResultItemUser) => subject.name, []);
+  const userComboBoxDefaultProps = useDefaultComboBox(userList, getSubjectName);
 
   const handleSubjectSelection = useCallback(
     (subject: SearchResultItemUser | undefined) => {

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -193,10 +193,10 @@ const ExpandedTrainForm = ({
 
   const { filteredRollingStockList: rollingStocks } = useFilterRollingStock();
 
-  const getRollingStockLabel = (rs: LightRollingStockWithLiveries) => {
+  const getRollingStockLabel = useCallback((rs: LightRollingStockWithLiveries) => {
     const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
     return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
-  };
+  }, []);
 
   const {
     suggestions: rollingStockSuggestions,

--- a/front/ui/storybook/stories/ui-core/ComboBox.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/ComboBox.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { ComboBox, useDefaultComboBox } from '@osrd-project/ui-core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -28,7 +28,7 @@ const useComboBoxStory = (initialSuggestions: Suggestion[]) => {
   const [allSuggestions, setAllSuggestions] = useState<Suggestion[]>(initialSuggestions);
   const [value, setValue] = useState<Suggestion>();
 
-  const getSuggestionLabel = (suggestion: Suggestion) => suggestion.label;
+  const getSuggestionLabel = useCallback((suggestion: Suggestion) => suggestion.label, []);
   const comboBoxDefaultProps = useDefaultComboBox(allSuggestions, getSuggestionLabel);
 
   const onAddCustomValue = (customLabel: string) => {

--- a/front/ui/ui-core/src/components/ComboBox/__tests__/useDefaultComboBox.spec.ts
+++ b/front/ui/ui-core/src/components/ComboBox/__tests__/useDefaultComboBox.spec.ts
@@ -80,12 +80,13 @@ function mockChangeEvent(value: string): ChangeEvent<HTMLInputElement> {
 }
 
 describe('useDefaultComboBox', () => {
-  it('should offer suggestions props for basic combo box', () => {
-    const GREEN = { id: '1-green', label: 'Green' };
-    const RED = { id: '2-red', label: 'Red' };
-    const ORANGE = { id: '3-orange', label: 'Orange' };
+  const GREEN = { id: '1-green', label: 'Green' };
+  const RED = { id: '2-red', label: 'Red' };
+  const ORANGE = { id: '3-orange', label: 'Orange' };
 
-    const SUGGESTIONS = [GREEN, RED, ORANGE];
+  const SUGGESTIONS = [GREEN, RED, ORANGE];
+
+  it('should offer suggestions props for basic combo box', () => {
     const { result } = renderHook(() => useDefaultComboBox(SUGGESTIONS, (color) => color.label));
 
     expect(result.current.suggestions).toEqual([GREEN, RED, ORANGE]);
@@ -116,6 +117,22 @@ describe('useDefaultComboBox', () => {
 
     act(() => {
       result.current.onChange(mockChangeEvent(' '));
+    });
+
+    expect(result.current.suggestions).toEqual([GREEN, RED, ORANGE]);
+  });
+
+  it('should reset suggestions using the relevant method', () => {
+    const { result } = renderHook(() => useDefaultComboBox(SUGGESTIONS, (color) => color.label));
+
+    act(() => {
+      result.current.onChange(mockChangeEvent('red'));
+    });
+
+    expect(result.current.suggestions).toEqual([RED]);
+
+    act(() => {
+      result.current.resetSuggestions();
     });
 
     expect(result.current.suggestions).toEqual([GREEN, RED, ORANGE]);

--- a/front/ui/ui-core/src/components/ComboBox/__tests__/useDefaultComboBox.spec.ts
+++ b/front/ui/ui-core/src/components/ComboBox/__tests__/useDefaultComboBox.spec.ts
@@ -1,0 +1,123 @@
+import type { ChangeEvent } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import useDefaultComboBox, {
+  defaultFilterSuggestions,
+  normalizeString,
+} from '../useDefaultComboBox';
+
+describe('normalizeString', () => {
+  describe('lowercases the input if necessary', () => {
+    it('should transform FOO into foo', () => {
+      expect(normalizeString('FOO')).toEqual('foo');
+    });
+
+    it('should transform bar into bar', () => {
+      expect(normalizeString('bar')).toEqual('bar');
+    });
+  });
+
+  describe('removes accents if any', () => {
+    it('should transform éclair into eclair', () => {
+      expect(normalizeString('éclair')).toEqual('eclair');
+    });
+
+    it('should transform AOÛT into aout', () => {
+      expect(normalizeString('AOÛT')).toEqual('aout');
+    });
+  });
+});
+
+describe('defaultFilterSuggestions', () => {
+  const labels = [
+    { label: 'red', suggestion: '#ff0000' },
+    { label: 'blue', suggestion: '#0000ff' },
+    { label: 'limegreen', suggestion: '#aacdaa' },
+    { label: 'green', suggestion: '#00ff00' },
+    { label: 'lightblue', suggestion: '#00aaff' },
+    { label: 'orange', suggestion: '#ffaa00' },
+  ];
+
+  describe('returns everything on emptyness', () => {
+    const ALL_COLORS = ['#ff0000', '#0000ff', '#aacdaa', '#00ff00', '#00aaff', '#ffaa00'];
+
+    it('should return all the suggestions if query is empty', () => {
+      expect(defaultFilterSuggestions(labels, '')).toEqual(ALL_COLORS);
+    });
+
+    it('should return all the suggestions if query is full of spaces', () => {
+      expect(defaultFilterSuggestions(labels, '  ')).toEqual(ALL_COLORS);
+    });
+  });
+
+  describe('returns suggestions containing the query', () => {
+    it("should return all greens on 'ee', 'EE' and 'ee ' (with a trailing space)", () => {
+      expect(defaultFilterSuggestions(labels, 'ee')).toEqual(['#aacdaa', '#00ff00']);
+      expect(defaultFilterSuggestions(labels, 'EE')).toEqual(['#aacdaa', '#00ff00']);
+      expect(defaultFilterSuggestions(labels, 'ee ')).toEqual(['#aacdaa', '#00ff00']);
+    });
+  });
+
+  describe('starts the suggestions by what starts with the query', () => {
+    it("should return the blue color first on 'blue', 'BLUE', 'blue ' (with a trailing space)", () => {
+      expect(defaultFilterSuggestions(labels, 'blue')).toEqual(['#0000ff', '#00aaff']);
+      expect(defaultFilterSuggestions(labels, 'BLUE')).toEqual(['#0000ff', '#00aaff']);
+      expect(defaultFilterSuggestions(labels, 'blue ')).toEqual(['#0000ff', '#00aaff']);
+    });
+  });
+
+  describe('filter out all suggestions if nothing matches', () => {
+    it("should return nothing on 'magenta'", () => {
+      expect(defaultFilterSuggestions(labels, 'magenta')).toEqual([]);
+    });
+  });
+});
+
+function mockChangeEvent(value: string): ChangeEvent<HTMLInputElement> {
+  return vi.mockObject({ target: { value } }) as ChangeEvent<HTMLInputElement>;
+}
+
+describe('useDefaultComboBox', () => {
+  it('should offer suggestions props for basic combo box', () => {
+    const GREEN = { id: '1-green', label: 'Green' };
+    const RED = { id: '2-red', label: 'Red' };
+    const ORANGE = { id: '3-orange', label: 'Orange' };
+
+    const SUGGESTIONS = [GREEN, RED, ORANGE];
+    const { result } = renderHook(() => useDefaultComboBox(SUGGESTIONS, (color) => color.label));
+
+    expect(result.current.suggestions).toEqual([GREEN, RED, ORANGE]);
+
+    act(() => {
+      result.current.onChange(mockChangeEvent('re'));
+    });
+
+    expect(result.current.suggestions).toEqual([RED, GREEN]);
+
+    act(() => {
+      result.current.onChange(mockChangeEvent('red'));
+    });
+
+    expect(result.current.suggestions).toEqual([RED]);
+
+    act(() => {
+      result.current.onChange(mockChangeEvent(' ang '));
+    });
+
+    expect(result.current.suggestions).toEqual([ORANGE]);
+
+    act(() => {
+      result.current.onChange(mockChangeEvent('blu'));
+    });
+
+    expect(result.current.suggestions).toEqual([]);
+
+    act(() => {
+      result.current.onChange(mockChangeEvent(' '));
+    });
+
+    expect(result.current.suggestions).toEqual([GREEN, RED, ORANGE]);
+  });
+});

--- a/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
+++ b/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 /**
  * Removes the accents and lowercases the input.
@@ -68,13 +68,13 @@ const useDefaultComboBox = <T>(suggestions: T[], getSuggestionLabel: (suggestion
     [labels, query]
   );
 
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
-  };
+  }, []);
 
-  const resetSuggestions = () => {
+  const resetSuggestions = useCallback(() => {
     setQuery('');
-  };
+  }, []);
 
   return { suggestions: filteredSuggestions, onChange, resetSuggestions };
 };

--- a/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
+++ b/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
@@ -38,8 +38,7 @@ const useDefaultComboBox = <T>(suggestions: T[], getSuggestionLabel: (suggestion
 
   const filteredSuggestions = useMemo(
     () => defaultFilterSuggestions(getSuggestionLabel, suggestions, query),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [suggestions, query]
+    [suggestions, query, getSuggestionLabel]
   );
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
+++ b/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
@@ -1,32 +1,41 @@
 import { useMemo, useState } from 'react';
 
-const normalizeString = (str: string) => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+/**
+ * Removes the accents and lowercases the input.
+ */
+export const normalizeString = (str: string) =>
+  str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
 
-const defaultFilterSuggestions = <T>(
-  getSuggestionLabel: (suggestion: T) => string,
-  suggestions: T[],
+/**
+ * Filter the options, keeping only the one that have a suggestion label that contain
+ * the query, and sorting them so the one that starts with the query come first.
+ */
+export const defaultFilterSuggestions = <T>(
+  labels: { label: string; suggestion: T }[],
   query: string
 ) => {
-  const input = normalizeString(query).trim().toLowerCase();
+  const input = normalizeString(query).trim();
   if (!input) {
-    return suggestions;
+    return labels.map(({ suggestion }) => suggestion);
   }
 
-  const getSuggestionScore = (suggestion: T) => {
-    const suggestionLabel = normalizeString(getSuggestionLabel(suggestion).toLowerCase());
-    if (suggestionLabel.startsWith(input)) {
+  const getSuggestionScore = (label: string) => {
+    if (label.startsWith(input)) {
       return 2;
     }
-    if (suggestionLabel.includes(input)) {
+    if (label.includes(input)) {
       return 1;
     }
     return 0;
   };
 
-  return suggestions
-    .map((suggestion) => ({
+  return labels
+    .map(({ label, suggestion }) => ({
       suggestion,
-      score: getSuggestionScore(suggestion),
+      score: getSuggestionScore(label),
     }))
     .filter(({ score }) => score > 0)
     .sort(({ score: scoreA }, { score: scoreB }) => scoreB - scoreA)
@@ -36,9 +45,18 @@ const defaultFilterSuggestions = <T>(
 const useDefaultComboBox = <T>(suggestions: T[], getSuggestionLabel: (suggestion: T) => string) => {
   const [query, setQuery] = useState('');
 
+  const labels = useMemo(
+    () =>
+      suggestions.map((suggestion: T) => ({
+        label: normalizeString(getSuggestionLabel(suggestion)),
+        suggestion,
+      })),
+    [suggestions, getSuggestionLabel]
+  );
+
   const filteredSuggestions = useMemo(
-    () => defaultFilterSuggestions(getSuggestionLabel, suggestions, query),
-    [suggestions, query, getSuggestionLabel]
+    () => defaultFilterSuggestions(labels, query),
+    [labels, query]
   );
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
+++ b/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
@@ -42,6 +42,15 @@ export const defaultFilterSuggestions = <T>(
     .map(({ suggestion }) => suggestion);
 };
 
+/**
+ * Create relevant props for a basic combo box with suggestions, ready to be spread in a `ComboBox`
+ * component. Suggestions are filtered and ordered using a very simple algorithm: options with
+ * a labels that starts with the query are shown first, and other options that contains the query
+ * follows, trimming spaces, accents and ignoring case.
+ *
+ * The second parameter, `getSuggestionLabel`, should be stable to prevent rerender and useless
+ * recomputations (see `useCallback`).
+ */
 const useDefaultComboBox = <T>(suggestions: T[], getSuggestionLabel: (suggestion: T) => string) => {
   const [query, setQuery] = useState('');
 


### PR DESCRIPTION
Fixes #16772.

Reviewing this pull request in a commit-by-commit manner is recommanded.

First, I make sure that all users of this hook properly use `useCallback` to properly apply the `exhaustive-deps` linter.

Then, this pull request refactors `useDefaultComboBox`, adding some `useMemo` to cache the suggestion labels between queries (we should not recompute the labels and their normalization on each query!).

Finally, it adds some quick documentation, and at least, adds some unit tests and integration tests for this hook.