### PR TITLE
front: fold deleted origin's arrival time into start time

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/__tests__/formatTrainSchedulePayload.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/__tests__/formatTrainSchedulePayload.spec.ts
@@ -133,4 +133,28 @@ describe('formatTrainSchedulePayload', () => {
       expect(newTrainSchedulePayload.rolling_stock_name).toBe('rollingStock1');
     });
   });
+
+  describe('The new origin has an arrival time (origin was deleted)', () => {
+    it('should fold the first waypoint arrival into the start time and shift the others', () => {
+      const osrdconf: OperationalStudiesConfState = {
+        ...rawOsrdconf,
+        pathSteps: [
+          { ...rawOsrdconf.pathSteps[0]!, arrival: Duration.parse('PT10M') },
+          { ...rawOsrdconf.pathSteps[1]!, arrival: Duration.parse('PT25M') },
+        ],
+      };
+
+      const payload = formatTrainSchedulePayload(osrdconf);
+
+      expect(payload.start_time).toBe(new Date('2025-06-02T12:55:00.000Z').getTime());
+      expect(payload.schedule).toEqual([
+        {
+          at: '1-1',
+          arrival: 'PT15M',
+          reception_signal: 'OPEN',
+          stop_for: undefined,
+        },
+      ]);
+    });
+  });
 });

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
@@ -3,7 +3,7 @@ import { compact } from 'lodash';
 import type { PacedTrainException, TrainSchedule } from 'common/api/osrdEditoastApi';
 import { isPacedTrainBase } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { PacedTrainWithDetails, TrainScheduleWithDetails } from 'modules/trainSchedule/types';
-import type { OperationalStudiesConfState, OccurrenceId } from 'reducers/osrdconf/types';
+import type { OperationalStudiesConfState, OccurrenceId, PathStep } from 'reducers/osrdconf/types';
 import { kmhToMs } from 'utils/physics';
 import { extractOccurrenceIndexFromOccurrenceId, isIndexedOccurrenceId } from 'utils/trainId';
 
@@ -11,20 +11,47 @@ import { generatePacedTrainException } from './buildPacedTrainException';
 import formatMargin from './formatMargin';
 import formatSchedule from './formatSchedule';
 
+/** Ensure the first waypoint do not have an arrival time by shifting
+ * the startTime and the arrival time of all the other waypoints.
+ *
+ * This is necessary because our backend API do not allow the first
+ * waypoint to have an arrival time.
+ */
+function normalizeFirstWaypointTimes(
+  pathSteps: PathStep[],
+  startTime: number
+): { pathSteps: PathStep[]; startTime: number } {
+  const firstArrival = pathSteps[0]?.arrival;
+  if (!firstArrival) return { pathSteps, startTime };
+
+  const shiftedPathSteps = pathSteps.map((step, index) => {
+    if (index === 0) return { ...step, arrival: null };
+    if (step.arrival) return { ...step, arrival: step.arrival.sub(firstArrival) };
+    return step;
+  });
+
+  return { pathSteps: shiftedPathSteps, startTime: startTime + firstArrival.ms };
+}
+
 export function formatTrainSchedulePayload(osrdconf: OperationalStudiesConfState): TrainSchedule {
+  const { pathSteps, startTime } = normalizeFirstWaypointTimes(
+    compact(osrdconf.pathSteps),
+    osrdconf.startTime.getTime()
+  );
+
   return {
     category: osrdconf.category,
     comfort: osrdconf.rollingStockComfort,
     constraint_distribution: osrdconf.constraintDistribution,
     initial_speed: osrdconf.initialSpeed ? kmhToMs(osrdconf.initialSpeed) : 0,
     labels: osrdconf.labels,
-    margins: formatMargin(compact(osrdconf.pathSteps)),
+    margins: formatMargin(pathSteps),
     options: {
       use_electrical_profiles: osrdconf.usingElectricalProfiles,
       use_speed_limits_for_simulation: osrdconf.usingSpeedLimits,
       stops_at_end_of_block: false,
     },
-    path: compact(osrdconf.pathSteps).map((step) => ({
+    path: pathSteps.map((step) => ({
       id: step.id,
       location: step.location,
     })),
@@ -40,9 +67,9 @@ export function formatTrainSchedulePayload(osrdconf: OperationalStudiesConfState
         : undefined,
     power_restrictions: osrdconf.powerRestriction,
     rolling_stock_name: osrdconf.rollingStockName,
-    schedule: formatSchedule(compact(osrdconf.pathSteps)),
+    schedule: formatSchedule(pathSteps),
     speed_limit_tag: osrdconf.speedLimitByTag,
-    start_time: osrdconf.startTime.getTime(),
+    start_time: startTime,
     train_name: osrdconf.name,
   };
 }


### PR DESCRIPTION
closes #17341 

The first waypoint of a path can't have an arrival time (the backend rejects it). This typically happens after deleting the origin: the new origin keeps the arrival offset it had as an intermediate waypoint.

To fix that and preserve the schedule, we fold that offset into the train's start time and shift the remaining waypoints arrivals back by the same amount, so every waypoint keeps the same absolute time. 
I'm open to any suggestions if you've found a better way to fix this bug
