### PR TITLE
front: do not persist a no-op change in header

### DIFF
--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -242,12 +242,15 @@ const ExpandedTrainForm = ({
   const onFieldImmediateChange = useCallback(
     (fieldName: keyof TrainFieldsState, newValue: TrainFieldsState[typeof fieldName]) => {
       const newFields = { ...fields, [fieldName]: newValue };
-      const updatedTrain = applyFieldsToTrain(newFields, train, selectedRollingStock);
-      onPersistTrain(updatedTrain);
+
+      if (fieldsFromTrain[fieldName] !== newValue) {
+        const updatedTrain = applyFieldsToTrain(newFields, train, selectedRollingStock);
+        onPersistTrain(updatedTrain);
+      }
 
       setFields(newFields);
     },
-    [fields, train, onPersistTrain]
+    [fields, train, fieldsFromTrain, onPersistTrain]
   );
 
   const constraintDistributionsOptions: { id: ConstraintDistribution; label: string }[] = useMemo(


### PR DESCRIPTION
Fixes #17305.

We didn't bother to check if a field was changed in those case at first, because we thought of it as an exception (no pun intended) on how we handled changes in the form, with discrete changes inputs like selectors. It just happened to be way more useful than that, and without this check, a lot of simple moves in the headers causes a call on `onPersistTrain`, which call the backend everytime :(

We don't have to use `extractChangesInFields` here because we know all the fields that have changed during this operation, so we now do a simple check with the field that have changed.