### PR TITLE
front, ui-charts: fade out-of-selection curves with reduced opacity

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -747,6 +747,7 @@ const SpaceTimeChartWrapper = ({
                   path={path}
                   color={style.color}
                   level={style.level}
+                  opacity={style.opacity}
                   border={style.outline}
                   label={style.label}
                 />

--- a/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getCurveStyle.spec.ts
@@ -149,11 +149,12 @@ describe('getCurveStyle', () => {
   });
 
   describe('out of selection', () => {
-    it('should use the background tint for the curve and the label', () => {
+    it('should keep the normal color and fade with a reduced opacity', () => {
       const style = getCurveStyle('none', { colors, isSimulated: true }, { outOfSelection: true });
-      expect(style.color).toBe(colors.surface);
+      expect(style.color).toBe(colors.base);
+      expect(style.opacity).toBeLessThan(1);
       expect(style.label).toEqual({
-        color: colors.surface,
+        color: colors.base,
         fontWeight: 400,
         background: { color: REST_BACKGROUND_COLOR, opacity: 0.9 },
       });

--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -18,6 +18,7 @@ export const INVALID_OUTLINE: CurveOutline = {
 
 const FONT_WEIGHT_REGULAR = 400;
 const FONT_WEIGHT_BOLD = 600;
+const OUT_OF_SELECTION_OPACITY = 0.3;
 const RESTING_LABEL_BACKGROUND: NonNullable<CurveStyle['label']>['background'] = {
   color: REST_BACKGROUND_COLOR,
   opacity: 0.9,
@@ -168,10 +169,10 @@ const getCurveStyle = (
   if (outOfSelection) {
     const { colors } = train;
     return {
-      color: colors.surface,
-      opacity: 1,
+      color: colors.base,
+      opacity: OUT_OF_SELECTION_OPACITY,
       label: {
-        color: colors.surface,
+        color: colors.base,
         fontWeight: FONT_WEIGHT_REGULAR,
         background: RESTING_LABEL_BACKGROUND,
       },

--- a/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import { flatten, inRange } from 'lodash';
 
 import { hexToRgb, indexToColor } from '../../common/helpers/colors';
-import { getCrispLineCoordinate } from '../../common/helpers/time';
 import { useDraw, usePicking } from '../../common/hooks/useCanvas';
 import type {
   CurveStyle,
@@ -262,7 +261,10 @@ export const PathLayer = ({
             // (i.e. when there's only one space pixel):
             const rawPixels = getSpacePixels(getSpacePixel, position);
             if (rawPixels.length === 1) {
-              const spacePixel = getCrispLineCoordinate(rawPixels[0], ctx.lineWidth);
+              // Use the raw coordinate so the pause sits exactly on the
+              // curve. Adjusting it for sharper rendering would move the
+              // pause, and one side would look thicker than the other.
+              const spacePixel = rawPixels[0];
               ctx.beginPath();
               if (!swapAxis) {
                 ctx.moveTo(getTimePixel(prevTime), spacePixel);

--- a/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -51,7 +51,6 @@ type PathStyle = {
   width: number;
   endWidth: number;
   dashArray?: number[];
-  opacity?: number;
   lineCap: CanvasLineCap;
 };
 
@@ -93,6 +92,7 @@ export type PathLayerProps = {
   color: string;
   pickingTolerance?: number;
   level?: PathLevel;
+  opacity?: number;
   border?: CurveStyle['outline'];
   label?: CurveStyle['label'];
 };
@@ -108,6 +108,7 @@ export const PathLayer = ({
   color,
   level = DEFAULT_LEVEL,
   pickingTolerance = DEFAULT_PICKING_TOLERANCE,
+  opacity = 1,
   border,
   label,
 }: PathLayerProps) => {
@@ -326,7 +327,7 @@ export const PathLayer = ({
       const ry = y - ascent - padding;
 
       // BACKGROUND
-      ctx.globalAlpha = alpha;
+      ctx.globalAlpha = alpha * opacity;
       ctx.fillStyle = background;
       ctx.beginPath();
       ctx.roundRect(rx, ry, w, h, 3);
@@ -335,7 +336,7 @@ export const PathLayer = ({
       // BORDER
       if (borderColor) {
         ctx.save();
-        ctx.globalAlpha = 1;
+        ctx.globalAlpha = opacity;
         ctx.strokeStyle = borderColor;
         ctx.lineWidth = 1;
         ctx.roundRect(rx, ry, w, h, 3);
@@ -344,13 +345,13 @@ export const PathLayer = ({
       }
 
       // TEXT
-      ctx.globalAlpha = 1;
+      ctx.globalAlpha = opacity;
       ctx.fillStyle = textColor;
       ctx.fillText(text, x, y);
 
       ctx.restore();
     },
-    []
+    [opacity]
   );
 
   /**
@@ -480,6 +481,7 @@ export const PathLayer = ({
       const backgroundColor = border.backgroundColor || '#fff';
       const lines = getPathLines(stcContext);
       ctx.save();
+      ctx.globalAlpha = opacity;
       const drawLines = (lineWidth: number, borderColor = border.color) => {
         ctx.strokeStyle = borderColor;
         ctx.lineWidth = lineWidth;
@@ -503,7 +505,7 @@ export const PathLayer = ({
 
       ctx.restore();
     },
-    [border, getPathLines, level]
+    [border, getPathLines, level, opacity]
   );
 
   const drawSinglePoint = useCallback(
@@ -568,7 +570,7 @@ export const PathLayer = ({
       // Draw stops:
       ctx.strokeStyle = color;
       ctx.lineWidth = PAUSE_THICKNESS;
-      ctx.globalAlpha = PAUSE_OPACITY;
+      ctx.globalAlpha = PAUSE_OPACITY * opacity;
       ctx.lineCap = 'round';
       drawPauses(ctx, stcContext);
 
@@ -578,7 +580,7 @@ export const PathLayer = ({
       ctx.strokeStyle = color;
       ctx.lineWidth = style.width;
       ctx.setLineDash(style.dashArray || []);
-      ctx.globalAlpha = style.opacity || 1;
+      ctx.globalAlpha = opacity;
       ctx.lineCap = style.lineCap;
       const lines = getPathLines(stcContext);
       lines.forEach((points) => {
@@ -609,6 +611,7 @@ export const PathLayer = ({
       color,
       drawPauses,
       level,
+      opacity,
       getPathLines,
       drawSinglePoint,
       computePathLength,


### PR DESCRIPTION
Quick-fix cherry-picked from #17274. Addresses the out-of-selection curves opacity for #1630.
