### PR TITLE
editoast: add authorization to the rolling stock endpoints

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -175,7 +175,18 @@ pub enum RollingStockPrivilege {
 }
 
 #[derive(
-    Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+    Debug,
+    Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    EnumIter,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -178,7 +178,18 @@ pub enum RollingStockPrivilege {
 }
 
 #[derive(
-    Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+    Debug,
+    Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    EnumIter,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -138,6 +138,7 @@ pub enum InfraGrant {
     Eq,
     Hash,
 )]
+#[cfg_attr(test, derive(PartialOrd, Ord))]
 #[fga(name = "rolling_stock")]
 pub struct RollingStock(pub i64);
 

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -140,6 +140,7 @@ pub enum InfraGrant {
     Eq,
     Hash,
 )]
+#[cfg_attr(test, derive(PartialOrd, Ord))]
 #[fga(name = "rolling_stock")]
 pub struct RollingStock(pub i64);
 

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -208,6 +208,12 @@ impl<T> Protected<T> {
     }
 }
 
+impl Protected<()> {
+    pub fn check(check: Check) -> Self {
+        Protected::<()>::default().with_check_iter([check])
+    }
+}
+
 impl<T: Send + 'static> Protected<T> {
     /// A [Protected] value that always succeeds with the provided value
     pub fn value(t: T) -> Self {

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -210,6 +210,12 @@ impl<T> Protected<T> {
     }
 }
 
+impl Protected<()> {
+    pub fn check(check: Check) -> Self {
+        Protected::<()>::default().with_check_iter([check])
+    }
+}
+
 impl<T: Send + 'static> Protected<T> {
     /// A [Protected] value that always succeeds with the provided value
     pub fn value(t: T) -> Self {

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -14,6 +14,8 @@ use crate::RollingStockPrivilege;
 use crate::Subject;
 use crate::User;
 use crate::v2::Actor;
+use crate::v2::ResourcesList;
+use crate::v2::subject_roles;
 use crate::v2::validate_direct_grant;
 
 pub fn rolling_stock_privileges(
@@ -418,6 +420,58 @@ pub fn rolling_stock_revoke_grant(
     .with_check(Check::IsNotLastRollingStockOwner(subject, rolling_stock))
 }
 
+pub fn rolling_stock_list(
+    user: User,
+    privilege: RollingStockPrivilege,
+) -> Protected<ResourcesList<RollingStock>> {
+    subject_roles(Subject::user(user)).map(move |openfga, roles| {
+        async move {
+            if roles.contains(&Role::Admin) {
+                return Ok(ResourcesList::All);
+            }
+            let authorized_rolling_stocks = match privilege {
+                RollingStockPrivilege::CanRead => {
+                    openfga
+                        .list_objects(RollingStock::can_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareRead => {
+                    openfga
+                        .list_objects(RollingStock::can_share_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_share_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanDelete => {
+                    openfga
+                        .list_objects(RollingStock::can_delete().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareOwnership => {
+                    openfga
+                        .list_objects(RollingStock::can_share_ownership().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanRevoke => {
+                    openfga
+                        .list_objects(RollingStock::can_revoke().query_objects(&user))
+                        .await?
+                }
+            };
+            Ok(ResourcesList::Privileged(authorized_rolling_stocks))
+        }
+        .boxed()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -756,7 +810,6 @@ mod tests {
             .execute()
             .await
             .unwrap();
-
         assert_eq!(
             openfga
                 .rolling_stock_direct_grant(Subject::user(1), RollingStock(1))
@@ -788,6 +841,79 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn check_rolling_stock_list_no_rights_and_admin() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(3)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .write(&User::role().tuple(&Role::Admin, &User(3)))
+            .execute()
+            .await
+            .unwrap();
+        let rolling_stocks_1 = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_2 = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_no_rights = openfga
+            .rolling_stock_list(User(4), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        let rolling_stocks_admin = openfga
+            .rolling_stock_list(User(3), RollingStockPrivilege::CanRead)
+            .await;
+        assert_eq!(
+            rolling_stocks_1.sorted().collect_vec(),
+            vec![RollingStock(1), RollingStock(3)]
+        );
+        assert_eq!(
+            rolling_stocks_2.sorted().collect_vec(),
+            vec![RollingStock(2)]
+        );
+        assert_eq!(rolling_stocks_no_rights, vec![]);
+        assert!(matches!(rolling_stocks_admin, ResourcesList::All));
+    }
+
+    #[tokio::test]
+    async fn rolling_stock_list_only_returns_resources_with_the_queried_privilege() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .execute()
+            .await
+            .unwrap();
+
+        // A reader grant grants read access and not write access
+        let reader_can_read = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_read, vec![RollingStock(1)]);
+
+        let reader_can_write = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_write, vec![]);
+
+        // A writer grant grants both read and write access
+        let writer_can_write = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(writer_can_write, vec![RollingStock(2)]);
+    }
+
     #[rstest]
     #[case::rolling_stock_privileges(
         rolling_stock_privileges(User(1), RollingStock(1)).checks,
@@ -812,6 +938,13 @@ mod tests {
         &[
            Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
            Check::RollingStockExists(RollingStock(1))
+        ]
+    )]
+    #[rstest]
+    #[case::rolling_stock_list(
+        rolling_stock_list(User(1), RollingStockPrivilege::CanRead).checks,
+        &[
+           Check::SubjectExists(Subject::user(1)),
         ]
     )]
     fn protected_contains_expected_checks(

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -14,6 +14,8 @@ use crate::RollingStockPrivilege;
 use crate::Subject;
 use crate::User;
 use crate::v2::Actor;
+use crate::v2::ResourcesList;
+use crate::v2::subject_roles;
 use crate::v2::validate_direct_grant;
 
 pub fn rolling_stock_privileges(
@@ -441,6 +443,63 @@ pub fn rolling_stock_revoke_grant(
     .with_check(Check::IsNotLastRollingStockOwner(subject, rolling_stock))
 }
 
+pub fn rolling_stock_list(
+    user: User,
+    privilege: RollingStockPrivilege,
+) -> Protected<ResourcesList<RollingStock>> {
+    subject_roles(Subject::user(user)).then(move |openfga, roles| {
+        async move {
+            if roles.contains(&Role::Admin) {
+                return Ok(ResourcesList::All);
+            }
+            let authorized_rolling_stocks = match privilege {
+                RollingStockPrivilege::CanRestrictedRead => {
+                    openfga
+                        .list_objects(RollingStock::can_restricted_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanRead => {
+                    openfga
+                        .list_objects(RollingStock::can_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareRead => {
+                    openfga
+                        .list_objects(RollingStock::can_share_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_share_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanDelete => {
+                    openfga
+                        .list_objects(RollingStock::can_delete().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareOwnership => {
+                    openfga
+                        .list_objects(RollingStock::can_share_ownership().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanRevoke => {
+                    openfga
+                        .list_objects(RollingStock::can_revoke().query_objects(&user))
+                        .await?
+                }
+            };
+            Ok(ResourcesList::Privileged(authorized_rolling_stocks))
+        }
+        .boxed()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -781,7 +840,6 @@ mod tests {
             .execute()
             .await
             .unwrap();
-
         assert_eq!(
             openfga
                 .rolling_stock_direct_grant(Subject::user(1), RollingStock(1))
@@ -813,6 +871,79 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn check_rolling_stock_list_no_rights_and_admin() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(3)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .write(&User::role().tuple(&Role::Admin, &User(3)))
+            .execute()
+            .await
+            .unwrap();
+        let rolling_stocks_1 = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_2 = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_no_rights = openfga
+            .rolling_stock_list(User(4), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        let rolling_stocks_admin = openfga
+            .rolling_stock_list(User(3), RollingStockPrivilege::CanRead)
+            .await;
+        assert_eq!(
+            rolling_stocks_1.sorted().collect_vec(),
+            vec![RollingStock(1), RollingStock(3)]
+        );
+        assert_eq!(
+            rolling_stocks_2.sorted().collect_vec(),
+            vec![RollingStock(2)]
+        );
+        assert_eq!(rolling_stocks_no_rights, vec![]);
+        assert!(matches!(rolling_stocks_admin, ResourcesList::All));
+    }
+
+    #[tokio::test]
+    async fn rolling_stock_list_only_returns_resources_with_the_queried_privilege() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .execute()
+            .await
+            .unwrap();
+
+        // A reader grant grants read access and not write access
+        let reader_can_read = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_read, vec![RollingStock(1)]);
+
+        let reader_can_write = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_write, vec![]);
+
+        // A writer grant grants both read and write access
+        let writer_can_write = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(writer_can_write, vec![RollingStock(2)]);
+    }
+
     #[rstest]
     #[case::rolling_stock_privileges(
         rolling_stock_privileges(User(1), RollingStock(1)).checks,
@@ -833,6 +964,11 @@ mod tests {
         &[
            Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1))
         ]
+    )]
+    #[rstest]
+    #[case::rolling_stock_list(
+        rolling_stock_list(User(1), RollingStockPrivilege::CanRead).checks,
+        &[]
     )]
     fn protected_contains_expected_checks(
         #[case] protected_checks: HashSet<Check>,

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -100,6 +100,11 @@ pub trait TestClientExt {
         project: Project,
     ) -> Option<ProjectGrant>;
     async fn project_set_grant(&self, subject: Subject, project: Project) -> ();
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock>;
 }
 
 impl TestClientExt for fga::Client {
@@ -320,6 +325,19 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(project_set_grant(subject, project))
+            .await
+            .unwrap()
+    }
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(crate::v2::rolling_stock::rolling_stock_list(
+                user, privilege,
+            ))
             .await
             .unwrap()
     }

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -109,6 +109,11 @@ pub trait TestClientExt {
     async fn project_privileges(&self, user: User, project: Project) -> HashSet<ProjectPrivilege>;
     async fn project_list(&self, user: User) -> ResourcesList<Project>;
     async fn project_granted_subjects(&self, project: Project) -> Vec<Subject>;
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock>;
 }
 
 impl TestClientExt for fga::Client {
@@ -357,6 +362,20 @@ impl TestClientExt for fga::Client {
     async fn project_granted_subjects(&self, project: Project) -> Vec<Subject> {
         special_authorizers::Authorize(self)
             .access_value(project_granted_subjects(project))
+            .await
+            .unwrap()
+    }
+
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(crate::v2::rolling_stock::rolling_stock_list(
+                user, privilege,
+            ))
             .await
             .unwrap()
     }

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -141,6 +141,9 @@ pub enum PathfindingInputError {
         items: Vec<InvalidPathItem>,
     },
     NotEnoughPathItems,
+    UnauthorizedRollingStock {
+        rolling_stock_id: i64,
+    },
     RollingStockNotFound {
         rolling_stock_name: String,
     },

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5834,6 +5834,19 @@ components:
             enum:
             - not_enough_path_items
       - type: object
+        title: PathfindingInputErrorUnauthorizedRollingStock
+        required:
+        - rolling_stock_id
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - unauthorized_rolling_stock
+          rolling_stock_id:
+            type: integer
+            format: int64
+      - type: object
         title: PathfindingInputErrorRollingStockNotFound
         required:
         - rolling_stock_name

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5700,6 +5700,19 @@ components:
             enum:
             - not_enough_path_items
       - type: object
+        title: PathfindingInputErrorUnauthorizedRollingStock
+        required:
+        - rolling_stock_id
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - unauthorized_rolling_stock
+          rolling_stock_id:
+            type: integer
+            format: int64
+      - type: object
         title: PathfindingInputErrorRollingStockNotFound
         required:
         - rolling_stock_name

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -2,6 +2,8 @@ use std::convert::Infallible;
 use std::ops::Not as _;
 
 use authz::ProjectGrant;
+use crate::views::AuthorizationError;
+use crate::views::AuthorizerError;
 use authz::v2::Access;
 use authz::v2::Actor;
 use authz::v2::Authorizer;
@@ -332,6 +334,38 @@ macro_rules! impossible {
     };
 }
 pub(crate) use impossible;
+
+/// Ensures the issuer holds a privilege satisfying `required`.
+/// `protected` is an operation yielding the set of privileges the issuer holds on a resource.
+/// Access is granted when the operation is authorized and the issuer holds a privilege equal to `required`.
+pub async fn require<I, U>(
+    authorizer: &U,
+    protected: Protected<I>,
+    required: &<I as IntoIterator>::Item,
+) -> Result<(), AuthorizationError>
+where
+    I: IntoIterator,
+    <I as IntoIterator>::Item: PartialEq,
+    U: Authorizer<Error = Error>,
+{
+    let access = authorizer.authorize(protected).await.map_err(|e| match e {
+        Error::Database(error) => {
+            AuthorizationError::AuthError(AuthorizerError::Storage(error.into()))
+        }
+        Error::OpenFga(error) => error.into(),
+    })?;
+    let Ok(privileges) = access.access().await? else {
+        return Err(AuthorizationError::Forbidden);
+    };
+    if privileges
+        .into_iter()
+        .any(|privilege| privilege == *required)
+    {
+        Ok(())
+    } else {
+        Err(AuthorizationError::Forbidden)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -11,7 +11,6 @@ use authz::v2::Check;
 use authz::v2::Protected;
 use futures::StreamExt as _;
 use futures::stream::FuturesUnordered;
-use models::prelude::RetrieveBatchUnchecked as _;
 use tracing::Instrument as _;
 
 /// An authorizer that represents editoast's authorization decisions
@@ -311,40 +310,6 @@ where
     } else {
         Err(AuthorizationError::Forbidden)
     }
-}
-
-/// Ensures the issuer can read every rolling stock of `rolling_stock_names`, and fails with a
-/// [`AuthorizationError::Forbidden`] as soon as one of them isn't readable.
-pub async fn require_readable_rolling_stocks(
-    rolling_stock_names: impl IntoIterator<Item = String>,
-    conn: &mut database::DbConnection,
-    authn_state: &crate::authentication::State,
-    openfga: &fga::Client,
-) -> crate::error::Result<()> {
-    let Some(user) = authn_state.user() else {
-        return Ok(());
-    };
-
-    // Rolling stocks are referenced by name, the authorization by id
-    let rolling_stock_names = rolling_stock_names
-        .into_iter()
-        .collect::<std::collections::HashSet<_>>();
-    let rolling_stocks: Vec<models::RollingStock> =
-        models::RollingStock::retrieve_batch_unchecked(conn, rolling_stock_names)
-            .await
-            .map_err(crate::views::rolling_stock::RollingStockError::from)?;
-
-    // Not using rolling_stock_list: we bail out as soon as one rolling stock isn't readable
-    let authorizer = authn_state.authorizer(openfga);
-    for rolling_stock in rolling_stocks {
-        require(
-            &authorizer,
-            authz::v2::rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
-            &authz::RollingStockPrivilege::CanRead,
-        )
-        .await?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -11,6 +11,7 @@ use authz::v2::Check;
 use authz::v2::Protected;
 use futures::StreamExt as _;
 use futures::stream::FuturesUnordered;
+use models::prelude::RetrieveBatchUnchecked as _;
 use tracing::Instrument as _;
 
 /// An authorizer that represents editoast's authorization decisions
@@ -310,6 +311,40 @@ where
     } else {
         Err(AuthorizationError::Forbidden)
     }
+}
+
+/// Ensures the issuer can read every rolling stock of `rolling_stock_names`, and fails with a
+/// [`AuthorizationError::Forbidden`] as soon as one of them isn't readable.
+pub async fn require_readable_rolling_stocks(
+    rolling_stock_names: impl IntoIterator<Item = String>,
+    conn: &mut database::DbConnection,
+    authn_state: &crate::authentication::State,
+    openfga: &fga::Client,
+) -> crate::error::Result<()> {
+    let Some(user) = authn_state.user() else {
+        return Ok(());
+    };
+
+    // Rolling stocks are referenced by name, the authorization by id
+    let rolling_stock_names = rolling_stock_names
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    let rolling_stocks: Vec<models::RollingStock> =
+        models::RollingStock::retrieve_batch_unchecked(conn, rolling_stock_names)
+            .await
+            .map_err(crate::views::rolling_stock::RollingStockError::from)?;
+
+    // Not using rolling_stock_list: we bail out as soon as one rolling stock isn't readable
+    let authorizer = authn_state.authorizer(openfga);
+    for rolling_stock in rolling_stocks {
+        require(
+            &authorizer,
+            authz::v2::rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &authz::RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -2,6 +2,7 @@ use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::ops::Not as _;
 
+use crate::views::AuthorizationError;
 use authz::ProjectGrant;
 use authz::v2::Access;
 use authz::v2::Actor;
@@ -280,6 +281,37 @@ impl Authorizer for UserAuthorizer<'_> {
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct Error(#[from] pub authz::v2::OpenFgaError);
+
+/// Ensures the issuer holds a privilege satisfying `required`.
+/// `protected` is an operation yielding the set of privileges the issuer holds on a resource.
+/// Access is granted when the operation is authorized and the issuer holds a privilege equal to `required`.
+#[expect(unused)]
+pub async fn require<I, U>(
+    authorizer: &U,
+    protected: Protected<I>,
+    required: &<I as IntoIterator>::Item,
+) -> Result<(), AuthorizationError>
+where
+    I: IntoIterator,
+    <I as IntoIterator>::Item: PartialEq,
+    U: Authorizer<Error = Error>,
+{
+    let access = authorizer
+        .authorize(protected)
+        .await
+        .map_err(|e| AuthorizationError::from(e.0))?;
+    let Ok(privileges) = access.access().await? else {
+        return Err(AuthorizationError::Forbidden);
+    };
+    if privileges
+        .into_iter()
+        .any(|privilege| privilege == *required)
+    {
+        Ok(())
+    } else {
+        Err(AuthorizationError::Forbidden)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,9 +1,9 @@
 use std::convert::Infallible;
 use std::ops::Not as _;
 
-use authz::ProjectGrant;
 use crate::views::AuthorizationError;
 use crate::views::AuthorizerError;
+use authz::ProjectGrant;
 use authz::v2::Access;
 use authz::v2::Actor;
 use authz::v2::Authorizer;

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -285,7 +285,6 @@ pub struct Error(#[from] pub authz::v2::OpenFgaError);
 /// Ensures the issuer holds a privilege satisfying `required`.
 /// `protected` is an operation yielding the set of privileges the issuer holds on a resource.
 /// Access is granted when the operation is authorized and the issuer holds a privilege equal to `required`.
-#[expect(unused)]
 pub async fn require<I, U>(
     authorizer: &U,
     protected: Protected<I>,

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1082,30 +1082,39 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn infra_list_filters_authorized_infras() {
+    async fn infra_list_user_only_sees_its_related_infras() {
         let app = test_app!().build();
         let db_pool = app.db_pool();
-        let infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
-
-        // Regular user with the correct roles should see only the infra he is associated with:
+        let infra_1 = create_small_infra(&mut db_pool.get_ok()).await;
+        let infra_2 = create_small_infra(&mut db_pool.get_ok()).await;
+        let _infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
         let user = app
             .user("user_identity", "user_name")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_infra_grant(infra_1.id, InfraGrant::Reader)
+            .with_infra_grant(infra_2.id, InfraGrant::Reader)
             .create()
             .await;
         let response: InfraListResponse = app
             .get("/infra/")
             .by_user(user.as_ref())
             .await
-            .assert_status(StatusCode::OK)
+            .assert_status_ok()
             .json();
         assert_eq!(
-            response.results.iter().map(|infra| infra.id).collect_vec(),
-            vec![infra.id]
+            response
+                .results
+                .iter()
+                .map(|infra| infra.id)
+                .collect::<Vec<_>>(),
+            vec![infra_1.id, infra_2.id]
         );
+    }
 
-        // An admin should see all the infras:
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_list_admin_can_see_unrelated_infra() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
         let admin = app
             .user("admin", "admin")
             .with_roles([Role::Admin])
@@ -1115,11 +1124,15 @@ pub mod tests {
             .get("/infra/")
             .by_user(admin.as_ref())
             .await
-            .assert_status(StatusCode::OK)
+            .assert_status_ok()
             .json();
         assert_eq!(
-            response.results.iter().map(|infra| infra.id).collect_vec(),
-            vec![infra.id, infra_no_grant.id]
+            response
+                .results
+                .iter()
+                .map(|infra| infra.id)
+                .collect::<Vec<_>>(),
+            vec![infra_no_grant.id]
         );
     }
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1086,30 +1086,39 @@ pub mod tests {
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-        async fn list_filters_authorized_infras() {
+        async fn user_only_sees_its_related_infras() {
             let app = test_app!().build();
             let db_pool = app.db_pool();
-            let infra = create_small_infra(&mut db_pool.get_ok()).await;
-            let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
-
-            // Regular user with the correct roles should see only the infra he is associated with:
+            let infra_1 = create_small_infra(&mut db_pool.get_ok()).await;
+            let infra_2 = create_small_infra(&mut db_pool.get_ok()).await;
+            let _infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
             let user = app
                 .user("user_identity", "user_name")
-                .with_infra_grant(infra.id, InfraGrant::Reader)
+                .with_infra_grant(infra_1.id, InfraGrant::Reader)
+                .with_infra_grant(infra_2.id, InfraGrant::Reader)
                 .create()
                 .await;
             let response: InfraListResponse = app
                 .get("/infra/")
                 .by_user(user.as_ref())
                 .await
-                .assert_status(StatusCode::OK)
+                .assert_status_ok()
                 .json();
             assert_eq!(
-                response.results.iter().map(|infra| infra.id).collect_vec(),
-                vec![infra.id]
+                response
+                    .results
+                    .iter()
+                    .map(|infra| infra.id)
+                    .collect::<Vec<_>>(),
+                vec![infra_1.id, infra_2.id]
             );
+        }
 
-            // An admin should see all the infras:
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn admin_can_see_unrelated_infras() {
+            let app = test_app!().build();
+            let db_pool = app.db_pool();
+            let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
             let admin = app
                 .user("admin", "admin")
                 .with_roles([Role::Admin])
@@ -1119,11 +1128,15 @@ pub mod tests {
                 .get("/infra/")
                 .by_user(admin.as_ref())
                 .await
-                .assert_status(StatusCode::OK)
+                .assert_status_ok()
                 .json();
             assert_eq!(
-                response.results.iter().map(|infra| infra.id).collect_vec(),
-                vec![infra.id, infra_no_grant.id]
+                response
+                    .results
+                    .iter()
+                    .map(|infra| infra.id)
+                    .collect::<Vec<_>>(),
+                vec![infra_no_grant.id]
             );
         }
 

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -1,12 +1,12 @@
 use crate::AppState;
 use crate::authentication;
-use crate::authorizers::SystemAuthorizer;
 use crate::error::Result;
 use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
 use crate::views::projection::interpolate_arrival_time;
 use crate::views::rolling_stock::RollingStockError;
+use crate::views::rolling_stock::filter_readable_occurrences;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::train_simulation_ordered_batch;
@@ -17,9 +17,6 @@ use models::Timetable;
 use models::TrainSchedule;
 use models::train_schedule::OccurrenceId;
 
-use authz::RollingStockPrivilege;
-use authz::v2::Authorizer as _;
-use authz::v2::ResourcesList;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
@@ -33,7 +30,6 @@ use itertools::Itertools;
 use models::TrainScheduleException;
 use models::prelude::*;
 use models::rolling_stock::RollingStock;
-use schemas::TrainOccurrence;
 use schemas::infra::Direction;
 use schemas::infra::LevelCrossing;
 use schemas::infra::TrackOffset;
@@ -255,54 +251,6 @@ pub(in crate::views) async fn occupancy(
     }
 
     Ok(Json(results))
-}
-
-/// Discards the occurrences whose rolling stock the user isn't allowed to read
-async fn filter_readable_occurrences(
-    train_occurrences: HashMap<String, Vec<(OccurrenceId, TrainOccurrence)>>,
-    rolling_stocks: &[RollingStock],
-    authn_state: &crate::authentication::State,
-    openfga: &fga::Client,
-) -> Result<Vec<(OccurrenceId, TrainOccurrence)>> {
-    // The request bypasses authorization
-    let Some(user) = authn_state.user() else {
-        return Ok(train_occurrences.into_values().flatten().collect());
-    };
-
-    // Listing the readable rolling stocks cannot be rejected: the issuer is already authenticated
-    let Ok(authorized_rolling_stocks) = SystemAuthorizer::new_infallible(openfga)
-        .authorize(authz::v2::rolling_stock_list(
-            user,
-            RollingStockPrivilege::CanRead,
-        ))
-        .await?
-        .access()
-        .await?;
-
-    let ResourcesList::Privileged(authorized_rolling_stocks) = authorized_rolling_stocks else {
-        // The user is an admin: every rolling stock is readable
-        return Ok(train_occurrences.into_values().flatten().collect());
-    };
-    let authorized_rolling_stock_ids = authorized_rolling_stocks
-        .into_iter()
-        .map(|rolling_stock| rolling_stock.0)
-        .collect::<HashSet<_>>();
-
-    // Occurrences are grouped by rolling stock name, the authorization by id
-
-    let authorized_rolling_stock_names = rolling_stocks
-        .iter()
-        .filter(|rs| authorized_rolling_stock_ids.contains(&rs.id))
-        .map(|rs| rs.name.clone())
-        .collect::<HashSet<_>>();
-
-    Ok(train_occurrences
-        .into_iter()
-        .filter(|(rolling_stock_name, _)| {
-            authorized_rolling_stock_names.contains(rolling_stock_name)
-        })
-        .flat_map(|(_, occurrences)| occurrences)
-        .collect())
 }
 
 fn find_level_crossing_occupancy(

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -1,5 +1,6 @@
 use crate::AppState;
 use crate::authentication;
+use crate::authorizers::SystemAuthorizer;
 use crate::error::Result;
 use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::PathfindingResult;
@@ -16,6 +17,9 @@ use models::Timetable;
 use models::TrainSchedule;
 use models::train_schedule::OccurrenceId;
 
+use authz::RollingStockPrivilege;
+use authz::v2::Authorizer as _;
+use authz::v2::ResourcesList;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
@@ -24,7 +28,6 @@ use common::units::millisecond;
 use common::units::quantities::Offset;
 use core_client::pathfinding::TrackRange;
 use core_client::simulation::ReportTrain;
-use database::DbConnection;
 use editoast_derive::EditoastError;
 use itertools::Itertools;
 use models::TrainScheduleException;
@@ -40,6 +43,7 @@ use schemas::timetable_type::TimetableType;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use thiserror::Error;
 use utoipa::ToSchema;
 
@@ -76,6 +80,7 @@ pub(in crate::views) struct LevelCrossingOccupancyForm {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[cfg_attr(test, derive(PartialEq))]
 pub(in crate::views) struct LevelCrossingOccupancy {
     #[serde(flatten)]
     #[schema(inline)]
@@ -168,15 +173,30 @@ pub(in crate::views) async fn occupancy(
         })
         .await?;
 
-    // Collect all occurrences from all trains
+    // Collect all occurrences from all trains, grouped by the rolling stock name of their train
     let train_occurrences = trains
         .iter()
         .flat_map(|train| {
+            let train_exceptions = exceptions.remove(&train.id).unwrap_or_default();
             train
-                .iter_occurrences(&exceptions.remove(&train.id).unwrap_or_default())
-                .collect::<Vec<_>>()
+                .iter_occurrences(&train_exceptions)
+                .map(|occurrence| (train.rolling_stock_name.clone(), occurrence))
+                .collect_vec()
         })
-        .collect_vec();
+        .into_group_map();
+
+    let rolling_stock_names: HashSet<_> = train_occurrences.keys().cloned().collect();
+    let rolling_stocks: Vec<_> = RollingStock::retrieve_batch_unchecked(conn, rolling_stock_names)
+        .await
+        .map_err(RollingStockError::from)?;
+
+    let train_occurrences = filter_readable_occurrences(
+        train_occurrences,
+        &rolling_stocks,
+        &authn_state,
+        &openfga,
+    )
+    .await?;
 
     // Extract train schedules for simulation
     let train_schedules = train_occurrences
@@ -195,7 +215,10 @@ pub(in crate::views) async fn occupancy(
     )
     .await?;
 
-    let rolling_stock_lengths = load_rolling_stock_lengths(&train_schedules, conn).await?;
+    let rolling_stock_lengths: HashMap<_, _> = rolling_stocks
+        .into_iter()
+        .map(|rs| (rs.name, common::units::millimeter::from(rs.length) as u64))
+        .collect();
 
     // For each occurrence + simulation result, compute level crossing occupancy and group by level crossing id
     let mut results: HashMap<Identifier, Vec<LevelCrossingOccupancy>> = HashMap::new();
@@ -238,24 +261,51 @@ pub(in crate::views) async fn occupancy(
     Ok(Json(results))
 }
 
-async fn load_rolling_stock_lengths(
-    train_schedules: &[TrainOccurrence],
-    conn: &mut DbConnection,
-) -> Result<HashMap<String, u64>> {
-    let rolling_stocks_names = train_schedules.iter().map(|t| t.rolling_stock_name.clone());
+/// Discards the occurrences whose rolling stock the user isn't allowed to read
+async fn filter_readable_occurrences(
+    train_occurrences: HashMap<String, Vec<(OccurrenceId, TrainOccurrence)>>,
+    rolling_stocks: &[RollingStock],
+    authn_state: &crate::authentication::State,
+    openfga: &fga::Client,
+) -> Result<Vec<(OccurrenceId, TrainOccurrence)>> {
+    // The request bypasses authorization
+    let Some(user) = authn_state.user() else {
+        return Ok(train_occurrences.into_values().flatten().collect());
+    };
 
-    let rolling_stocks: Vec<_> = RollingStock::retrieve_batch_unchecked(conn, rolling_stocks_names)
-        .await
-        .map_err(RollingStockError::from)?;
+    // Listing the readable rolling stocks cannot be rejected: the issuer is already authenticated
+    let Ok(authorized_rolling_stocks) = SystemAuthorizer::new_infallible(openfga)
+        .authorize(authz::v2::rolling_stock_list(
+            user,
+            RollingStockPrivilege::CanRead,
+        ))
+        .await?
+        .access()
+        .await?;
 
-    Ok(rolling_stocks
+    let ResourcesList::Privileged(authorized_rolling_stocks) = authorized_rolling_stocks else {
+        // The user is an admin: every rolling stock is readable
+        return Ok(train_occurrences.into_values().flatten().collect());
+    };
+    let authorized_rolling_stock_ids = authorized_rolling_stocks
         .into_iter()
-        .map(|rs| {
-            (
-                rs.name.clone(),
-                common::units::millimeter::from(rs.length) as u64,
-            )
+        .map(|rolling_stock| rolling_stock.0)
+        .collect::<HashSet<_>>();
+
+    // Occurrences are grouped by rolling stock name, the authorization by id
+
+    let authorized_rolling_stock_names = rolling_stocks
+        .iter()
+        .filter(|rs| authorized_rolling_stock_ids.contains(&rs.id))
+        .map(|rs| rs.name.clone())
+        .collect::<HashSet<_>>();
+
+    Ok(train_occurrences
+        .into_iter()
+        .filter(|(rolling_stock_name, _)| {
+            authorized_rolling_stock_names.contains(rolling_stock_name)
         })
+        .flat_map(|(_, occurrences)| occurrences)
         .collect())
 }
 
@@ -378,12 +428,15 @@ fn find_pedal_position(
 mod tests {
     use super::*;
     use crate::fixtures::create_fast_rolling_stock;
-    use crate::fixtures::create_hourly_timetable_with_train_schedule_set;
     use crate::fixtures::create_small_infra;
     use crate::fixtures::create_timetable_with_train_schedule_set;
+    use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::test_app;
-    use axum_test::TestResponse;
 
+    use authz::InfraGrant;
+    use authz::Role;
+    use authz::RollingStockGrant;
     use chrono::TimeDelta;
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::PathfindingResultSuccess;
@@ -530,11 +583,7 @@ mod tests {
         })
     }
 
-    async fn init_level_crossing_test(
-        lc_position: f64,
-        lc_id: &str,
-        track: &str,
-    ) -> (TestResponse, Identifier, TrainSchedule) {
+    fn mocked_core() -> MockingClient {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
             .response(StatusCode::OK)
@@ -544,17 +593,17 @@ mod tests {
             .response(StatusCode::OK)
             .json(simulation_with_realistic_positions())
             .finish();
-
-        create_and_fetch_occupancy(core, lc_id, track, lc_position).await
+        core
     }
 
-    async fn create_and_fetch_occupancy(
-        core: MockingClient,
+    /// Creates the infra, the rolling stock, the timetable, the level crossing and the train the
+    /// occupancy tests run on, and returns the form querying them
+    async fn create_occupancy_fixtures(
+        app: &TestApp,
         lc_id: &str,
         track: &str,
         lc_position: f64,
-    ) -> (TestResponse, Identifier, TrainSchedule) {
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+    ) -> (LevelCrossingOccupancyForm, TrainSchedule, RollingStock) {
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =
@@ -582,46 +631,65 @@ mod tests {
             .await
             .expect("Failed to create level crossing");
 
-        let train = models::TrainSchedule::default()
+        let train = create_train(app, train_schedule_set.id, &rolling_stock.name).await;
+
+        let form = LevelCrossingOccupancyForm {
+            train_ids: vec![train.id],
+            level_crossing_ids: vec![level_crossing.obj_id.into()],
+            infra_id: small_infra.id,
+            timetable_id: timetable.id,
+            electrical_profile_set_id: None,
+        };
+        (form, train, rolling_stock)
+    }
+
+    /// A train running from `Mid_West_station` to `Mid_East_station`, paced every 15 minutes
+    /// over an hour
+    async fn create_train(
+        app: &TestApp,
+        train_schedule_set_id: i64,
+        rolling_stock_name: &str,
+    ) -> TrainSchedule {
+        TrainSchedule::default()
             .into_changeset()
-            .train_schedule_set_id(train_schedule_set.id)
-            .rolling_stock_name(rolling_stock.name)
+            .train_schedule_set_id(train_schedule_set_id)
+            .rolling_stock_name(rolling_stock_name.to_string())
             .path(vec![
                 PathItem::new_operational_point("Mid_West_station"),
                 PathItem::new_operational_point("Mid_East_station"),
             ])
             .interval(Some(TimeDelta::minutes(15)))
             .time_window(Some(TimeDelta::hours(1)))
-            .create(&mut db_pool.get_ok())
+            .create(&mut app.db_pool().get_ok())
             .await
-            .expect("Failed to create train");
-
-        (
-            app.post("/level_crossing_occupancy")
-                .json(&LevelCrossingOccupancyForm {
-                    train_ids: vec![train.id],
-                    level_crossing_ids: vec![level_crossing.obj_id.clone().into()],
-                    infra_id: small_infra.id,
-                    timetable_id: timetable.id,
-                    electrical_profile_set_id: None,
-                })
-                .await,
-            level_crossing.obj_id.clone().into(),
-            train,
-        )
+            .expect("Failed to create train")
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_level_crossing_occupancy_endpoint() {
-        // Level crossing at 750m on TC1 (on train path)
-        let (response, level_crossing_id, train) =
-            init_level_crossing_test(750.0, "LC_TC1", "TC1").await;
+        let app = test_app!().core_client(mocked_core().into()).build();
+        let (form, train, rolling_stock) =
+            create_occupancy_fixtures(&app, "LC_TC1", "TC1", 750.0).await;
 
-        let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> =
-            response.assert_status_ok().json();
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(form.infra_id, InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
-        assert!(occupancies.contains_key(&level_crossing_id));
-        let lc_occupancies = occupancies.get(&level_crossing_id).unwrap();
+        let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> = app
+            .post("/level_crossing_occupancy")
+            .json(&form)
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        let level_crossing_obj_id = &form.level_crossing_ids[0];
+        assert!(occupancies.contains_key(level_crossing_obj_id));
+        let lc_occupancies = occupancies.get(level_crossing_obj_id).unwrap();
         assert_eq!(lc_occupancies.len(), 4);
 
         // Expected values:
@@ -643,45 +711,116 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_level_crossing_occupancy_returns_empty() {
-        // Level crossing at 750m on TX1 (not on train path)
-        let (response, level_crossing_id, ..) =
-            init_level_crossing_test(750.0, "LC_TX1", "TX1").await;
+        // A level crossing at 750m on TX1, which is not on the train path
+        let app = test_app!().core_client(mocked_core().into()).build();
+        let (form, _, rolling_stock) =
+            create_occupancy_fixtures(&app, "LC_TX1", "TX1", 750.0).await;
 
-        let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> =
-            response.assert_status_ok().json();
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(form.infra_id, InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
-        // Level crossing should exist but have no occupancies
+        // WHEN
+        let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> = app
+            .post("/level_crossing_occupancy")
+            .json(&form)
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // The level crossing is reported, without any occupancy
         assert_eq!(
-            occupancies
-                .get(&level_crossing_id)
-                .map(|vec| vec.len())
-                .unwrap_or(0),
-            0
+            occupancies.get(&form.level_crossing_ids[0]).unwrap(),
+            &Vec::new()
         );
     }
 
+    /// The trains whose rolling stock the user cannot read are filtered out of the response,
+    /// instead of failing the whole request with a 403
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn test_level_crossing_occupancy_rejects_hourly_timetable() {
-        let app = test_app!()
-            .skip_authz()
-            .core_client(MockingClient::new().into())
-            .build();
-        let db_pool = app.db_pool();
-        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let (timetable, _train_schedule_set) =
-            create_hourly_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+    async fn test_level_crossing_occupancy_without_rolling_stock_permission() {
+        // GIVEN
+        let app = test_app!().core_client(mocked_core().into()).build();
+        let (form, ..) = create_occupancy_fixtures(&app, "LC_TC1", "TC1", 750.0).await;
 
-        let response = app
-            .post("/level_crossing_occupancy")
-            .json(&LevelCrossingOccupancyForm {
-                train_ids: vec![],
-                level_crossing_ids: vec![],
-                infra_id: small_infra.id,
-                timetable_id: timetable.id,
-                electrical_profile_set_id: None,
-            })
+        // a user that has the role to reach the endpoint and a read grant on the infra,
+        // but no read grant on the rolling stock of the train
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(form.infra_id, InfraGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
             .await;
 
-        response.assert_status_unprocessable_entity();
+        // WHEN
+        let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> = app
+            .post("/level_crossing_occupancy")
+            .json(&form)
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        assert_eq!(
+            occupancies.get(&form.level_crossing_ids[0]).unwrap(),
+            &Vec::new()
+        );
+    }
+
+    /// Among several trains, only the occurrences of those whose rolling stock the user can read
+    /// are reported, the others are filtered out
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_level_crossing_occupancy_filters_out_unreadable_trains_only() {
+        // GIVEN
+        let app = test_app!().core_client(mocked_core().into()).build();
+        let (mut form, readable_train, readable_rolling_stock) =
+            create_occupancy_fixtures(&app, "LC_TC1", "TC1", 750.0).await;
+
+        // a second train of the same timetable, running on another rolling stock
+        let unreadable_rolling_stock =
+            create_fast_rolling_stock(&mut app.db_pool().get_ok(), "unreadable_rolling_stock")
+                .await;
+        let unreadable_train = create_train(
+            &app,
+            readable_train.train_schedule_set_id,
+            &unreadable_rolling_stock.name,
+        )
+        .await;
+        form.train_ids.push(unreadable_train.id);
+
+        // a user granted a read access on the rolling stock of the first train only
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(form.infra_id, InfraGrant::Reader)
+            .with_rolling_stock_grant(readable_rolling_stock.id, RollingStockGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let occupancies: HashMap<Identifier, Vec<LevelCrossingOccupancy>> = app
+            .post("/level_crossing_occupancy")
+            .json(&form)
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN the occurrences of the readable train are reported, and only those
+        let reported_occurrences: HashSet<_> = occupancies
+            .get(&form.level_crossing_ids[0])
+            .expect("the level crossing should be reported")
+            .iter()
+            .map(|occupancy| occupancy.occurrence_id.clone())
+            .collect();
+        let readable_occurrences: HashSet<_> = (0..4)
+            .map(|index| OccurrenceId::new_base(readable_train.id, index))
+            .collect();
+        assert_eq!(reported_occurrences, readable_occurrences);
     }
 }

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -190,13 +190,9 @@ pub(in crate::views) async fn occupancy(
         .await
         .map_err(RollingStockError::from)?;
 
-    let train_occurrences = filter_readable_occurrences(
-        train_occurrences,
-        &rolling_stocks,
-        &authn_state,
-        &openfga,
-    )
-    .await?;
+    let train_occurrences =
+        filter_readable_occurrences(train_occurrences, &rolling_stocks, &authn_state, &openfga)
+            .await?;
 
     // Extract train schedules for simulation
     let train_schedules = train_occurrences

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -714,7 +714,7 @@ pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
     core_client: Arc<CoreClient>,
     train_schedules: &[T],
     op_cache: &OperationalPointCache,
-    operational_points_projection: OperationalPointProjection,
+    operational_points_projection: &OperationalPointProjection,
     infra: &Infra,
     electrical_profile_set_id: Option<i64>,
     app_version: Option<&str>,
@@ -763,7 +763,7 @@ pub async fn compute_projected_train_path_op<T: TrainScheduleLike>(
         let curves = Arc::new(project_train_path_op(
             &train_to_project,
             op_cache,
-            &operational_points_projection,
+            operational_points_projection,
         ));
 
         for index in context.indexes {
@@ -839,7 +839,7 @@ fn project_train_path_op(
 pub fn compute_projected_train_path_op_without_simulation<T: TrainScheduleLike>(
     train_schedules: &[T],
     op_cache: &OperationalPointCache,
-    operational_points_projection: OperationalPointProjection,
+    operational_points_projection: &OperationalPointProjection,
 ) -> Vec<Arc<Vec<SpaceTimeCurve>>> {
     train_schedules
         .iter()
@@ -848,7 +848,7 @@ pub fn compute_projected_train_path_op_without_simulation<T: TrainScheduleLike>(
             Arc::new(project_train_path_op(
                 &train_to_project,
                 op_cache,
-                &operational_points_projection,
+                operational_points_projection,
             ))
         })
         .collect_vec()

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -3,7 +3,9 @@ pub(in crate::views) mod towed;
 
 type RollingStockForm = schemas::RollingStock<schemas::rolling_stock::RollingResistancePerWeight>;
 
+use authz::RollingStockGrant;
 use authz::RollingStockPrivilege;
+use authz::v2;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 
@@ -41,6 +43,9 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
+use crate::authorizers::SystemAuthorizer;
+use crate::authorizers::impossible;
 use crate::error::InternalError;
 use crate::error::Result;
 
@@ -290,8 +295,11 @@ pub(in crate::views) struct PostRollingStockQueryParams {
     )
 )]
 pub(in crate::views) async fn create(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
     Query(query_params): Query<PostRollingStockQueryParams>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Json(rolling_stock_form): Json<RollingStockForm>,
 ) -> Result<Json<RollingStock>> {
     let conn = &mut db_pool.get().await?;
@@ -303,6 +311,37 @@ pub(in crate::views) async fn create(
         .create(conn)
         .await
         .map_err(RollingStockError::from)?;
+
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        match v2::rolling_stock_set_grant(
+            authz::Subject::User(*user),
+            authz::RollingStock(rolling_stock.id),
+            RollingStockGrant::Owner,
+        )
+        .authorize(&SystemAuthorizer {
+            openfga: regulator.openfga(),
+            conn: conn.clone(),
+        })
+        .await?
+        .access()
+        .await?
+        {
+            Ok(()) => {}
+            Err(v2::Check::SubjectExists(subject)) => {
+                panic!("authenticated user should exist: {subject:?}")
+            }
+            Err(v2::Check::RollingStockExists(rolling_stock)) => {
+                panic!("rolling stock was just created: {rolling_stock:?}")
+            }
+            Err(
+                check @ (v2::Check::HasRollingStockPrivilege(..)
+                | v2::Check::CanAlterSubjectRollingStockGrant(..)),
+            ) => {
+                panic!("SystemAuthorizer should not reject rolling stock grant checks: {check:?}")
+            }
+            Err(check) => impossible!(check),
+        }
+    }
 
     Ok(Json(rolling_stock))
 }
@@ -815,8 +854,14 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_successfully() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
+
+        let user = app
+            .user(uuid::Uuid::new_v4().to_string(), "name")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock_form = fast_rolling_stock_form(rs_name);
@@ -824,6 +869,7 @@ pub mod tests {
         // WHEN
         let raw_response = app
             .rolling_stock_create_request(&fast_rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -833,6 +879,7 @@ pub mod tests {
             .await
             .expect("Failed to retrieve rolling stock")
             .expect("Rolling stock not found");
+        let rs_id = rolling_stock.id;
 
         assert_eq!(rolling_stock.name, rs_name);
         assert_eq!(
@@ -846,6 +893,9 @@ pub mod tests {
                 .contains("ETCS_LEVEL2"),
             false
         );
+        // Check if the issuer was added as owner to the rolling stock
+        app.assert_rolling_stock_grant(rs_id, user.id, Some(RollingStockGrant::Owner))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -319,10 +319,22 @@ pub(in crate::views) async fn create(
     )
 )]
 pub(in crate::views) async fn update(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     Json(rolling_stock_form): Json<RollingStockForm>,
 ) -> Result<Json<RollingStockWithLiveries>> {
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanWrite,
+        )
+        .await?;
+    }
     let new_rolling_stock = db_pool
         .get()
         .await?
@@ -703,6 +715,7 @@ async fn create_compound_image(
 
 #[cfg(test)]
 pub mod tests {
+    use authz::RollingStockGrant;
     use itertools::Itertools;
     use models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
@@ -1154,26 +1167,32 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_unlocked_rolling_stock() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
 
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
         let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
         let updated_rs_name = "updated_fast_rolling_stock_name";
         rolling_stock_form.name = updated_rs_name.to_string();
 
         // WHEN
-        let raw_response = app
-            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
             .json(&&rolling_stock_form)
-            .await;
+            .await
+            .assert_status_ok();
 
         // THEN
-        raw_response.assert_status_ok();
-
         let updated_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
@@ -1188,9 +1207,146 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn update_rolling_stock_with_new_categories() {
+    async fn update_rolling_stock_without_authorization() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unauthorized_rolling_stock").await;
+
+        // A user with the OperationalStudies role but only a read grant on the rolling stock
+        let user = app
+            .user("reader", "Reader")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        rolling_stock_form.name = "should_not_be_updated".to_string();
+
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_forbidden();
+
+        // The rolling stock should not have been modified
+        let rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+
+        assert_eq!(rolling_stock.name, fast_rolling_stock.name);
+        assert_eq!(rolling_stock.version, fast_rolling_stock.version);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_as_admin_without_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "admin_updated_rolling_stock").await;
+
+        // An admin holds no grant on the rolling stock but can still update it
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        let updated_rs_name = "updated_by_admin";
+        rolling_stock_form.name = updated_rs_name.to_string();
+
+        // WHEN
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(admin.as_ref())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_ok();
+
+        // THEN
+        let updated_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert_eq!(updated_rolling_stock.name, updated_rs_name);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_with_skip_authz_without_grant() {
         // GIVEN
         let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "skip_authz_updated_rolling_stock")
+                .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        let updated_rs_name = "updated_with_skip_authz";
+        rolling_stock_form.name = updated_rs_name.to_string();
+
+        // WHEN (no grant set up, authorization is skipped)
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_ok();
+
+        // THEN
+        let updated_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert_eq!(updated_rolling_stock.name, updated_rs_name);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_without_operational_studies_role() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "missing_role_rolling_stock").await;
+
+        // A user with the right write grant but lacking the OperationalStudies role
+        let user = app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        rolling_stock_form.name = "should_not_be_updated".to_string();
+
+        // WHEN
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_forbidden();
+
+        // THEN the rolling stock should not have been modified
+        let rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert_eq!(rolling_stock.name, fast_rolling_stock.name);
+        assert_eq!(rolling_stock.version, fast_rolling_stock.version);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_with_new_categories() {
+        // GIVEN
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let fast_rolling_stock =
@@ -1210,10 +1366,18 @@ pub mod tests {
         let other_categories = vec![schemas::rolling_stock::TrainMainCategory::RegionalTrain];
         rolling_stock_form.other_categories = other_categories;
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
         // WHEN
         let raw_response = app
             .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
             .json(&&rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -1241,12 +1405,19 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_categories_should_fail_when_invalid() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let fast_rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_with_categories")
                 .await;
+
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
 
         let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
         let primary_category =
@@ -1259,6 +1430,7 @@ pub mod tests {
         let raw_response = app
             .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
             .json(&&rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -1280,13 +1452,19 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_failure_name_already_used() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let first_rs_name = "first_fast_rolling_stock_name";
         let first_fast_rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), first_rs_name).await;
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(first_fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
         let second_rs_name = "second_fast_rolling_stock_name";
         let second_fast_rolling_stock =
             create_rolling_stock_with_energy_sources(&mut db_pool.get_ok(), second_rs_name).await;
@@ -1297,6 +1475,7 @@ pub mod tests {
         let raw_response = app
             .put(format!("/rolling_stock/{}", first_fast_rolling_stock.id).as_str())
             .json(&second_fast_rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -1311,7 +1490,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_locked_rolling_stock_fails() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1325,6 +1504,13 @@ pub mod tests {
             .await
             .expect("Failed to create rolling stock");
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(locked_fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
         let mut second_fast_rolling_stock_form: RollingStockForm =
             schemas::fixtures::fast_rolling_stock();
         second_fast_rolling_stock_form.name = "second_fast_rolling_stock_name".to_owned();
@@ -1333,6 +1519,7 @@ pub mod tests {
         let raw_response = app
             .put(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())
             .json(&second_fast_rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -319,10 +319,22 @@ pub(in crate::views) async fn create(
     )
 )]
 pub(in crate::views) async fn update(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     Json(rolling_stock_form): Json<RollingStockForm>,
 ) -> Result<Json<RollingStockWithLiveries>> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanWrite,
+        )
+        .await?;
+    }
     let new_rolling_stock = db_pool
         .get()
         .await?
@@ -703,6 +715,7 @@ async fn create_compound_image(
 
 #[cfg(test)]
 pub mod tests {
+    use authz::RollingStockGrant;
     use editoast_models::rolling_stock::TrainMainCategory;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
@@ -1154,26 +1167,32 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_unlocked_rolling_stock() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
 
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
         let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
         let updated_rs_name = "updated_fast_rolling_stock_name";
         rolling_stock_form.name = updated_rs_name.to_string();
 
         // WHEN
-        let raw_response = app
-            .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
             .json(&&rolling_stock_form)
-            .await;
+            .await
+            .assert_status_ok();
 
         // THEN
-        raw_response.assert_status_ok();
-
         let updated_rolling_stock: RollingStock =
             RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
                 .await
@@ -1188,9 +1207,146 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn update_rolling_stock_with_new_categories() {
+    async fn update_rolling_stock_without_authorization() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unauthorized_rolling_stock").await;
+
+        // A user with the OperationalStudies role but only a read grant on the rolling stock
+        let user = app
+            .user("reader", "Reader")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        rolling_stock_form.name = "should_not_be_updated".to_string();
+
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_forbidden();
+
+        // The rolling stock should not have been modified
+        let rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+
+        assert_eq!(rolling_stock.name, fast_rolling_stock.name);
+        assert_eq!(rolling_stock.version, fast_rolling_stock.version);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_as_admin_without_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "admin_updated_rolling_stock").await;
+
+        // An admin holds no grant on the rolling stock but can still update it
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        let updated_rs_name = "updated_by_admin";
+        rolling_stock_form.name = updated_rs_name.to_string();
+
+        // WHEN
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(admin.as_ref())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_ok();
+
+        // THEN
+        let updated_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert_eq!(updated_rolling_stock.name, updated_rs_name);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_with_skip_authz_without_grant() {
         // GIVEN
         let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "skip_authz_updated_rolling_stock")
+                .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        let updated_rs_name = "updated_with_skip_authz";
+        rolling_stock_form.name = updated_rs_name.to_string();
+
+        // WHEN (no grant set up, authorization is skipped)
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_ok();
+
+        // THEN
+        let updated_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert_eq!(updated_rolling_stock.name, updated_rs_name);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_without_operational_studies_role() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "missing_role_rolling_stock").await;
+
+        // A user with the right write grant but lacking the OperationalStudies role
+        let user = app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        rolling_stock_form.name = "should_not_be_updated".to_string();
+
+        // WHEN
+        app.put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .json(&&rolling_stock_form)
+            .await
+            .assert_status_forbidden();
+
+        // THEN the rolling stock should not have been modified
+        let rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert_eq!(rolling_stock.name, fast_rolling_stock.name);
+        assert_eq!(rolling_stock.version, fast_rolling_stock.version);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_rolling_stock_with_new_categories() {
+        // GIVEN
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let fast_rolling_stock =
@@ -1210,10 +1366,18 @@ pub mod tests {
         let other_categories = vec![schemas::rolling_stock::TrainMainCategory::RegionalTrain];
         rolling_stock_form.other_categories = other_categories;
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
         // WHEN
         let raw_response = app
             .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
             .json(&&rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -1241,12 +1405,19 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_categories_should_fail_when_invalid() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let fast_rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_with_categories")
                 .await;
+
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
 
         let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
         let primary_category =
@@ -1259,6 +1430,7 @@ pub mod tests {
         let raw_response = app
             .put(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
             .json(&&rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -1280,13 +1452,19 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_rolling_stock_failure_name_already_used() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let first_rs_name = "first_fast_rolling_stock_name";
         let first_fast_rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), first_rs_name).await;
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(first_fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
         let second_rs_name = "second_fast_rolling_stock_name";
         let second_fast_rolling_stock =
             create_rolling_stock_with_energy_sources(&mut db_pool.get_ok(), second_rs_name).await;
@@ -1297,6 +1475,7 @@ pub mod tests {
         let raw_response = app
             .put(format!("/rolling_stock/{}", first_fast_rolling_stock.id).as_str())
             .json(&second_fast_rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -1311,7 +1490,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_locked_rolling_stock_fails() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1325,6 +1504,13 @@ pub mod tests {
             .await
             .expect("Failed to create rolling stock");
 
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(locked_fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
         let mut second_fast_rolling_stock_form: RollingStockForm =
             schemas::fixtures::fast_rolling_stock();
         second_fast_rolling_stock_form.name = "second_fast_rolling_stock_name".to_owned();
@@ -1333,6 +1519,7 @@ pub mod tests {
         let raw_response = app
             .put(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())
             .json(&second_fast_rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -3,6 +3,10 @@ pub(in crate::views) mod towed;
 
 type RollingStockForm = schemas::RollingStock<schemas::rolling_stock::RollingResistancePerWeight>;
 
+use authz::RollingStockPrivilege;
+use authz::v2::rolling_stock_privileges;
+use axum::Extension;
+
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -36,6 +40,7 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
+use crate::AppState;
 use crate::error::InternalError;
 use crate::error::Result;
 
@@ -180,9 +185,22 @@ pub struct RollingStockNameParam {
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
 ) -> Result<Json<RollingStockWithLiveries>> {
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock = retrieve_existing_rolling_stock(
         &mut db_pool.get().await?,
         RollingStockKey::Id(rolling_stock_id),
@@ -204,7 +222,10 @@ pub(in crate::views) async fn get(
     )
 )]
 pub(in crate::views) async fn get_by_name(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_name): Path<String>,
 ) -> Result<Json<RollingStockWithLiveries>> {
     let rolling_stock = retrieve_existing_rolling_stock(
@@ -212,6 +233,17 @@ pub(in crate::views) async fn get_by_name(
         RollingStockKey::Name(rolling_stock_name),
     )
     .await?;
+
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock_with_liveries =
         RollingStockWithLiveries::try_fetch(&mut db_pool.get().await?, rolling_stock).await?;
     Ok(Json(rolling_stock_with_liveries))
@@ -689,6 +721,7 @@ pub mod tests {
     use crate::fixtures::simple_paced_train_changeset;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt;
     use models::rolling_stock::RollingStock;
 
     impl TestApp {
@@ -1012,21 +1045,72 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_by_id() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with the role to reach the endpoint and a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let raw_response = app
             .rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
             .await;
 
         // THEN
         let response: RollingStock = raw_response.assert_status_ok().json();
 
         assert_eq!(response, fast_rolling_stock);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_rolling_stock_by_id_with_privilege_and_no_roles() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that does not have the role to reach the endpoint but has a read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
+        app.rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_rolling_stock_by_id_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -3,6 +3,10 @@ pub(in crate::views) mod towed;
 
 type RollingStockForm = schemas::RollingStock<schemas::rolling_stock::RollingResistancePerWeight>;
 
+use authz::RollingStockPrivilege;
+use authz::v2::rolling_stock_privileges;
+use axum::Extension;
+
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -36,6 +40,7 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
+use crate::AppState;
 use crate::error::InternalError;
 use crate::error::Result;
 
@@ -180,9 +185,22 @@ pub struct RollingStockNameParam {
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
 ) -> Result<Json<RollingStockWithLiveries>> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock = retrieve_existing_rolling_stock(
         &mut db_pool.get().await?,
         RollingStockKey::Id(rolling_stock_id),
@@ -204,7 +222,10 @@ pub(in crate::views) async fn get(
     )
 )]
 pub(in crate::views) async fn get_by_name(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_name): Path<String>,
 ) -> Result<Json<RollingStockWithLiveries>> {
     let rolling_stock = retrieve_existing_rolling_stock(
@@ -212,6 +233,17 @@ pub(in crate::views) async fn get_by_name(
         RollingStockKey::Name(rolling_stock_name),
     )
     .await?;
+
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock_with_liveries =
         RollingStockWithLiveries::try_fetch(&mut db_pool.get().await?, rolling_stock).await?;
     Ok(Json(rolling_stock_with_liveries))
@@ -689,6 +721,7 @@ pub mod tests {
     use crate::fixtures::simple_paced_train_changeset;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt;
     use editoast_models::rolling_stock::RollingStock;
 
     impl TestApp {
@@ -1012,21 +1045,72 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_by_id() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with the role to reach the endpoint and a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let raw_response = app
             .rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
             .await;
 
         // THEN
         let response: RollingStock = raw_response.assert_status_ok().json();
 
         assert_eq!(response, fast_rolling_stock);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_rolling_stock_by_id_with_privilege_and_no_roles() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that does not have the role to reach the endpoint but has a read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
+        app.rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_rolling_stock_by_id_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -3,7 +3,9 @@ pub(in crate::views) mod towed;
 
 type RollingStockForm = schemas::RollingStock<schemas::rolling_stock::RollingResistancePerWeight>;
 
+use authz::RollingStockGrant;
 use authz::RollingStockPrivilege;
+use authz::v2;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 
@@ -41,6 +43,8 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
+use crate::authorizers::SystemAuthorizer;
 use crate::error::InternalError;
 use crate::error::Result;
 
@@ -290,8 +294,11 @@ pub(in crate::views) struct PostRollingStockQueryParams {
     )
 )]
 pub(in crate::views) async fn create(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
     Query(query_params): Query<PostRollingStockQueryParams>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Json(rolling_stock_form): Json<RollingStockForm>,
 ) -> Result<Json<RollingStock>> {
     let conn = &mut db_pool.get().await?;
@@ -303,6 +310,18 @@ pub(in crate::views) async fn create(
         .create(conn)
         .await
         .map_err(RollingStockError::from)?;
+
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::rolling_stock_set_grant(
+            authz::Subject::User(*user),
+            authz::RollingStock(rolling_stock.id),
+            RollingStockGrant::Owner,
+        )
+        .authorize(&SystemAuthorizer::new_infallible(&openfga))
+        .await?
+        .access()
+        .await?;
+    }
 
     Ok(Json(rolling_stock))
 }
@@ -815,8 +834,14 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn create_rolling_stock_successfully() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
+
+        let user = app
+            .user(uuid::Uuid::new_v4().to_string(), "name")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock_form = fast_rolling_stock_form(rs_name);
@@ -824,6 +849,7 @@ pub mod tests {
         // WHEN
         let raw_response = app
             .rolling_stock_create_request(&fast_rolling_stock_form)
+            .by_user(user.as_ref())
             .await;
 
         // THEN
@@ -833,6 +859,7 @@ pub mod tests {
             .await
             .expect("Failed to retrieve rolling stock")
             .expect("Rolling stock not found");
+        let rs_id = rolling_stock.id;
 
         assert_eq!(rolling_stock.name, rs_name);
         assert_eq!(
@@ -846,6 +873,9 @@ pub mod tests {
                 .contains("ETCS_LEVEL2"),
             false
         );
+        // Check if the issuer was added as owner to the rolling stock
+        app.assert_rolling_stock_grant(rs_id, user.id, Some(RollingStockGrant::Owner))
+            .await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -627,20 +627,29 @@ pub(in crate::views) async fn create_livery(
     )
 )]
 pub(in crate::views) async fn get_usage(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
 ) -> Result<Json<Vec<ScenarioReference>>> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            authz::v2::rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    };
     let mut conn = db_pool.get().await?;
-
     let rolling_stock = RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
         RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
         }
     })
     .await?;
-
     let related_train_schedules = rolling_stock.get_usage(&mut conn).await?;
-
     Ok(Json(related_train_schedules))
 }
 
@@ -759,6 +768,7 @@ pub mod tests {
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
     use serde_json::json;
+    use strum::IntoEnumIterator as _;
     use uuid::Uuid;
 
     use super::*;
@@ -886,139 +896,274 @@ pub mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_rolling_stock_usage_with_no_usage_returns_empty_ok() {
-        let app = test_app!().skip_authz().build();
-        let stock_name = Uuid::new_v4().to_string();
-        let rolling_stock = fast_rolling_stock_form(stock_name.as_str());
-        let RollingStock { id, .. } = app
-            .rolling_stock_create_request(&rolling_stock)
-            .await
-            .assert_status_ok()
-            .json();
-        let related_schedules: Vec<ScenarioReference> = app
-            .get(&format!("/rolling_stock/{id}/usage"))
-            .await
-            .assert_status_ok()
-            .json();
-        assert!(related_schedules.is_empty());
-    }
+    mod get_rolling_stock_usage {
+        use super::*;
+        use authz::v2::TestClientExt as _;
+        use pretty_assertions::assert_eq;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_rolling_stock_usage_with_related_schedules_returns_schedules_list() {
-        let app = test_app!().skip_authz().build();
-        let db_pool = app.db_pool();
+        mod authorization {
+            use std::iter::once;
 
-        let create_rolling_stock_request =
-            app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
-        let rolling_stock: RollingStock = (create_rolling_stock_request)
-            .await
-            .assert_status_ok()
-            .json();
-        let create_other_rolling_stock_request =
-            app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
-        let other_rolling_stock: RollingStock = (create_other_rolling_stock_request)
-            .await
-            .assert_status_ok()
-            .json();
+            use super::*;
 
-        let project = create_project(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let study = create_study(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            project.id,
-        )
-        .await;
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn all_grant_levels_should_allow_usage() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock")
+                        .await
+                        .id;
+                for grant in RollingStockGrant::iter() {
+                    let user = app
+                        .user(uuid::Uuid::new_v4().to_string(), "name")
+                        .with_rolling_stock_grant(rolling_stock_id, grant)
+                        .create()
+                        .await;
+                    app.get(&format!("/rolling_stock/{rolling_stock_id}/usage"))
+                        .by_user(user.as_ref())
+                        .await
+                        .assert_status_ok();
+                }
+            }
 
-        let (timetable_1, train_schedule_set_1) =
-            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn roles_should_not_authorize_user() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock")
+                        .await
+                        .id;
+                for role in authz::Role::iter().map(Option::Some).chain(once(None)) {
+                    let user_builder = app.user(uuid::Uuid::new_v4().to_string(), "name");
+                    match role {
+                        Some(Role::Admin) => continue, // admins should be authorized
+                        Some(role) => user_builder.with_roles(vec![role]),
+                        None => user_builder,
+                    }
+                    .create()
+                    .await;
+                    let user = app
+                        .user(uuid::Uuid::new_v4().to_string(), "name")
+                        .create()
+                        .await;
+                    app.get(&format!("/rolling_stock/{rolling_stock_id}/usage"))
+                        .by_user(user.as_ref())
+                        .await
+                        .assert_status_forbidden();
+                }
+            }
 
-        let (timetable_2, train_schedule_set_2) =
-            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        let (timetable_3, train_schedule_set_3) =
-            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn skip_authz_should_succeed() {
+                let app = test_app!().skip_authz().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock")
+                        .await
+                        .id;
+                app.get(&format!("/rolling_stock/{rolling_stock_id}/usage"))
+                    .skip_authz()
+                    .await
+                    .assert_status_ok();
+            }
+        }
 
-        let infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let scenario_1 = create_scenario(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            study.id,
-            timetable_1.id,
-            infra.id,
-        )
-        .await;
-        let scenario_2 = create_scenario(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            study.id,
-            timetable_2.id,
-            infra.id,
-        )
-        .await;
-        // scenario_3 will not use the required rolling stock and should thus not be queried
-        let _scenario_3 = create_scenario(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            study.id,
-            timetable_3.id,
-            infra.id,
-        )
-        .await;
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_rolling_stock_usage_with_no_usage_returns_empty_ok() {
+            let app = test_app!().build();
+            let stock_name = Uuid::new_v4().to_string();
+            let rolling_stock = fast_rolling_stock_form(stock_name.as_str());
+            let user = app
+                .user(uuid::Uuid::new_v4().to_string(), "name")
+                .with_roles([Role::OperationalStudies])
+                .create()
+                .await;
+            let RollingStock { id, .. } = app
+                .rolling_stock_create_request(&rolling_stock)
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
 
-        simple_paced_train_changeset(train_schedule_set_1.id)
-            .rolling_stock_name(rolling_stock.name.clone())
-            .create(&mut db_pool.get_ok())
-            .await
-            .unwrap();
-        simple_paced_train_changeset(train_schedule_set_2.id)
-            .rolling_stock_name(rolling_stock.name)
-            .create(&mut db_pool.get_ok())
-            .await
-            .unwrap();
-        simple_paced_train_changeset(train_schedule_set_3.id)
-            .rolling_stock_name(other_rolling_stock.name)
-            .create(&mut db_pool.get_ok())
-            .await
-            .unwrap();
+            // TODO remove me once `POST:/rolling_stock` setups the grants on the created rolling
+            // stock
+            app.openfga()
+                .rolling_stock_set_grant(
+                    authz::RollingStock(id),
+                    authz::Subject::user(user.clone()),
+                    RollingStockGrant::Reader,
+                )
+                .await;
 
-        let related_scenarios: Vec<ScenarioReference> = app
-            .get(&format!("/rolling_stock/{}/usage", rolling_stock.id))
-            .await
-            .assert_status_ok()
-            .json();
-        let expected_scenarios = [
-            ScenarioReference {
-                project_id: project.id,
-                project_name: project.name.clone(),
-                study_id: study.id,
-                study_name: study.name.clone(),
-                scenario_id: scenario_1.id,
-                scenario_name: scenario_1.name.clone(),
-            },
-            ScenarioReference {
-                project_id: project.id,
-                project_name: project.name.clone(),
-                study_id: study.id,
-                study_name: study.name.clone(),
-                scenario_id: scenario_2.id,
-                scenario_name: scenario_2.name.clone(),
-            },
-        ];
-        assert_eq!(
-            related_scenarios.iter().sorted().collect_vec(),
-            expected_scenarios.iter().sorted().collect_vec()
-        );
-    }
+            let related_schedules: Vec<ScenarioReference> = app
+                .get(&format!("/rolling_stock/{id}/usage"))
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            assert!(related_schedules.is_empty());
+        }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_invalid_rolling_stock_id_returns_404_not_found() {
-        let app = test_app!().skip_authz().build();
-        let db_pool = app.db_pool();
-        let _ = RollingStock::delete_static(&mut db_pool.get_ok(), 1).await;
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_rolling_stock_usage_with_related_schedules_returns_schedules_list() {
+            let app = test_app!().build();
+            let db_pool = app.db_pool();
+            let user = app
+                .user(uuid::Uuid::new_v4().to_string(), "name")
+                .with_roles([Role::OperationalStudies])
+                .create()
+                .await;
 
-        app.get("/rolling_stock/1/usage")
-            .await
-            .assert_status_not_found();
+            let create_rolling_stock_request = app.rolling_stock_create_request(
+                &fast_rolling_stock_form(&Uuid::new_v4().to_string()),
+            );
+            let rolling_stock: RollingStock = (create_rolling_stock_request)
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            let create_other_rolling_stock_request = app.rolling_stock_create_request(
+                &fast_rolling_stock_form(&Uuid::new_v4().to_string()),
+            );
+            let other_rolling_stock: RollingStock = (create_other_rolling_stock_request)
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+
+            // TODO remove me once `POST:/rolling_stock` setups the grants on the created rolling
+            // stock
+            app.openfga()
+                .rolling_stock_set_grant(
+                    authz::RollingStock(rolling_stock.id),
+                    authz::Subject::user(user.clone()),
+                    RollingStockGrant::Reader,
+                )
+                .await;
+            app.openfga()
+                .rolling_stock_set_grant(
+                    authz::RollingStock(other_rolling_stock.id),
+                    authz::Subject::user(user.clone()),
+                    RollingStockGrant::Reader,
+                )
+                .await;
+
+            let project = create_project(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+            let study = create_study(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                project.id,
+            )
+            .await;
+
+            let (timetable_1, train_schedule_set_1) =
+                create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+
+            let (timetable_2, train_schedule_set_2) =
+                create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+            let (timetable_3, train_schedule_set_3) =
+                create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+
+            let infra = create_small_infra(&mut db_pool.get_ok()).await;
+            let scenario_1 = create_scenario(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                study.id,
+                timetable_1.id,
+                infra.id,
+            )
+            .await;
+            let scenario_2 = create_scenario(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                study.id,
+                timetable_2.id,
+                infra.id,
+            )
+            .await;
+            // scenario_3 will not use the required rolling stock and should thus not be queried
+            let _scenario_3 = create_scenario(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                study.id,
+                timetable_3.id,
+                infra.id,
+            )
+            .await;
+
+            simple_paced_train_changeset(train_schedule_set_1.id)
+                .rolling_stock_name(rolling_stock.name.clone())
+                .create(&mut db_pool.get_ok())
+                .await
+                .unwrap();
+            simple_paced_train_changeset(train_schedule_set_2.id)
+                .rolling_stock_name(rolling_stock.name)
+                .create(&mut db_pool.get_ok())
+                .await
+                .unwrap();
+            simple_paced_train_changeset(train_schedule_set_3.id)
+                .rolling_stock_name(other_rolling_stock.name)
+                .create(&mut db_pool.get_ok())
+                .await
+                .unwrap();
+
+            let related_scenarios: Vec<ScenarioReference> = app
+                .get(&format!("/rolling_stock/{}/usage", rolling_stock.id))
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            let expected_scenarios = [
+                ScenarioReference {
+                    project_id: project.id,
+                    project_name: project.name.clone(),
+                    study_id: study.id,
+                    study_name: study.name.clone(),
+                    scenario_id: scenario_1.id,
+                    scenario_name: scenario_1.name.clone(),
+                },
+                ScenarioReference {
+                    project_id: project.id,
+                    project_name: project.name.clone(),
+                    study_id: study.id,
+                    study_name: study.name.clone(),
+                    scenario_id: scenario_2.id,
+                    scenario_name: scenario_2.name.clone(),
+                },
+            ];
+            assert_eq!(
+                related_scenarios.iter().sorted().collect_vec(),
+                expected_scenarios.iter().sorted().collect_vec()
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_invalid_rolling_stock_id_returns_404_not_found() {
+            // TODO: skipping authz here is not trivial because the checks execution order is
+            // undefined. It could indifferently return a 403 Forbidden or a 404 not found if the
+            // rolling stock does not exist.
+            // Not: in practice, it seems to always return 404 not found as that check future executes
+            // faster than the 403 one.
+            // => do we:
+            //   - keep skipping authz here for the time being ?
+            //   - update `Authorizer::authorize` implementations to define a check order ?
+            //      1. FuturesUnordered => FuturesOrdered in `authorize`
+            //      2. #[derive(PartialOrd, Ord)] on Check
+            //      3. use an ordered collection in `Protected.checks` that uses the PartialOrd
+            //         trait
+            //   - update the protected ops to insert the checks in the correct order
+            //      1. FuturesUnordered => FuturesOrdered in `authorize`
+            //      2. use an ordered collection in `Protected.checks` that keeps insertion order
+            //      3. make sure when we create protected ops that we insert the checks in the
+            //         correct order
+            //  github discussion ref: https://github.com/OpenRailAssociation/osrd/pull/17383#issuecomment-4868190929
+            let app = test_app!().skip_authz().build();
+            let db_pool = app.db_pool();
+            let _ = RollingStock::delete_static(&mut db_pool.get_ok(), 1).await;
+
+            app.get("/rolling_stock/1/usage")
+                .await
+                .assert_status_not_found();
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -494,6 +494,7 @@ pub(in crate::views) async fn update_locked(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// TODO delete that struct: it is used to document the API and is wrong
 #[derive(ToSchema)]
 #[allow(unused)] // Schema only
 struct RollingStockLiveryCreateForm {
@@ -551,11 +552,25 @@ async fn parse_multipart_content(
         (status = 404, description = "The requested rolling stock was not found"),
     )
 )]
+// TODO update openapi: the request body description is wrong
 pub(in crate::views) async fn create_livery(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     form: Multipart,
 ) -> Result<Json<schemas::rolling_stock::RollingStockLivery>> {
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            authz::v2::rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanWrite,
+        )
+        .await?;
+    }
+
     let conn = &mut db_pool.get().await?;
 
     let (name, images) = parse_multipart_content(form)
@@ -2042,5 +2057,168 @@ pub mod tests {
                 .expect("Failed to check if rolling stock exists");
 
         assert!(!rolling_stock_exists);
+    }
+
+    mod post_rolling_stock_livery {
+        use super::*;
+
+        const DATA: &[u8] = &[
+            // PNG Signature (8 bytes)
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // IHDR Chunk (Image Header)
+            0x00, 0x00, 0x00, 0x0D, // Chunk Length
+            0x49, 0x48, 0x44, 0x52, // "IHDR"
+            0x00, 0x00, 0x00, 0x02, // Width: 2 pixels
+            0x00, 0x00, 0x00, 0x02, // Height: 2 pixels
+            0x08, // Bit depth: 8
+            0x02, // Color type: Truecolor (RGB)
+            0x00, // Compression method: 0 (deflate)
+            0x00, // Filter method: 0
+            0x00, // Interlace method: 0 (no interlace)
+            0xFD, 0xD4, 0x9A, 0x73, // CRC
+            // IDAT Chunk (Image Data)
+            0x00, 0x00, 0x00, 0x13, // Chunk Length
+            0x49, 0x44, 0x41, 0x54, // "IDAT"
+            0x78, 0x01, // zlib compression header
+            0x63, 0x64, 0x60, 0xF8, 0xCF, 0xC0, 0xC0, 0xC0, 0x04, 0xC4, 0x40, 0x00, 0x00, 0x0B,
+            0x1F, 0x01, // Compressed image data
+            0x03, 0xD5, 0xA9, 0x3F, 0xA9, // CRC
+            // IEND Chunk (Image End)
+            0x00, 0x00, 0x00, 0x00, // Chunk Length
+            0x49, 0x45, 0x4E, 0x44, // "IEND"
+            0xAE, 0x42, 0x60, 0x82, // CRC
+        ];
+
+        mod authorization {
+            use axum_test::multipart::MultipartForm;
+            use axum_test::multipart::Part;
+            use pretty_assertions::assert_eq;
+            use rstest::rstest;
+
+            use super::*;
+
+            fn valid_request_body() -> MultipartForm {
+                let part_name = Part::text(Uuid::new_v4().to_string());
+                let part_images = Part::bytes(DATA)
+                    .file_name(Uuid::new_v4().to_string())
+                    .mime_type("image/bpm");
+                MultipartForm::new()
+                    .add_part("name", part_name)
+                    .add_part("images", part_images)
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn authorized_grant_level() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let grant = RollingStockGrant::Writer;
+                let user = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_rolling_stock_grant(rolling_stock_id, grant)
+                    .with_roles([Role::OperationalStudies])
+                    .create()
+                    .await;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user.as_ref())
+                    .await
+                    .assert_status_ok();
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn reader_and_no_grant_are_forbidden() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let user_no_grant = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([Role::OperationalStudies])
+                    .create()
+                    .await;
+                let user_reader = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([Role::OperationalStudies])
+                    .with_rolling_stock_grant(rolling_stock_id, RollingStockGrant::Reader)
+                    .create()
+                    .await;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user_no_grant.as_ref())
+                    .await
+                    .assert_status_forbidden();
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user_reader.as_ref())
+                    .await
+                    .assert_status_forbidden();
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn admin_is_authorized_without_grant() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let user = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([Role::Admin])
+                    .create()
+                    .await;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user.as_ref())
+                    .await
+                    .assert_status_ok();
+            }
+
+            #[rstest]
+            #[case::admin(Role::Admin, StatusCode::OK)]
+            #[case::operational_studies(Role::OperationalStudies, StatusCode::OK)]
+            #[case::stdcm(Role::Stdcm, StatusCode::FORBIDDEN)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn need_operational_studies_or_admin_role_and_grant(
+                #[case] role: Role,
+                #[case] expected_status_code: StatusCode,
+            ) {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let user = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([role])
+                    .with_rolling_stock_grant(rolling_stock_id, RollingStockGrant::Writer)
+                    .create()
+                    .await;
+                let response = app
+                    .post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user.as_ref())
+                    .await;
+                assert_eq!(response.status_code(), expected_status_code);
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn skip_authz_is_authorized() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .skip_authz()
+                    .await
+                    .assert_status_ok();
+            }
+        }
+
+        // TODO Add tests
     }
 }

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -8,11 +8,17 @@ use authz::RollingStockPrivilege;
 use authz::v2;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
+use models::train_schedule::OccurrenceId;
+use schemas::TrainOccurrence;
 
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::io::Cursor;
 use std::sync::Arc;
 
 use authz::Role;
+use authz::v2::Authorizer as _;
+use authz::v2::ResourcesList;
 use axum::extract::Json;
 use axum::extract::Multipart;
 use axum::extract::Path;
@@ -778,6 +784,55 @@ async fn create_compound_image(
         .create(conn)
         .await?;
     Ok(compound_image)
+}
+
+/// Discards the occurrences whose rolling stock the user isn't allowed to read
+pub(in crate::views) async fn filter_readable_occurrences(
+    train_occurrences: HashMap<String, Vec<(OccurrenceId, TrainOccurrence)>>,
+    rolling_stocks: &[RollingStock],
+    authn_state: &crate::authentication::State,
+    openfga: &fga::Client,
+) -> Result<Vec<(OccurrenceId, TrainOccurrence)>> {
+    // The request bypasses authorization
+    let Some(user) = authn_state.user() else {
+        return Ok(train_occurrences.into_values().flatten().collect());
+    };
+
+    // Listing the readable rolling stocks cannot be rejected: the issuer is already authenticated
+    let Ok(authorized_rolling_stocks) = SystemAuthorizer::new_infallible(openfga)
+        .authorize(authz::v2::rolling_stock_list(
+            user,
+            RollingStockPrivilege::CanRead,
+        ))
+        .await?
+        .access()
+        .await?;
+
+    let authorized_rolling_stocks = match authorized_rolling_stocks {
+        ResourcesList::All => return Ok(train_occurrences.into_values().flatten().collect()),
+        ResourcesList::Privileged(authorized_rolling_stocks) => authorized_rolling_stocks,
+    };
+
+    let authorized_rolling_stock_ids = authorized_rolling_stocks
+        .into_iter()
+        .map(|rolling_stock| rolling_stock.0)
+        .collect::<HashSet<_>>();
+
+    // Occurrences are grouped by rolling stock name, the authorization by id
+
+    let authorized_rolling_stock_names = rolling_stocks
+        .iter()
+        .filter(|rs| authorized_rolling_stock_ids.contains(&rs.id))
+        .map(|rs| rs.name.clone())
+        .collect::<HashSet<_>>();
+
+    Ok(train_occurrences
+        .into_iter()
+        .filter(|(rolling_stock_name, _)| {
+            authorized_rolling_stock_names.contains(rolling_stock_name)
+        })
+        .flat_map(|(_, occurrences)| occurrences)
+        .collect())
 }
 
 #[cfg(test)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -467,12 +467,23 @@ pub(in crate::views) struct RollingStockLockedUpdateForm {
     )
 )]
 pub(in crate::views) async fn update_locked(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     Json(RollingStockLockedUpdateForm { locked }): Json<RollingStockLockedUpdateForm>,
 ) -> Result<impl IntoResponse> {
     let conn = &mut db_pool.get().await?;
-
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanWrite,
+        )
+        .await?;
+    };
     RollingStock::changeset()
         .locked(locked)
         .update_or_fail(conn, rolling_stock_id, || RollingStockError::KeyNotFound {
@@ -1553,16 +1564,23 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_lock_rolling_stock_successfully() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        let user = app
+            .user("authorized", "Authorized")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Owner)
+            .create()
+            .await;
         assert!(!fast_rolling_stock.locked);
 
         app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
             .json(&json!({ "locked": true }))
+            .by_user(user.as_ref())
             .await
             .assert_status_no_content();
 
@@ -1577,7 +1595,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_unlock_rolling_stock_successfully() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1592,8 +1610,19 @@ pub mod tests {
             .expect("Failed to create rolling stock");
         assert!(locked_fast_rolling_stock.locked);
 
+        let user = app
+            .user("authorized", "Authorized")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(
+                locked_fast_rolling_stock.id,
+                authz::RollingStockGrant::Owner,
+            )
+            .create()
+            .await;
+
         app.patch(format!("/rolling_stock/{}/locked", locked_fast_rolling_stock.id).as_str())
             .json(&json!({ "locked": false }))
+            .by_user(user.as_ref())
             .await
             .assert_status_no_content();
 
@@ -1603,6 +1632,132 @@ pub mod tests {
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
 
+        assert!(!fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_without_sufficient_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unauthorized_rolling_stock").await;
+        assert!(!fast_rolling_stock.locked);
+
+        // A user with the OperationalStudies role but only a read grant on the rolling stock
+        let user = app
+            .user("reader", "Reader")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
+        // WHEN
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
+
+        // THEN the locked flag should not have changed
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert!(!fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_as_admin_without_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "admin_locked_rolling_stock").await;
+        assert!(!fast_rolling_stock.locked);
+
+        // An admin holds no grant on the rolling stock but can still lock it
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+
+        // WHEN
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert!(fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_with_skip_authz_without_grant() {
+        // GIVEN
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "skip_authz_locked_rolling_stock")
+                .await;
+        assert!(!fast_rolling_stock.locked);
+
+        // WHEN (no grant set up, authorization is skipped)
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert!(fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_without_operational_studies_role() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "missing_role_rolling_stock").await;
+        assert!(!fast_rolling_stock.locked);
+
+        // A user with a write grant but lacking the OperationalStudies role
+        let user = app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Writer)
+            .create()
+            .await;
+
+        // WHEN
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+
+        // THEN the locked flag should not have changed
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
         assert!(!fast_rolling_stock.locked);
     }
 

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -494,6 +494,7 @@ pub(in crate::views) async fn update_locked(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// TODO delete that struct: it is used to document the API and is wrong
 #[derive(ToSchema)]
 #[allow(unused)] // Schema only
 struct RollingStockLiveryCreateForm {
@@ -551,11 +552,25 @@ async fn parse_multipart_content(
         (status = 404, description = "The requested rolling stock was not found"),
     )
 )]
+// TODO update openapi: the request body description is wrong
 pub(in crate::views) async fn create_livery(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     form: Multipart,
 ) -> Result<Json<schemas::rolling_stock::RollingStockLivery>> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            authz::v2::rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanWrite,
+        )
+        .await?;
+    }
+
     let conn = &mut db_pool.get().await?;
 
     let (name, images) = parse_multipart_content(form)
@@ -2042,5 +2057,168 @@ pub mod tests {
                 .expect("Failed to check if rolling stock exists");
 
         assert!(!rolling_stock_exists);
+    }
+
+    mod post_rolling_stock_livery {
+        use super::*;
+
+        const DATA: &[u8] = &[
+            // PNG Signature (8 bytes)
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // IHDR Chunk (Image Header)
+            0x00, 0x00, 0x00, 0x0D, // Chunk Length
+            0x49, 0x48, 0x44, 0x52, // "IHDR"
+            0x00, 0x00, 0x00, 0x02, // Width: 2 pixels
+            0x00, 0x00, 0x00, 0x02, // Height: 2 pixels
+            0x08, // Bit depth: 8
+            0x02, // Color type: Truecolor (RGB)
+            0x00, // Compression method: 0 (deflate)
+            0x00, // Filter method: 0
+            0x00, // Interlace method: 0 (no interlace)
+            0xFD, 0xD4, 0x9A, 0x73, // CRC
+            // IDAT Chunk (Image Data)
+            0x00, 0x00, 0x00, 0x13, // Chunk Length
+            0x49, 0x44, 0x41, 0x54, // "IDAT"
+            0x78, 0x01, // zlib compression header
+            0x63, 0x64, 0x60, 0xF8, 0xCF, 0xC0, 0xC0, 0xC0, 0x04, 0xC4, 0x40, 0x00, 0x00, 0x0B,
+            0x1F, 0x01, // Compressed image data
+            0x03, 0xD5, 0xA9, 0x3F, 0xA9, // CRC
+            // IEND Chunk (Image End)
+            0x00, 0x00, 0x00, 0x00, // Chunk Length
+            0x49, 0x45, 0x4E, 0x44, // "IEND"
+            0xAE, 0x42, 0x60, 0x82, // CRC
+        ];
+
+        mod authorization {
+            use axum_test::multipart::MultipartForm;
+            use axum_test::multipart::Part;
+            use pretty_assertions::assert_eq;
+            use rstest::rstest;
+
+            use super::*;
+
+            fn valid_request_body() -> MultipartForm {
+                let part_name = Part::text(Uuid::new_v4().to_string());
+                let part_images = Part::bytes(DATA)
+                    .file_name(Uuid::new_v4().to_string())
+                    .mime_type("image/bpm");
+                MultipartForm::new()
+                    .add_part("name", part_name)
+                    .add_part("images", part_images)
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn authorized_grant_level() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let grant = RollingStockGrant::Writer;
+                let user = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_rolling_stock_grant(rolling_stock_id, grant)
+                    .with_roles([Role::OperationalStudies])
+                    .create()
+                    .await;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user.as_ref())
+                    .await
+                    .assert_status_ok();
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn reader_and_no_grant_are_forbidden() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let user_no_grant = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([Role::OperationalStudies])
+                    .create()
+                    .await;
+                let user_reader = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([Role::OperationalStudies])
+                    .with_rolling_stock_grant(rolling_stock_id, RollingStockGrant::Reader)
+                    .create()
+                    .await;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user_no_grant.as_ref())
+                    .await
+                    .assert_status_forbidden();
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user_reader.as_ref())
+                    .await
+                    .assert_status_forbidden();
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn admin_is_authorized_without_grant() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let user = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([Role::Admin])
+                    .create()
+                    .await;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user.as_ref())
+                    .await
+                    .assert_status_ok();
+            }
+
+            #[rstest]
+            #[case::admin(Role::Admin, StatusCode::OK)]
+            #[case::operational_studies(Role::OperationalStudies, StatusCode::OK)]
+            #[case::stdcm(Role::Stdcm, StatusCode::FORBIDDEN)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn need_operational_studies_or_admin_role_and_grant(
+                #[case] role: Role,
+                #[case] expected_status_code: StatusCode,
+            ) {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                let user = app
+                    .user(Uuid::new_v4().to_string(), "name")
+                    .with_roles([role])
+                    .with_rolling_stock_grant(rolling_stock_id, RollingStockGrant::Writer)
+                    .create()
+                    .await;
+                let response = app
+                    .post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .by_user(user.as_ref())
+                    .await;
+                assert_eq!(response.status_code(), expected_status_code);
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn skip_authz_is_authorized() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling stock")
+                        .await
+                        .id;
+                app.post(&format!("/rolling_stock/{rolling_stock_id}/livery"))
+                    .multipart(valid_request_body())
+                    .skip_authz()
+                    .await
+                    .assert_status_ok();
+            }
+        }
+
+        // TODO Add tests
     }
 }

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -394,10 +394,23 @@ pub(in crate::views) struct DeleteRollingStockQueryParams {
     )
 )]
 pub(in crate::views) async fn delete(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     Query(DeleteRollingStockQueryParams { force }): Query<DeleteRollingStockQueryParams>,
 ) -> Result<impl IntoResponse> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanDelete,
+        )
+        .await?;
+    }
+
     let conn = &mut db_pool.get().await?;
 
     let rolling_stock = RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
@@ -1619,7 +1632,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_locked_rolling_stock_fails() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1633,9 +1646,16 @@ pub mod tests {
             .await
             .expect("Failed to create rolling stock");
 
+        let user = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(locked_fast_rolling_stock.id, RollingStockGrant::Owner)
+            .create()
+            .await;
         // WHEN
         let raw_response = app
             .delete(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
             .await;
 
         // THEN
@@ -1654,16 +1674,24 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unlocked_unused_rolling_stock_succeeds() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
         assert!(!fast_rolling_stock.locked);
 
+        let user = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Owner)
+            .create()
+            .await;
+
         // WHEN
         let raw_response = app
             .delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
             .await;
 
         // THEN
@@ -1674,6 +1702,124 @@ pub mod tests {
                 .await
                 .expect("Failed to check if rolling stock exists");
         assert!(!rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_without_authorization() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unauthorized_rolling_stock").await;
+
+        // A user with the OperationalStudies role but only a write grant on the rolling stock
+        // (delete requires an owner/delete grant)
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
+        // WHEN
+        let raw_response = app
+            .delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .await;
+
+        // THEN
+        raw_response.assert_status_forbidden();
+
+        // The rolling stock should still exist
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_as_admin_without_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "admin_deleted_rolling_stock").await;
+
+        // An admin holds no grant on the rolling stock but can still delete it
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+
+        // WHEN
+        app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(!rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_with_skip_authz_without_user() {
+        // GIVEN
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "skip_authz_deleted_rolling_stock")
+                .await;
+
+        // WHEN (no grant set up, authorization is skipped)
+        app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(!rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_without_operational_studies_role() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "missing_role_rolling_stock").await;
+
+        // A user with an owner grant but lacking the OperationalStudies role
+        let user = app
+            .user("owner", "Owner")
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Owner)
+            .create()
+            .await;
+
+        // WHEN
+        app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
+
+        // THEN the rolling stock should still exist
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(rolling_stock_exists);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -627,20 +627,29 @@ pub(in crate::views) async fn create_livery(
     )
 )]
 pub(in crate::views) async fn get_usage(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
 ) -> Result<Json<Vec<ScenarioReference>>> {
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            authz::v2::rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanRestrictedRead,
+        )
+        .await?;
+    };
     let mut conn = db_pool.get().await?;
-
     let rolling_stock = RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
         RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
         }
     })
     .await?;
-
     let related_train_schedules = rolling_stock.get_usage(&mut conn).await?;
-
     Ok(Json(related_train_schedules))
 }
 
@@ -759,6 +768,7 @@ pub mod tests {
     use models::rolling_stock::TrainMainCategory;
     use pretty_assertions::assert_eq;
     use serde_json::json;
+    use strum::IntoEnumIterator as _;
     use uuid::Uuid;
 
     use super::*;
@@ -886,139 +896,274 @@ pub mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_rolling_stock_usage_with_no_usage_returns_empty_ok() {
-        let app = test_app!().skip_authz().build();
-        let stock_name = Uuid::new_v4().to_string();
-        let rolling_stock = fast_rolling_stock_form(stock_name.as_str());
-        let RollingStock { id, .. } = app
-            .rolling_stock_create_request(&rolling_stock)
-            .await
-            .assert_status_ok()
-            .json();
-        let related_schedules: Vec<ScenarioReference> = app
-            .get(&format!("/rolling_stock/{id}/usage"))
-            .await
-            .assert_status_ok()
-            .json();
-        assert!(related_schedules.is_empty());
-    }
+    mod get_rolling_stock_usage {
+        use super::*;
+        use authz::v2::TestClientExt as _;
+        use pretty_assertions::assert_eq;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_rolling_stock_usage_with_related_schedules_returns_schedules_list() {
-        let app = test_app!().skip_authz().build();
-        let db_pool = app.db_pool();
+        mod authorization {
+            use std::iter::once;
 
-        let create_rolling_stock_request =
-            app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
-        let rolling_stock: RollingStock = (create_rolling_stock_request)
-            .await
-            .assert_status_ok()
-            .json();
-        let create_other_rolling_stock_request =
-            app.rolling_stock_create_request(&fast_rolling_stock_form(&Uuid::new_v4().to_string()));
-        let other_rolling_stock: RollingStock = (create_other_rolling_stock_request)
-            .await
-            .assert_status_ok()
-            .json();
+            use super::*;
 
-        let project = create_project(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
-        let study = create_study(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            project.id,
-        )
-        .await;
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn all_grant_levels_should_allow_usage() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock")
+                        .await
+                        .id;
+                for grant in RollingStockGrant::iter() {
+                    let user = app
+                        .user(uuid::Uuid::new_v4().to_string(), "name")
+                        .with_rolling_stock_grant(rolling_stock_id, grant)
+                        .create()
+                        .await;
+                    app.get(&format!("/rolling_stock/{rolling_stock_id}/usage"))
+                        .by_user(user.as_ref())
+                        .await
+                        .assert_status_ok();
+                }
+            }
 
-        let (timetable_1, train_schedule_set_1) =
-            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn roles_should_not_authorize_user() {
+                let app = test_app!().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock")
+                        .await
+                        .id;
+                for role in authz::Role::iter().map(Option::Some).chain(once(None)) {
+                    let user_builder = app.user(uuid::Uuid::new_v4().to_string(), "name");
+                    match role {
+                        Some(Role::Admin) => continue, // admins should be authorized
+                        Some(role) => user_builder.with_roles(vec![role]),
+                        None => user_builder,
+                    }
+                    .create()
+                    .await;
+                    let user = app
+                        .user(uuid::Uuid::new_v4().to_string(), "name")
+                        .create()
+                        .await;
+                    app.get(&format!("/rolling_stock/{rolling_stock_id}/usage"))
+                        .by_user(user.as_ref())
+                        .await
+                        .assert_status_forbidden();
+                }
+            }
 
-        let (timetable_2, train_schedule_set_2) =
-            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        let (timetable_3, train_schedule_set_3) =
-            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn skip_authz_should_succeed() {
+                let app = test_app!().skip_authz().build();
+                let rolling_stock_id =
+                    create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock")
+                        .await
+                        .id;
+                app.get(&format!("/rolling_stock/{rolling_stock_id}/usage"))
+                    .skip_authz()
+                    .await
+                    .assert_status_ok();
+            }
+        }
 
-        let infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let scenario_1 = create_scenario(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            study.id,
-            timetable_1.id,
-            infra.id,
-        )
-        .await;
-        let scenario_2 = create_scenario(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            study.id,
-            timetable_2.id,
-            infra.id,
-        )
-        .await;
-        // scenario_3 will not use the required rolling stock and should thus not be queried
-        let _scenario_3 = create_scenario(
-            &mut db_pool.get_ok(),
-            &Uuid::new_v4().to_string(),
-            study.id,
-            timetable_3.id,
-            infra.id,
-        )
-        .await;
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_rolling_stock_usage_with_no_usage_returns_empty_ok() {
+            let app = test_app!().build();
+            let stock_name = Uuid::new_v4().to_string();
+            let rolling_stock = fast_rolling_stock_form(stock_name.as_str());
+            let user = app
+                .user(uuid::Uuid::new_v4().to_string(), "name")
+                .with_roles([Role::OperationalStudies])
+                .create()
+                .await;
+            let RollingStock { id, .. } = app
+                .rolling_stock_create_request(&rolling_stock)
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
 
-        simple_paced_train_changeset(train_schedule_set_1.id)
-            .rolling_stock_name(rolling_stock.name.clone())
-            .create(&mut db_pool.get_ok())
-            .await
-            .unwrap();
-        simple_paced_train_changeset(train_schedule_set_2.id)
-            .rolling_stock_name(rolling_stock.name)
-            .create(&mut db_pool.get_ok())
-            .await
-            .unwrap();
-        simple_paced_train_changeset(train_schedule_set_3.id)
-            .rolling_stock_name(other_rolling_stock.name)
-            .create(&mut db_pool.get_ok())
-            .await
-            .unwrap();
+            // TODO remove me once `POST:/rolling_stock` setups the grants on the created rolling
+            // stock
+            app.openfga()
+                .rolling_stock_set_grant(
+                    authz::RollingStock(id),
+                    authz::Subject::user(user.clone()),
+                    RollingStockGrant::Reader,
+                )
+                .await;
 
-        let related_scenarios: Vec<ScenarioReference> = app
-            .get(&format!("/rolling_stock/{}/usage", rolling_stock.id))
-            .await
-            .assert_status_ok()
-            .json();
-        let expected_scenarios = [
-            ScenarioReference {
-                project_id: project.id,
-                project_name: project.name.clone(),
-                study_id: study.id,
-                study_name: study.name.clone(),
-                scenario_id: scenario_1.id,
-                scenario_name: scenario_1.name.clone(),
-            },
-            ScenarioReference {
-                project_id: project.id,
-                project_name: project.name.clone(),
-                study_id: study.id,
-                study_name: study.name.clone(),
-                scenario_id: scenario_2.id,
-                scenario_name: scenario_2.name.clone(),
-            },
-        ];
-        assert_eq!(
-            related_scenarios.iter().sorted().collect_vec(),
-            expected_scenarios.iter().sorted().collect_vec()
-        );
-    }
+            let related_schedules: Vec<ScenarioReference> = app
+                .get(&format!("/rolling_stock/{id}/usage"))
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            assert!(related_schedules.is_empty());
+        }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_invalid_rolling_stock_id_returns_404_not_found() {
-        let app = test_app!().skip_authz().build();
-        let db_pool = app.db_pool();
-        let _ = RollingStock::delete_static(&mut db_pool.get_ok(), 1).await;
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_rolling_stock_usage_with_related_schedules_returns_schedules_list() {
+            let app = test_app!().build();
+            let db_pool = app.db_pool();
+            let user = app
+                .user(uuid::Uuid::new_v4().to_string(), "name")
+                .with_roles([Role::OperationalStudies])
+                .create()
+                .await;
 
-        app.get("/rolling_stock/1/usage")
-            .await
-            .assert_status_not_found();
+            let create_rolling_stock_request = app.rolling_stock_create_request(
+                &fast_rolling_stock_form(&Uuid::new_v4().to_string()),
+            );
+            let rolling_stock: RollingStock = (create_rolling_stock_request)
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            let create_other_rolling_stock_request = app.rolling_stock_create_request(
+                &fast_rolling_stock_form(&Uuid::new_v4().to_string()),
+            );
+            let other_rolling_stock: RollingStock = (create_other_rolling_stock_request)
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+
+            // TODO remove me once `POST:/rolling_stock` setups the grants on the created rolling
+            // stock
+            app.openfga()
+                .rolling_stock_set_grant(
+                    authz::RollingStock(rolling_stock.id),
+                    authz::Subject::user(user.clone()),
+                    RollingStockGrant::Reader,
+                )
+                .await;
+            app.openfga()
+                .rolling_stock_set_grant(
+                    authz::RollingStock(other_rolling_stock.id),
+                    authz::Subject::user(user.clone()),
+                    RollingStockGrant::Reader,
+                )
+                .await;
+
+            let project = create_project(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+            let study = create_study(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                project.id,
+            )
+            .await;
+
+            let (timetable_1, train_schedule_set_1) =
+                create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+
+            let (timetable_2, train_schedule_set_2) =
+                create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+            let (timetable_3, train_schedule_set_3) =
+                create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+
+            let infra = create_small_infra(&mut db_pool.get_ok()).await;
+            let scenario_1 = create_scenario(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                study.id,
+                timetable_1.id,
+                infra.id,
+            )
+            .await;
+            let scenario_2 = create_scenario(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                study.id,
+                timetable_2.id,
+                infra.id,
+            )
+            .await;
+            // scenario_3 will not use the required rolling stock and should thus not be queried
+            let _scenario_3 = create_scenario(
+                &mut db_pool.get_ok(),
+                &Uuid::new_v4().to_string(),
+                study.id,
+                timetable_3.id,
+                infra.id,
+            )
+            .await;
+
+            simple_paced_train_changeset(train_schedule_set_1.id)
+                .rolling_stock_name(rolling_stock.name.clone())
+                .create(&mut db_pool.get_ok())
+                .await
+                .unwrap();
+            simple_paced_train_changeset(train_schedule_set_2.id)
+                .rolling_stock_name(rolling_stock.name)
+                .create(&mut db_pool.get_ok())
+                .await
+                .unwrap();
+            simple_paced_train_changeset(train_schedule_set_3.id)
+                .rolling_stock_name(other_rolling_stock.name)
+                .create(&mut db_pool.get_ok())
+                .await
+                .unwrap();
+
+            let related_scenarios: Vec<ScenarioReference> = app
+                .get(&format!("/rolling_stock/{}/usage", rolling_stock.id))
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            let expected_scenarios = [
+                ScenarioReference {
+                    project_id: project.id,
+                    project_name: project.name.clone(),
+                    study_id: study.id,
+                    study_name: study.name.clone(),
+                    scenario_id: scenario_1.id,
+                    scenario_name: scenario_1.name.clone(),
+                },
+                ScenarioReference {
+                    project_id: project.id,
+                    project_name: project.name.clone(),
+                    study_id: study.id,
+                    study_name: study.name.clone(),
+                    scenario_id: scenario_2.id,
+                    scenario_name: scenario_2.name.clone(),
+                },
+            ];
+            assert_eq!(
+                related_scenarios.iter().sorted().collect_vec(),
+                expected_scenarios.iter().sorted().collect_vec()
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_invalid_rolling_stock_id_returns_404_not_found() {
+            // TODO: skipping authz here is not trivial because the checks execution order is
+            // undefined. It could indifferently return a 403 Forbidden or a 404 not found if the
+            // rolling stock does not exist.
+            // Not: in practice, it seems to always return 404 not found as that check future executes
+            // faster than the 403 one.
+            // => do we:
+            //   - keep skipping authz here for the time being ?
+            //   - update `Authorizer::authorize` implementations to define a check order ?
+            //      1. FuturesUnordered => FuturesOrdered in `authorize`
+            //      2. #[derive(PartialOrd, Ord)] on Check
+            //      3. use an ordered collection in `Protected.checks` that uses the PartialOrd
+            //         trait
+            //   - update the protected ops to insert the checks in the correct order
+            //      1. FuturesUnordered => FuturesOrdered in `authorize`
+            //      2. use an ordered collection in `Protected.checks` that keeps insertion order
+            //      3. make sure when we create protected ops that we insert the checks in the
+            //         correct order
+            //  github discussion ref: https://github.com/OpenRailAssociation/osrd/pull/17383#issuecomment-4868190929
+            let app = test_app!().skip_authz().build();
+            let db_pool = app.db_pool();
+            let _ = RollingStock::delete_static(&mut db_pool.get_ok(), 1).await;
+
+            app.get("/rolling_stock/1/usage")
+                .await
+                .assert_status_not_found();
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -467,12 +467,23 @@ pub(in crate::views) struct RollingStockLockedUpdateForm {
     )
 )]
 pub(in crate::views) async fn update_locked(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     Json(RollingStockLockedUpdateForm { locked }): Json<RollingStockLockedUpdateForm>,
 ) -> Result<impl IntoResponse> {
     let conn = &mut db_pool.get().await?;
-
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanWrite,
+        )
+        .await?;
+    };
     RollingStock::changeset()
         .locked(locked)
         .update_or_fail(conn, rolling_stock_id, || RollingStockError::KeyNotFound {
@@ -1553,16 +1564,23 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_lock_rolling_stock_successfully() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        let user = app
+            .user("authorized", "Authorized")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Owner)
+            .create()
+            .await;
         assert!(!fast_rolling_stock.locked);
 
         app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
             .json(&json!({ "locked": true }))
+            .by_user(user.as_ref())
             .await
             .assert_status_no_content();
 
@@ -1577,7 +1595,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn patch_unlock_rolling_stock_successfully() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1592,8 +1610,19 @@ pub mod tests {
             .expect("Failed to create rolling stock");
         assert!(locked_fast_rolling_stock.locked);
 
+        let user = app
+            .user("authorized", "Authorized")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(
+                locked_fast_rolling_stock.id,
+                authz::RollingStockGrant::Owner,
+            )
+            .create()
+            .await;
+
         app.patch(format!("/rolling_stock/{}/locked", locked_fast_rolling_stock.id).as_str())
             .json(&json!({ "locked": false }))
+            .by_user(user.as_ref())
             .await
             .assert_status_no_content();
 
@@ -1603,6 +1632,132 @@ pub mod tests {
                 .expect("Failed to retrieve rolling stock")
                 .expect("Rolling stock not found");
 
+        assert!(!fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_without_sufficient_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unauthorized_rolling_stock").await;
+        assert!(!fast_rolling_stock.locked);
+
+        // A user with the OperationalStudies role but only a read grant on the rolling stock
+        let user = app
+            .user("reader", "Reader")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
+        // WHEN
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
+
+        // THEN the locked flag should not have changed
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert!(!fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_as_admin_without_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "admin_locked_rolling_stock").await;
+        assert!(!fast_rolling_stock.locked);
+
+        // An admin holds no grant on the rolling stock but can still lock it
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+
+        // WHEN
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert!(fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_with_skip_authz_without_grant() {
+        // GIVEN
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "skip_authz_locked_rolling_stock")
+                .await;
+        assert!(!fast_rolling_stock.locked);
+
+        // WHEN (no grant set up, authorization is skipped)
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+        assert!(fast_rolling_stock.locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn patch_locked_rolling_stock_without_operational_studies_role() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "missing_role_rolling_stock").await;
+        assert!(!fast_rolling_stock.locked);
+
+        // A user with a write grant but lacking the OperationalStudies role
+        let user = app
+            .user("writer", "Writer")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Writer)
+            .create()
+            .await;
+
+        // WHEN
+        app.patch(format!("/rolling_stock/{}/locked", fast_rolling_stock.id).as_str())
+            .json(&json!({ "locked": true }))
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+
+        // THEN the locked flag should not have changed
+        let fast_rolling_stock: RollingStock =
+            RollingStock::retrieve(db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
         assert!(!fast_rolling_stock.locked);
     }
 

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -859,13 +859,15 @@ pub mod tests {
             .await
             .expect("Failed to retrieve rolling stock")
             .expect("Rolling stock not found");
-        let rs_id = rolling_stock.id;
-
         assert_eq!(rolling_stock.name, rs_name);
         assert_eq!(
             fast_rolling_stock_form.startup_time,
             rolling_stock.startup_time
         );
+        // Check if the issuer was added as owner to the rolling stock
+        app.assert_rolling_stock_grant(rolling_stock.id, user.id, Some(RollingStockGrant::Owner))
+            .await;
+
         let rolling_stock: RollingStockForm = rolling_stock.into();
         assert_eq!(
             rolling_stock
@@ -873,9 +875,6 @@ pub mod tests {
                 .contains("ETCS_LEVEL2"),
             false
         );
-        // Check if the issuer was added as owner to the rolling stock
-        app.assert_rolling_stock_grant(rs_id, user.id, Some(RollingStockGrant::Owner))
-            .await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -394,10 +394,23 @@ pub(in crate::views) struct DeleteRollingStockQueryParams {
     )
 )]
 pub(in crate::views) async fn delete(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     Query(DeleteRollingStockQueryParams { force }): Query<DeleteRollingStockQueryParams>,
 ) -> Result<impl IntoResponse> {
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanDelete,
+        )
+        .await?;
+    }
+
     let conn = &mut db_pool.get().await?;
 
     let rolling_stock = RollingStock::retrieve_or_fail(conn.clone(), rolling_stock_id, || {
@@ -1619,7 +1632,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_locked_rolling_stock_fails() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let locked_rs_name = "locked_fast_rolling_stock_name";
@@ -1633,9 +1646,16 @@ pub mod tests {
             .await
             .expect("Failed to create rolling stock");
 
+        let user = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(locked_fast_rolling_stock.id, RollingStockGrant::Owner)
+            .create()
+            .await;
         // WHEN
         let raw_response = app
             .delete(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
             .await;
 
         // THEN
@@ -1654,16 +1674,24 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn delete_unlocked_unused_rolling_stock_succeeds() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
         assert!(!fast_rolling_stock.locked);
 
+        let user = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Owner)
+            .create()
+            .await;
+
         // WHEN
         let raw_response = app
             .delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
             .await;
 
         // THEN
@@ -1674,6 +1702,124 @@ pub mod tests {
                 .await
                 .expect("Failed to check if rolling stock exists");
         assert!(!rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_without_authorization() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unauthorized_rolling_stock").await;
+
+        // A user with the OperationalStudies role but only a write grant on the rolling stock
+        // (delete requires an owner/delete grant)
+        let user = app
+            .user("writer", "Writer")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Writer)
+            .create()
+            .await;
+
+        // WHEN
+        let raw_response = app
+            .delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .await;
+
+        // THEN
+        raw_response.assert_status_forbidden();
+
+        // The rolling stock should still exist
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_as_admin_without_grant() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "admin_deleted_rolling_stock").await;
+
+        // An admin holds no grant on the rolling stock but can still delete it
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+
+        // WHEN
+        app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(!rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_with_skip_authz_without_user() {
+        // GIVEN
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "skip_authz_deleted_rolling_stock")
+                .await;
+
+        // WHEN (no grant set up, authorization is skipped)
+        app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .await
+            .assert_status_no_content();
+
+        // THEN
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(!rolling_stock_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_rolling_stock_without_operational_studies_role() {
+        // GIVEN
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "missing_role_rolling_stock").await;
+
+        // A user with an owner grant but lacking the OperationalStudies role
+        let user = app
+            .user("owner", "Owner")
+            .with_rolling_stock_grant(fast_rolling_stock.id, RollingStockGrant::Owner)
+            .create()
+            .await;
+
+        // WHEN
+        app.delete(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
+
+        // THEN the rolling stock should still exist
+        let rolling_stock_exists =
+            RollingStock::exists(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to check if rolling stock exists");
+        assert!(rolling_stock_exists);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,3 +1,6 @@
+use authz::RollingStockPrivilege;
+use authz::v2::rolling_stock_privileges;
+use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -28,6 +31,7 @@ use super::RollingStockError;
 use super::RollingStockIdParam;
 use super::RollingStockKey;
 use super::RollingStockNameParam;
+use crate::AppState;
 use crate::error::Result;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
@@ -118,9 +122,22 @@ pub(in crate::views) async fn list(
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(light_rolling_stock_id): Path<i64>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(light_rolling_stock_id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock =
         RollingStock::retrieve_or_fail(db_pool.get().await?, light_rolling_stock_id, || {
             RollingStockError::KeyNotFound {
@@ -144,7 +161,10 @@ pub(in crate::views) async fn get(
     )
 )]
 pub(in crate::views) async fn get_by_name(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        openfga, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(light_rolling_stock_name): Path<String>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
     let rolling_stock = RollingStock::retrieve_or_fail(
@@ -155,6 +175,17 @@ pub(in crate::views) async fn get_by_name(
         },
     )
     .await?;
+
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let light_rolling_stock_with_liveries =
         LightRollingStockWithLiveries::try_fetch(&mut db_pool.get().await?, rolling_stock).await?;
     Ok(Json(light_rolling_stock_with_liveries))
@@ -282,6 +313,7 @@ mod tests {
     use crate::error::InternalError;
     use crate::fixtures::create_fast_rolling_stock;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt;
 
     fn is_sorted(data: &[i64]) -> bool {
         for elem in data.windows(2) {
@@ -301,15 +333,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let response: LightRollingStockWithLiveries = app
             .get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -321,15 +361,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock_by_name() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let response: LightRollingStockWithLiveries = app
             .get(format!("/light_rolling_stock/name/{rs_name}").as_str())
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -346,6 +394,48 @@ mod tests {
         app.get(format!("/light_rolling_stock/{}", -1).as_str())
             .await
             .assert_status_not_found();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_light_rolling_stock_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_light_rolling_stock_by_name_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let rs_name = "fast_rolling_stock_name";
+        create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(format!("/light_rolling_stock/name/{rs_name}").as_str())
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,4 +1,6 @@
 use authz::RollingStockPrivilege;
+use authz::v2::Authorizer;
+use authz::v2::Check;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 use axum::extract::Json;
@@ -8,7 +10,6 @@ use axum::extract::State;
 use common::units;
 use common::units::quantities::Length;
 use database::DbConnection;
-use database::DbConnectionPoolV2;
 use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
 use editoast_models::rolling_stock::TrainMainCategory;
@@ -22,7 +23,6 @@ use schemas::rolling_stock::SupportedSignalingSystem;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 use uom::si::f64::Mass;
 use uom::si::f64::Velocity;
 use utoipa::ToSchema;
@@ -32,7 +32,9 @@ use super::RollingStockIdParam;
 use super::RollingStockKey;
 use super::RollingStockNameParam;
 use crate::AppState;
+use crate::authorizers::impossible;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -88,14 +90,48 @@ pub(in crate::views) struct LightRollingStockWithLiveriesCountList {
     )
 )]
 pub(in crate::views) async fn list(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+
+    Extension(authn_state): Extension<crate::authentication::State>,
     Query(page_settings): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<LightRollingStockWithLiveriesCountList>> {
-    let settings = page_settings
-        .into_selection_settings()
-        .order_by(|| RollingStock::ID.asc());
+    let conn = &mut db_pool.get().await?;
+    let default_settings = page_settings.into_selection_settings();
+    let settings = if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        let authorized_rolling_stocks = authorizer
+            .authorize(authz::v2::rolling_stock_list(
+                user,
+                RollingStockPrivilege::CanRead,
+            ))
+            .await?
+            .access()
+            .await?
+            .map_err(|err| match err {
+                Check::SubjectExists(_) => AuthorizationError::Forbidden,
+                check => impossible!(check),
+            })?;
+        match authorized_rolling_stocks {
+            authz::v2::ResourcesList::All => default_settings,
+            authz::v2::ResourcesList::Privileged(authorized_rolling_stocks) => default_settings
+                .filter(move || {
+                    RollingStock::ID.eq_any(
+                        authorized_rolling_stocks
+                            .iter()
+                            .map(|rolling_stock| rolling_stock.0)
+                            .collect(),
+                    )
+                }),
+        }
+    } else {
+        default_settings
+    };
+
     let (rolling_stocks, stats) =
-        RollingStock::list_paginated(&mut db_pool.get().await?, settings).await?;
+        RollingStock::list_paginated(conn, settings.order_by(move || RollingStock::ID.asc()))
+            .await?;
 
     let results = rolling_stocks.into_iter().zip(db_pool.iter_conn()).map(
         |(rolling_stock, conn)| async move {
@@ -302,6 +338,8 @@ impl From<ModeEffortCurves> for LightModeEffortCurves {
 
 #[cfg(test)]
 mod tests {
+    use authz::Role;
+    use authz::RollingStockGrant;
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -328,6 +366,57 @@ mod tests {
     async fn list_light_rolling_stock() {
         let app = test_app!().skip_authz().build();
         app.get("/light_rolling_stock").await.assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn rolling_stock_list_filters_authorized_rolling_stocks() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let rolling_stock_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_grant").await;
+        let rolling_stock_no_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_no_grant").await;
+        // Regular user with the correct roles should see only the rolling stock he is associated with:
+        let user = app
+            .user("user_identity", "user_name")
+            .with_rolling_stock_grant(rolling_stock_grant.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock")
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id]
+        );
+        // TODO: separate in two tests (admins_can_list_all_rolling_stocks and user_can_list_their_rolling_stocks)
+        // An admin should see all the rolling stocks:
+        let admin = app
+            .user("admin", "admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock/")
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id, rolling_stock_no_grant.id]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,4 +1,5 @@
 use authz::RollingStockPrivilege;
+use authz::v2::Authorizer;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 use axum::extract::Json;
@@ -8,7 +9,6 @@ use axum::extract::State;
 use common::units;
 use common::units::quantities::Length;
 use database::DbConnection;
-use database::DbConnectionPoolV2;
 use itertools::Itertools as _;
 use models::prelude::*;
 use models::rolling_stock::RollingStock;
@@ -22,7 +22,6 @@ use schemas::rolling_stock::SupportedSignalingSystem;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 use uom::si::f64::Mass;
 use uom::si::f64::Velocity;
 use utoipa::ToSchema;
@@ -32,6 +31,7 @@ use super::RollingStockIdParam;
 use super::RollingStockKey;
 use super::RollingStockNameParam;
 use crate::AppState;
+use crate::authorizers::SystemAuthorizer;
 use crate::error::Result;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
@@ -88,14 +88,44 @@ pub(in crate::views) struct LightRollingStockWithLiveriesCountList {
     )
 )]
 pub(in crate::views) async fn list(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, openfga, ..
+    }): State<AppState>,
+
+    Extension(authn_state): Extension<crate::authentication::State>,
     Query(page_settings): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<LightRollingStockWithLiveriesCountList>> {
-    let settings = page_settings
-        .into_selection_settings()
-        .order_by(|| RollingStock::ID.asc());
+    let conn = &mut db_pool.get().await?;
+    let default_settings = page_settings.into_selection_settings();
+    let settings = if let Some(user) = authn_state.user() {
+        let system_authorizer = SystemAuthorizer::new_infallible(&openfga);
+        let Ok(authorized_rolling_stocks) = system_authorizer
+            .authorize(authz::v2::rolling_stock_list(
+                user,
+                RollingStockPrivilege::CanRead,
+            ))
+            .await?
+            .access()
+            .await?;
+        match authorized_rolling_stocks {
+            authz::v2::ResourcesList::All => default_settings,
+            authz::v2::ResourcesList::Privileged(authorized_rolling_stocks) => default_settings
+                .filter(move || {
+                    RollingStock::ID.eq_any(
+                        authorized_rolling_stocks
+                            .iter()
+                            .map(|rolling_stock| rolling_stock.0)
+                            .collect(),
+                    )
+                }),
+        }
+    } else {
+        default_settings
+    };
+
     let (rolling_stocks, stats) =
-        RollingStock::list_paginated(&mut db_pool.get().await?, settings).await?;
+        RollingStock::list_paginated(conn, settings.order_by(move || RollingStock::ID.asc()))
+            .await?;
 
     let results = rolling_stocks.into_iter().zip(db_pool.iter_conn()).map(
         |(rolling_stock, conn)| async move {
@@ -302,6 +332,8 @@ impl From<ModeEffortCurves> for LightModeEffortCurves {
 
 #[cfg(test)]
 mod tests {
+    use authz::Role;
+    use authz::RollingStockGrant;
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -328,6 +360,57 @@ mod tests {
     async fn list_light_rolling_stock() {
         let app = test_app!().skip_authz().build();
         app.get("/light_rolling_stock").await.assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn rolling_stock_list_filters_authorized_rolling_stocks() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let rolling_stock_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_grant").await;
+        let rolling_stock_no_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_no_grant").await;
+        // Regular user with the correct roles should see only the rolling stock he is associated with:
+        let user = app
+            .user("user_identity", "user_name")
+            .with_rolling_stock_grant(rolling_stock_grant.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock")
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id]
+        );
+        // TODO: separate in two tests (admins_can_list_all_rolling_stocks and user_can_list_their_rolling_stocks)
+        // An admin should see all the rolling stocks:
+        let admin = app
+            .user("admin", "admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock/")
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id, rolling_stock_no_grant.id]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,3 +1,6 @@
+use authz::RollingStockPrivilege;
+use authz::v2::rolling_stock_privileges;
+use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -28,6 +31,7 @@ use super::RollingStockError;
 use super::RollingStockIdParam;
 use super::RollingStockKey;
 use super::RollingStockNameParam;
+use crate::AppState;
 use crate::error::Result;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
@@ -118,9 +122,22 @@ pub(in crate::views) async fn list(
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(light_rolling_stock_id): Path<i64>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(light_rolling_stock_id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock =
         RollingStock::retrieve_or_fail(db_pool.get().await?, light_rolling_stock_id, || {
             RollingStockError::KeyNotFound {
@@ -144,7 +161,10 @@ pub(in crate::views) async fn get(
     )
 )]
 pub(in crate::views) async fn get_by_name(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(light_rolling_stock_name): Path<String>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
     let rolling_stock = RollingStock::retrieve_or_fail(
@@ -155,6 +175,17 @@ pub(in crate::views) async fn get_by_name(
         },
     )
     .await?;
+
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let light_rolling_stock_with_liveries =
         LightRollingStockWithLiveries::try_fetch(&mut db_pool.get().await?, rolling_stock).await?;
     Ok(Json(light_rolling_stock_with_liveries))
@@ -282,6 +313,7 @@ mod tests {
     use crate::error::InternalError;
     use crate::fixtures::create_fast_rolling_stock;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt;
 
     fn is_sorted(data: &[i64]) -> bool {
         for elem in data.windows(2) {
@@ -301,15 +333,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let response: LightRollingStockWithLiveries = app
             .get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -321,15 +361,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock_by_name() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let response: LightRollingStockWithLiveries = app
             .get(format!("/light_rolling_stock/name/{rs_name}").as_str())
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -346,6 +394,48 @@ mod tests {
         app.get(format!("/light_rolling_stock/{}", -1).as_str())
             .await
             .assert_status_not_found();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_light_rolling_stock_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_light_rolling_stock_by_name_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let rs_name = "fast_rolling_stock_name";
+        create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(format!("/light_rolling_stock/name/{rs_name}").as_str())
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -363,17 +363,16 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn rolling_stock_list_filters_authorized_rolling_stocks() {
+    async fn rolling_stock_list_user_only_sees_its_related_rolling_stocks() {
         let app = test_app!().build();
         let db_pool = app.db_pool();
-        let rolling_stock_grant =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_grant").await;
-        let rolling_stock_no_grant =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_no_grant").await;
-        // Regular user with the correct roles should see only the rolling stock he is associated with:
+        let rs_1 = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_1").await;
+        let rs_2 = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_2").await;
+        let _rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let user = app
             .user("user_identity", "user_name")
-            .with_rolling_stock_grant(rolling_stock_grant.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rs_1.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rs_2.id, RollingStockGrant::Reader)
             .create()
             .await;
         let response: LightRollingStockWithLiveriesCountList = app
@@ -388,10 +387,15 @@ mod tests {
                 .iter()
                 .map(|rolling_stock| rolling_stock.rolling_stock.id)
                 .collect::<Vec<_>>(),
-            vec![rolling_stock_grant.id]
+            vec![rs_1.id, rs_2.id]
         );
-        // TODO: separate in two tests (admins_can_list_all_rolling_stocks and user_can_list_their_rolling_stocks)
-        // An admin should see all the rolling stocks:
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn rolling_stock_list_admin_can_see_unrelated_rolling_stock() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let admin = app
             .user("admin", "admin")
             .with_roles([Role::Admin])
@@ -409,7 +413,7 @@ mod tests {
                 .iter()
                 .map(|rolling_stock| rolling_stock.rolling_stock.id)
                 .collect::<Vec<_>>(),
-            vec![rolling_stock_grant.id, rolling_stock_no_grant.id]
+            vec![rs_no_grant.id]
         );
     }
 

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -369,17 +369,16 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn rolling_stock_list_filters_authorized_rolling_stocks() {
+    async fn rolling_stock_list_user_only_sees_its_related_rolling_stocks() {
         let app = test_app!().build();
         let db_pool = app.db_pool();
-        let rolling_stock_grant =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_grant").await;
-        let rolling_stock_no_grant =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_no_grant").await;
-        // Regular user with the correct roles should see only the rolling stock he is associated with:
+        let rs_1 = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_1").await;
+        let rs_2 = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_2").await;
+        let _rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let user = app
             .user("user_identity", "user_name")
-            .with_rolling_stock_grant(rolling_stock_grant.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rs_1.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rs_2.id, RollingStockGrant::Reader)
             .create()
             .await;
         let response: LightRollingStockWithLiveriesCountList = app
@@ -394,10 +393,15 @@ mod tests {
                 .iter()
                 .map(|rolling_stock| rolling_stock.rolling_stock.id)
                 .collect::<Vec<_>>(),
-            vec![rolling_stock_grant.id]
+            vec![rs_1.id, rs_2.id]
         );
-        // TODO: separate in two tests (admins_can_list_all_rolling_stocks and user_can_list_their_rolling_stocks)
-        // An admin should see all the rolling stocks:
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn rolling_stock_list_admin_can_see_unrelated_rolling_stock() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let admin = app
             .user("admin", "admin")
             .with_roles([Role::Admin])
@@ -415,7 +419,7 @@ mod tests {
                 .iter()
                 .map(|rolling_stock| rolling_stock.rolling_stock.id)
                 .collect::<Vec<_>>(),
-            vec![rolling_stock_grant.id, rolling_stock_no_grant.id]
+            vec![rs_no_grant.id]
         );
     }
 

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -278,13 +278,13 @@ pub struct ElectricalProfileSetIdQueryParam {
         (status = 200, description = "The paginated list of timetable requirements", body = inline(TrainRequirementsPage)),
     ),
 )]
+// TODO test the endpoint
 pub(in crate::views) async fn requirements(
     State(AppState {
         db_pool,
         valkey_client,
         core_client,
         config,
-        openfga,
         ..
     }): State<AppState>,
     Extension(authn_state): Extension<authentication::State>,
@@ -295,12 +295,9 @@ pub(in crate::views) async fn requirements(
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
 ) -> Result<Json<TrainRequirementsPage>> {
-    v2::infra_privilege_check(
-        authz::Infra(infra_id),
-        authz::InfraPrivilege::CanRestrictedRead,
-    )
-    .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
-    .await?;
+    if !matches!(&authn_state, authentication::State::Skip) {
+        return Err(AuthorizationError::Forbidden.into());
+    }
 
     let conn = &mut db_pool.get().await?;
 

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -1,6 +1,8 @@
 use authz::v2;
+use schemas::paced_train::RollingStockChangeGroup;
 use std::collections::HashMap;
 
+use authz::RollingStockPrivilege;
 use axum::Extension;
 use axum::Json;
 use axum::extract::Path;
@@ -19,6 +21,7 @@ use utoipa::ToSchema;
 
 use crate::AppState;
 use crate::authentication;
+use crate::authorizers::SystemAuthorizer;
 use crate::error::Result;
 use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
@@ -367,6 +370,14 @@ pub(in crate::views) async fn conflicts(
         })
         .collect();
 
+    let train_schedules_with_exceptions = filter_unauthorized_train_schedules_and_exceptions(
+        &openfga,
+        conn.clone(),
+        authn_state,
+        train_schedules_with_exceptions,
+    )
+    .await?;
+
     // Flatten paced trains occurrences
     let (occurrence_ids, occurrence_trains): (Vec<_>, Vec<_>) = train_schedules_with_exceptions
         .iter()
@@ -447,15 +458,87 @@ pub(in crate::views) async fn conflicts(
     Ok(Json(conflicts_response?))
 }
 
+/// Take a collection of train schedules and their associated exceptions and filter out those with
+/// an unauthorized rolling stock. When a train schedule is filtered out all its exceptions are
+/// skipped aswell, but when an exception is filtered its associated train schedule is kept if its
+/// rolling stock is authorized given the provided authentication state.
+pub async fn filter_unauthorized_train_schedules_and_exceptions(
+    openfga: &fga::Client,
+    conn: DbConnection,
+    authn_state: crate::authentication::State,
+    train_schedules_with_exceptions: Vec<(
+        models::TrainSchedule,
+        Vec<schemas::TrainScheduleException>,
+    )>,
+) -> crate::error::Result<Vec<(models::TrainSchedule, Vec<schemas::TrainScheduleException>)>> {
+    let Some(user) = authn_state.user() else {
+        return Ok(train_schedules_with_exceptions);
+    };
+    let system_authorizer = SystemAuthorizer::new_infallible(openfga);
+    let Ok(authorized_train_schedules) =
+        authz::v2::rolling_stock_list(user, RollingStockPrivilege::CanRead)
+            .authorize(&system_authorizer)
+            .await?
+            .access()
+            .await?;
+    match authorized_train_schedules {
+        authz::v2::ResourcesList::All => Ok(train_schedules_with_exceptions),
+        authz::v2::ResourcesList::Privileged(authorized_rs_list) => {
+            let authorized_rolling_stocks: Vec<models::RollingStock> =
+                models::RollingStock::retrieve_batch_unchecked(
+                    &mut conn.clone(),
+                    authorized_rs_list.iter().map(|rs| rs.0),
+                )
+                .await?;
+            let authorized_rolling_stock_names: Vec<String> = authorized_rolling_stocks
+                .into_iter()
+                .map(|rolling_stock| rolling_stock.name)
+                .collect();
+
+            Ok(train_schedules_with_exceptions
+                .into_iter()
+                .filter(|(train_schedule, _)| {
+                    authorized_rolling_stock_names.contains(&train_schedule.rolling_stock_name)
+                })
+                .map(|(train_schedule, exceptions)| {
+                    (
+                        train_schedule,
+                        exceptions
+                            .into_iter()
+                            .filter(|exception| {
+                                if let Some(RollingStockChangeGroup {
+                                    rolling_stock_name, ..
+                                }) = &exception.change_groups.rolling_stock
+                                {
+                                    authorized_rolling_stock_names.contains(rolling_stock_name)
+                                } else {
+                                    true
+                                }
+                            })
+                            .collect(),
+                    )
+                })
+                .collect_vec())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::InternalError;
+    use crate::fixtures::create_fast_rolling_stock;
     use crate::fixtures::create_hourly_timetable_with_train_schedule_set;
     use crate::fixtures::create_small_infra;
+    use crate::fixtures::create_timetable_with_train_schedule_set;
+    use crate::fixtures::create_train_schedule_exception;
     use crate::fixtures::simple_paced_train_base;
+    use crate::fixtures::simple_paced_train_changeset;
+    use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::test_app;
 
     use super::*;
+    use authz::InfraGrant;
+    use authz::RollingStockGrant;
     use common::units;
     use core_client::simulation::RoutingRequirement;
     use core_client::simulation::RoutingZoneRequirement;
@@ -463,6 +546,9 @@ mod tests {
     use models::train_schedule::TrainScheduleChangeset;
     use reqwest::StatusCode;
     use rstest::rstest;
+    use schemas::TrainScheduleExceptionChangeGroups;
+    use schemas::paced_train::RollingStockChangeGroup;
+    use schemas::train_schedule::Comfort;
 
     fn spacing(zone: &str, begin_time: u64, end_time: u64) -> SpacingRequirement {
         SpacingRequirement {
@@ -661,12 +747,17 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn conflicts_hourly_rejects_period_over_24h() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let pool = app.db_pool();
 
         let infra = create_small_infra(&mut pool.get_ok()).await;
         let (timetable, train_schedule_set) =
             create_hourly_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         // Period = 5 * 7 = 35h.
         for time_window in [5, 7] {
@@ -690,9 +781,111 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(user.as_ref())
             .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
             .json();
         assert_eq!(response.error_type, "editoast:timetable:InvalidPeriod");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn filter_unauthorized_train_schedules() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let rs_authorized = create_fast_rolling_stock(&mut pool.get_ok(), "authorized_rs").await;
+        let rs_no_grant = create_fast_rolling_stock(&mut pool.get_ok(), "forbidden_rs").await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
+        let train_schedule_authorized = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("train_schedule_authorized".into())
+            .rolling_stock_name(rs_authorized.name.clone())
+            .create(&mut pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+        let train_schedule_unauthorized_exception =
+            simple_paced_train_changeset(train_schedule_set.id)
+                .train_name("train_schedule_forbidden_exception".into())
+                .rolling_stock_name(rs_authorized.name.clone())
+                .create(&mut pool.get_ok())
+                .await
+                .expect("failed to create train schedule");
+        let train_schedule_unauthorized = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("train_schedule_no_grant".into())
+            .rolling_stock_name(rs_no_grant.name.clone())
+            .create(&mut pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+        let change_group_authorized = TrainScheduleExceptionChangeGroups {
+            rolling_stock: Some(RollingStockChangeGroup {
+                rolling_stock_name: rs_authorized.name.clone(),
+                comfort: Comfort::AirConditioning,
+            }),
+            ..Default::default()
+        };
+        let change_group_no_grant = TrainScheduleExceptionChangeGroups {
+            rolling_stock: Some(RollingStockChangeGroup {
+                rolling_stock_name: rs_no_grant.name.clone(),
+                comfort: Comfort::AirConditioning,
+            }),
+            ..Default::default()
+        };
+        let exception_authorized: schemas::TrainScheduleException =
+            create_train_schedule_exception(
+                &mut pool.get_ok(),
+                timetable.id,
+                train_schedule_authorized.id,
+                None,
+                None,
+                Some(change_group_authorized),
+            )
+            .await
+            .into();
+        let exception_unauthorized: schemas::TrainScheduleException =
+            create_train_schedule_exception(
+                &mut pool.get_ok(),
+                timetable.id,
+                train_schedule_authorized.id,
+                None,
+                None,
+                Some(change_group_no_grant),
+            )
+            .await
+            .into();
+
+        let openfga = app.openfga();
+
+        let user = app
+            .user("user", "User")
+            .with_rolling_stock_grant(rs_authorized.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let authn_state = crate::authentication::State::Authenticated {
+            user: authz::User(user.id),
+            roles: vec![],
+        };
+        let train_schedules_with_exceptions = vec![
+            (
+                train_schedule_authorized.clone(),
+                vec![exception_authorized.clone()],
+            ),
+            (
+                train_schedule_unauthorized_exception.clone(),
+                vec![exception_unauthorized],
+            ),
+            (train_schedule_unauthorized, vec![]),
+        ];
+        let authorized_train_schedules = filter_unauthorized_train_schedules_and_exceptions(
+            openfga,
+            pool.get_ok(),
+            authn_state,
+            train_schedules_with_exceptions,
+        )
+        .await
+        .expect("the authorization filter method should succeed");
+        let expected_response = vec![
+            (train_schedule_authorized, vec![exception_authorized]),
+            (train_schedule_unauthorized_exception, vec![]),
+        ];
+        assert_eq!(expected_response, authorized_train_schedules);
     }
 }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -1,6 +1,11 @@
 pub(crate) mod request;
 
 use authz;
+use authz::RollingStockPrivilege;
+use authz::v2::Actor;
+use authz::v2::Authorizer as _;
+use authz::v2::Check;
+use authz::v2::Protected;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -53,9 +58,11 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authorizers::impossible;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::TrainScheduleWithConsist;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::simulation;
@@ -142,6 +149,10 @@ enum StdcmError {
         expected_max: f64,
     },
     #[error(transparent)]
+    #[editoast_error(forward)]
+    #[serde(skip)]
+    Authorization(AuthorizationError),
+    #[error(transparent)]
     #[from(forward)]
     #[serde(skip)]
     Database(editoast_models::Error),
@@ -191,13 +202,41 @@ pub(in crate::views) async fn stdcm(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Extension(auth): AuthenticationExt,
     Path(id): Path<i64>,
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
 ) -> Result<Response> {
+    let consist_schedule_values = &request.consist_schedule.values;
+    if authn_state.regular_user().is_some() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        let checks = consist_schedule_values
+            .iter()
+            .map(|consist| {
+                Check::HasRollingStockPrivilege(
+                    Actor::Issuer,
+                    RollingStockPrivilege::CanRead,
+                    authz::RollingStock(consist.rolling_stock_id),
+                )
+            })
+            .map(Protected::check);
+        let protected = Protected::from_iter(checks);
+        authz::v2::Access::access(authorizer.authorize(protected).await?)
+            .await?
+            .map_err(|check| match check {
+                authz::v2::Check::HasRollingStockPrivilege(
+                    Actor::Issuer,
+                    RollingStockPrivilege::CanRead,
+                    _,
+                ) => StdcmError::Authorization(AuthorizationError::Forbidden),
+                check => impossible!(check),
+            })?;
+    }
+
     let mut conn = db_pool.get().await?;
 
     let timetable_id = id;
@@ -228,9 +267,7 @@ pub(in crate::views) async fn stdcm(
     let work_schedules = request.get_work_schedules(&mut conn).await?;
 
     // 3. Get RollingStock
-    let rolling_stock_ids: Vec<i64> = request
-        .consist_schedule
-        .values
+    let rolling_stock_ids: Vec<i64> = consist_schedule_values
         .iter()
         .map(|consist_config| consist_config.rolling_stock_id)
         .collect();
@@ -567,6 +604,9 @@ pub fn as_core_work_schedule(
 
 #[cfg(test)]
 mod tests {
+    use authz::InfraGrant;
+    use authz::Role;
+    use authz::RollingStockGrant;
     use axum::http::StatusCode;
     use chrono::DateTime;
     use common::units;
@@ -604,6 +644,7 @@ mod tests {
     use crate::fixtures::create_timetable;
     use crate::fixtures::create_towed_rolling_stock;
     use crate::views::path::pathfinding::PathfindingResult;
+    use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::TestResponseExt as _;
     use crate::views::test_app::test_app;
     use crate::views::timetable::stdcm::Request;
@@ -973,12 +1014,19 @@ mod tests {
             core
         };
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             Some(mass.get::<kilogram>()),
@@ -990,7 +1038,8 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule))
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule.clone()))
             .await
             .assert_status_ok()
             .last_jsonl();
@@ -1055,12 +1104,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             total_mass,
@@ -1072,6 +1128,7 @@ mod tests {
 
         let stdcm_response: InternalError = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_bad_request()
@@ -1096,12 +1153,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1113,6 +1177,7 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1147,12 +1212,17 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("admin", "identity")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1164,6 +1234,7 @@ mod tests {
 
         let stdcm_response: Vec<StdcmProgression> = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1217,12 +1288,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1234,6 +1312,7 @@ mod tests {
 
         let stdcm_response: Vec<StdcmProgression> = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1403,7 +1482,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1449,9 +1528,19 @@ mod tests {
         // WS -> MWS
         // Consist change
         // MWS -> SS
+        //
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&payload)
             .await
             .assert_status_ok()
@@ -1500,7 +1589,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1510,6 +1599,15 @@ mod tests {
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
         let third_rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(third_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let mut payload = get_stdcm_payload(
             None,
@@ -1535,6 +1633,7 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&payload)
             .await
             .assert_status_ok()
@@ -1624,7 +1723,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1641,8 +1740,16 @@ mod tests {
             Some(towed_rolling_stock.id),
         ));
 
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1657,5 +1764,147 @@ mod tests {
                     .expect("Failed to parse datetime"),
             })
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_with_no_grant_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_without_stdcm_role_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_without_infra_grant_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn multiple_consist_one_missing_grant_makes_request_forbidden() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let first_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let second_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let third_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        // User missing the Reader privilege on one of the request rolling stocks
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+
+        let mut payload = get_stdcm_payload(
+            None,
+            ConsistSchedule {
+                boundaries: vec![1, 2],
+                values: vec![
+                    build_consist_config(first_rolling_stock.id, None, None, None, None, None),
+                    build_consist_config(second_rolling_stock.id, None, None, None, None, None),
+                    build_consist_config(third_rolling_stock.id, None, None, None, None, None),
+                ],
+            },
+        );
+
+        payload.steps.push(build_step("MES"));
+        payload.steps.push(build_step("SES"));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&payload)
+            .await
+            .assert_status_forbidden();
     }
 }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -2,6 +2,11 @@ pub(crate) mod request;
 
 use authz;
 use authz::v2;
+use authz::RollingStockPrivilege;
+use authz::v2::Actor;
+use authz::v2::Authorizer as _;
+use authz::v2::Check;
+use authz::v2::Protected;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -144,6 +149,10 @@ enum StdcmError {
         expected_max: f64,
     },
     #[error(transparent)]
+    #[editoast_error(forward)]
+    #[serde(skip)]
+    Authorization(AuthorizationError),
+    #[error(transparent)]
     #[from(forward)]
     #[serde(skip)]
     Database(models::Error),
@@ -201,6 +210,25 @@ pub(in crate::views) async fn stdcm(
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
 ) -> Result<Response> {
+    let consist_schedule_values = &request.consist_schedule.values;
+    if authn_state.user().is_some() {
+        let authorizer = authn_state.authorizer(&openfga);
+        let checks = consist_schedule_values
+            .iter()
+            .map(|consist| {
+                Check::HasRollingStockPrivilege(
+                    Actor::Issuer,
+                    RollingStockPrivilege::CanRead,
+                    authz::RollingStock(consist.rolling_stock_id),
+                )
+            })
+            .map(Protected::check);
+        let protected = Protected::from_iter(checks);
+        authz::v2::Access::access(authorizer.authorize(protected).await?)
+            .await?
+            .map_err(|_| StdcmError::Authorization(AuthorizationError::Forbidden))?;
+    }
+
     let mut conn = db_pool.get().await?;
 
     let timetable_id = id;
@@ -229,9 +257,7 @@ pub(in crate::views) async fn stdcm(
     let work_schedules = request.get_work_schedules(&mut conn).await?;
 
     // 3. Get RollingStock
-    let rolling_stock_ids: Vec<i64> = request
-        .consist_schedule
-        .values
+    let rolling_stock_ids: Vec<i64> = consist_schedule_values
         .iter()
         .map(|consist_config| consist_config.rolling_stock_id)
         .collect();
@@ -588,6 +614,9 @@ pub fn as_core_work_schedule(
 
 #[cfg(test)]
 mod tests {
+    use authz::InfraGrant;
+    use authz::Role;
+    use authz::RollingStockGrant;
     use axum::http::StatusCode;
     use chrono::DateTime;
     use common::units;
@@ -626,6 +655,7 @@ mod tests {
     use crate::fixtures::create_towed_rolling_stock;
     use crate::views::path::pathfinding::PathfindingItem;
     use crate::views::path::pathfinding::PathfindingResult;
+    use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::TestResponseExt as _;
     use crate::views::test_app::test_app;
     use crate::views::timetable::stdcm::Request;
@@ -1007,12 +1037,19 @@ mod tests {
             core
         };
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             Some(mass.get::<kilogram>()),
@@ -1024,7 +1061,8 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule))
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule.clone()))
             .await
             .assert_status_ok()
             .last_jsonl();
@@ -1089,12 +1127,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             total_mass,
@@ -1106,6 +1151,7 @@ mod tests {
 
         let stdcm_response: InternalError = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_bad_request()
@@ -1130,12 +1176,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1147,6 +1200,7 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1181,12 +1235,17 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("admin", "identity")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1198,6 +1257,7 @@ mod tests {
 
         let stdcm_response: Vec<StdcmProgression> = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1251,12 +1311,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1268,6 +1335,7 @@ mod tests {
 
         let stdcm_response: Vec<StdcmProgression> = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1437,7 +1505,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1483,9 +1551,19 @@ mod tests {
         // WS -> MWS
         // Consist change
         // MWS -> SS
+        //
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&payload)
             .await
             .assert_status_ok()
@@ -1534,7 +1612,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1544,6 +1622,15 @@ mod tests {
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
         let third_rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(third_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let mut payload = get_stdcm_payload(
             None,
@@ -1569,6 +1656,7 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&payload)
             .await
             .assert_status_ok()
@@ -1658,7 +1746,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1675,8 +1763,16 @@ mod tests {
             Some(towed_rolling_stock.id),
         ));
 
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1691,5 +1787,147 @@ mod tests {
                     .expect("Failed to parse datetime"),
             })
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_with_no_grant_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_without_stdcm_role_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_without_infra_grant_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn multiple_consist_one_missing_grant_makes_request_forbidden() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let first_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let second_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let third_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        // User missing the Reader privilege on one of the request rolling stocks
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+
+        let mut payload = get_stdcm_payload(
+            None,
+            ConsistSchedule {
+                boundaries: vec![1, 2],
+                values: vec![
+                    build_consist_config(first_rolling_stock.id, None, None, None, None, None),
+                    build_consist_config(second_rolling_stock.id, None, None, None, None, None),
+                    build_consist_config(third_rolling_stock.id, None, None, None, None, None),
+                ],
+            },
+        );
+
+        payload.steps.push(build_step("MES"));
+        payload.steps.push(build_step("SES"));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&payload)
+            .await
+            .assert_status_forbidden();
     }
 }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -1,8 +1,8 @@
 pub(crate) mod request;
 
 use authz;
-use authz::v2;
 use authz::RollingStockPrivilege;
+use authz::v2;
 use authz::v2::Actor;
 use authz::v2::Authorizer as _;
 use authz::v2::Check;

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -5,6 +5,8 @@ use std::iter::Extend as _;
 use std::sync::Arc;
 
 use authz;
+use authz::InfraPrivilege;
+use authz::v2::infra_privileges;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -723,9 +725,10 @@ pub(in crate::views) async fn simulation(
         valkey_client,
         core_client,
         db_pool,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(TrainScheduleIdParam {
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
@@ -742,12 +745,15 @@ pub(in crate::views) async fn simulation(
     .await?;
 
     // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
-            .await
-    })
-    .await?;
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            infra_privileges(user, authz::Infra(infra_id)),
+            &InfraPrivilege::CanRead,
+        )
+        .await?;
+    }
 
     // Retrieve train_schedule or fail
     let train_schedule = editoast_models::TrainSchedule::retrieve_or_fail(
@@ -1940,6 +1946,7 @@ mod tests {
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt;
 
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::simulation;
@@ -2262,7 +2269,6 @@ mod tests {
 
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = test_app!()
-            .skip_authz()
             .db_pool(db_pool)
             .core_client(core.into())
             .build();
@@ -2283,6 +2289,12 @@ mod tests {
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: core_client::simulation::Response = app
             .get(
                 format!(
@@ -2291,6 +2303,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -2309,6 +2322,12 @@ mod tests {
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: InternalError = app
             .get(
                 format!(
@@ -2317,6 +2336,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_not_found()
             .json();
@@ -2336,6 +2356,12 @@ mod tests {
             exception,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: simulation::Response = app
             .get(
                 format!(
@@ -2344,6 +2370,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -2400,6 +2427,12 @@ mod tests {
             exception,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
 
         let mut change_group = exception.change_groups;
         change_group.rolling_stock = Some(RollingStockChangeGroup {
@@ -2422,6 +2455,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -2442,13 +2476,71 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_not_found() {
         let SimulationTestsSetup { app, infra_id, .. } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: InternalError = app
             .get(format!("/train_schedules/{}/simulation/?infra_id={}", 0, infra_id).as_str())
+            .by_user(&user.info)
             .await
             .assert_status_not_found()
             .json();
 
         assert_eq!(&response.error_type, "editoast:train_schedule:NotFound")
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_with_privilege_and_no_roles() {
+        // GIVEN
+        let (app, infra_id, _timetable, train_schedule, _exception) =
+            app_infra_id_paced_train_id_for_simulation_tests().await;
+
+        // a user that does not have the role to reach the endpoint but has a read grant on the infra
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .create()
+            .await;
+
+        // WHEN / THEN
+        app.get(
+            format!(
+                "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                train_schedule.id
+            )
+            .as_str(),
+        )
+        .by_user(&user.info)
+        .await
+        .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_without_permission() {
+        // GIVEN
+        let (app, infra_id, _timetable, train_schedule, _exception) =
+            app_infra_id_paced_train_id_for_simulation_tests().await;
+
+        // a user that has the role to reach the endpoint but no read grant on the infra
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN / THEN
+        app.get(
+            format!(
+                "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                train_schedule.id
+            )
+            .as_str(),
+        )
+        .by_user(&user.info)
+        .await
+        .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -2722,6 +2814,12 @@ mod tests {
     async fn paced_train_simulation_summary_not_found() {
         let SimulationTestsSetup { app, infra_id, .. } = simulation_tests_initial_setup().await;
         let timetable = create_timetable(&mut app.db_pool().get_ok()).await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: InternalError = app
             .post("/train_schedules/simulation_summary")
             .json(&json!({
@@ -2729,6 +2827,7 @@ mod tests {
                 "timetable_id": timetable.id,
                 "ids": vec![0],
             }))
+            .by_user(&user.info)
             .await
             .assert_status_not_found()
             .json();
@@ -3132,6 +3231,12 @@ mod tests {
             train_schedule,
             exception,
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let db_pool = app.db_pool();
 
         // First remove all already generated exceptions
@@ -3186,6 +3291,7 @@ mod tests {
                     "blocks":[],
                 },
             }))
+            .by_user(&user.info)
             .await;
         let response: HashMap<i64, OccupancyBlocksTrainScheduleResult> =
             response.assert_status_ok().json();

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -45,6 +45,7 @@ use schemas::infra::OperationalPoint;
 use schemas::paced_train::TrainSchedule;
 use schemas::primitives::NonBlankString;
 use schemas::primitives::TimeWindow;
+use schemas::rolling_stock::RollingResistanceRaw;
 use schemas::train_schedule::OperationalPointPartReference;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
@@ -688,16 +689,27 @@ pub(in crate::views) async fn get_path(
     };
 
     let rolling_stock_name = train_occurrence.rolling_stock_name().to_owned();
-    let Some(consist) = RollingStock::retrieve(conn.clone(), rolling_stock_name.clone())
-        .await?
-        .map(schemas::RollingStock::from)
-        .map(PhysicsConsistParameters::from_traction_engine)
+    let Some(rolling_stock_model) =
+        RollingStock::retrieve(conn.clone(), rolling_stock_name.clone()).await?
     else {
         let failure = PathfindingFailure::PathfindingInputError(
             PathfindingInputError::RollingStockNotFound { rolling_stock_name },
         );
         return Ok(Json(PathfindingResult::Failure(failure)));
     };
+
+    if let Some(user) = authn_state.user() {
+        let system_authorizer = SystemAuthorizer::new_infallible(&openfga);
+        crate::authorizers::require(
+            &system_authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_model.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
+    let rolling_stock = schemas::RollingStock::<RollingResistanceRaw>::from(rolling_stock_model);
+    let consist = PhysicsConsistParameters::from_traction_engine(rolling_stock);
 
     // The path items are kept whole, and not only their location, to relate each of them to its
     // schedule item below
@@ -1977,6 +1989,8 @@ pub(in crate::views) async fn move_train_schedules_to_another_train_schedule_set
 mod tests {
     use std::collections::HashMap;
 
+    use authz::InfraGrant;
+    use authz::RollingStockGrant;
     use axum::http::StatusCode;
     use chrono::Duration;
     use chrono::TimeDelta;
@@ -3339,17 +3353,19 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_infra_not_found() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let pool = app.db_pool();
         let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
         let paced_train =
             create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
+        let user_no_grant = app.user("user", "User").create().await;
 
         let response: InternalError = app
             .get(&format!(
                 "/train_schedules/{}/path?infra_id={}",
                 paced_train.id, 0
             ))
+            .by_user(user_no_grant.as_ref())
             .await
             .assert_status_not_found()
             .json();
@@ -3362,15 +3378,21 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_paced_train_path_not_found() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let pool = app.db_pool();
         let small_infra = create_small_infra(&mut pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let response: InternalError = app
             .get(&format!(
                 "/train_schedules/{}/path?infra_id={}",
                 0, small_infra.id
             ))
+            .by_user(user.as_ref())
             .await
             .assert_status_not_found()
             .json();
@@ -3421,20 +3443,28 @@ mod tests {
                 "status": "success"
             }))
             .finish();
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
 
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
         let paced_train =
             create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &paced_train.rolling_stock_name).await;
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let response = app
             .get(&format!(
                 "/train_schedules/{}/path?infra_id={}",
                 paced_train.id, small_infra.id
             ))
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json::<PathfindingResult>();
@@ -3452,6 +3482,81 @@ mod tests {
                 length: 1
             })
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_paced_train_path_requires_reader_grant_on_the_infra_and_rolling_stock() {
+        // Setup the app and the mocked core client
+        let mut core = MockingClient::new();
+        for _ in 0..2 {
+            core.stub("/pathfinding/blocks")
+                .response(StatusCode::OK)
+                .json(json!({
+                    "path": {
+                        "blocks":[],
+                        "routes": [],
+                        "track_section_ranges": [],
+                    },
+                    "path_item_positions": [],
+                    "backtrack_path_items": [],
+                    "length": 1,
+                    "status": "success"
+                }))
+                .finish();
+        }
+        let app = test_app!().core_client(core.into()).build();
+
+        // Setup the rolling stock, train schedule and infra
+        let db_pool = app.db_pool();
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
+        let mut paced_train =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        paced_train.rolling_stock_name = rolling_stock.name;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+        // Setup the users
+        let authorized_user = app
+            .user("user", "User")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+        let user_missing_infra_grant = app
+            .user("alice", "Alice")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let user_missing_rolling_stock_grant = app
+            .user("bob", "Bob")
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+
+        // Authorized user request succeeds
+        app.get(&format!(
+            "/train_schedules/{}/path?infra_id={}",
+            paced_train.id, small_infra.id
+        ))
+        .by_user(authorized_user.as_ref())
+        .await
+        .assert_status_ok();
+
+        // Users missing grants requests fail with 403 Forbidden
+        app.get(&format!(
+            "/train_schedules/{}/path?infra_id={}",
+            paced_train.id, small_infra.id
+        ))
+        .by_user(user_missing_infra_grant.as_ref())
+        .await
+        .assert_status_forbidden();
+        app.get(&format!(
+            "/train_schedules/{}/path?infra_id={}",
+            paced_train.id, small_infra.id
+        ))
+        .by_user(user_missing_rolling_stock_grant.as_ref())
+        .await
+        .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -3489,19 +3594,27 @@ mod tests {
                 "status": "success"
             }))
             .finish();
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
 
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
         let paced_train =
             create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &paced_train.rolling_stock_name).await;
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
 
         app.get(&format!(
             "/train_schedules/{}/path?infra_id={}&begin_index=1&end_index=2",
             paced_train.id, small_infra.id
         ))
+        .by_user(user.as_ref())
         .await
         .assert_status_ok();
     }
@@ -3514,20 +3627,29 @@ mod tests {
         #[case] begin_index: usize,
         #[case] end_index: usize,
     ) {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
         let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
-        let paced_train =
+        let mut paced_train =
             create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &paced_train.rolling_stock_name).await;
+        paced_train.rolling_stock_name = rolling_stock.name;
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
 
         let response: InternalError = app
             .get(&format!(
                 "/train_schedules/{}/path?infra_id={}&begin_index={}&end_index={}",
                 paced_train.id, small_infra.id, begin_index, end_index
             ))
+            .by_user(user.as_ref())
             .await
             .assert_status_bad_request()
             .json();
@@ -3552,15 +3674,17 @@ mod tests {
                 "status": "success"
             }))
             .finish();
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
 
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
 
         let train_schedule =
             create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &train_schedule.rolling_stock_name)
+                .await;
 
         let change_rolling_stock_exception = create_train_schedule_exception(
             &mut db_pool.get_ok(),
@@ -3582,12 +3706,19 @@ mod tests {
         .await;
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user_no_grant = app
+            .user("user", "User")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let response = app
             .get(&format!(
                 "/train_schedules/{}/path?infra_id={}&exception_id={}",
                 train_schedule.id, small_infra.id, change_rolling_stock_exception.id
             ))
+            .by_user(user_no_grant.as_ref())
             .await
             .assert_status_ok()
             .json::<PathfindingResult>();

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use authz;
 use authz::InfraPrivilege;
 use authz::RollingStockPrivilege;
+use authz::v2::Authorizer as _;
+use authz::v2::Check;
 use authz::v2::infra_privileges;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
@@ -55,6 +57,7 @@ use utoipa::ToSchema;
 
 use super::AppState;
 use super::AuthenticationExt;
+use crate::authorizers::impossible;
 use crate::error::EditoastError as _;
 use crate::error::Result;
 use crate::views::AuthorizationError;
@@ -331,9 +334,10 @@ pub(in crate::views) async fn simulation_summary(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Json(SimulationBatchForm {
         infra_id,
         timetable_id,
@@ -349,12 +353,15 @@ pub(in crate::views) async fn simulation_summary(
     .await?;
 
     // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
-            .await
-    })
-    .await?;
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            infra_privileges(user, authz::Infra(infra_id)),
+            &InfraPrivilege::CanRead,
+        )
+        .await?;
+    }
 
     /////
     // Init the simulation environment
@@ -409,21 +416,61 @@ pub(in crate::views) async fn simulation_summary(
         .map::<String, _>(|train_occurrence| train_occurrence.rolling_stock_name.to_string())
         .collect::<HashSet<_>>();
 
-    let consists =
+    let rolling_stocks =
         RollingStock::retrieve_batch_unchecked::<_, Vec<_>>(&mut conn.clone(), rolling_stocks_ids)
             .await
-            .map_err(RollingStockError::from)?
-            .into_iter()
-            .map(|rolling_stock| {
-                (
-                    rolling_stock.name.clone(),
-                    PhysicsConsistParameters::from_traction_engine(rolling_stock.into()),
-                )
-            })
-            .collect::<HashMap<_, _>>();
+            .map_err(RollingStockError::from)?;
+
+    // Check user privilege on the rolling stocks used by the train occurrences.
+    // Those the user cannot read are kept aside to be reported per occurrence below.
+    let unauthorized_rolling_stocks = match authn_state.regular_user() {
+        Some(user) => {
+            let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+            let authorized_rolling_stocks = authorizer
+                .authorize(authz::v2::rolling_stock_list(
+                    user,
+                    RollingStockPrivilege::CanRead,
+                ))
+                .await?
+                .access()
+                .await?
+                .map_err(|err| match err {
+                    Check::SubjectExists(_) => AuthorizationError::Forbidden,
+                    check => impossible!(check),
+                })?;
+            match authorized_rolling_stocks {
+                authz::v2::ResourcesList::All => HashMap::new(),
+                authz::v2::ResourcesList::Privileged(authorized_rolling_stocks) => {
+                    let authorized_rolling_stock_ids = authorized_rolling_stocks
+                        .into_iter()
+                        .map(|rolling_stock| rolling_stock.0)
+                        .collect::<HashSet<_>>();
+                    rolling_stocks
+                        .iter()
+                        .filter(|rolling_stock| {
+                            !authorized_rolling_stock_ids.contains(&rolling_stock.id)
+                        })
+                        .map(|rolling_stock| (rolling_stock.name.clone(), rolling_stock.id))
+                        .collect()
+                }
+            }
+        }
+        None => HashMap::new(),
+    };
+
+    let consists = rolling_stocks
+        .into_iter()
+        .filter(|rolling_stock| !unauthorized_rolling_stocks.contains_key(&rolling_stock.name))
+        .map(|rolling_stock| {
+            (
+                rolling_stock.name.clone(),
+                PhysicsConsistParameters::from_traction_engine(rolling_stock.into()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     // Associate train schedules with their consist, when possible
-    let (train_occurrences_with_physics_consist, not_found_rolling_stock_names) = train_occurrences
+    let (train_occurrences_with_physics_consist, occurrences_without_consist) = train_occurrences
         .into_iter()
         .map(|(occurrence_id, train_occurrence)| {
             let rolling_stock_name = train_occurrence.rolling_stock_name.clone();
@@ -504,13 +551,15 @@ pub(in crate::views) async fn simulation_summary(
             };
             (occurrence_id, summary_response)
         })
-        .chain(not_found_rolling_stock_names.into_iter().map(
+        .chain(occurrences_without_consist.into_iter().map(
             |(occurrence_id, rolling_stock_name)| {
+                let input_error = match unauthorized_rolling_stocks.get(&rolling_stock_name) {
+                    Some(&rolling_stock_id) => UnauthorizedRollingStock { rolling_stock_id },
+                    None => PathfindingInputError::RollingStockNotFound { rolling_stock_name },
+                };
                 (
                     occurrence_id,
-                    SummaryResponse::PathfindingInputError(
-                        PathfindingInputError::RollingStockNotFound { rolling_stock_name },
-                    ),
+                    SummaryResponse::PathfindingInputError(input_error),
                 )
             },
         ))
@@ -2845,7 +2894,6 @@ mod tests {
         // Setup tests tools
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = test_app!()
-            .skip_authz()
             .db_pool(DbConnectionPoolV2::for_tests())
             .core_client(core.into())
             .build();
@@ -2856,12 +2904,21 @@ mod tests {
 
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
-        create_rolling_stock_with_energy_sources(
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let exception_rolling_stock = create_rolling_stock_with_energy_sources(
             &mut app.db_pool().get_ok(),
             "exception_rolling_stock",
         )
         .await;
+
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(exception_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
 
         let train_schedule = TrainSchedule {
             train_occurrence: schemas::TrainOccurrence::fake(),
@@ -2959,6 +3016,7 @@ mod tests {
                 "timetable_id": timetable.id,
                 "ids": vec![train_schedule.id],
             }))
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -3047,7 +3105,6 @@ mod tests {
     async fn paced_train_simulation_summary_with_all_occurrences_disabled() {
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = test_app!()
-            .skip_authz()
             .db_pool(DbConnectionPoolV2::for_tests())
             .core_client(core.into())
             .build();
@@ -3056,7 +3113,15 @@ mod tests {
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
 
         let train_schedule = TrainSchedule {
             train_occurrence: schemas::TrainOccurrence::fake(),
@@ -3096,6 +3161,7 @@ mod tests {
                 "timetable_id": timetable.id,
                 "ids": vec![train_schedule.id],
             }))
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -3105,6 +3171,118 @@ mod tests {
             .remove(&train_schedule.id)
             .expect("missing simulation summary for train schedule");
         assert_eq!(train_schedule_summary.exceptions.len(), 4);
+    }
+
+    /// Like [`simulation`], a rolling stock the user cannot read is reported as a pathfinding
+    /// input error, per occurrence, instead of failing the whole request with a 403.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_summary_without_rolling_stock_permission() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            timetable,
+            train_schedule,
+            exception,
+        } = simulation_tests_initial_setup().await;
+
+        // a user that has the role to reach the endpoint and a read grant on the infra,
+        // but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let mut response: HashMap<i64, TrainScheduleSummaryResponse> = app
+            .post("/train_schedules/simulation_summary")
+            .json(&json!({
+                "infra_id": infra_id,
+                "timetable_id": timetable.id,
+                "ids": vec![train_schedule.id],
+            }))
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN
+        let summary = response
+            .remove(&train_schedule.id)
+            .expect("missing simulation summary for train schedule");
+        let unauthorized = SummaryResponse::PathfindingInputError(
+            PathfindingInputError::UnauthorizedRollingStock { rolling_stock_id },
+        );
+        assert_eq!(summary.train_schedule, unauthorized);
+        assert_eq!(summary.exceptions.get(&exception.id), Some(&unauthorized));
+    }
+
+    /// An exception can swap the rolling stock of an occurrence: the occurrences the user is
+    /// allowed to read must still be simulated, only the swapped one is rejected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_summary_without_permission_on_exception_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            timetable,
+            train_schedule,
+            exception,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        let exception = swap_exception_rolling_stock(&app, &train_schedule, exception).await;
+        let swapped_rolling_stock = RollingStock::retrieve(
+            app.db_pool().get_ok(),
+            EXCEPTION_ROLLING_STOCK_NAME.to_string(),
+        )
+        .await
+        .expect("Failed to retrieve rolling stock")
+        .expect("Swapped rolling stock not found");
+
+        // a user granted on the base rolling stock only, not on the one the exception swaps to
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let mut response: HashMap<i64, TrainScheduleSummaryResponse> = app
+            .post("/train_schedules/simulation_summary")
+            .json(&json!({
+                "infra_id": infra_id,
+                "timetable_id": timetable.id,
+                "ids": vec![train_schedule.id],
+            }))
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN the base occurrence is simulated, the swapped one names the rolling stock it
+        // resolves to
+        let summary = response
+            .remove(&train_schedule.id)
+            .expect("missing simulation summary for train schedule");
+        assert!(matches!(
+            summary.train_schedule,
+            SummaryResponse::Success { .. }
+        ));
+        assert_eq!(
+            summary.exceptions.get(&exception.id),
+            Some(&SummaryResponse::PathfindingInputError(
+                PathfindingInputError::UnauthorizedRollingStock {
+                    rolling_stock_id: swapped_rolling_stock.id
+                }
+            ))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1688,6 +1688,20 @@ pub(in crate::views) async fn track_occupancy(
         })
         .unzip();
 
+    // Check user privilege on the rolling stocks of the occurrences.
+    // Without a simulation, no rolling stock is involved: the check is skipped.
+    if use_simulation {
+        crate::authorizers::require_readable_rolling_stocks(
+            trains
+                .iter()
+                .map(|occurrence| occurrence.rolling_stock_name.clone()),
+            conn,
+            &authn_state,
+            &openfga,
+        )
+        .await?;
+    }
+
     let op_location =
         PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
             operational_point: operational_point_reference.clone(),
@@ -4076,12 +4090,13 @@ mod tests {
         }
     }
 
-    async fn init_paced_train_test(
+    async fn init_track_occupancy_test(
         with_exception: bool,
         path: Vec<PathItem>,
         schedule: Vec<ScheduleItem>,
         operational_point_reference: OperationalPointReference,
         use_simulation: bool,
+        rolling_stock_grant: Option<authz::RollingStockGrant>,
     ) -> TestResponse {
         let mut core = MockingClient::new();
         core.stub("/pathfinding/blocks")
@@ -4092,13 +4107,21 @@ mod tests {
             .response(StatusCode::OK)
             .json(simulation_empty_response(path.len()))
             .finish();
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let mut user_builder = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies]);
+        if let Some(grant) = rolling_stock_grant {
+            user_builder = user_builder.with_rolling_stock_grant(rolling_stock.id, grant);
+        }
+        let user = user_builder.create().await;
         let train_schedule = models::TrainSchedule::default()
             .into_changeset()
             .train_schedule_set_id(train_schedule_set.id)
@@ -4130,7 +4153,73 @@ mod tests {
                 electrical_profile_set_id: None,
                 use_simulation,
             })
+            .by_user(&user.info)
             .await
+    }
+
+    /// [init_track_occupancy_test] as a user allowed to read the rolling stock of the train
+    async fn init_paced_train_test(
+        with_exception: bool,
+        path: Vec<PathItem>,
+        schedule: Vec<ScheduleItem>,
+        operational_point_reference: OperationalPointReference,
+        use_simulation: bool,
+    ) -> TestResponse {
+        init_track_occupancy_test(
+            with_exception,
+            path,
+            schedule,
+            operational_point_reference,
+            use_simulation,
+            Some(authz::RollingStockGrant::Reader),
+        )
+        .await
+    }
+
+    /// The very same setup as [paced_train_track_occupancy_without_exceptions], but the user is
+    /// granted a read access on the infra only, not on the rolling stock of the train
+    async fn init_track_occupancy_test_without_rolling_stock_permission(
+        use_simulation: bool,
+    ) -> TestResponse {
+        init_track_occupancy_test(
+            false,
+            vec![
+                PathItem::new_operational_point("Mid_West_station"),
+                PathItem::new_operational_point("Mid_East_station"),
+            ],
+            vec![ScheduleItem::new_with_stop(
+                "Mid_East_station",
+                Duration::new(0, 0).expect("Failed to parse duration"),
+            )],
+            OperationalPointReference::Id {
+                operational_point: "Mid_West_station".into(),
+            },
+            use_simulation,
+            None,
+        )
+        .await
+    }
+
+    /// With a simulation, a train whose rolling stock the user cannot read is forbidden
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_without_rolling_stock_permission() {
+        init_track_occupancy_test_without_rolling_stock_permission(true)
+            .await
+            .assert_status_forbidden();
+    }
+
+    /// Without a simulation, no rolling stock is involved: the train is reported even though the
+    /// user cannot read its rolling stock
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn track_occupancy_without_simulation_skips_rolling_stock_permission() {
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            init_track_occupancy_test_without_rolling_stock_permission(false)
+                .await
+                .assert_status_ok()
+                .json();
+
+        assert_eq!(track_occupancies.len(), 1);
+        assert_eq!(track_occupancies[0].trains.len(), 4);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 
 use authz;
 use authz::InfraPrivilege;
+use authz::RollingStockPrivilege;
 use authz::v2::infra_privileges;
+use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -17,6 +19,7 @@ use common::units::millisecond;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::PathfindingInputError;
+use core_client::pathfinding::PathfindingInputError::UnauthorizedRollingStock;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::signal_projection::SignalUpdate;
 use core_client::simulation::PhysicsConsist;
@@ -54,6 +57,7 @@ use super::AppState;
 use super::AuthenticationExt;
 use crate::error::EditoastError as _;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::path::pathfinding::PathfindingFailure;
@@ -744,17 +748,6 @@ pub(in crate::views) async fn simulation(
     })
     .await?;
 
-    // Check user privilege on infra
-    if let Some(user) = authn_state.regular_user() {
-        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
-        crate::authorizers::require(
-            &authorizer,
-            infra_privileges(user, authz::Infra(infra_id)),
-            &InfraPrivilege::CanRead,
-        )
-        .await?;
-    }
-
     // Retrieve train_schedule or fail
     let train_schedule = editoast_models::TrainSchedule::retrieve_or_fail(
         db_pool.get().await?,
@@ -777,9 +770,8 @@ pub(in crate::views) async fn simulation(
     };
 
     let rolling_stock_name = train_schedule.rolling_stock_name().to_owned();
-    let Some(consist) = RollingStock::retrieve(db_pool.get().await?, rolling_stock_name.clone())
-        .await?
-        .map(|rs| PhysicsConsistParameters::from_traction_engine(rs.into()))
+    let Some(rolling_stock) =
+        RollingStock::retrieve(db_pool.get().await?, rolling_stock_name.clone()).await?
     else {
         return Ok(Json(simulation::Response::PathfindingFailed {
             pathfinding_failed: PathfindingFailure::PathfindingInputError(
@@ -787,6 +779,38 @@ pub(in crate::views) async fn simulation(
             ),
         }));
     };
+
+    // Check user privilege on infra and rolling stock
+    // Done here because we need to retrieve the exception if it exists.
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            infra_privileges(user, authz::Infra(infra_id)),
+            &InfraPrivilege::CanRead,
+        )
+        .await?;
+        match crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(AuthorizationError::Forbidden) => {
+                return Ok(Json(simulation::Response::PathfindingFailed {
+                    pathfinding_failed: PathfindingFailure::PathfindingInputError(
+                        UnauthorizedRollingStock {
+                            rolling_stock_id: rolling_stock.id,
+                        },
+                    ),
+                }));
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+    let consist = PhysicsConsistParameters::from_traction_engine(rolling_stock.into());
 
     let path_item_locations = train_schedule.locations();
     let op_cache = OperationalPointCache::load_path_items(
@@ -2225,6 +2249,7 @@ mod tests {
     struct SimulationTestsSetup {
         app: TestApp,
         infra_id: i64,
+        rolling_stock_id: i64,
         timetable: Timetable,
         train_schedule: editoast_models::TrainSchedule,
         exception: TrainScheduleException,
@@ -2275,6 +2300,7 @@ mod tests {
         SimulationTestsSetup {
             app,
             infra_id: small_infra.id,
+            rolling_stock_id: rolling_stock.id,
             timetable,
             train_schedule,
             exception,
@@ -2286,12 +2312,14 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2319,12 +2347,14 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2352,6 +2382,7 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             exception,
             ..
@@ -2359,6 +2390,7 @@ mod tests {
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2423,6 +2455,7 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             exception,
             ..
@@ -2430,6 +2463,7 @@ mod tests {
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2447,7 +2481,7 @@ mod tests {
             .expect("Fail to update exception");
 
         // WHEN
-        let response: simulation::Response = app
+        let response: InternalError = app
             .get(
                 format!(
                     "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
@@ -2457,28 +2491,28 @@ mod tests {
             )
             .by_user(&user.info)
             .await
-            .assert_status_ok()
+            .assert_status_not_found()
             .json();
 
         // THEN
         assert_eq!(
-            response,
-            simulation::Response::PathfindingFailed {
-                pathfinding_failed: PathfindingFailure::PathfindingInputError(
-                    PathfindingInputError::RollingStockNotFound {
-                        rolling_stock_name: "R2D2".into()
-                    }
-                )
-            }
+            &response.error_type,
+            "editoast:train_schedule:RollingStockNotFound"
         );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_not_found() {
-        let SimulationTestsSetup { app, infra_id, .. } = simulation_tests_initial_setup().await;
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            ..
+        } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2494,13 +2528,20 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_with_privilege_and_no_roles() {
         // GIVEN
-        let (app, infra_id, _timetable, train_schedule, _exception) =
-            app_infra_id_paced_train_id_for_simulation_tests().await;
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
 
         // a user that does not have the role to reach the endpoint but has a read grant on the infra
+        // and the rolling stock
         let user = app
             .user("unauthorized", "Unauthorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .create()
             .await;
 
@@ -2520,12 +2561,19 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_without_permission() {
         // GIVEN
-        let (app, infra_id, _timetable, train_schedule, _exception) =
-            app_infra_id_paced_train_id_for_simulation_tests().await;
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
 
-        // a user that has the role to reach the endpoint but no read grant on the infra
+        // a user that has the role to reach the endpoint and a read grant on the rolling stock,
+        // but no read grant on the infra
         let user = app
             .user("unauthorized", "Unauthorized")
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2541,6 +2589,259 @@ mod tests {
         .by_user(&user.info)
         .await
         .assert_status_forbidden();
+    }
+
+    /// A rolling stock the user cannot read is reported as a pathfinding input error in the
+    /// response body, not as a 403: the endpoint answers about the train, not about the user.
+    fn unauthorized_rolling_stock_response(rolling_stock_id: i64) -> simulation::Response {
+        simulation::Response::PathfindingFailed {
+            pathfinding_failed: PathfindingFailure::PathfindingInputError(
+                PathfindingInputError::UnauthorizedRollingStock { rolling_stock_id },
+            ),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_without_rolling_stock_permission() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        // a user that has the role to reach the endpoint and a read grant on the infra,
+        // but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                    train_schedule.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN
+        assert_eq!(
+            response,
+            unauthorized_rolling_stock_response(rolling_stock_id)
+        );
+    }
+
+    const EXCEPTION_ROLLING_STOCK_NAME: &str = "exception_rolling_stock";
+
+    /// Creates a rolling stock and rewrites `exception` so it swaps the train schedule onto it.
+    async fn swap_exception_rolling_stock(
+        app: &TestApp,
+        train_schedule: &editoast_models::TrainSchedule,
+        exception: TrainScheduleException,
+    ) -> TrainScheduleException {
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), EXCEPTION_ROLLING_STOCK_NAME).await;
+
+        let mut change_groups = exception.change_groups;
+        change_groups.rolling_stock = Some(RollingStockChangeGroup {
+            rolling_stock_name: EXCEPTION_ROLLING_STOCK_NAME.into(),
+            comfort: Comfort::AirConditioning,
+        });
+        editoast_models::TrainScheduleException::changeset()
+            .change_groups(change_groups)
+            .update(&mut app.db_pool().get_ok(), train_schedule.id)
+            .await
+            .expect("Failed to update exception")
+            .expect("Failed to update exception")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_with_grant_on_another_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        let other_rolling_stock =
+            create_fast_rolling_stock(&mut app.db_pool().get_ok(), "other_rolling_stock").await;
+
+        // a user granted on another rolling stock than the one used by the train schedule
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(other_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                    train_schedule.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN
+        assert_eq!(
+            response,
+            unauthorized_rolling_stock_response(rolling_stock_id)
+        );
+    }
+
+    /// An exception can swap the rolling stock of a train schedule: privileges must be
+    /// checked against the rolling stock the exception resolves to, not the base one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_exception_simulation_without_permission_on_exception_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            exception,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        let exception = swap_exception_rolling_stock(&app, &train_schedule, exception).await;
+        let swapped_rolling_stock = RollingStock::retrieve(
+            app.db_pool().get_ok(),
+            EXCEPTION_ROLLING_STOCK_NAME.to_string(),
+        )
+        .await
+        .expect("Failed to retrieve rolling stock")
+        .expect("Swapped rolling stock not found");
+
+        // a user granted on the base rolling stock only, not on the one the exception swaps to
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                    train_schedule.id, exception.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN the failure names the rolling stock the exception resolves to, not the base one
+        assert_eq!(
+            response,
+            unauthorized_rolling_stock_response(swapped_rolling_stock.id)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_exception_simulation_with_permission_on_exception_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            train_schedule,
+            exception,
+            ..
+        } = simulation_tests_initial_setup().await;
+        let exception = swap_exception_rolling_stock(&app, &train_schedule, exception).await;
+        let swapped_rolling_stock = RollingStock::retrieve(
+            app.db_pool().get_ok(),
+            EXCEPTION_ROLLING_STOCK_NAME.to_string(),
+        )
+        .await
+        .expect("Failed to retrieve rolling stock")
+        .expect("Swapped rolling stock not found");
+
+        // a user granted on the rolling stock the exception swaps to, not on the base one
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(swapped_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                    train_schedule.id, exception.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response,
+            simulation::Response::Success(SimulationResponseSuccess {
+                base: ReportTrain {
+                    positions: vec![0, 500_000, 15_050_000],
+                    times: vec![0, 30_000, 100_000],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 1, 2, 3]
+                },
+                provisional: ReportTrain {
+                    positions: vec![0, 500_000, 15_050_000],
+                    times: vec![0, 30_000, 100_000],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 1, 2, 3]
+                },
+                final_output: CompleteReportTrain {
+                    report_train: ReportTrain {
+                        positions: vec![0, 500_000, 15_050_000],
+                        times: vec![0, 30_000, 100_000],
+                        speeds: vec![],
+                        energy_consumption: 0.0,
+                        path_item_times: vec![0, 1, 2, 3]
+                    },
+                    signal_critical_positions: vec![],
+                    zone_updates: vec![],
+                    spacing_requirements: vec![],
+                    routing_requirements: vec![]
+                },
+                mrsp: SpeedLimitProperties {
+                    boundaries: vec![],
+                    values: vec![]
+                },
+                electrical_profiles: ElectricalProfiles {
+                    boundaries: vec![],
+                    values: vec![]
+                }
+            })
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -3230,6 +3531,7 @@ mod tests {
             timetable,
             train_schedule,
             exception,
+            ..
         } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -964,6 +964,7 @@ pub(in crate::views) async fn simulation(
         (status = 200, description = "ETCS Braking Curves Output", body = core_client::etcs_braking_curves::Response),
     ),
 )]
+// TODO test the endpoint
 pub(in crate::views) async fn etcs_braking_curves(
     State(AppState {
         config,
@@ -1018,6 +1019,25 @@ pub(in crate::views) async fn etcs_braking_curves(
         None => train_schedule.clone().into_train_occurrence(),
     };
 
+    let rs = RollingStock::retrieve_or_fail(
+        db_pool.get().await?,
+        train_occurrence.rolling_stock_name.clone(),
+        || TrainScheduleError::RollingStockNotFound {
+            rolling_stock_name: train_occurrence.rolling_stock_name.clone(),
+        },
+    )
+    .await?;
+
+    if let Some(user) = authn_state.user() {
+        let system_authorizer = SystemAuthorizer::new_infallible(&openfga);
+        crate::authorizers::require(
+            &system_authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rs.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     // Compute simulation of a train schedule
     let (simulation_result, pathfinding_result) = train_simulation_ordered_batch(
         &mut db_pool.get().await?,
@@ -1049,14 +1069,6 @@ pub(in crate::views) async fn etcs_braking_curves(
     };
 
     // Build physics consist
-    let rs = RollingStock::retrieve_or_fail(
-        db_pool.get().await?,
-        train_occurrence.rolling_stock_name.clone(),
-        || TrainScheduleError::RollingStockNotFound {
-            rolling_stock_name: train_occurrence.rolling_stock_name.clone(),
-        },
-    )
-    .await?;
     let physics_consist: PhysicsConsist =
         PhysicsConsistParameters::from_traction_engine(rs.into()).into();
 

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1326,6 +1326,20 @@ pub(in crate::views) async fn project_path_op(
         })
         .unzip();
 
+    // Check user privilege on the rolling stocks of the occurrences.
+    // Without a simulation, no rolling stock is involved: the check is skipped.
+    if use_simulation {
+        crate::authorizers::require_readable_rolling_stocks(
+            occurrences
+                .iter()
+                .map(|occurrence| occurrence.rolling_stock_name.clone()),
+            conn,
+            &authn_state,
+            &openfga,
+        )
+        .await?;
+    }
+
     // Transform operational point references into a list of path item locations
     let path_item_locations_projection = operational_points_refs
         .iter()
@@ -3816,7 +3830,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_project_path() {
-        // SETUP
         let db_pool = DbConnectionPoolV2::for_tests();
 
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
@@ -3834,12 +3847,17 @@ mod tests {
 
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = test_app!()
-            .skip_authz()
             .db_pool(db_pool)
             .core_client(core.into())
             .build();
 
-        // TEST
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
         let response: HashMap<i64, ProjectPathTrainScheduleResult> = app
             .post("/train_schedules/project_path")
             .json(&json!({
@@ -3856,12 +3874,100 @@ mod tests {
                     }
                 ],
             }))
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
         // EXPECT
         // TODO: improve this test
         assert_eq!(response.len(), 2);
+    }
+
+    /// With a simulation, projecting a train whose rolling stock the user cannot read is forbidden
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_path_op_without_rolling_stock_permission() {
+        let app = test_app!()
+            .core_client(mocked_core_pathfinding_sim_and_proj().into())
+            .build();
+        let db_pool = app.db_pool();
+
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let paced_train =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        create_fast_rolling_stock(&mut db_pool.get_ok(), &paced_train.rolling_stock_name).await;
+
+        // a user that can read the infra, but not the rolling stock of the train
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.post("/train_schedules/project_path_op")
+            .json(&json!({
+                "infra_id": small_infra.id,
+                "timetable_id": timetable.id,
+                "electrical_profile_set_id": null,
+                "train_ids": vec![paced_train.id],
+                "operational_points_refs": [
+                    { "type": "domestic", "country_code": "FR", "main_code": "MWS", "secondary_code": "BV" },
+                    { "type": "id", "operational_point": "Mid_East_station" },
+                ],
+                "operational_points_distances": [10000],
+                "use_simulation": true,
+            }))
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+    }
+
+    /// Without a simulation, no rolling stock is involved: projecting a train whose rolling stock
+    /// the user cannot read is allowed
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_path_op_without_simulation_skips_rolling_stock_permission() {
+        let app = test_app!()
+            .core_client(mocked_core_pathfinding_sim_and_proj().into())
+            .build();
+        let db_pool = app.db_pool();
+
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let paced_train =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        create_fast_rolling_stock(&mut db_pool.get_ok(), &paced_train.rolling_stock_name).await;
+
+        // the very same user as above, without any grant on the rolling stock of the train
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        let response: HashMap<i64, ProjectPathTrainScheduleResult> = app
+            .post("/train_schedules/project_path_op")
+            .json(&json!({
+                "infra_id": small_infra.id,
+                "timetable_id": timetable.id,
+                "electrical_profile_set_id": null,
+                "train_ids": vec![paced_train.id],
+                "operational_points_refs": [
+                    { "type": "domestic", "country_code": "FR", "main_code": "MWS", "secondary_code": "BV" },
+                    { "type": "id", "operational_point": "Mid_East_station" },
+                ],
+                "operational_points_distances": [10000],
+                "use_simulation": false,
+            }))
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        assert!(response.contains_key(&paced_train.id));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -5,7 +5,11 @@ use std::iter::Extend as _;
 use std::sync::Arc;
 
 use authz;
+use authz::InfraPrivilege;
+use authz::RollingStockPrivilege;
 use authz::v2;
+use authz::v2::infra_privileges;
+use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -16,6 +20,7 @@ use common::units::millisecond;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::PathfindingInputError;
+use core_client::pathfinding::PathfindingInputError::UnauthorizedRollingStock;
 use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::signal_projection::SignalUpdate;
 use core_client::simulation::PhysicsConsist;
@@ -800,16 +805,43 @@ pub(in crate::views) async fn simulation(
     };
 
     let rolling_stock_name = train_schedule.rolling_stock_name().to_owned();
-    let Some(consist) = RollingStock::retrieve(db_pool.get().await?, rolling_stock_name.clone())
-        .await?
-        .map(|rs| PhysicsConsistParameters::from_traction_engine(rs.into()))
-    else {
-        return Ok(Json(simulation::Response::PathfindingFailed {
-            pathfinding_failed: PathfindingFailure::PathfindingInputError(
-                PathfindingInputError::RollingStockNotFound { rolling_stock_name },
-            ),
-        }));
+    let rolling_stock =
+        RollingStock::retrieve(db_pool.get().await?, rolling_stock_name.clone()).await?;
+    let Some(rolling_stock) = rolling_stock else {
+        return Err(TrainScheduleError::RollingStockNotFound { rolling_stock_name }.into());
     };
+    // Check user privilege on infra and rolling stock
+    // Done here because we need to retrieve the exception if it exists.
+    if let Some(user) = authn_state.user() {
+        let authorizer = authn_state.authorizer(&openfga);
+        crate::authorizers::require(
+            &authorizer,
+            infra_privileges(user, authz::Infra(infra_id)),
+            &InfraPrivilege::CanRead,
+        )
+        .await?;
+        match crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(AuthorizationError::Forbidden) => {
+                return Ok(Json(simulation::Response::PathfindingFailed {
+                    pathfinding_failed: PathfindingFailure::PathfindingInputError(
+                        UnauthorizedRollingStock {
+                            rolling_stock_id: rolling_stock.id,
+                        },
+                    ),
+                }));
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    let consist = PhysicsConsistParameters::from_traction_engine(rolling_stock.into());
 
     let path_item_locations = train_schedule.locations();
     let op_cache = OperationalPointCache::load_path_items(
@@ -2246,6 +2278,7 @@ mod tests {
     struct SimulationTestsSetup {
         app: TestApp,
         infra_id: i64,
+        rolling_stock_id: i64,
         timetable: Timetable,
         train_schedule: models::TrainSchedule,
         exception: TrainScheduleException,
@@ -2296,6 +2329,7 @@ mod tests {
         SimulationTestsSetup {
             app,
             infra_id: small_infra.id,
+            rolling_stock_id: rolling_stock.id,
             timetable,
             train_schedule,
             exception,
@@ -2307,12 +2341,14 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2340,12 +2376,14 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2373,6 +2411,7 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             exception,
             ..
@@ -2380,6 +2419,7 @@ mod tests {
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2444,6 +2484,7 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             exception,
             ..
@@ -2451,6 +2492,7 @@ mod tests {
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2468,7 +2510,7 @@ mod tests {
             .expect("Fail to update exception");
 
         // WHEN
-        let response: simulation::Response = app
+        let response: InternalError = app
             .get(
                 format!(
                     "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
@@ -2478,28 +2520,28 @@ mod tests {
             )
             .by_user(&user.info)
             .await
-            .assert_status_ok()
+            .assert_status_not_found()
             .json();
 
         // THEN
         assert_eq!(
-            response,
-            simulation::Response::PathfindingFailed {
-                pathfinding_failed: PathfindingFailure::PathfindingInputError(
-                    PathfindingInputError::RollingStockNotFound {
-                        rolling_stock_name: "R2D2".into()
-                    }
-                )
-            }
+            &response.error_type,
+            "editoast:train_schedule:RollingStockNotFound"
         );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_not_found() {
-        let SimulationTestsSetup { app, infra_id, .. } = simulation_tests_initial_setup().await;
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            ..
+        } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2518,14 +2560,17 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
 
         // a user that does not have the role to reach the endpoint but has a read grant on the infra
+        // and the rolling stock
         let user = app
             .user("unauthorized", "Unauthorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .create()
             .await;
 
@@ -2548,13 +2593,16 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
 
-        // a user that has the role to reach the endpoint but no read grant on the infra
+        // a user that has the role to reach the endpoint and a read grant on the rolling stock,
+        // but no read grant on the infra
         let user = app
             .user("unauthorized", "Unauthorized")
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -2570,6 +2618,259 @@ mod tests {
         .by_user(&user.info)
         .await
         .assert_status_forbidden();
+    }
+
+    /// A rolling stock the user cannot read is reported as a pathfinding input error in the
+    /// response body, not as a 403: the endpoint answers about the train, not about the user.
+    fn unauthorized_rolling_stock_response(rolling_stock_id: i64) -> simulation::Response {
+        simulation::Response::PathfindingFailed {
+            pathfinding_failed: PathfindingFailure::PathfindingInputError(
+                PathfindingInputError::UnauthorizedRollingStock { rolling_stock_id },
+            ),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_without_rolling_stock_permission() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        // a user that has the role to reach the endpoint and a read grant on the infra,
+        // but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                    train_schedule.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN
+        assert_eq!(
+            response,
+            unauthorized_rolling_stock_response(rolling_stock_id)
+        );
+    }
+
+    const EXCEPTION_ROLLING_STOCK_NAME: &str = "exception_rolling_stock";
+
+    /// Creates a rolling stock and rewrites `exception` so it swaps the train schedule onto it.
+    async fn swap_exception_rolling_stock(
+        app: &TestApp,
+        train_schedule: &models::TrainSchedule,
+        exception: TrainScheduleException,
+    ) -> TrainScheduleException {
+        create_fast_rolling_stock(&mut app.db_pool().get_ok(), EXCEPTION_ROLLING_STOCK_NAME).await;
+
+        let mut change_groups = exception.change_groups;
+        change_groups.rolling_stock = Some(RollingStockChangeGroup {
+            rolling_stock_name: EXCEPTION_ROLLING_STOCK_NAME.into(),
+            comfort: Comfort::AirConditioning,
+        });
+        models::TrainScheduleException::changeset()
+            .change_groups(change_groups)
+            .update(&mut app.db_pool().get_ok(), train_schedule.id)
+            .await
+            .expect("Failed to update exception")
+            .expect("Failed to update exception")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_with_grant_on_another_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        let other_rolling_stock =
+            create_fast_rolling_stock(&mut app.db_pool().get_ok(), "other_rolling_stock").await;
+
+        // a user granted on another rolling stock than the one used by the train schedule
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(other_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                    train_schedule.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN
+        assert_eq!(
+            response,
+            unauthorized_rolling_stock_response(rolling_stock_id)
+        );
+    }
+
+    /// An exception can swap the rolling stock of a train schedule: privileges must be
+    /// checked against the rolling stock the exception resolves to, not the base one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_exception_simulation_without_permission_on_exception_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            train_schedule,
+            exception,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        let exception = swap_exception_rolling_stock(&app, &train_schedule, exception).await;
+        let swapped_rolling_stock = RollingStock::retrieve(
+            app.db_pool().get_ok(),
+            EXCEPTION_ROLLING_STOCK_NAME.to_string(),
+        )
+        .await
+        .expect("Failed to retrieve rolling stock")
+        .expect("Swapped rolling stock not found");
+
+        // a user granted on the base rolling stock only, not on the one the exception swaps to
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                    train_schedule.id, exception.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN the failure names the rolling stock the exception resolves to, not the base one
+        assert_eq!(
+            response,
+            unauthorized_rolling_stock_response(swapped_rolling_stock.id)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_exception_simulation_with_permission_on_exception_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            train_schedule,
+            exception,
+            ..
+        } = simulation_tests_initial_setup().await;
+        let exception = swap_exception_rolling_stock(&app, &train_schedule, exception).await;
+        let swapped_rolling_stock = RollingStock::retrieve(
+            app.db_pool().get_ok(),
+            EXCEPTION_ROLLING_STOCK_NAME.to_string(),
+        )
+        .await
+        .expect("Failed to retrieve rolling stock")
+        .expect("Swapped rolling stock not found");
+
+        // a user granted on the rolling stock the exception swaps to, not on the base one
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(swapped_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        let response: simulation::Response = app
+            .get(
+                format!(
+                    "/train_schedules/{}/simulation/?infra_id={infra_id}&exception_id={}",
+                    train_schedule.id, exception.id
+                )
+                .as_str(),
+            )
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response,
+            simulation::Response::Success(SimulationResponseSuccess {
+                base: ReportTrain {
+                    positions: vec![0, 500_000, 15_050_000],
+                    times: vec![0, 30_000, 100_000],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 1, 2, 3]
+                },
+                provisional: ReportTrain {
+                    positions: vec![0, 500_000, 15_050_000],
+                    times: vec![0, 30_000, 100_000],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 1, 2, 3]
+                },
+                final_output: CompleteReportTrain {
+                    report_train: ReportTrain {
+                        positions: vec![0, 500_000, 15_050_000],
+                        times: vec![0, 30_000, 100_000],
+                        speeds: vec![],
+                        energy_consumption: 0.0,
+                        path_item_times: vec![0, 1, 2, 3]
+                    },
+                    signal_critical_positions: vec![],
+                    zone_updates: vec![],
+                    spacing_requirements: vec![],
+                    routing_requirements: vec![]
+                },
+                mrsp: SpeedLimitProperties {
+                    boundaries: vec![],
+                    values: vec![]
+                },
+                electrical_profiles: ElectricalProfiles {
+                    boundaries: vec![],
+                    values: vec![]
+                }
+            })
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -3259,6 +3560,7 @@ mod tests {
             timetable,
             train_schedule,
             exception,
+            ..
         } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -8,6 +8,7 @@ use authz;
 use authz::InfraPrivilege;
 use authz::RollingStockPrivilege;
 use authz::v2;
+use authz::v2::Authorizer as _;
 use authz::v2::infra_privileges;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
@@ -56,6 +57,7 @@ use utoipa::ToSchema;
 
 use super::AppState;
 use crate::authentication;
+use crate::authorizers::SystemAuthorizer;
 use crate::error::EditoastError as _;
 use crate::error::Result;
 use crate::views::AuthorizationError;
@@ -409,21 +411,57 @@ pub(in crate::views) async fn simulation_summary(
         .map::<String, _>(|train_occurrence| train_occurrence.rolling_stock_name.to_string())
         .collect::<HashSet<_>>();
 
-    let consists =
+    let rolling_stocks =
         RollingStock::retrieve_batch_unchecked::<_, Vec<_>>(&mut conn.clone(), rolling_stocks_ids)
             .await
-            .map_err(RollingStockError::from)?
-            .into_iter()
-            .map(|rolling_stock| {
-                (
-                    rolling_stock.name.clone(),
-                    PhysicsConsistParameters::from_traction_engine(rolling_stock.into()),
-                )
-            })
-            .collect::<HashMap<_, _>>();
+            .map_err(RollingStockError::from)?;
+
+    // Check user privilege on the rolling stocks used by the train occurrences.
+    // Those the user cannot read are kept aside to be reported per occurrence below.
+    let unauthorized_rolling_stocks = match authn_state.user() {
+        Some(user) => {
+            let system_authorizer = SystemAuthorizer::new_infallible(&openfga);
+            let Ok(authorized_rolling_stocks) = system_authorizer
+                .authorize(authz::v2::rolling_stock_list(
+                    user,
+                    RollingStockPrivilege::CanRead,
+                ))
+                .await?
+                .access()
+                .await?;
+            match authorized_rolling_stocks {
+                authz::v2::ResourcesList::All => HashMap::new(),
+                authz::v2::ResourcesList::Privileged(authorized_rolling_stocks) => {
+                    let authorized_rolling_stock_ids = authorized_rolling_stocks
+                        .into_iter()
+                        .map(|rolling_stock| rolling_stock.0)
+                        .collect::<HashSet<_>>();
+                    rolling_stocks
+                        .iter()
+                        .filter(|rolling_stock| {
+                            !authorized_rolling_stock_ids.contains(&rolling_stock.id)
+                        })
+                        .map(|rolling_stock| (rolling_stock.name.clone(), rolling_stock.id))
+                        .collect()
+                }
+            }
+        }
+        None => HashMap::new(),
+    };
+
+    let consists = rolling_stocks
+        .into_iter()
+        .filter(|rolling_stock| !unauthorized_rolling_stocks.contains_key(&rolling_stock.name))
+        .map(|rolling_stock| {
+            (
+                rolling_stock.name.clone(),
+                PhysicsConsistParameters::from_traction_engine(rolling_stock.into()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     // Associate train schedules with their consist, when possible
-    let (train_occurrences_with_physics_consist, not_found_rolling_stock_names) = train_occurrences
+    let (train_occurrences_with_physics_consist, occurrences_without_consist) = train_occurrences
         .into_iter()
         .map(|(occurrence_id, train_occurrence)| {
             let rolling_stock_name = train_occurrence.rolling_stock_name.clone();
@@ -504,13 +542,15 @@ pub(in crate::views) async fn simulation_summary(
             };
             (occurrence_id, summary_response)
         })
-        .chain(not_found_rolling_stock_names.into_iter().map(
+        .chain(occurrences_without_consist.into_iter().map(
             |(occurrence_id, rolling_stock_name)| {
+                let input_error = match unauthorized_rolling_stocks.get(&rolling_stock_name) {
+                    Some(&rolling_stock_id) => UnauthorizedRollingStock { rolling_stock_id },
+                    None => PathfindingInputError::RollingStockNotFound { rolling_stock_name },
+                };
                 (
                     occurrence_id,
-                    SummaryResponse::PathfindingInputError(
-                        PathfindingInputError::RollingStockNotFound { rolling_stock_name },
-                    ),
+                    SummaryResponse::PathfindingInputError(input_error),
                 )
             },
         ))
@@ -2878,7 +2918,6 @@ mod tests {
         // Setup tests tools
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = test_app!()
-            .skip_authz()
             .db_pool(DbConnectionPoolV2::for_tests())
             .core_client(core.into())
             .build();
@@ -2889,12 +2928,21 @@ mod tests {
 
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
-        create_rolling_stock_with_energy_sources(
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let exception_rolling_stock = create_rolling_stock_with_energy_sources(
             &mut app.db_pool().get_ok(),
             "exception_rolling_stock",
         )
         .await;
+
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(exception_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
 
         let train_schedule = TrainSchedule {
             train_occurrence: schemas::TrainOccurrence::fake(),
@@ -2992,6 +3040,7 @@ mod tests {
                 "timetable_id": timetable.id,
                 "ids": vec![train_schedule.id],
             }))
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -3080,7 +3129,6 @@ mod tests {
     async fn paced_train_simulation_summary_with_all_occurrences_disabled() {
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = test_app!()
-            .skip_authz()
             .db_pool(DbConnectionPoolV2::for_tests())
             .core_client(core.into())
             .build();
@@ -3089,7 +3137,15 @@ mod tests {
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
 
         let train_schedule = TrainSchedule {
             train_occurrence: schemas::TrainOccurrence::fake(),
@@ -3129,6 +3185,7 @@ mod tests {
                 "timetable_id": timetable.id,
                 "ids": vec![train_schedule.id],
             }))
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -3138,6 +3195,118 @@ mod tests {
             .remove(&train_schedule.id)
             .expect("missing simulation summary for train schedule");
         assert_eq!(train_schedule_summary.exceptions.len(), 4);
+    }
+
+    /// Like [`simulation`], a rolling stock the user cannot read is reported as a pathfinding
+    /// input error, per occurrence, instead of failing the whole request with a 403.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_summary_without_rolling_stock_permission() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            timetable,
+            train_schedule,
+            exception,
+        } = simulation_tests_initial_setup().await;
+
+        // a user that has the role to reach the endpoint and a read grant on the infra,
+        // but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let mut response: HashMap<i64, TrainScheduleSummaryResponse> = app
+            .post("/train_schedules/simulation_summary")
+            .json(&json!({
+                "infra_id": infra_id,
+                "timetable_id": timetable.id,
+                "ids": vec![train_schedule.id],
+            }))
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN
+        let summary = response
+            .remove(&train_schedule.id)
+            .expect("missing simulation summary for train schedule");
+        let unauthorized = SummaryResponse::PathfindingInputError(
+            PathfindingInputError::UnauthorizedRollingStock { rolling_stock_id },
+        );
+        assert_eq!(summary.train_schedule, unauthorized);
+        assert_eq!(summary.exceptions.get(&exception.id), Some(&unauthorized));
+    }
+
+    /// An exception can swap the rolling stock of an occurrence: the occurrences the user is
+    /// allowed to read must still be simulated, only the swapped one is rejected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_summary_without_permission_on_exception_rolling_stock() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            rolling_stock_id,
+            timetable,
+            train_schedule,
+            exception,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        let exception = swap_exception_rolling_stock(&app, &train_schedule, exception).await;
+        let swapped_rolling_stock = RollingStock::retrieve(
+            app.db_pool().get_ok(),
+            EXCEPTION_ROLLING_STOCK_NAME.to_string(),
+        )
+        .await
+        .expect("Failed to retrieve rolling stock")
+        .expect("Swapped rolling stock not found");
+
+        // a user granted on the base rolling stock only, not on the one the exception swaps to
+        let user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN
+        let mut response: HashMap<i64, TrainScheduleSummaryResponse> = app
+            .post("/train_schedules/simulation_summary")
+            .json(&json!({
+                "infra_id": infra_id,
+                "timetable_id": timetable.id,
+                "ids": vec![train_schedule.id],
+            }))
+            .by_user(&user.info)
+            .await
+            .assert_status_ok()
+            .json();
+
+        // THEN the base occurrence is simulated, the swapped one names the rolling stock it
+        // resolves to
+        let summary = response
+            .remove(&train_schedule.id)
+            .expect("missing simulation summary for train schedule");
+        assert!(matches!(
+            summary.train_schedule,
+            SummaryResponse::Success { .. }
+        ));
+        assert_eq!(
+            summary.exceptions.get(&exception.id),
+            Some(&SummaryResponse::PathfindingInputError(
+                PathfindingInputError::UnauthorizedRollingStock {
+                    rolling_stock_id: swapped_rolling_stock.id
+                }
+            ))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -77,6 +77,7 @@ use crate::views::projection::compute_projected_train_path_op;
 use crate::views::projection::compute_projected_train_path_op_without_simulation;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::rolling_stock::RollingStockError;
+use crate::views::rolling_stock::filter_readable_occurrences;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::occupancy_blocks::OccupancyBlockForm;
 use crate::views::timetable::occupancy_blocks::OccupancyBlocks;
@@ -1212,56 +1213,105 @@ pub(in crate::views) async fn project_path(
         })
         .collect();
 
-    // Check user privilege on the rolling stocks of the occurrences: they are all simulated
-    crate::authorizers::require_readable_rolling_stocks(
-        simulation_contexts
-            .iter()
-            .map(|context| context.train_schedule.rolling_stock_name.clone()),
-        conn,
+    // A simulation context is either a train schedule or one of its exceptions. The contexts are
+    // consumed here: their train schedules are simulated as they are, and never cloned.
+    let occurrences = simulation_contexts
+        .into_iter()
+        .map(|context| {
+            let occurrence_id = match context.exception_id {
+                Some(exception_id) => {
+                    OccurrenceId::new_created(context.train_schedule_id, exception_id)
+                }
+                None => OccurrenceId::new_base(context.train_schedule_id, 0),
+            };
+            (occurrence_id, context.train_schedule)
+        })
+        .collect_vec();
+    let occurrences_ids = occurrences
+        .iter()
+        .map(|(occurrence_id, _)| occurrence_id.clone())
+        .collect_vec();
+
+    // Check user privilege on the rolling stocks of the occurrences.
+    // Those the user cannot read are not simulated, and are projected like invalid trains.
+    let occurrences_by_rolling_stock = occurrences
+        .into_iter()
+        .map(|(id, occurrence)| (occurrence.rolling_stock_name.clone(), (id, occurrence)))
+        .into_group_map();
+
+    let rolling_stock_names = occurrences_by_rolling_stock.keys().cloned().collect_vec();
+    let rolling_stocks: Vec<RollingStock> =
+        RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stock_names)
+            .await
+            .map_err(RollingStockError::from)?;
+
+    let (readable_ids, readable_train_schedules): (Vec<_>, Vec<_>) = filter_readable_occurrences(
+        occurrences_by_rolling_stock,
+        &rolling_stocks,
         &authn_state,
         &openfga,
     )
-    .await?;
+    .await?
+    .into_iter()
+    .unzip();
 
-    let project_path_result = compute_projected_train_paths(
+    let simulated_projections = compute_projected_train_paths(
         conn,
         core_client,
         valkey_client,
         track_section_ranges,
         infra,
-        &simulation_contexts
-            .iter()
-            .map(|c| c.train_schedule.clone())
-            .collect::<Vec<_>>(),
+        &readable_train_schedules,
         electrical_profile_set_id,
         config.app_version.as_deref(),
     )
-    .await?
-    .into_iter()
-    .collect::<Vec<_>>();
+    .await?;
+    let projections = readable_ids
+        .into_iter()
+        .zip(simulated_projections)
+        .collect::<HashMap<_, _>>();
 
+    // The occurrences that were not simulated share the same empty projection, like invalid trains
+    let unsimulated = Arc::<Vec<SpaceTimeCurve>>::default();
     let mut base_project_path = Default::default();
 
-    let results = simulation_contexts.into_iter().enumerate().fold(
+    let results = occurrences_ids.into_iter().fold(
         HashMap::<i64, ProjectPathTrainScheduleResult>::new(),
-        |mut results, (index, simulation_context)| {
-            if let Some(exception_id) = simulation_context.exception_id {
-                if !Arc::ptr_eq(&base_project_path, &project_path_result[index]) {
-                    results
-                        .get_mut(&simulation_context.train_schedule_id)
-                        .expect("train_schedule_id should exist")
-                        .exceptions
-                        .insert(exception_id, (*project_path_result[index]).clone());
+        |mut results, occurrence_id| {
+            let projection = projections
+                .get(&occurrence_id)
+                .unwrap_or(&unsimulated)
+                .clone();
+            match occurrence_id {
+                OccurrenceId::Created {
+                    train_schedule_id,
+                    exception_id,
                 }
-            } else {
-                results.insert(
-                    simulation_context.train_schedule_id,
-                    ProjectPathTrainScheduleResult {
-                        train_schedule: (*project_path_result[index]).clone(),
-                        exceptions: HashMap::new(),
-                    },
-                );
-                base_project_path = project_path_result[index].clone();
+                | OccurrenceId::Modified {
+                    train_schedule_id,
+                    exception_id,
+                    ..
+                } => {
+                    if !Arc::ptr_eq(&base_project_path, &projection) {
+                        results
+                            .get_mut(&train_schedule_id)
+                            .expect("train_schedule_id should exist")
+                            .exceptions
+                            .insert(exception_id, (*projection).clone());
+                    }
+                }
+                OccurrenceId::Base {
+                    train_schedule_id, ..
+                } => {
+                    results.insert(
+                        train_schedule_id,
+                        ProjectPathTrainScheduleResult {
+                            train_schedule: (*projection).clone(),
+                            exceptions: HashMap::new(),
+                        },
+                    );
+                    base_project_path = projection;
+                }
             };
             results
         },
@@ -1342,17 +1392,33 @@ pub(in crate::views) async fn project_path_op(
 
     // Check user privilege on the rolling stocks of the occurrences.
     // Without a simulation, no rolling stock is involved: the check is skipped.
-    if use_simulation {
-        crate::authorizers::require_readable_rolling_stocks(
-            occurrences
-                .iter()
-                .map(|occurrence| occurrence.rolling_stock_name.clone()),
-            conn,
+    let readable_occurrence_ids = if use_simulation {
+        let occurrences_by_rolling_stock = occurrences_ids
+            .iter()
+            .cloned()
+            .zip(occurrences.iter().cloned())
+            .map(|(id, occurrence)| (occurrence.rolling_stock_name.clone(), (id, occurrence)))
+            .into_group_map();
+
+        let rolling_stock_names = occurrences_by_rolling_stock.keys().cloned().collect_vec();
+        let rolling_stocks: Vec<RollingStock> =
+            RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stock_names)
+                .await
+                .map_err(RollingStockError::from)?;
+
+        filter_readable_occurrences(
+            occurrences_by_rolling_stock,
+            &rolling_stocks,
             &authn_state,
             &openfga,
         )
-        .await?;
-    }
+        .await?
+        .into_iter()
+        .map(|(occurrence_id, _)| occurrence_id)
+        .collect::<HashSet<_>>()
+    } else {
+        occurrences_ids.iter().cloned().collect()
+    };
 
     // Transform operational point references into a list of path item locations
     let path_item_locations_projection = operational_points_refs
@@ -1385,23 +1451,49 @@ pub(in crate::views) async fn project_path_op(
     )?;
 
     let projected_trains = if use_simulation {
-        compute_projected_train_path_op(
+        // Occurrences whose rolling stock the user cannot read are not simulated: like invalid trains
+        let occurrences_count = occurrences.len();
+        let (readable, unreadable): (Vec<_>, Vec<_>) = occurrences
+            .into_iter()
+            .enumerate()
+            .partition(|(index, _)| readable_occurrence_ids.contains(&occurrences_ids[*index]));
+        let (unreadable_indexes, unreadable_occurrences): (Vec<_>, Vec<_>) =
+            unreadable.into_iter().unzip();
+        let (readable_indexes, readable_occurrences): (Vec<_>, Vec<_>) =
+            readable.into_iter().unzip();
+
+        let simulated_projections = compute_projected_train_path_op(
             conn,
             valkey_client,
             core_client,
-            &occurrences,
+            &readable_occurrences,
             &op_cache,
-            operational_points_projection,
+            &operational_points_projection,
             infra,
             electrical_profile_set_id,
             config.app_version.as_deref(),
         )
-        .await?
+        .await?;
+        let unsimulated_projections = compute_projected_train_path_op_without_simulation(
+            &unreadable_occurrences,
+            &op_cache,
+            &operational_points_projection,
+        );
+
+        let mut projected_trains = vec![Arc::<Vec<SpaceTimeCurve>>::default(); occurrences_count];
+        for (index, projection) in readable_indexes
+            .into_iter()
+            .zip(simulated_projections)
+            .chain(unreadable_indexes.into_iter().zip(unsimulated_projections))
+        {
+            projected_trains[index] = projection;
+        }
+        projected_trains
     } else {
         compute_projected_train_path_op_without_simulation(
             &occurrences,
             &op_cache,
-            operational_points_projection,
+            &operational_points_projection,
         )
     };
 
@@ -4020,7 +4112,8 @@ mod tests {
         assert_eq!(response.len(), 2);
     }
 
-    /// Projecting a train whose rolling stock the user cannot read is forbidden
+    /// A train whose rolling stock the user cannot read is projected: like an invalid train, it is
+    /// not simulated and its projection is empty
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_path_without_rolling_stock_permission() {
         // SETUP
@@ -4045,7 +4138,8 @@ mod tests {
             .await;
 
         // TEST
-        app.post("/train_schedules/project_path")
+        let response: HashMap<i64, ProjectPathTrainScheduleResult> = app
+            .post("/train_schedules/project_path")
             .json(&json!({
                 "infra_id": small_infra.id,
                 "timetable_id": timetable.id,
@@ -4062,10 +4156,19 @@ mod tests {
             }))
             .by_user(&user.info)
             .await
-            .assert_status_forbidden();
+            .assert_status_ok()
+            .json();
+
+        // EXPECT
+        let projection = response
+            .get(&paced_train.id)
+            .expect("the train should be projected");
+        assert!(projection.train_schedule.is_empty());
+        assert!(projection.exceptions.is_empty());
     }
 
-    /// With a simulation, projecting a train whose rolling stock the user cannot read is forbidden
+    /// Even with a simulation, a train whose rolling stock the user cannot read is projected: like
+    /// an invalid train, it is projected without simulation
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_path_op_without_rolling_stock_permission() {
         let app = test_app!()
@@ -4088,22 +4191,28 @@ mod tests {
             .create()
             .await;
 
-        app.post("/train_schedules/project_path_op")
-            .json(&json!({
-                "infra_id": small_infra.id,
-                "timetable_id": timetable.id,
-                "electrical_profile_set_id": null,
-                "train_ids": vec![paced_train.id],
-                "operational_points_refs": [
-                    { "type": "domestic", "country_code": "FR", "main_code": "MWS", "secondary_code": "BV" },
-                    { "type": "id", "operational_point": "Mid_East_station" },
-                ],
-                "operational_points_distances": [10000],
-                "use_simulation": true,
-            }))
-            .by_user(&user.info)
-            .await
-            .assert_status_forbidden();
+        let project = async |use_simulation: bool| -> serde_json::Value {
+            app.post("/train_schedules/project_path_op")
+                .json(&json!({
+                    "infra_id": small_infra.id,
+                    "timetable_id": timetable.id,
+                    "electrical_profile_set_id": null,
+                    "train_ids": vec![paced_train.id],
+                    "operational_points_refs": [
+                        { "type": "domestic", "country_code": "FR", "main_code": "MWS", "secondary_code": "BV" },
+                        { "type": "id", "operational_point": "Mid_East_station" },
+                    ],
+                    "operational_points_distances": [10000],
+                    "use_simulation": use_simulation,
+                }))
+                .by_user(&user.info)
+                .await
+                .assert_status_ok()
+                .json()
+        };
+
+        // The train is projected as if no simulation had been requested
+        assert_eq!(project(true).await, project(false).await);
     }
 
     /// Without a simulation, no rolling stock is involved: projecting a train whose rolling stock
@@ -4150,6 +4259,187 @@ mod tests {
             .json();
 
         assert!(response.contains_key(&paced_train.id));
+    }
+
+    /// Trains whose rolling stock the user cannot read don't prevent the other trains of the
+    /// request from being simulated
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_path_with_partial_rolling_stock_permission() {
+        let app = test_app!()
+            .core_client(mocked_core_pathfinding_sim_and_proj().into())
+            .build();
+        let db_pool = app.db_pool();
+
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let readable_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "readable_rolling_stock").await;
+        let unreadable_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unreadable_rolling_stock").await;
+        let readable_train = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("readable".into())
+            .rolling_stock_name(readable_rolling_stock.name.clone())
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+        let unreadable_train = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("unreadable".into())
+            .rolling_stock_name(unreadable_rolling_stock.name.clone())
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+
+        // a user that can read the infra and only one of the two rolling stocks
+        let user = app
+            .user("partially-authorized", "Partially authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+        // a user that can read both rolling stocks: both trains are simulated
+        let authorized_user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(
+                unreadable_rolling_stock.id,
+                authz::RollingStockGrant::Reader,
+            )
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        let project = async |user: &authz::identity::UserInfo| -> HashMap<i64, ProjectPathTrainScheduleResult> {
+            app.post("/train_schedules/project_path")
+                .json(&json!({
+                    "infra_id": small_infra.id,
+                    "timetable_id": timetable.id,
+                    "electrical_profile_set_id": null,
+                    "ids": vec![readable_train.id, unreadable_train.id],
+                    "track_section_ranges": [
+                        {
+                            "track_section": "TA1",
+                            "begin": 0,
+                            "end": 100,
+                            "direction": "START_TO_STOP"
+                        }
+                    ],
+                }))
+                .by_user(user)
+                .await
+                .assert_status_ok()
+                .json()
+        };
+
+        let response = project(&user.info).await;
+        let simulated = project(&authorized_user.info).await;
+
+        // The unreadable train isn't simulated: its projection is empty
+        assert!(response[&unreadable_train.id].train_schedule.is_empty());
+        // The readable train is simulated all the same
+        assert_eq!(
+            serde_json::to_value(&response[&readable_train.id]).unwrap(),
+            serde_json::to_value(&simulated[&readable_train.id]).unwrap(),
+            "the readable train should be simulated"
+        );
+        // Otherwise the assertion above holds no matter how the projections are assembled
+        assert!(!simulated[&unreadable_train.id].train_schedule.is_empty());
+    }
+
+    /// Trains whose rolling stock the user cannot read don't prevent the other trains of the
+    /// request from being simulated
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_path_op_with_partial_rolling_stock_permission() {
+        let app = test_app!()
+            .core_client(mocked_core_pathfinding_sim_and_proj().into())
+            .build();
+        let db_pool = app.db_pool();
+
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let readable_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "readable_rolling_stock").await;
+        let unreadable_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "unreadable_rolling_stock").await;
+        let readable_train = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("readable".into())
+            .rolling_stock_name(readable_rolling_stock.name.clone())
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+        let unreadable_train = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("unreadable".into())
+            .rolling_stock_name(unreadable_rolling_stock.name.clone())
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+
+        // a user that can read the infra and only one of the two rolling stocks
+        let user = app
+            .user("partially-authorized", "Partially authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+        // a user that can read both rolling stocks: both trains are simulated
+        let authorized_user = app
+            .user("authorized", "Authorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(
+                unreadable_rolling_stock.id,
+                authz::RollingStockGrant::Reader,
+            )
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        let project = async |user: &authz::identity::UserInfo,
+                             use_simulation: bool|
+               -> serde_json::Value {
+            app.post("/train_schedules/project_path_op")
+                .json(&json!({
+                    "infra_id": small_infra.id,
+                    "timetable_id": timetable.id,
+                    "electrical_profile_set_id": null,
+                    "train_ids": vec![readable_train.id, unreadable_train.id],
+                    "operational_points_refs": [
+                        { "type": "domestic", "country_code": "FR", "main_code": "MWS", "secondary_code": "BV" },
+                        { "type": "id", "operational_point": "Mid_East_station" },
+                    ],
+                    "operational_points_distances": [10000],
+                    "use_simulation": use_simulation,
+                }))
+                .by_user(user)
+                .await
+                .assert_status_ok()
+                .json()
+        };
+
+        let response = project(&user.info, true).await;
+        let simulated = project(&authorized_user.info, true).await;
+        let unsimulated = project(&user.info, false).await;
+        let readable_train_id = readable_train.id.to_string();
+        let unreadable_train_id = unreadable_train.id.to_string();
+
+        // The readable train is simulated, the other one is projected without simulation
+        assert_eq!(
+            response[&readable_train_id], simulated[&readable_train_id],
+            "the readable train should be simulated"
+        );
+        assert_eq!(
+            response[&unreadable_train_id], unsimulated[&unreadable_train_id],
+            "the unreadable train should be projected without simulation"
+        );
+        // Otherwise the assertions above hold no matter how the projections are assembled
+        assert_ne!(
+            simulated[&unreadable_train_id],
+            unsimulated[&unreadable_train_id]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1209,6 +1209,17 @@ pub(in crate::views) async fn project_path(
         })
         .collect();
 
+    // Check user privilege on the rolling stocks of the occurrences: they are all simulated
+    crate::authorizers::require_readable_rolling_stocks(
+        simulation_contexts
+            .iter()
+            .map(|context| context.train_schedule.rolling_stock_name.clone()),
+        conn,
+        &authn_state,
+        &openfga,
+    )
+    .await?;
+
     let project_path_result = compute_projected_train_paths(
         conn,
         core_client,
@@ -3849,9 +3860,11 @@ mod tests {
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let (timetable, train_schedule_set) =
             create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
-        let _ = create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
         let paced_train_valid =
             create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &paced_train_valid.rolling_stock_name)
+                .await;
         let paced_train_fail = simple_paced_train_changeset(train_schedule_set.id)
             .rolling_stock_name("fail".to_string())
             .start_time(millisecond::i64::new(0))
@@ -3868,6 +3881,7 @@ mod tests {
         let user = app
             .user("authorized", "Authorized")
             .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -3895,6 +3909,51 @@ mod tests {
         // EXPECT
         // TODO: improve this test
         assert_eq!(response.len(), 2);
+    }
+
+    /// Projecting a train whose rolling stock the user cannot read is forbidden
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_path_without_rolling_stock_permission() {
+        // SETUP
+        let app = test_app!()
+            .core_client(mocked_core_pathfinding_sim_and_proj().into())
+            .build();
+        let db_pool = app.db_pool();
+
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut db_pool.get_ok()).await;
+        let paced_train =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        create_fast_rolling_stock(&mut db_pool.get_ok(), &paced_train.rolling_stock_name).await;
+
+        // a user that can read the infra, but not the rolling stock of the train
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // TEST
+        app.post("/train_schedules/project_path")
+            .json(&json!({
+                "infra_id": small_infra.id,
+                "timetable_id": timetable.id,
+                "electrical_profile_set_id": null,
+                "ids": vec![paced_train.id],
+                "track_section_ranges": [
+                    {
+                        "track_section": "TA1",
+                        "begin": 0,
+                        "end": 100,
+                        "direction": "START_TO_STOP"
+                    }
+                ],
+            }))
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
     }
 
     /// With a simulation, projecting a train whose rolling stock the user cannot read is forbidden

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -770,16 +770,11 @@ pub(in crate::views) async fn simulation(
     };
 
     let rolling_stock_name = train_schedule.rolling_stock_name().to_owned();
-    let Some(rolling_stock) =
-        RollingStock::retrieve(db_pool.get().await?, rolling_stock_name.clone()).await?
-    else {
-        return Ok(Json(simulation::Response::PathfindingFailed {
-            pathfinding_failed: PathfindingFailure::PathfindingInputError(
-                PathfindingInputError::RollingStockNotFound { rolling_stock_name },
-            ),
-        }));
+    let rolling_stock =
+        RollingStock::retrieve(db_pool.get().await?, rolling_stock_name.clone()).await?;
+    let Some(rolling_stock) = rolling_stock else {
+        return Err(TrainScheduleError::RollingStockNotFound { rolling_stock_name }.into());
     };
-
     // Check user privilege on infra and rolling stock
     // Done here because we need to retrieve the exception if it exists.
     if let Some(user) = authn_state.regular_user() {
@@ -810,6 +805,7 @@ pub(in crate::views) async fn simulation(
             Err(err) => return Err(err.into()),
         }
     }
+
     let consist = PhysicsConsistParameters::from_traction_engine(rolling_stock.into());
 
     let path_item_locations = train_schedule.locations();

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1902,17 +1902,33 @@ pub(in crate::views) async fn track_occupancy(
 
     // Check user privilege on the rolling stocks of the occurrences.
     // Without a simulation, no rolling stock is involved: the check is skipped.
-    if use_simulation {
-        crate::authorizers::require_readable_rolling_stocks(
-            trains
-                .iter()
-                .map(|occurrence| occurrence.rolling_stock_name.clone()),
-            conn,
+    let readable_occurrence_ids = if use_simulation {
+        let occurrences_by_rolling_stock = train_ids
+            .iter()
+            .cloned()
+            .zip(trains.iter().cloned())
+            .map(|(id, occurrence)| (occurrence.rolling_stock_name.clone(), (id, occurrence)))
+            .into_group_map();
+
+        let rolling_stock_names = occurrences_by_rolling_stock.keys().cloned().collect_vec();
+        let rolling_stocks: Vec<RollingStock> =
+            RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stock_names)
+                .await
+                .map_err(RollingStockError::from)?;
+
+        filter_readable_occurrences(
+            occurrences_by_rolling_stock,
+            &rolling_stocks,
             &authn_state,
             &openfga,
         )
-        .await?;
-    }
+        .await?
+        .into_iter()
+        .map(|(occurrence_id, _)| occurrence_id)
+        .collect::<HashSet<_>>()
+    } else {
+        train_ids.iter().cloned().collect()
+    };
 
     let op_location =
         PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
@@ -1935,6 +1951,15 @@ pub(in crate::views) async fn track_occupancy(
     let occupancies = match operational_point {
         Some(operational_point) => {
             if use_simulation {
+                // Occurrences whose rolling stock the user cannot read are not simulated: like
+                // invalid trains, their occupancy is computed from their schedule only
+                let (readable, unreadable): (Vec<_>, Vec<_>) = izip!(train_ids, trains)
+                    .partition(|(train_id, _)| readable_occurrence_ids.contains(train_id));
+                let (readable_ids, readable_trains): (Vec<_>, Vec<_>) =
+                    readable.into_iter().unzip();
+                let (unreadable_ids, unreadable_trains): (Vec<_>, Vec<_>) =
+                    unreadable.into_iter().unzip();
+
                 let simulation_params = TrackOccupancySimulationParams {
                     conn,
                     valkey_client,
@@ -1943,14 +1968,24 @@ pub(in crate::views) async fn track_occupancy(
                     electrical_profile_set_id,
                     app_version: config.app_version.as_deref(),
                 };
-                find_track_occupancy_for_known_operational_point_with_simulation(
-                    train_ids,
-                    trains,
-                    &op_cache,
-                    operational_point,
-                    simulation_params,
-                )
-                .await?
+                let mut occupancies =
+                    find_track_occupancy_for_known_operational_point_with_simulation(
+                        readable_ids,
+                        readable_trains,
+                        &op_cache,
+                        operational_point,
+                        simulation_params,
+                    )
+                    .await?;
+                occupancies.extend(
+                    find_track_occupancy_for_known_operational_point_without_simulation(
+                        unreadable_ids,
+                        unreadable_trains,
+                        &op_cache,
+                        operational_point,
+                    ),
+                );
+                occupancies
             } else {
                 find_track_occupancy_for_known_operational_point_without_simulation(
                     train_ids,
@@ -4676,12 +4711,19 @@ mod tests {
         .await
     }
 
-    /// With a simulation, a train whose rolling stock the user cannot read is forbidden
+    /// Even with a simulation, a train whose rolling stock the user cannot read is reported: like
+    /// an invalid train, its occupancy is computed without simulation
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn track_occupancy_without_rolling_stock_permission() {
-        init_track_occupancy_test_without_rolling_stock_permission(true)
-            .await
-            .assert_status_forbidden();
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            init_track_occupancy_test_without_rolling_stock_permission(true)
+                .await
+                .assert_status_ok()
+                .json();
+
+        // The very same result as without a simulation
+        assert_eq!(track_occupancies.len(), 1);
+        assert_eq!(track_occupancies[0].trains.len(), 4);
     }
 
     /// Without a simulation, no rolling stock is involved: the train is reported even though the

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::convert::Infallible;
 use std::iter::Extend as _;
 use std::sync::Arc;
 
@@ -41,7 +42,9 @@ use models::round_trips::TrainScheduleRoundTrips;
 use models::train_schedule::BaseTrainOrOccurrenceId;
 use models::train_schedule::train_schedule_schema_from_model;
 use reqwest::StatusCode;
+use schemas::TrainScheduleExceptionChangeGroups;
 use schemas::infra::OperationalPoint;
+use schemas::paced_train::RollingStockChangeGroup;
 use schemas::paced_train::TrainSchedule;
 use schemas::primitives::NonBlankString;
 use schemas::primitives::TimeWindow;
@@ -1514,7 +1517,7 @@ pub(in crate::views) async fn occupancy_blocks(
         })
         .await?;
 
-    let mut exceptions = models::TrainScheduleException::retrieve_exceptions_by_train_schedules(
+    let exceptions = models::TrainScheduleException::retrieve_exceptions_by_train_schedules(
         conn,
         timetable_id,
         &train_schedules.iter().map(|t| t.id).collect::<Vec<_>>(),
@@ -1523,6 +1526,107 @@ pub(in crate::views) async fn occupancy_blocks(
     .into_iter()
     .map_into::<schemas::TrainScheduleException>()
     .into_group_map_by(|e| e.train_schedule_id);
+
+    // Retrieve the names of the rolling stocks used by the train schedules and exceptions:
+    let rolling_stocks_from_exceptions = exceptions.values().flatten().filter_map(|exception| {
+        if let TrainScheduleExceptionChangeGroups {
+            rolling_stock:
+                Some(RollingStockChangeGroup {
+                    rolling_stock_name, ..
+                }),
+            ..
+        } = &exception.change_groups
+        {
+            Some(rolling_stock_name.clone())
+        } else {
+            None
+        }
+    });
+
+    let rolling_stock_names: HashSet<String> = train_schedules
+        .iter()
+        .map(|train_schedule| train_schedule.rolling_stock_name.clone())
+        .chain(rolling_stocks_from_exceptions)
+        .collect::<HashSet<_>>();
+
+    // The paced trains and exceptions using a missing rolling stock are filtered out afterwards:
+    // 1. We retrieve from the database the rolling stocks used by the request paced trains and
+    //    exceptions.
+    // 2. We filter out unauthorized rolling stocks.
+    // 3. We only keep the paced trains and exceptions which are using an authorized rolling stock.
+    // => The paced trains and exceptions which are associated with a missing rolling stock will be
+    // automatically filtered out in the step `(3)`.
+    let rolling_stocks: Vec<_> = RollingStock::retrieve_batch_unchecked::<HashSet<String>, _>(
+        &mut conn.clone(),
+        rolling_stock_names,
+    )
+    .await?;
+
+    // Filter out unauthorized rolling stocks:
+    let authorized_rolling_stocks: HashSet<String> = match &authn_state {
+        crate::authentication::State::Skip => {
+            // The services should not be calling this endpoint
+            Err(AuthorizationError::Unauthenticated)?
+        }
+        crate::authentication::State::Authenticated { user, .. } => {
+            let system_authorizer = SystemAuthorizer::new_infallible(&openfga);
+            let protected_authorized_rs = rolling_stocks.into_iter().map(|rolling_stock| {
+                authz::v2::rolling_stock_privileges(*user, authz::RollingStock(rolling_stock.id))
+                    .map(async move |grants| {
+                        grants
+                            .contains(&RollingStockPrivilege::CanRead)
+                            .then_some(rolling_stock.name.clone())
+                    })
+            });
+            let accesses = system_authorizer
+                .authorize_all(protected_authorized_rs)
+                .await?;
+            let Ok(authorized_rs) = authz::v2::Access::access_all(accesses)
+                .await?
+                .into_iter()
+                .collect::<Result<Vec<_>, Infallible>>();
+            authorized_rs.into_iter().flatten().collect::<HashSet<_>>()
+        }
+    };
+
+    // Filter out the train schedules and exceptions which are using unauthorized rolling stocks:
+    let train_schedules = train_schedules
+        .into_iter()
+        .filter(|train_schedule| {
+            authorized_rolling_stocks.contains(train_schedule.rolling_stock_name.as_str())
+        })
+        .collect_vec();
+    let mut exceptions: HashMap<i64, Vec<schemas::TrainScheduleException>> = exceptions
+        .into_iter()
+        .filter(|(train_schedule, _exceptions)| {
+            // Filter out the exceptions related to unauthorized train schedules:
+            train_schedules
+                .iter()
+                .map(|train| train.id)
+                .contains(train_schedule)
+        })
+        .map(|(train_schedule, exceptions)| {
+            let filtered_exceptions = exceptions
+                .into_iter()
+                .filter(|exception| {
+                    // Filter out exceptions updating the rolling stock to an unauthorized one:
+                    if let TrainScheduleExceptionChangeGroups {
+                        rolling_stock:
+                            Some(RollingStockChangeGroup {
+                                rolling_stock_name, ..
+                            }),
+                        ..
+                    } = &exception.change_groups
+                    {
+                        authorized_rolling_stocks.contains(rolling_stock_name)
+                    } else {
+                        true
+                    }
+                })
+                .collect_vec();
+            (train_schedule, filtered_exceptions)
+        })
+        .collect();
 
     let simulation_contexts: Vec<SimulationContext> = train_schedules
         .iter()
@@ -1550,6 +1654,11 @@ pub(in crate::views) async fn occupancy_blocks(
         .iter()
         .map(|c| c.train_schedule.clone())
         .collect::<Vec<_>>();
+
+    // TODO: core-task should be able to handle this case on its own
+    if train_schedules.is_empty() {
+        return Ok(Json(HashMap::new()));
+    }
 
     let occupancy_blocks_result = compute_occupancy_blocks(
         conn,
@@ -4048,14 +4157,15 @@ mod tests {
         let SimulationTestsSetup {
             app,
             infra_id,
+            rolling_stock_id,
             timetable,
             train_schedule,
             exception,
-            ..
         } = simulation_tests_initial_setup().await;
         let user = app
             .user("authorized", "authorized")
             .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock_id, RollingStockGrant::Reader)
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -4097,22 +4207,23 @@ mod tests {
         )
         .await;
 
+        let json_payload = &json!({"ids": vec![train_schedule.id],
+            "infra_id": infra_id,
+            "timetable_id": timetable.id,
+            "path": {
+                "track_section_ranges": [{
+                    "track_section": "T1",
+                    "begin": 0,
+                    "end": 100,
+                    "direction": "START_TO_STOP",
+                }],
+                "routes": [],
+                "blocks":[],
+            },
+        });
         let response = app
             .post("/train_schedules/occupancy_blocks")
-            .json(&json!({"ids": vec![train_schedule.id],
-                "infra_id": infra_id,
-                "timetable_id": timetable.id,
-                "path": {
-                    "track_section_ranges": [{
-                        "track_section": "T1",
-                        "begin": 0,
-                        "end": 100,
-                        "direction": "START_TO_STOP",
-                    }],
-                    "routes": [],
-                    "blocks":[],
-                },
-            }))
+            .json(&json_payload)
             .by_user(&user.info)
             .await;
         let response: HashMap<i64, OccupancyBlocksTrainScheduleResult> =
@@ -4131,6 +4242,22 @@ mod tests {
             response.get(&train_schedule.id).unwrap().exceptions.len(),
             0
         );
+
+        // User without rolling stock reader rights should have a filtered out response:
+        let user_missing_rs_grant = app
+            .user("bob", "Bob")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+        let response_unauthorized: HashMap<i64, OccupancyBlocksTrainScheduleResult> = app
+            .post("/train_schedules/occupancy_blocks")
+            .json(&json_payload)
+            .by_user(&user_missing_rs_grant.info)
+            .await
+            .assert_status_ok()
+            .json();
+        assert!(response_unauthorized.is_empty());
     }
 
     fn pathfinding_result_success() -> PathfindingResultSuccess {

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -764,12 +764,20 @@ pub(in crate::views) async fn simulation(
     })
     .await?;
 
-    v2::infra_privilege_check(
-        authz::Infra(infra_id),
-        authz::InfraPrivilege::CanRestrictedRead,
-    )
-    .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        let authorizer = authn_state.authorizer(&openfga);
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authorizer)
+            .await??;
+        v2::infra_privilege_check(
+            authz::Infra(infra_id),
+            authz::InfraPrivilege::CanRestrictedRead,
+        )
+        .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
+        .await?;
+    }
 
     // Retrieve train_schedule or fail
     let train_schedule =
@@ -1958,6 +1966,7 @@ mod tests {
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt;
 
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::simulation;
@@ -2281,7 +2290,6 @@ mod tests {
 
         let core = mocked_core_pathfinding_sim_and_proj();
         let app = test_app!()
-            .skip_authz()
             .db_pool(db_pool)
             .core_client(core.into())
             .build();
@@ -2302,6 +2310,12 @@ mod tests {
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: core_client::simulation::Response = app
             .get(
                 format!(
@@ -2310,6 +2324,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -2328,6 +2343,12 @@ mod tests {
             train_schedule,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: InternalError = app
             .get(
                 format!(
@@ -2336,6 +2357,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_not_found()
             .json();
@@ -2355,6 +2377,12 @@ mod tests {
             exception,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: simulation::Response = app
             .get(
                 format!(
@@ -2363,6 +2391,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -2419,6 +2448,12 @@ mod tests {
             exception,
             ..
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
 
         let mut change_group = exception.change_groups;
         change_group.rolling_stock = Some(RollingStockChangeGroup {
@@ -2441,6 +2476,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -2461,13 +2497,79 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn paced_train_simulation_not_found() {
         let SimulationTestsSetup { app, infra_id, .. } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: InternalError = app
             .get(format!("/train_schedules/{}/simulation/?infra_id={}", 0, infra_id).as_str())
+            .by_user(&user.info)
             .await
             .assert_status_not_found()
             .json();
 
         assert_eq!(&response.error_type, "editoast:train_schedule:NotFound")
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_with_privilege_and_no_roles() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        // a user that does not have the role to reach the endpoint but has a read grant on the infra
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .create()
+            .await;
+
+        // WHEN / THEN
+        app.get(
+            format!(
+                "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                train_schedule.id
+            )
+            .as_str(),
+        )
+        .by_user(&user.info)
+        .await
+        .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn paced_train_simulation_without_permission() {
+        // GIVEN
+        let SimulationTestsSetup {
+            app,
+            infra_id,
+            train_schedule,
+            ..
+        } = simulation_tests_initial_setup().await;
+
+        // a user that has the role to reach the endpoint but no read grant on the infra
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        // WHEN / THEN
+        app.get(
+            format!(
+                "/train_schedules/{}/simulation/?infra_id={infra_id}",
+                train_schedule.id
+            )
+            .as_str(),
+        )
+        .by_user(&user.info)
+        .await
+        .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -2741,6 +2843,12 @@ mod tests {
     async fn paced_train_simulation_summary_not_found() {
         let SimulationTestsSetup { app, infra_id, .. } = simulation_tests_initial_setup().await;
         let timetable = create_timetable(&mut app.db_pool().get_ok()).await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let response: InternalError = app
             .post("/train_schedules/simulation_summary")
             .json(&json!({
@@ -2748,6 +2856,7 @@ mod tests {
                 "timetable_id": timetable.id,
                 "ids": vec![0],
             }))
+            .by_user(&user.info)
             .await
             .assert_status_not_found()
             .json();
@@ -3151,6 +3260,12 @@ mod tests {
             train_schedule,
             exception,
         } = simulation_tests_initial_setup().await;
+        let user = app
+            .user("authorized", "authorized")
+            .with_infra_grant(infra_id, authz::InfraGrant::Reader)
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
         let db_pool = app.db_pool();
 
         // First remove all already generated exceptions
@@ -3205,6 +3320,7 @@ mod tests {
                     "blocks":[],
                 },
             }))
+            .by_user(&user.info)
             .await;
         let response: HashMap<i64, OccupancyBlocksTrainScheduleResult> =
             response.assert_status_ok().json();

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -235,6 +235,7 @@
         "pathfinding_not_found": "Pathfinding not found",
         "rolling_stock_not_found": "RS not found",
         "simulation_failed": "Simulation failed",
+        "unauthorized_rolling_stock": "Unauthorized Rolling Stock",
         "zero_length_path": "Departure and arrival are identical"
       },
       "invalidTrains": "Some trains are invalid",
@@ -490,6 +491,7 @@
       "not_found_in_tracks": "Missing track",
       "pathfinding_failure": "No path found",
       "rolling_stock_not_found": "Rolling stock not found",
+      "unauthorized_rolling_stock": "You are not authorized to use this rolling stock",
       "zero_length_path": "Departure and arrival are identical"
     },
     "pathfindingInProgress": "Pathfinding in progress…",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -235,7 +235,7 @@
         "pathfinding_not_found": "Pathfinding not found",
         "rolling_stock_not_found": "RS not found",
         "simulation_failed": "Simulation failed",
-        "unauthorized_rolling_stock": "Unauthorized Rolling Stock",
+        "unauthorized_rolling_stock": "Unauthorized RS",
         "zero_length_path": "Departure and arrival are identical"
       },
       "invalidTrains": "Some trains are invalid",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -235,6 +235,7 @@
         "pathfinding_not_found": "Pathfinding not found",
         "rolling_stock_not_found": "RS not found",
         "simulation_failed": "Simulation failed",
+        "unauthorized_rolling_stock": "Unauthorized Rolling Stock",
         "zero_length_path": "Departure and arrival are identical"
       },
       "invalidTrains": "Some trains are invalid",
@@ -495,6 +496,7 @@
       "not_found_in_tracks": "Missing track",
       "pathfinding_failure": "No path found",
       "rolling_stock_not_found": "Rolling stock not found",
+      "unauthorized_rolling_stock": "You are not authorized to use this rolling stock",
       "zero_length_path": "Departure and arrival are identical"
     },
     "pathfindingInProgress": "Pathfinding in progress…",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -235,7 +235,7 @@
         "pathfinding_not_found": "Chemin introuvable",
         "rolling_stock_not_found": "MR non trouvé",
         "simulation_failed": "Simulation impossible",
-        "unauthorized_rolling_stock": "Matériel roulant non autorisé",
+        "unauthorized_rolling_stock": "MR interdit",
         "zero_length_path": "L'origine et la destination sont identiques"
       },
       "invalidTrains": "Certains trains sont invalides",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -235,6 +235,7 @@
         "pathfinding_not_found": "Chemin introuvable",
         "rolling_stock_not_found": "MR non trouvé",
         "simulation_failed": "Simulation impossible",
+        "unauthorized_rolling_stock": "Matériel roulant non autorisé",
         "zero_length_path": "L'origine et la destination sont identiques"
       },
       "invalidTrains": "Certains trains sont invalides",
@@ -490,6 +491,7 @@
       "not_found_in_tracks": "Voie manquante",
       "pathfinding_failure": "Aucun chemin trouvé",
       "rolling_stock_not_found": "Matériel roulant non trouvé",
+      "unauthorized_rolling_stock": "Vous n'êtes pas autorisé à utiliser ce matériel roulant",
       "zero_length_path": "L'origine et la destination sont identiques"
     },
     "pathfindingInProgress": "Recherche d’itinéraire en cours…",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -235,6 +235,7 @@
         "pathfinding_not_found": "Chemin introuvable",
         "rolling_stock_not_found": "MR non trouvé",
         "simulation_failed": "Simulation impossible",
+        "unauthorized_rolling_stock": "Matériel roulant non autorisé",
         "zero_length_path": "L'origine et la destination sont identiques"
       },
       "invalidTrains": "Certains trains sont invalides",
@@ -495,6 +496,7 @@
       "not_found_in_tracks": "Voie manquante",
       "pathfinding_failure": "Aucun chemin trouvé",
       "rolling_stock_not_found": "Matériel roulant non trouvé",
+      "unauthorized_rolling_stock": "Vous n'êtes pas autorisé à utiliser ce matériel roulant",
       "zero_length_path": "L'origine et la destination sont identiques"
     },
     "pathfindingInProgress": "Recherche d’itinéraire en cours…",

--- a/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
+++ b/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
@@ -5,6 +5,8 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import { useTranslation } from 'react-i18next';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import GrantsManager from 'common/authorization/components/GrantsManager';
+import useAuthz from 'common/authorization/hooks/useAuthz';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { ModalProvider } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { LoaderFill } from 'common/Loaders';
@@ -40,6 +42,9 @@ const RollingStockEditor = () => {
     return undefined;
   }, [pageMode]);
 
+  const { checkUserRole } = useAuthz();
+  const hasOperationalStudiesRole = checkUserRole(['OperationalStudies']);
+
   const [postRollingstock] = osrdEditoastApi.endpoints.postRollingStock.useMutation();
 
   const { data: selectedRollingStock, isFetching: isSelectedRollingStockLoading } =
@@ -57,8 +62,9 @@ const RollingStockEditor = () => {
     searchRollingStock,
     toggleFilter,
     selectCategoryFilter,
-    searchIsLoading,
+    isLoading,
     resetFilters,
+    userPrivilegesByRollingStockId,
   } = useFilterRollingStock();
 
   // depending on the current key of ref2scroll, scroll to the selected rolling stock card when it is opened with scrollIntoView()
@@ -133,12 +139,14 @@ const RollingStockEditor = () => {
     );
   }, [openModal, setPageMode]);
 
+  const isRollingStockReady = userPrivilegesByRollingStockId.type === 'ready';
+
   return (
     <>
       <NavBar appName={<>{t('applications.rolling-stocks-editor')}</>} />
       <div className="d-flex rollingstock-editor">
         {/*  Aside */}
-        <div className="d-flex ml-4 flex-column rollingstock-editor-left-container">
+        <div className="rollingstock-editor-left-container">
           {/* Overlay to disable the list while editing */}
           {(pageMode.type === 'create' || pageMode.type === 'edit') && (
             <div
@@ -151,26 +159,28 @@ const RollingStockEditor = () => {
             </div>
           )}
 
-          <div className="d-flex items-center mb-4 w-100 rollingstock-editor-actions">
-            <button
-              type="button"
-              className="btn btn-primary"
-              data-testid="new-rollingstock-button"
-              onClick={() => setPageMode({ type: 'create' })}
-            >
-              {t('rollingStock.addNewRollingStock')}
-            </button>
-            <button
-              type="button"
-              className="d-flex justify-content-start mb-2 py-1 px-2"
-              aria-label={t('rollingStock.importRollingStock')}
-              title={t('rollingStock.importRollingStock')}
-              onClick={openUploadFileModal}
-            >
-              <Upload className="mr-2" />
-              {t('rollingStock.importRollingStock')}
-            </button>
-          </div>
+          {hasOperationalStudiesRole && (
+            <div className="d-flex items-center mb-4 w-100 rollingstock-editor-actions">
+              <button
+                type="button"
+                className="btn btn-primary"
+                data-testid="new-rollingstock-button"
+                onClick={() => setPageMode({ type: 'create' })}
+              >
+                {t('rollingStock.addNewRollingStock')}
+              </button>
+              <button
+                type="button"
+                className="d-flex justify-content-start mb-2 py-1 px-2"
+                aria-label={t('rollingStock.importRollingStock')}
+                title={t('rollingStock.importRollingStock')}
+                onClick={openUploadFileModal}
+              >
+                <Upload className="mr-2" />
+                {t('rollingStock.importRollingStock')}
+              </button>
+            </div>
+          )}
 
           <SearchRollingStock
             filteredRollingStockList={filteredRollingStockList}
@@ -180,19 +190,23 @@ const RollingStockEditor = () => {
             selectCategoryFilter={selectCategoryFilter}
             hasWhiteBackground
           />
+
           <RollingStockEditorList
-            isLoading={searchIsLoading}
+            isLoading={isLoading}
             pageMode={pageMode}
             setPageMode={setPageMode}
             resetFilters={resetFilters}
             data={filteredRollingStockList}
             selectedRollingStock={selectedRollingStock}
             ref2scroll={ref2scroll}
+            userPrivilegesByRollingStockId={
+              isRollingStockReady ? userPrivilegesByRollingStockId.data : {}
+            }
           />
         </div>
 
         {/* Main  */}
-        <div className="d-flex flex-column pl-0 rollingstock-editor-form-container mb-3">
+        <div className="rollingstock-editor-main-container">
           {/* Create */}
           {pageMode.type === 'create' && <RollingStockEditorForm setPageMode={setPageMode} />}
           {/* Edit */}
@@ -212,18 +226,27 @@ const RollingStockEditor = () => {
             <>
               {isSelectedRollingStockLoading && <LoaderFill />}
               {selectedRollingStock && (
-                <RollingStockInformationPanel
-                  id={pageMode.rollingStockId}
-                  rollingStock={selectedRollingStock}
-                />
+                <div className={'rollingstock-editor-form'}>
+                  <RollingStockInformationPanel
+                    id={pageMode.rollingStockId}
+                    rollingStock={selectedRollingStock}
+                  />
+                  <GrantsManager
+                    resourceId={selectedRollingStock.id}
+                    resourceType="rolling_stock"
+                    userPrivileges={
+                      isRollingStockReady
+                        ? userPrivilegesByRollingStockId.data[selectedRollingStock.id]
+                        : undefined
+                    }
+                  />
+                </div>
               )}
             </>
           )}
           {/* Empty placeholder */}
           {pageMode.type === 'idle' && (
-            <p className="rollingstock-editor-unselected pt-1 px-5">
-              {t('rollingStock.chooseRollingStock')}
-            </p>
+            <p className="rollingstock-editor-unselected">{t('rollingStock.chooseRollingStock')}</p>
           )}
         </div>
       </div>

--- a/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
+++ b/front/src/applications/rollingStockEditor/RollingStockEditorView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Upload } from '@osrd-project/ui-icons';
 import { skipToken } from '@reduxjs/toolkit/query';
@@ -7,10 +7,9 @@ import { useTranslation } from 'react-i18next';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { ModalProvider } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
-import { Loader } from 'common/Loaders/Loader';
+import { LoaderFill } from 'common/Loaders';
 import NavBar from 'common/NavBar';
 import UploadFileModal from 'common/uploadFileModal';
-import { RollingStockCard } from 'modules/rollingStock/components/RollingStockCard';
 import { SearchRollingStock } from 'modules/rollingStock/components/RollingStockSelector';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 import { setFailure, setSuccess } from 'reducers/main';
@@ -19,27 +18,35 @@ import { castErrorToFailure } from 'utils/error';
 
 import {
   RollingStockEditorForm,
-  RollingStockEditorButtons,
   RollingStockEditorFormModal,
   RollingStockInformationPanel,
 } from './components';
+import { RollingStockEditorList } from './components/RollingStockEditorList';
+
+export type PageMode =
+  | { type: 'idle' }
+  | { type: 'create' }
+  | { type: 'view'; rollingStockId: number }
+  | { type: 'edit'; rollingStockId: number };
 
 const RollingStockEditor = () => {
   const { t } = useTranslation();
   const ref2scroll = useRef<HTMLInputElement>(null);
-  const [isEditing, setIsEditing] = useState(false);
-  const [isAdding, setIsAdding] = useState(false);
   const { openModal, closeModal } = useModal();
   const dispatch = useAppDispatch();
+  const [pageMode, setPageMode] = useState<PageMode>({ type: 'idle' });
+  const selectedRollingStockId = useMemo(() => {
+    if (pageMode.type === 'view' || pageMode.type === 'edit') return pageMode.rollingStockId;
+    return undefined;
+  }, [pageMode]);
 
-  const [openedRollingStockCardId, setOpenedRollingStockCardId] = useState<number>();
   const [postRollingstock] = osrdEditoastApi.endpoints.postRollingStock.useMutation();
 
-  const { data: selectedRollingStock } =
+  const { data: selectedRollingStock, isFetching: isSelectedRollingStockLoading } =
     osrdEditoastApi.endpoints.getRollingStockByRollingStockId.useQuery(
-      openedRollingStockCardId
+      pageMode.type === 'view' || pageMode.type === 'edit'
         ? {
-            rollingStockId: openedRollingStockCardId,
+            rollingStockId: pageMode.rollingStockId,
           }
         : skipToken
     );
@@ -54,81 +61,10 @@ const RollingStockEditor = () => {
     resetFilters,
   } = useFilterRollingStock();
 
-  const rollingStocksList = (
-    <div className="rollingstock-editor-list pr-1" data-testid="rollingstock-editor-list">
-      {filteredRollingStockList.map((data) => (
-        <div key={data.id}>
-          <div className="rolling-stock-card-container">
-            <div
-              role="button"
-              tabIndex={-1}
-              className="d-flex align-self-start rollingstock-elements w-100 rollingstock-editor-list-cards"
-              aria-label={t('rollingStock.selectRollingStock')}
-              onClick={() => {
-                setIsEditing(false);
-                setIsAdding(false);
-              }}
-            >
-              <RollingStockCard
-                isOnEditMode
-                rollingStock={data}
-                noCardSelected={openedRollingStockCardId === undefined}
-                isOpen={data.id === openedRollingStockCardId}
-                setOpenedRollingStockCardId={setOpenedRollingStockCardId}
-                ref2scroll={openedRollingStockCardId === data.id ? ref2scroll : undefined}
-              />
-            </div>
-            {data.id === openedRollingStockCardId && selectedRollingStock && (
-              <RollingStockEditorButtons
-                setOpenedRollingStockCardId={setOpenedRollingStockCardId}
-                isCondensed
-                rollingStock={selectedRollingStock}
-                setIsEditing={setIsEditing}
-                resetFilters={resetFilters}
-                isRollingStockLocked={selectedRollingStock.locked}
-              />
-            )}
-          </div>
-          {openedRollingStockCardId === data.id && (
-            <div className="d-flex flex-column pl-0 rollingstock-editor-form-container mb-3">
-              {selectedRollingStock &&
-                (isEditing ? (
-                  <RollingStockEditorForm
-                    rollingStockData={selectedRollingStock}
-                    setAddOrEditState={setIsEditing}
-                  />
-                ) : (
-                  <RollingStockInformationPanel
-                    id={openedRollingStockCardId}
-                    isEditing={isEditing}
-                    rollingStock={selectedRollingStock}
-                  />
-                ))}
-            </div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-
-  function displayList() {
-    if (searchIsLoading) {
-      return <Loader msg={t('rollingStock.waitingLoader')} />;
-    }
-    if (filteredRollingStockList.length === 0) {
-      return (
-        <div data-testid="rollingstock-empty-result" className="rollingstock-empty">
-          {t('rollingStock.resultFound', { count: 0 })}
-        </div>
-      );
-    }
-    return rollingStocksList;
-  }
-
   // depending on the current key of ref2scroll, scroll to the selected rolling stock card when it is opened with scrollIntoView()
   // scrollBy() is used to ensure that the card will be found even if the list is too long
   useEffect(() => {
-    if (openedRollingStockCardId !== undefined) {
+    if (selectedRollingStockId !== undefined) {
       setTimeout(() => {
         ref2scroll.current?.scrollIntoView({
           behavior: 'smooth',
@@ -136,45 +72,48 @@ const RollingStockEditor = () => {
         window.scrollBy(0, -500);
       }, 1000);
     }
-  }, [ref2scroll.current]);
+  }, [ref2scroll.current, isLoading]);
 
-  const importFile = async (file: File) => {
-    closeModal();
-    const failure = (error: unknown) => {
-      dispatch(
-        setFailure(
-          castErrorToFailure(error, {
-            name: t('rollingStock.messages.failure'),
-          })
-        )
-      );
-    };
-    try {
-      const fileContent = await file.text();
-      const data = JSON.parse(fileContent);
-      postRollingstock({
-        locked: false,
-        rollingStockForm: data,
-      })
-        .unwrap()
-        .then((res) => {
-          if (setOpenedRollingStockCardId) setOpenedRollingStockCardId(res.id);
-          dispatch(
-            setSuccess({
-              title: t('rollingStock.messages.success'),
-              text: t('rollingStock.messages.rollingStockAdded'),
+  const importFile = useCallback(
+    async (file: File) => {
+      closeModal();
+      const failure = (error: unknown) => {
+        dispatch(
+          setFailure(
+            castErrorToFailure(error, {
+              name: t('rollingStock.messages.failure'),
             })
-          );
+          )
+        );
+      };
+      try {
+        const fileContent = await file.text();
+        const data = JSON.parse(fileContent);
+        postRollingstock({
+          locked: false,
+          rollingStockForm: data,
         })
-        .catch((error) => {
-          console.error('Error posting rolling stock:', error);
-          failure(error);
-        });
-    } catch (error) {
-      console.error('Error reading file:', error);
-      failure(error);
-    }
-  };
+          .unwrap()
+          .then((res) => {
+            setPageMode({ type: 'view', rollingStockId: res.id });
+            dispatch(
+              setSuccess({
+                title: t('rollingStock.messages.success'),
+                text: t('rollingStock.messages.rollingStockAdded'),
+              })
+            );
+          })
+          .catch((error) => {
+            console.error('Error posting rolling stock:', error);
+            failure(error);
+          });
+      } catch (error) {
+        console.error('Error reading file:', error);
+        failure(error);
+      }
+    },
+    [closeModal, dispatch, t]
+  );
 
   const openUploadFileModal = useCallback(() => {
     openModal(<UploadFileModal handleSubmit={importFile} />);
@@ -184,21 +123,24 @@ const RollingStockEditor = () => {
     openModal(
       <RollingStockEditorFormModal
         mainText={t('common.leaveEditionMode')}
-        request={() => {
-          setIsAdding(false);
-          setIsEditing(false);
-        }}
+        onSubmit={() =>
+          setPageMode((prev) =>
+            prev.type === 'edit' ? { ...prev, type: 'view' } : { type: 'idle' }
+          )
+        }
         buttonText={t('common.confirm')}
       />
     );
-  }, [openModal, setIsAdding, setIsEditing]);
+  }, [openModal, setPageMode]);
 
   return (
     <>
       <NavBar appName={<>{t('applications.rolling-stocks-editor')}</>} />
       <div className="d-flex rollingstock-editor">
+        {/*  Aside */}
         <div className="d-flex ml-4 flex-column rollingstock-editor-left-container">
-          {(isEditing || isAdding) && (
+          {/* Overlay to disable the list while editing */}
+          {(pageMode.type === 'create' || pageMode.type === 'edit') && (
             <div
               className="rollingstock-editor-disablelist"
               role="button"
@@ -208,15 +150,13 @@ const RollingStockEditor = () => {
               <span>{t('rollingStock.listDisabled')}</span>
             </div>
           )}
+
           <div className="d-flex items-center mb-4 w-100 rollingstock-editor-actions">
             <button
               type="button"
               className="btn btn-primary"
               data-testid="new-rollingstock-button"
-              onClick={() => {
-                setIsAdding(true);
-                setOpenedRollingStockCardId(undefined);
-              }}
+              onClick={() => setPageMode({ type: 'create' })}
             >
               {t('rollingStock.addNewRollingStock')}
             </button>
@@ -231,15 +171,7 @@ const RollingStockEditor = () => {
               {t('rollingStock.importRollingStock')}
             </button>
           </div>
-          {isAdding && (
-            <div className="d-flex flex-column pl-0 rollingstock-editor-form-container mb-3">
-              <RollingStockEditorForm
-                isAdding={isAdding}
-                setAddOrEditState={setIsAdding}
-                setOpenedRollingStockCardId={setOpenedRollingStockCardId}
-              />
-            </div>
-          )}
+
           <SearchRollingStock
             filteredRollingStockList={filteredRollingStockList}
             filters={filters}
@@ -248,13 +180,52 @@ const RollingStockEditor = () => {
             selectCategoryFilter={selectCategoryFilter}
             hasWhiteBackground
           />
-          {displayList()}
+          <RollingStockEditorList
+            isLoading={searchIsLoading}
+            pageMode={pageMode}
+            setPageMode={setPageMode}
+            resetFilters={resetFilters}
+            data={filteredRollingStockList}
+            selectedRollingStock={selectedRollingStock}
+            ref2scroll={ref2scroll}
+          />
         </div>
-        {!openedRollingStockCardId && !isAdding && (
-          <p className="rollingstock-editor-unselected pt-1 px-5">
-            {t('rollingStock.chooseRollingStock')}
-          </p>
-        )}
+
+        {/* Main  */}
+        <div className="d-flex flex-column pl-0 rollingstock-editor-form-container mb-3">
+          {/* Create */}
+          {pageMode.type === 'create' && <RollingStockEditorForm setPageMode={setPageMode} />}
+          {/* Edit */}
+          {pageMode.type === 'edit' && (
+            <>
+              {selectedRollingStock && (
+                <RollingStockEditorForm
+                  rollingStockData={selectedRollingStock}
+                  setPageMode={setPageMode}
+                />
+              )}
+              {isSelectedRollingStockLoading && <LoaderFill />}
+            </>
+          )}
+          {/* View */}
+          {pageMode.type === 'view' && (
+            <>
+              {isSelectedRollingStockLoading && <LoaderFill />}
+              {selectedRollingStock && (
+                <RollingStockInformationPanel
+                  id={pageMode.rollingStockId}
+                  rollingStock={selectedRollingStock}
+                />
+              )}
+            </>
+          )}
+          {/* Empty placeholder */}
+          {pageMode.type === 'idle' && (
+            <p className="rollingstock-editor-unselected pt-1 px-5">
+              {t('rollingStock.chooseRollingStock')}
+            </p>
+          )}
+        </div>
       </div>
     </>
   );

--- a/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
+++ b/front/src/applications/rollingStockEditor/components/CurveParamSelectors.tsx
@@ -230,7 +230,7 @@ const CurveParamSelectors = ({
     openModal(
       <RollingStockEditorFormModal
         mainText={t(`rollingStock.delete.${title}`)}
-        request={() =>
+        onSubmit={() =>
           title === 'tractionMode' ? removeTractionMode(value) : removeAnotherRsParam(title, value)
         }
         buttonText={t('common.confirm')}

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorButtons.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorButtons.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { Duplicate, Pencil, Trash } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -9,23 +11,20 @@ import { setSuccess, setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure, getErrorStatus } from 'utils/error';
 
+import type { PageMode } from '../RollingStockEditorView';
 import RollingStockEditorFormModal from './RollingStockEditorFormModal';
 
 type RollingStockEditorButtonsProps = {
   rollingStock: RollingStock;
-  setIsEditing: (isEditing: boolean) => void;
   resetFilters: () => void;
-  setOpenedRollingStockCardId: React.Dispatch<React.SetStateAction<number | undefined>>;
-  isRollingStockLocked: boolean;
+  setPageMode: React.Dispatch<React.SetStateAction<PageMode>>;
   isCondensed: boolean;
 };
 
 const RollingStockEditorButtons = ({
   rollingStock,
-  setIsEditing,
   resetFilters,
-  setOpenedRollingStockCardId,
-  isRollingStockLocked,
+  setPageMode,
   isCondensed,
 }: RollingStockEditorButtonsProps) => {
   const dispatch = useAppDispatch();
@@ -35,8 +34,37 @@ const RollingStockEditorButtons = ({
     osrdEditoastApi.endpoints.deleteRollingStockByRollingStockId.useMutation();
   const [postRollingstock] = osrdEditoastApi.endpoints.postRollingStock.useMutation();
 
-  const deleteRollingStock = () => {
-    setOpenedRollingStockCardId(undefined);
+  const editRollingStock = useCallback(() => {
+    setPageMode({ type: 'edit', rollingStockId: rollingStock.id });
+  }, [setPageMode, rollingStock.id]);
+
+  const duplicateRollingStock = () => {
+    const date = new Date().getTime().toString().slice(-3);
+    const duplicatedRollingstock = { ...rollingStock, name: `${rollingStock.name}-${date}` };
+    postRollingstock({
+      locked: false,
+      rollingStockForm: duplicatedRollingstock,
+    })
+      .unwrap()
+      .then((res) => {
+        setPageMode({ type: 'edit', rollingStockId: res.id });
+        resetFilters();
+        dispatch(
+          setSuccess({
+            title: t('rollingStock.messages.success'),
+            text: t('rollingStock.messages.rollingStockAdded'),
+          })
+        );
+      })
+      .catch((error) => {
+        dispatch(
+          setFailure(castErrorToFailure(error, { name: t('rollingStock.messages.failure') }))
+        );
+      });
+  };
+
+  const deleteRollingStock = useCallback(() => {
+    setPageMode({ type: 'idle' });
     if (!rollingStock.locked)
       deleteRollingStockById({ rollingStockId: rollingStock.id })
         .unwrap()
@@ -66,38 +94,12 @@ const RollingStockEditorButtons = ({
             )
           );
         });
-  };
-
-  const duplicateRollingStock = () => {
-    const date = new Date().getTime().toString().slice(-3);
-    const duplicatedRollingstock = { ...rollingStock, name: `${rollingStock.name}-${date}` };
-    postRollingstock({
-      locked: false,
-      rollingStockForm: duplicatedRollingstock,
-    })
-      .unwrap()
-      .then((res) => {
-        setOpenedRollingStockCardId(res.id);
-        setIsEditing(true);
-        resetFilters();
-        dispatch(
-          setSuccess({
-            title: t('rollingStock.messages.success'),
-            text: t('rollingStock.messages.rollingStockAdded'),
-          })
-        );
-      })
-      .catch((error) => {
-        dispatch(
-          setFailure(castErrorToFailure(error, { name: t('rollingStock.messages.failure') }))
-        );
-      });
-  };
+  }, [setPageMode, rollingStock.id, rollingStock.locked]);
 
   const confirmDelete = () => {
     openModal(
       <RollingStockEditorFormModal
-        request={deleteRollingStock}
+        onSubmit={deleteRollingStock}
         mainText={t('rollingStock.deleteRollingStock')}
         buttonText={t('common.yes')}
         deleteAction
@@ -118,11 +120,12 @@ const RollingStockEditorButtons = ({
         aria-label={t('common.edit')}
         title={t('common.edit')}
         tabIndex={0}
-        disabled={isRollingStockLocked}
-        onClick={() => setIsEditing(true)}
+        disabled={rollingStock.locked}
+        onClick={editRollingStock}
       >
         <Pencil />
       </button>
+
       <button
         data-testid="rollingstock-duplicate-button"
         type="button"
@@ -130,10 +133,11 @@ const RollingStockEditorButtons = ({
         aria-label={t('common.duplicate')}
         title={t('common.duplicate')}
         tabIndex={0}
-        onClick={() => duplicateRollingStock()}
+        onClick={duplicateRollingStock}
       >
         <Duplicate />
       </button>
+
       <button
         data-testid="rollingstock-delete-button"
         type="button"
@@ -141,8 +145,8 @@ const RollingStockEditorButtons = ({
         aria-label={t('common.delete')}
         title={t('common.delete')}
         tabIndex={0}
-        disabled={isRollingStockLocked}
-        onClick={() => confirmDelete()}
+        disabled={rollingStock.locked}
+        onClick={confirmDelete}
       >
         <Trash />
       </button>

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorButtons.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorButtons.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from 'react-i18next';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { RollingStock } from 'common/api/osrdEditoastApi';
+import { useCheckProtectedAction } from 'common/authorization/hooks/useProtectedAction';
+import type { Privilege } from 'common/authorization/types';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { setSuccess, setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
@@ -19,6 +21,7 @@ type RollingStockEditorButtonsProps = {
   resetFilters: () => void;
   setPageMode: React.Dispatch<React.SetStateAction<PageMode>>;
   isCondensed: boolean;
+  userPrivileges: Set<Privilege>;
 };
 
 const RollingStockEditorButtons = ({
@@ -26,10 +29,12 @@ const RollingStockEditorButtons = ({
   resetFilters,
   setPageMode,
   isCondensed,
+  userPrivileges,
 }: RollingStockEditorButtonsProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const { openModal } = useModal();
+  const checkProtectedAction = useCheckProtectedAction();
   const [deleteRollingStockById] =
     osrdEditoastApi.endpoints.deleteRollingStockByRollingStockId.useMutation();
   const [postRollingstock] = osrdEditoastApi.endpoints.postRollingStock.useMutation();
@@ -38,63 +43,71 @@ const RollingStockEditorButtons = ({
     setPageMode({ type: 'edit', rollingStockId: rollingStock.id });
   }, [setPageMode, rollingStock.id]);
 
-  const duplicateRollingStock = () => {
-    const date = new Date().getTime().toString().slice(-3);
-    const duplicatedRollingstock = { ...rollingStock, name: `${rollingStock.name}-${date}` };
-    postRollingstock({
-      locked: false,
-      rollingStockForm: duplicatedRollingstock,
-    })
-      .unwrap()
-      .then((res) => {
-        setPageMode({ type: 'edit', rollingStockId: res.id });
-        resetFilters();
-        dispatch(
-          setSuccess({
-            title: t('rollingStock.messages.success'),
-            text: t('rollingStock.messages.rollingStockAdded'),
-          })
-        );
-      })
-      .catch((error) => {
-        dispatch(
-          setFailure(castErrorToFailure(error, { name: t('rollingStock.messages.failure') }))
-        );
-      });
-  };
-
-  const deleteRollingStock = useCallback(() => {
-    setPageMode({ type: 'idle' });
-    if (!rollingStock.locked)
-      deleteRollingStockById({ rollingStockId: rollingStock.id })
-        .unwrap()
-        .then(() => {
-          dispatch(
-            setSuccess({
-              title: t('rollingStock.messages.success'),
-              text: t('rollingStock.messages.rollingStockDeleted'),
-            })
-          );
+  const duplicateRollingStock = useCallback(
+    () =>
+      checkProtectedAction(userPrivileges, ['can_read'], () => {
+        const date = new Date().getTime().toString().slice(-3);
+        const duplicatedRollingStock = { ...rollingStock, name: `${rollingStock.name}-${date}` };
+        postRollingstock({
+          locked: false,
+          rollingStockForm: duplicatedRollingStock,
         })
-        .catch((error) => {
-          if (getErrorStatus(error) === 409) {
-            openModal(
-              <RollingStockEditorFormModal
-                mainText={t('rollingStock.messages.rollingStockNotDeleted')}
-                errorObject={error.data.context.usage}
-              />
-            );
-          }
-          dispatch(
-            setFailure(
-              castErrorToFailure(error, {
-                name: t('rollingStock.messages.failure'),
-                message: t('rollingStock.messages.rollingStockNotDeleted'),
+          .unwrap()
+          .then((res) => {
+            setPageMode({ type: 'edit', rollingStockId: res.id });
+            resetFilters();
+            dispatch(
+              setSuccess({
+                title: t('rollingStock.messages.success'),
+                text: t('rollingStock.messages.rollingStockAdded'),
               })
-            )
-          );
-        });
-  }, [setPageMode, rollingStock.id, rollingStock.locked]);
+            );
+          })
+          .catch((error) => {
+            dispatch(
+              setFailure(castErrorToFailure(error, { name: t('rollingStock.messages.failure') }))
+            );
+          });
+      }),
+    [userPrivileges, rollingStock]
+  );
+
+  const deleteRollingStock = useCallback(
+    () =>
+      checkProtectedAction(userPrivileges, ['can_delete'], () => {
+        setPageMode({ type: 'idle' });
+        if (!rollingStock.locked)
+          deleteRollingStockById({ rollingStockId: rollingStock.id })
+            .unwrap()
+            .then(() => {
+              dispatch(
+                setSuccess({
+                  title: t('rollingStock.messages.success'),
+                  text: t('rollingStock.messages.rollingStockDeleted'),
+                })
+              );
+            })
+            .catch((error) => {
+              if (getErrorStatus(error) === 409) {
+                openModal(
+                  <RollingStockEditorFormModal
+                    mainText={t('rollingStock.messages.rollingStockNotDeleted')}
+                    errorObject={error.data.context.usage}
+                  />
+                );
+              }
+              dispatch(
+                setFailure(
+                  castErrorToFailure(error, {
+                    name: t('rollingStock.messages.failure'),
+                    message: t('rollingStock.messages.rollingStockNotDeleted'),
+                  })
+                )
+              );
+            });
+      }),
+    [setPageMode, rollingStock.id, rollingStock.locked, userPrivileges]
+  );
 
   const confirmDelete = () => {
     openModal(
@@ -118,9 +131,11 @@ const RollingStockEditorButtons = ({
         type="button"
         className="btn btn-primary bg-orange px-1 py-0"
         aria-label={t('common.edit')}
-        title={t('common.edit')}
+        title={
+          userPrivileges.has('can_write') ? t('common.edit') : t('authorization.permissionDenied')
+        }
         tabIndex={0}
-        disabled={rollingStock.locked}
+        disabled={rollingStock.locked || !userPrivileges.has('can_write')}
         onClick={editRollingStock}
       >
         <Pencil />
@@ -143,9 +158,13 @@ const RollingStockEditorButtons = ({
         type="button"
         className="btn btn-primary bg-red px-1 py-0"
         aria-label={t('common.delete')}
-        title={t('common.delete')}
+        title={
+          userPrivileges.has('can_delete')
+            ? t('common.delete')
+            : t('authorization.permissionDenied')
+        }
         tabIndex={0}
-        disabled={rollingStock.locked}
+        disabled={rollingStock.locked || !userPrivileges.has('can_delete')}
         onClick={confirmDelete}
       >
         <Trash />

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
@@ -24,6 +24,7 @@ import {
 import { modifyRollingStockElectricalValues } from '../helpers/electricalValues';
 import isRollingStockFormValid from '../helpers/isRollingStockFormValid';
 import { rollingStockEditorQueryArg } from '../helpers/utils';
+import type { PageMode } from '../RollingStockEditorView';
 import type { EffortCurveForms, RollingStockParametersValues } from '../types';
 import CategoryForm from './CategoryForm';
 import MetadataForm from './MetadataForm';
@@ -34,23 +35,17 @@ import RollingStockEditorFormModal from './RollingStockEditorFormModal';
 
 type RollingStockParametersProps = {
   rollingStockData?: RollingStockWithLiveries;
-  setAddOrEditState: React.Dispatch<React.SetStateAction<boolean>>;
-  setOpenedRollingStockCardId?: React.Dispatch<React.SetStateAction<number | undefined>>;
-  isAdding?: boolean;
+  setPageMode: React.Dispatch<React.SetStateAction<PageMode>>;
 };
 
-const RollingStockEditorForm = ({
-  rollingStockData,
-  setAddOrEditState,
-  setOpenedRollingStockCardId,
-  isAdding,
-}: RollingStockParametersProps) => {
+const RollingStockEditorForm = ({ rollingStockData, setPageMode }: RollingStockParametersProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const { t: rollingStockT } = useTranslation('translation', { keyPrefix: 'rollingStock' });
   const { openModal } = useModal();
   const [postRollingstock] = osrdEditoastApi.endpoints.postRollingStock.useMutation();
   const [putRollingStock] = osrdEditoastApi.endpoints.putRollingStockByRollingStockId.useMutation();
+  const isAdding = rollingStockData === undefined;
 
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -66,6 +61,10 @@ const RollingStockEditorForm = ({
   );
 
   useEffect(() => {
+    setRollingStockValues(getRollingStockEditorDefaultValues(rollingStockData));
+  }, [rollingStockData]);
+
+  useEffect(() => {
     if (prevRsEffortCurve !== undefined) {
       setRollingStockValues(modifyRollingStockElectricalValues(rollingStockValues, effortCurves));
     }
@@ -75,21 +74,20 @@ const RollingStockEditorForm = ({
     RollingStock['power_restrictions']
   >(rollingStockData?.power_restrictions || {});
 
-  const addNewRollingstock = (payload: RollingStockForm) => () => {
+  const addNewRollingstock = (payload: RollingStockForm) => {
     postRollingstock({
       locked: false,
       rollingStockForm: payload,
     })
       .unwrap()
       .then((res) => {
-        if (setOpenedRollingStockCardId) setOpenedRollingStockCardId(res.id);
         dispatch(
           setSuccess({
             title: t('rollingStock.messages.success'),
             text: t('rollingStock.messages.rollingStockAdded'),
           })
         );
-        setAddOrEditState(false);
+        setPageMode({ type: 'view', rollingStockId: res.id });
       })
       .catch((error) => {
         dispatch(
@@ -102,7 +100,7 @@ const RollingStockEditorForm = ({
       });
   };
 
-  const updateRollingStock = (payload: RollingStockForm) => () => {
+  const updateRollingStock = (payload: RollingStockForm) => {
     if (rollingStockData) {
       putRollingStock({
         rollingStockId: rollingStockData.id,
@@ -116,7 +114,7 @@ const RollingStockEditorForm = ({
               text: t('rollingStock.messages.rollingStockUpdated'),
             })
           );
-          setAddOrEditState(false);
+          setPageMode({ type: 'view', rollingStockId: rollingStockData.id });
         })
         .catch((error) => {
           dispatch(
@@ -189,8 +187,7 @@ const RollingStockEditorForm = ({
     );
     openModal(
       <RollingStockEditorFormModal
-        setAddOrEditState={setAddOrEditState}
-        request={isAdding ? addNewRollingstock(payload) : updateRollingStock(payload)}
+        onSubmit={() => (isAdding ? addNewRollingstock(payload) : updateRollingStock(payload))}
         mainText={
           isAdding
             ? t('rollingStock.confirmAddRollingStock')
@@ -204,9 +201,13 @@ const RollingStockEditorForm = ({
   const cancel = () => {
     openModal(
       <RollingStockEditorFormModal
-        setAddOrEditState={setAddOrEditState}
         mainText={t('rollingStock.cancelUpdateRollingStock')}
         buttonText={t('common.yes')}
+        onSubmit={() =>
+          setPageMode(
+            isAdding ? { type: 'idle' } : { type: 'view', rollingStockId: rollingStockData.id }
+          )
+        }
       />
     );
   };

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorFormModal.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorFormModal.tsx
@@ -5,9 +5,8 @@ import type { ScenarioReference } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 
 type RollingStockEditorFormModalProps = {
-  setAddOrEditState?: React.Dispatch<React.SetStateAction<boolean>>;
-  // request can be a POST, PUT, PATCH or DELETE request
-  request?: () => void;
+  onSubmit?: () => void | Promise<void>;
+  onCancel?: () => void;
   mainText: string;
   errorObject?: ScenarioReference[];
   buttonText?: string;
@@ -15,8 +14,8 @@ type RollingStockEditorFormModalProps = {
 };
 
 const RollingStockEditorFormModal = ({
-  request,
-  setAddOrEditState,
+  onSubmit,
+  onCancel,
   mainText,
   errorObject,
   buttonText,
@@ -61,7 +60,10 @@ const RollingStockEditorFormModal = ({
           data-testid="confirm-modal-button-no"
           type="button"
           className="btn btn-sm btn-primary-gray"
-          onClick={() => closeModal()}
+          onClick={() => {
+            if (onCancel) onCancel();
+            closeModal();
+          }}
         >
           {t('common.no')}
         </button>
@@ -71,10 +73,7 @@ const RollingStockEditorFormModal = ({
             type="button"
             className={`btn btn-sm ${deleteAction ? 'bg-red text-white' : 'btn-primary'} ml-3`}
             onClick={() => {
-              if (request) request();
-              if (!request && setAddOrEditState) {
-                setAddOrEditState(false);
-              }
+              if (onSubmit) onSubmit();
               closeModal();
             }}
           >

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorList.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorList.tsx
@@ -1,0 +1,77 @@
+import { useMemo, type RefObject } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import type {
+  LightRollingStockWithLiveries,
+  RollingStockWithLiveries,
+} from 'common/api/osrdEditoastApi';
+import { Loader } from 'common/Loaders';
+import { RollingStockCard } from 'modules/rollingStock/components/RollingStockCard';
+
+import type { PageMode } from '../RollingStockEditorView';
+import RollingStockEditorButtons from './RollingStockEditorButtons';
+
+type RollingStockEditorListProps = {
+  isLoading: boolean;
+  data: LightRollingStockWithLiveries[];
+  pageMode: PageMode;
+  setPageMode: React.Dispatch<React.SetStateAction<PageMode>>;
+  resetFilters: () => void;
+  ref2scroll: RefObject<HTMLInputElement | null>;
+  selectedRollingStock?: RollingStockWithLiveries;
+};
+
+export const RollingStockEditorList = ({
+  isLoading,
+  data,
+  pageMode,
+  setPageMode,
+  resetFilters,
+  ref2scroll,
+  selectedRollingStock,
+}: RollingStockEditorListProps) => {
+  const { t } = useTranslation();
+
+  const selectedRollingStockId = useMemo(() => {
+    if ('rollingStockId' in pageMode) return pageMode.rollingStockId;
+    return undefined;
+  }, [pageMode]);
+
+  return (
+    <div className="rollingstock-editor-list pr-1" data-testid="rollingstock-editor-list">
+      {isLoading && <Loader msg={t('rollingStock.waitingLoader')} />}
+      {!isLoading && (
+        <>
+          {data.map((rs) => (
+            <div key={rs.id}>
+              <div className="rolling-stock-card-container">
+                <RollingStockCard
+                  isOnEditMode
+                  rollingStock={rs}
+                  noCardSelected={selectedRollingStockId === undefined}
+                  isOpen={rs.id === selectedRollingStockId}
+                  onClick={() => setPageMode({ type: 'view', rollingStockId: rs.id })}
+                  ref2scroll={selectedRollingStockId === rs.id ? ref2scroll : undefined}
+                />
+                {rs.id === selectedRollingStockId && selectedRollingStock && (
+                  <RollingStockEditorButtons
+                    setPageMode={setPageMode}
+                    isCondensed
+                    rollingStock={selectedRollingStock}
+                    resetFilters={resetFilters}
+                  />
+                )}
+              </div>
+            </div>
+          ))}
+          {data.length === 0 && (
+            <div data-testid="rollingstock-empty-result" className="rollingstock-empty">
+              {t('rollingStock.resultFound', { count: 0 })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorList.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorList.tsx
@@ -6,6 +6,7 @@ import type {
   LightRollingStockWithLiveries,
   RollingStockWithLiveries,
 } from 'common/api/osrdEditoastApi';
+import type { Privilege } from 'common/authorization/types';
 import { Loader } from 'common/Loaders';
 import { RollingStockCard } from 'modules/rollingStock/components/RollingStockCard';
 
@@ -20,6 +21,7 @@ type RollingStockEditorListProps = {
   resetFilters: () => void;
   ref2scroll: RefObject<HTMLInputElement | null>;
   selectedRollingStock?: RollingStockWithLiveries;
+  userPrivilegesByRollingStockId: Record<number, Set<Privilege>>;
 };
 
 export const RollingStockEditorList = ({
@@ -30,6 +32,7 @@ export const RollingStockEditorList = ({
   resetFilters,
   ref2scroll,
   selectedRollingStock,
+  userPrivilegesByRollingStockId,
 }: RollingStockEditorListProps) => {
   const { t } = useTranslation();
 
@@ -60,6 +63,7 @@ export const RollingStockEditorList = ({
                     isCondensed
                     rollingStock={selectedRollingStock}
                     resetFilters={resetFilters}
+                    userPrivileges={userPrivilegesByRollingStockId[rs.id] || new Set()}
                   />
                 )}
               </div>

--- a/front/src/applications/rollingStockEditor/components/RollingStockInformationPanel.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockInformationPanel.tsx
@@ -13,13 +13,11 @@ import { RollingStockInfo } from 'modules/rollingStock/components/RollingStockSe
 
 type RollingStockInformationPanelProps = {
   id: number;
-  isEditing: boolean;
   rollingStock: RollingStockWithLiveries;
 };
 
 export default function RollingStockInformationPanel({
   id,
-  isEditing,
   rollingStock,
 }: RollingStockInformationPanelProps) {
   const [curvesComfortList, setCurvesComfortList] = useState<Comfort[]>([]);
@@ -37,7 +35,7 @@ export default function RollingStockInformationPanel({
   };
 
   return (
-    <div className={cx('rollingstock-editor-form', { borders: !isEditing })}>
+    <div className={cx('rollingstock-editor-form borders')}>
       <div>
         <div className="rollingstock-card-header">
           <div data-testid="rollingstock-title" className="rollingstock-title">

--- a/front/src/applications/rollingStockEditor/components/RollingStockInformationPanel.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockInformationPanel.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import type { Comfort, RollingStockWithLiveries } from 'common/api/osrdEditoastApi';
@@ -35,42 +34,40 @@ export default function RollingStockInformationPanel({
   };
 
   return (
-    <div className={cx('rollingstock-editor-form borders')}>
-      <div>
-        <div className="rollingstock-card-header">
-          <div data-testid="rollingstock-title" className="rollingstock-title">
-            <RollingStockInfo rollingStock={rollingStock} />
-          </div>
+    <div>
+      <div className="rollingstock-card-header">
+        <div data-testid="rollingstock-title" className="rollingstock-title">
+          <RollingStockInfo rollingStock={rollingStock} />
         </div>
-        <RollingStockCardDetail
-          id={id}
-          hideCurves
-          form="rollingstock-editor-form-text"
-          curvesComfortList={curvesComfortList}
-          setCurvesComfortList={setCurvesComfortList}
+      </div>
+      <RollingStockCardDetail
+        id={id}
+        hideCurves
+        form="rollingstock-editor-form-text"
+        curvesComfortList={curvesComfortList}
+        setCurvesComfortList={setCurvesComfortList}
+      />
+      <div className="rollingstock-card-body border-0">
+        <RollingStockCurve
+          curvesComfortList={getCurvesComforts(rollingStock.effort_curves.modes)}
+          data={rollingStock.effort_curves.modes}
         />
-        <div className="rollingstock-card-body border-0">
-          <RollingStockCurve
-            curvesComfortList={getCurvesComforts(rollingStock.effort_curves.modes)}
-            data={rollingStock.effort_curves.modes}
-          />
-          <div className="rollingstock-detail-container-img">
-            <div className="rollingstock-detail-img">
-              <RollingStock2Img rollingStock={rollingStock} />
-            </div>
+        <div className="rollingstock-detail-container-img">
+          <div className="rollingstock-detail-img">
+            <RollingStock2Img rollingStock={rollingStock} />
           </div>
         </div>
-        <div className="d-flex justify-content-end">
-          <button
-            type="button"
-            className="btn btn-primary mt-4"
-            aria-label={t('rollingStock.exportRollingStock')}
-            title={t('rollingStock.exportRollingStock')}
-            onClick={exportRollingStock}
-          >
-            {t('rollingStock.export')}
-          </button>
-        </div>
+      </div>
+      <div className="d-flex justify-content-end">
+        <button
+          type="button"
+          className="btn btn-primary mt-4"
+          aria-label={t('rollingStock.exportRollingStock')}
+          title={t('rollingStock.exportRollingStock')}
+          onClick={exportRollingStock}
+        >
+          {t('rollingStock.export')}
+        </button>
       </div>
     </div>
   );

--- a/front/src/applications/rollingStockEditor/styles.scss
+++ b/front/src/applications/rollingStockEditor/styles.scss
@@ -1,5 +1,4 @@
 .rollingstock-editor {
-  padding-top: 80px;
   max-height: calc(100dvh - var(--header-height));
 
   &-list {
@@ -8,15 +7,6 @@
 
     .rollingstock-body-container-img {
       min-height: 38.4px;
-    }
-
-    &-cards {
-      .active {
-        .rollingstock-card-header,
-        .rollingstock-footer {
-          cursor: default;
-        }
-      }
     }
 
     .rolling-stock-card-container {
@@ -55,15 +45,12 @@
   }
 
   &-form {
+    align-self: center;
     height: 100%;
-    width: 100%;
     justify-content: space-between;
     max-height: 88vh;
-    overflow-y: scroll;
-
-    width: 100%;
-    align-self: center;
     overflow: auto;
+    width: 100%;
 
     > .rollingstock-card-header {
       @media screen and (min-width: 1140px) {
@@ -142,47 +129,23 @@
       }
     }
 
-    &-container {
-      height: 100%;
+    .tab-content {
+      background-color: var(--white);
+      border-radius: 8px;
+    }
 
-      .tab-content {
-        background-color: var(--white);
-        border-radius: 8px;
-      }
-
-      .tab-pane {
-        padding-top: 16px;
-      }
-
-      .tabs {
-        margin-bottom: 16px;
-      }
-
-      overflow-y: auto;
-      width: 100%;
-
-      @media screen and (min-width: 767px) {
-        padding-right: 24px;
-        width: 50%;
-        position: fixed;
-        right: 0;
-        top: 80px;
-      }
-
-      @media screen and (min-width: 1140px) {
-        width: 60%;
-      }
+    .tab-pane {
+      padding-top: 16px;
     }
   }
 
-  &borders {
-    border: 3.2px solid #d7d7d7;
-    border-radius: 8px;
-  }
-
   &-left-container {
-    width: 94%;
+    display: flex;
+    flex-direction: column;
+    margin-left: 24px;
     padding-right: 24px;
+    padding-top: 80px;
+    width: 94%;
 
     @media screen and (min-width: 767px) {
       width: 45%;
@@ -193,9 +156,28 @@
     }
   }
 
+  &-main-container {
+    max-width: 60%;
+    padding: 40px 24px 24px 20px;
+    flex-grow: 1;
+
+    .grant-manager {
+      margin: 24px 0 0 0;
+      padding: 16px 0;
+      border-top: 1px solid var(--grey20);
+
+      .grant-manager-body {
+        margin: 16px 24px 0 24px;
+        padding: 16px;
+      }
+    }
+  }
+
   &-unselected {
     margin: 0 auto;
     display: none;
+    text-align: center;
+    margin-top: 44px;
 
     @media screen and (min-width: 767px) {
       display: block;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3821,6 +3821,10 @@ export type CorePathfindingInputError =
       error_type: 'not_enough_path_items';
     }
   | {
+      error_type: 'unauthorized_rolling_stock';
+      rolling_stock_id: number;
+    }
+  | {
       error_type: 'rolling_stock_not_found';
       rolling_stock_name: string;
     }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3760,6 +3760,10 @@ export type CorePathfindingInputError =
       error_type: 'not_enough_path_items';
     }
   | {
+      error_type: 'unauthorized_rolling_stock';
+      rolling_stock_id: number;
+    }
+  | {
       error_type: 'rolling_stock_not_found';
       rolling_stock_name: string;
     }

--- a/front/src/common/authorization/_grantsManager.scss
+++ b/front/src/common/authorization/_grantsManager.scss
@@ -7,6 +7,8 @@
   &-header {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+
     .user-grant {
       font-size: 0.875rem;
       color: var(--info60);
@@ -23,6 +25,8 @@
     // Overrides the default "pointer" cursor style applied to the div.grant-manager-body with role="button"
     // Necessary because we want to keep the role for accessibility but without the visual cursor effect
     cursor: default !important;
+    border-radius: 8px;
+    background-color: #fff;
   }
 
   .subject {

--- a/front/src/common/authorization/components/GrantsManagerSubject.tsx
+++ b/front/src/common/authorization/components/GrantsManagerSubject.tsx
@@ -82,6 +82,7 @@ const GrantsManagerSubject = ({
           getOptionLabel={(option) => option.label}
           getOptionValue={(option) => option.value || ''}
           onChange={(option) => updateUserGrant(option?.value)}
+          disabled={subject.id === userId && selectProps.value?.value === 'OWNER'}
           narrow
           {...selectProps}
         />

--- a/front/src/common/authorization/hooks/useAuthz.tsx
+++ b/front/src/common/authorization/hooks/useAuthz.tsx
@@ -52,7 +52,7 @@ export default function useAuthz() {
    * Retrieve grants of the connected user for a list of resources.
    */
   const getUserGrants = useCallback(
-    async (resources: Record<ResourceType, number[]>) => {
+    async (resources: Partial<Record<ResourceType, number[]>>) => {
       const result = await retrieveUserGrants({ body: resources }).unwrap();
       return Object.keys(result).reduce(
         (accByType, resourceType) => {
@@ -75,7 +75,7 @@ export default function useAuthz() {
    * Retrieve privileges of the connected user for a list of resources.
    */
   const getUserPrivileges = useCallback(
-    async (resources: Record<ResourceType, number[]>) => {
+    async (resources: Partial<Record<ResourceType, number[]>>) => {
       const result = await retrieveUserPrivileges({ body: resources }).unwrap();
       return Object.keys(result).reduce(
         (accByType, resourceType) => {

--- a/front/src/common/authorization/hooks/useResourceListUser.tsx
+++ b/front/src/common/authorization/hooks/useResourceListUser.tsx
@@ -19,7 +19,6 @@ export default function useResourceListSubjects(resourceType: ResourceType, id: 
 
   /**
    * Fetches the user list for a given resource type and resource id.
-   * @param pageNb the page number to fetch
    */
   const fetchPage = useCallback(async () => {
     setLoading(true);
@@ -29,7 +28,7 @@ export default function useResourceListSubjects(resourceType: ResourceType, id: 
         resourceType,
         resourceId: id,
       }).unwrap();
-      setSubjects((prev) => [...prev, ...response]);
+      setSubjects(response);
     } catch (err) {
       setError(err as Error);
     } finally {

--- a/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
@@ -20,7 +20,7 @@ type RollingStockCardProps = {
   noCardSelected: boolean;
   ref2scroll?: React.RefObject<HTMLDivElement | null>;
   rollingStock: LightRollingStockWithLiveries;
-  setOpenedRollingStockCardId: (openCardId: number | undefined) => void;
+  onClick: () => void;
   onSelectRollingStock?: (rollingStock: LightRollingStockWithLiveries, comfort: Comfort) => void;
 };
 
@@ -30,7 +30,7 @@ const RollingStockCard = ({
   noCardSelected,
   rollingStock,
   ref2scroll = undefined,
-  setOpenedRollingStockCardId,
+  onClick,
   onSelectRollingStock,
 }: RollingStockCardProps) => {
   const [curvesComfortList, setCurvesComfortList] = useState<Comfort[]>([]);
@@ -55,13 +55,6 @@ const RollingStockCard = ({
     return { ...localModes, voltages: localVoltages };
   }, [rollingStock.effort_curves.modes]);
 
-  function displayCardDetail() {
-    if (!isOpen) {
-      setOpenedRollingStockCardId(rollingStock.id);
-      setTimeout(() => ref2scrollWhenOpened.current?.scrollIntoView({ behavior: 'smooth' }), 500);
-    }
-  }
-
   return (
     <div
       className={cx('rollingstock-card', {
@@ -70,18 +63,13 @@ const RollingStockCard = ({
         solid: noCardSelected,
       })}
       role="button"
-      onClick={displayCardDetail}
+      onClick={onClick}
       tabIndex={0}
       ref={ref2scroll}
       data-testid={`rollingstock-${rollingStock.name}`}
     >
       <div
         className="rollingstock-card-header"
-        onClick={() => {
-          if (isOpen) setOpenedRollingStockCardId(undefined);
-        }}
-        role="button"
-        tabIndex={0}
         ref={isOpen && !isOnEditMode ? ref2scrollWhenOpened : undefined}
       >
         <div data-testid="rollingstock-title" className="rollingstock-title">

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
@@ -32,7 +32,7 @@ function RollingStockModal({
     searchRollingStock,
     toggleFilter,
     selectCategoryFilter,
-    searchIsLoading,
+    isLoading,
   } = useFilterRollingStock();
 
   useEffect(() => {
@@ -81,7 +81,7 @@ function RollingStockModal({
           />
         </div>
         <div className="rollingstock-search-list">
-          {searchIsLoading ? <Loader msg={t('rollingStock.waitingLoader')} /> : rollingStocksList}
+          {isLoading ? <Loader msg={t('rollingStock.waitingLoader')} /> : rollingStocksList}
         </div>
       </div>
     </ModalBodySNCF>

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
@@ -54,7 +54,7 @@ function RollingStockModal({
             key={item.id}
             noCardSelected={openRollingStockCardId === undefined}
             isOpen={item.id === openRollingStockCardId}
-            setOpenedRollingStockCardId={setOpenRollingStockCardId}
+            onClick={() => setOpenRollingStockCardId(item.id)}
             ref2scroll={openRollingStockCardId === item.id ? ref2scroll : undefined}
             onSelectRollingStock={onSelectRollingStock}
           />

--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
@@ -8,9 +8,11 @@ import type {
   LightRollingStockWithLiveries,
   TrainMainCategory,
 } from 'common/api/osrdEditoastApi';
+import useAuthz from 'common/authorization/hooks/useAuthz';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
+import { useAsyncMemo } from 'utils/useAsyncMemo';
 
 /**
  * - id: the rolling stock id
@@ -164,6 +166,7 @@ const useFilterRollingStock = ({
   isDebugMode?: boolean;
 } = {}) => {
   const dispatch = useAppDispatch();
+  const { getUserPrivileges } = useAuthz();
 
   const [filters, setFilters] = useState<RollingStockFilters>(initialFilters);
 
@@ -183,6 +186,23 @@ const useFilterRollingStock = ({
         : allRollingStocks,
     [isStdcm, isDebugMode, allRollingStocks]
   );
+
+  const userPrivilegesByRollingStockId = useAsyncMemo(async () => {
+    // early exit if rollingstock is empty
+    if (allRollingStocks.length === 0) return {};
+    // call editoast
+    const data = await getUserPrivileges({
+      rolling_stock: allRollingStocks.map((rs) => rs.id),
+      infra: [],
+    });
+    return data.rolling_stock || {};
+  }, [
+    getUserPrivileges,
+    allRollingStocks
+      .map((rs) => rs.id)
+      .sort()
+      .join('|'),
+  ]);
 
   const [searchIsLoading, setSearchIsLoading] = useState(true);
 
@@ -232,12 +252,13 @@ const useFilterRollingStock = ({
   return {
     filteredRollingStockList,
     filters,
-    searchIsLoading,
+    isLoading: searchIsLoading || userPrivilegesByRollingStockId.type === 'loading',
     resetFilters,
     searchRollingStock,
     searchRollingStockById,
     toggleFilter,
     selectCategoryFilter,
+    userPrivilegesByRollingStockId,
   };
 };
 

--- a/front/src/modules/trainSchedule/types.ts
+++ b/front/src/modules/trainSchedule/types.ts
@@ -85,7 +85,8 @@ type TrainScheduleWithSummaries = Omit<
 export type InvalidReason =
   | Extract<SimulationSummaryResult['status'], 'pathfinding_failure' | 'simulation_failed'>
   | CorePathfindingNotFound['error_type']
-  | CorePathfindingInputError['error_type'];
+  | CorePathfindingInputError['error_type']
+  | 'unauthorized_rolling_stock';
 
 export type SimulatedException = PacedTrainException & { summary?: SimulationSummary };
 

--- a/front/src/store/listeners/authorization.ts
+++ b/front/src/store/listeners/authorization.ts
@@ -1,14 +1,37 @@
 import { isRejectedWithValue, type PayloadAction } from '@reduxjs/toolkit';
 import { type FetchBaseQueryError } from '@reduxjs/toolkit/query';
 
+import type { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+
 import { type AppStartListening } from './types';
+
+type EditoastEndpointName = keyof typeof osrdEditoastApi.endpoints;
+
+type RTKQueryRejectedAction = PayloadAction<
+  FetchBaseQueryError,
+  string,
+  {
+    arg: {
+      endpointName: EditoastEndpointName;
+    };
+  }
+>;
+
+/**
+ * Endpoints for which a 403 response should NOT trigger a global redirect.
+ * Add an endpoint name here when a 403 is expected and handled locally.
+ */
+const ENDPOINTS_SKIP_403_REDIRECT = new Set<EditoastEndpointName>([
+  'getRollingStockNameByRollingStockName',
+  'getTrainSchedulesByIdPath',
+]);
 
 export default function add403HttpErrorListener(startListening: AppStartListening) {
   startListening({
     matcher: isRejectedWithValue,
-    effect: (action: PayloadAction<unknown>) => {
-      const error = action.payload as FetchBaseQueryError;
-      if (error?.status === 403) {
+    effect: (action) => {
+      const { payload: error, meta } = action as RTKQueryRejectedAction;
+      if (error?.status === 403 && !ENDPOINTS_SKIP_403_REDIRECT.has(meta.arg.endpointName)) {
         window.location.href = '/403';
       }
     },

--- a/front/src/utils/hooks/useAuth.ts
+++ b/front/src/utils/hooks/useAuth.ts
@@ -38,10 +38,13 @@ function useAuth() {
   }, [isUserLogged]);
 
   useEffect(() => {
-    if (data) {
-      dispatch(updateAuthzUser(data ? { userRoles: data.roles, userId: data.id } : undefined));
+    if (impersonatedUser) {
+      dispatch(updateAuthzUser({ userRoles: impersonatedUser.roles, userId: impersonatedUser.id }));
     }
-  }, [isUserLogged, data]);
+    if (data) {
+      dispatch(updateAuthzUser({ userRoles: data.roles, userId: data.id }));
+    }
+  }, [isUserLogged, data, impersonatedUser]);
 
   /**
    * Function to impersonate the given user, or if undefined, stop the impersonation.

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -208,6 +208,11 @@ class PathfindingInputErrorNotEnoughPathItems(BaseModel):
     error_type: Literal["not_enough_path_items"]
 
 
+class PathfindingInputErrorUnauthorizedRollingStock(BaseModel):
+    error_type: Literal["unauthorized_rolling_stock"]
+    rolling_stock_id: int
+
+
 class PathfindingInputErrorRollingStockNotFound(BaseModel):
     error_type: Literal["rolling_stock_not_found"]
     rolling_stock_name: str
@@ -3127,12 +3132,19 @@ class PathfindingFailurePathfindingInputError3(
 
 
 class PathfindingFailurePathfindingInputError4(
-    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError1
+    PathfindingInputErrorUnauthorizedRollingStock,
+    PathfindingFailurePathfindingInputError1,
 ):
     pass
 
 
 class PathfindingFailurePathfindingInputError5(
+    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError1
+):
+    pass
+
+
+class PathfindingFailurePathfindingInputError6(
     PathfindingInputErrorZeroLengthPath, PathfindingFailurePathfindingInputError1
 ):
     pass
@@ -3162,24 +3174,31 @@ class PathfindingOutput(BaseModel):
     track_ranges: list[DirectionalTrackRange]
 
 
-class PathfindingFailurePathfindingInputError7(BaseModel):
+class PathfindingFailurePathfindingInputError8(BaseModel):
     failed_status: Literal["pathfinding_input_error"]
 
 
-class PathfindingFailurePathfindingInputError9(
-    PathfindingInputErrorNotEnoughPathItems, PathfindingFailurePathfindingInputError7
-):
-    pass
-
-
 class PathfindingFailurePathfindingInputError10(
-    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError7
+    PathfindingInputErrorNotEnoughPathItems, PathfindingFailurePathfindingInputError8
 ):
     pass
 
 
 class PathfindingFailurePathfindingInputError11(
-    PathfindingInputErrorZeroLengthPath, PathfindingFailurePathfindingInputError7
+    PathfindingInputErrorUnauthorizedRollingStock,
+    PathfindingFailurePathfindingInputError8,
+):
+    pass
+
+
+class PathfindingFailurePathfindingInputError12(
+    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError8
+):
+    pass
+
+
+class PathfindingFailurePathfindingInputError13(
+    PathfindingInputErrorZeroLengthPath, PathfindingFailurePathfindingInputError8
 ):
     pass
 
@@ -3767,7 +3786,7 @@ class SummaryResponsePathfindingInputError3(
 
 
 class SummaryResponsePathfindingInputError4(
-    PathfindingInputErrorRollingStockNotFound, SummaryResponsePathfindingInputError1
+    PathfindingInputErrorUnauthorizedRollingStock, SummaryResponsePathfindingInputError1
 ):
     """
     InputError
@@ -3775,6 +3794,14 @@ class SummaryResponsePathfindingInputError4(
 
 
 class SummaryResponsePathfindingInputError5(
+    PathfindingInputErrorRollingStockNotFound, SummaryResponsePathfindingInputError1
+):
+    """
+    InputError
+    """
+
+
+class SummaryResponsePathfindingInputError6(
     PathfindingInputErrorZeroLengthPath, SummaryResponsePathfindingInputError1
 ):
     """
@@ -5403,25 +5430,27 @@ class PathfindingInputErrorInvalidPathItems2(BaseModel):
     items: list[Item]
 
 
-class PathfindingFailurePathfindingInputError8(
-    PathfindingInputErrorInvalidPathItems2, PathfindingFailurePathfindingInputError7
+class PathfindingFailurePathfindingInputError9(
+    PathfindingInputErrorInvalidPathItems2, PathfindingFailurePathfindingInputError8
 ):
     pass
 
 
-class PathfindingFailurePathfindingInputError6(
+class PathfindingFailurePathfindingInputError7(
     RootModel[
-        PathfindingFailurePathfindingInputError8
-        | PathfindingFailurePathfindingInputError9
+        PathfindingFailurePathfindingInputError9
         | PathfindingFailurePathfindingInputError10
         | PathfindingFailurePathfindingInputError11
+        | PathfindingFailurePathfindingInputError12
+        | PathfindingFailurePathfindingInputError13
     ]
 ):
     root: Annotated[
-        PathfindingFailurePathfindingInputError8
-        | PathfindingFailurePathfindingInputError9
+        PathfindingFailurePathfindingInputError9
         | PathfindingFailurePathfindingInputError10
-        | PathfindingFailurePathfindingInputError11,
+        | PathfindingFailurePathfindingInputError11
+        | PathfindingFailurePathfindingInputError12
+        | PathfindingFailurePathfindingInputError13,
         Field(title="PathfindingFailurePathfindingInputError"),
     ]
 
@@ -6033,6 +6062,7 @@ class CorePathfindingInputError(
     RootModel[
         PathfindingInputErrorInvalidPathItems
         | PathfindingInputErrorNotEnoughPathItems
+        | PathfindingInputErrorUnauthorizedRollingStock
         | PathfindingInputErrorRollingStockNotFound
         | PathfindingInputErrorZeroLengthPath
     ]
@@ -6040,6 +6070,7 @@ class CorePathfindingInputError(
     root: (
         PathfindingInputErrorInvalidPathItems
         | PathfindingInputErrorNotEnoughPathItems
+        | PathfindingInputErrorUnauthorizedRollingStock
         | PathfindingInputErrorRollingStockNotFound
         | PathfindingInputErrorZeroLengthPath
     )
@@ -6732,6 +6763,7 @@ class ResponsePathfindingFailed(BaseModel):
         | PathfindingFailurePathfindingInputError3
         | PathfindingFailurePathfindingInputError4
         | PathfindingFailurePathfindingInputError5
+        | PathfindingFailurePathfindingInputError6
         | PathfindingFailurePathfindingNotFound2
         | PathfindingFailurePathfindingNotFound3
         | PathfindingFailurePathfindingNotFound4
@@ -6824,7 +6856,8 @@ class TrainScheduleSimulationSummaryResult(BaseModel):
         | SummaryResponsePathfindingInputError2
         | SummaryResponsePathfindingInputError3
         | SummaryResponsePathfindingInputError4
-        | SummaryResponsePathfindingInputError5,
+        | SummaryResponsePathfindingInputError5
+        | SummaryResponsePathfindingInputError6,
     ]
     """
     The key is the `exception_id`
@@ -6840,6 +6873,7 @@ class TrainScheduleSimulationSummaryResult(BaseModel):
         | SummaryResponsePathfindingInputError3
         | SummaryResponsePathfindingInputError4
         | SummaryResponsePathfindingInputError5
+        | SummaryResponsePathfindingInputError6
     )
 
 

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -216,6 +216,11 @@ class PathfindingInputErrorNotEnoughPathItems(BaseModel):
     error_type: Literal["not_enough_path_items"]
 
 
+class PathfindingInputErrorUnauthorizedRollingStock(BaseModel):
+    error_type: Literal["unauthorized_rolling_stock"]
+    rolling_stock_id: int
+
+
 class PathfindingInputErrorRollingStockNotFound(BaseModel):
     error_type: Literal["rolling_stock_not_found"]
     rolling_stock_name: str
@@ -3042,12 +3047,19 @@ class PathfindingFailurePathfindingInputError3(
 
 
 class PathfindingFailurePathfindingInputError4(
-    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError1
+    PathfindingInputErrorUnauthorizedRollingStock,
+    PathfindingFailurePathfindingInputError1,
 ):
     pass
 
 
 class PathfindingFailurePathfindingInputError5(
+    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError1
+):
+    pass
+
+
+class PathfindingFailurePathfindingInputError6(
     PathfindingInputErrorZeroLengthPath, PathfindingFailurePathfindingInputError1
 ):
     pass
@@ -3077,24 +3089,31 @@ class PathfindingOutput(BaseModel):
     track_ranges: list[DirectionalTrackRange]
 
 
-class PathfindingFailurePathfindingInputError7(BaseModel):
+class PathfindingFailurePathfindingInputError8(BaseModel):
     failed_status: Literal["pathfinding_input_error"]
 
 
-class PathfindingFailurePathfindingInputError9(
-    PathfindingInputErrorNotEnoughPathItems, PathfindingFailurePathfindingInputError7
-):
-    pass
-
-
 class PathfindingFailurePathfindingInputError10(
-    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError7
+    PathfindingInputErrorNotEnoughPathItems, PathfindingFailurePathfindingInputError8
 ):
     pass
 
 
 class PathfindingFailurePathfindingInputError11(
-    PathfindingInputErrorZeroLengthPath, PathfindingFailurePathfindingInputError7
+    PathfindingInputErrorUnauthorizedRollingStock,
+    PathfindingFailurePathfindingInputError8,
+):
+    pass
+
+
+class PathfindingFailurePathfindingInputError12(
+    PathfindingInputErrorRollingStockNotFound, PathfindingFailurePathfindingInputError8
+):
+    pass
+
+
+class PathfindingFailurePathfindingInputError13(
+    PathfindingInputErrorZeroLengthPath, PathfindingFailurePathfindingInputError8
 ):
     pass
 
@@ -3743,7 +3762,7 @@ class SummaryResponsePathfindingInputError3(
 
 
 class SummaryResponsePathfindingInputError4(
-    PathfindingInputErrorRollingStockNotFound, SummaryResponsePathfindingInputError1
+    PathfindingInputErrorUnauthorizedRollingStock, SummaryResponsePathfindingInputError1
 ):
     """
     InputError
@@ -3751,6 +3770,14 @@ class SummaryResponsePathfindingInputError4(
 
 
 class SummaryResponsePathfindingInputError5(
+    PathfindingInputErrorRollingStockNotFound, SummaryResponsePathfindingInputError1
+):
+    """
+    InputError
+    """
+
+
+class SummaryResponsePathfindingInputError6(
     PathfindingInputErrorZeroLengthPath, SummaryResponsePathfindingInputError1
 ):
     """
@@ -5412,25 +5439,27 @@ class PathfindingInputErrorInvalidPathItems2(BaseModel):
     items: list[Item]
 
 
-class PathfindingFailurePathfindingInputError8(
-    PathfindingInputErrorInvalidPathItems2, PathfindingFailurePathfindingInputError7
+class PathfindingFailurePathfindingInputError9(
+    PathfindingInputErrorInvalidPathItems2, PathfindingFailurePathfindingInputError8
 ):
     pass
 
 
-class PathfindingFailurePathfindingInputError6(
+class PathfindingFailurePathfindingInputError7(
     RootModel[
-        PathfindingFailurePathfindingInputError8
-        | PathfindingFailurePathfindingInputError9
+        PathfindingFailurePathfindingInputError9
         | PathfindingFailurePathfindingInputError10
         | PathfindingFailurePathfindingInputError11
+        | PathfindingFailurePathfindingInputError12
+        | PathfindingFailurePathfindingInputError13
     ]
 ):
     root: Annotated[
-        PathfindingFailurePathfindingInputError8
-        | PathfindingFailurePathfindingInputError9
+        PathfindingFailurePathfindingInputError9
         | PathfindingFailurePathfindingInputError10
-        | PathfindingFailurePathfindingInputError11,
+        | PathfindingFailurePathfindingInputError11
+        | PathfindingFailurePathfindingInputError12
+        | PathfindingFailurePathfindingInputError13,
         Field(title="PathfindingFailurePathfindingInputError"),
     ]
 
@@ -6016,6 +6045,7 @@ class CorePathfindingInputError(
     RootModel[
         PathfindingInputErrorInvalidPathItems
         | PathfindingInputErrorNotEnoughPathItems
+        | PathfindingInputErrorUnauthorizedRollingStock
         | PathfindingInputErrorRollingStockNotFound
         | PathfindingInputErrorZeroLengthPath
     ]
@@ -6023,6 +6053,7 @@ class CorePathfindingInputError(
     root: (
         PathfindingInputErrorInvalidPathItems
         | PathfindingInputErrorNotEnoughPathItems
+        | PathfindingInputErrorUnauthorizedRollingStock
         | PathfindingInputErrorRollingStockNotFound
         | PathfindingInputErrorZeroLengthPath
     )
@@ -6655,6 +6686,7 @@ class ResponsePathfindingFailed(BaseModel):
         | PathfindingFailurePathfindingInputError3
         | PathfindingFailurePathfindingInputError4
         | PathfindingFailurePathfindingInputError5
+        | PathfindingFailurePathfindingInputError6
         | PathfindingFailurePathfindingNotFound2
         | PathfindingFailurePathfindingNotFound3
         | PathfindingFailurePathfindingNotFound4
@@ -6747,7 +6779,8 @@ class TrainScheduleSimulationSummaryResult(BaseModel):
         | SummaryResponsePathfindingInputError2
         | SummaryResponsePathfindingInputError3
         | SummaryResponsePathfindingInputError4
-        | SummaryResponsePathfindingInputError5,
+        | SummaryResponsePathfindingInputError5
+        | SummaryResponsePathfindingInputError6,
     ]
     """
     The key is the `exception_id`
@@ -6763,6 +6796,7 @@ class TrainScheduleSimulationSummaryResult(BaseModel):
         | SummaryResponsePathfindingInputError3
         | SummaryResponsePathfindingInputError4
         | SummaryResponsePathfindingInputError5
+        | SummaryResponsePathfindingInputError6
     )
 
 


### PR DESCRIPTION
Add authorization to the rolling stock and light rolling stock endpoints.

Related ticket: https://github.com/osrd-project/osrd-confidential/issues/1064

>[!WARNING]
This PR is a feature branch and is **not** ready for review yet.

### TODO

#### Backend - Add authorization on the following endpoints:

- [x] POST /authz/grants/: https://github.com/OpenRailAssociation/osrd/pull/17242 https://github.com/OpenRailAssociation/osrd/pull/17245
- [x] GET /rolling_stock/{rolling_stock_id}: CanRead https://github.com/OpenRailAssociation/osrd/pull/17218
- [x] GET /rolling_stock/name/{rolling_stock_name}: CanRead https://github.com/OpenRailAssociation/osrd/pull/17218
- [x] GET /light_rolling_stock/: filter to readable IDs https://github.com/OpenRailAssociation/osrd/pull/17243
- [x] GET /light_rolling_stock/{rolling_stock_id}: CanRead https://github.com/OpenRailAssociation/osrd/pull/17218
- [x] GET /light_rolling_stock/name/{rolling_stock_name}: CanRead https://github.com/OpenRailAssociation/osrd/pull/17218
- [x] POST /rolling_stock/: grant Owner via SystemAuthorizer https://github.com/OpenRailAssociation/osrd/pull/17875
- [x] PUT /rolling_stock/{rolling_stock_id}: CanWrite https://github.com/OpenRailAssociation/osrd/pull/17359
- [x] DELETE /rolling_stock/{rolling_stock_id}: CanDelete https://github.com/OpenRailAssociation/osrd/pull/17359
- [x] PATCH /rolling_stock/{rolling_stock_id}/locked: CanWrite https://github.com/OpenRailAssociation/osrd/pull/17402
- [x] POST /rolling_stock/{rolling_stock_id}/livery: CanWrite https://github.com/OpenRailAssociation/osrd/pull/17392
- [x] GET /rolling_stock/{rolling_stock_id}/usage: CanRead https://github.com/OpenRailAssociation/osrd/pull/17383
- [x] POST /timetable/{id}/stdcm: CanRead for every rolling stock https://github.com/OpenRailAssociation/osrd/pull/17433
- [x] All the endpoints which are calling `pathfinding_from_train_batch`, `core_task` or something which depends on them (example: batch simulations).
  - [x] `POST:/level_crossing_occupancy`: CanRead, filter out the trains that are unauthorized for the user (#17993) (#18031)
  - [x] `POST:/train_schedules/project_path_op`: CanRead, same thing as `train_schedule/track_occupancy`. (#18007) (#18116) (#18189)
  - [x] `POST:/train_schedules/project_path`: CanRead, 403 Forbidden is some train schedules are unauthorized (#18025) (#18116)
  - [x] `GET:/timetable/{id}/requirements`: only available for admins or when authz is skipped (endpoint called by core). https://github.com/OpenRailAssociation/osrd/pull/18021https://github.com/OpenRailAssociation/osrd/pull/18021
  - [x] `GET:/timetable/{id}/conflicts`: CanRead, also filter out the unauthorized trains https://github.com/OpenRailAssociation/osrd/pull/18024
  - [x] `POST:/train_schedule/occupancy_blocks`: CanRead, filter out unauhtorized rolling stocks https://github.com/OpenRailAssociation/osrd/pull/18104
  - [x] `GET:/train_schedule/{id}/etcs_braking_curves`: CanRead, 403 Forbidden if unauthorized https://github.com/OpenRailAssociation/osrd/pull/18019
  - [x] `POST:/train_schedule/track_occupancy`: CanRead, if the endpoint is called with `use_simulation`, then unauthorized trains are also used but they are not simulated. If there is no simulation, the train schedules authorization is simply skipped. https://github.com/OpenRailAssociation/osrd/pull/18012
- [x] `GET:train_schedule/{id}/path`: CanRead, 403 Forbidden if unauthorized https://github.com/OpenRailAssociation/osrd/pull/18013
- [x] GET /rolling_stock/power_restrictions? no authorization