### PR TITLE
editoast: fix nightly clippy lints

### DIFF
--- a/editoast/editoast_derive/src/model/codegen/changeset_builder_impl_block.rs
+++ b/editoast/editoast_derive/src/model/codegen/changeset_builder_impl_block.rs
@@ -29,7 +29,7 @@ impl ChangesetBuilderImplBlock {
         let ty = &field.ty;
         let value = field.into_transformed(parse_quote! { #ident });
         let statement = quote! { self.#ident = #ident.map(|#ident| #value) };
-        let name = syn::Ident::new(&format!("flat_{}", &field.builder_ident), Span::call_site());
+        let name = syn::Ident::new(&format!("flat_{}", field.builder_ident), Span::call_site());
         parse_quote! {
             pub fn #name(mut self, #ident: Option<#ty>) -> Self {
                 #statement;

--- a/editoast/editoast_models/src/map/geo_json_and_data.rs
+++ b/editoast/editoast_models/src/map/geo_json_and_data.rs
@@ -203,14 +203,14 @@ fn get_geo_json_sql_query(table_name: &str, view: &View) -> String {
         ",
         on_field = view.on_field,
         data_expr = view.data_expr,
-        exclude_fields = &view
+        exclude_fields = view
             .exclude_fields
             .iter()
             .map(|field| format!("- '{field}'"))
             .collect::<Vec<_>>()
             .join(" "),
         joins = view.joins.join(" "),
-        where_condition = &view
+        where_condition = view
             .where_expr
             .iter()
             .map(|field| format!("AND ({field})"))

--- a/editoast/src/client/import_rolling_stock.rs
+++ b/editoast/src/client/import_rolling_stock.rs
@@ -54,15 +54,15 @@ pub async fn import_rolling_stock(
                     .unwrap();
                 println!(
                     "   ↳ ✅ Rolling stock {}[{}] saved! (forced update)",
-                    &rolling_stock_name.bold(),
-                    &rolling_stock.id,
+                    rolling_stock_name.bold(),
+                    rolling_stock.id,
                 );
             }
             (Some(existing_rolling_stock), false) => {
                 println!(
                     "   ↳ ⚠️  Rolling stock {}[{}] already existing! (try use \"--force\" to update it)",
-                    &rolling_stock_name.bold(),
-                    &existing_rolling_stock.id,
+                    rolling_stock_name.bold(),
+                    existing_rolling_stock.id,
                 );
             }
             _ => {
@@ -73,8 +73,8 @@ pub async fn import_rolling_stock(
                     .await?;
                 println!(
                     "   ↳ ✅ Rolling stock {}[{}] saved!",
-                    &rolling_stock_name.bold(),
-                    &rolling_stock.id,
+                    rolling_stock_name.bold(),
+                    rolling_stock.id,
                 );
             }
         };
@@ -106,8 +106,8 @@ pub async fn import_towed_rolling_stock(
             .await?;
         println!(
             "✅ Towed rolling stock {}[{}] saved!",
-            &towed_rolling_stock.name.bold(),
-            &towed_rolling_stock.id
+            towed_rolling_stock.name.bold(),
+            towed_rolling_stock.id
         );
     }
     Ok(())

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -319,8 +319,6 @@ mod tests {
     use crate::fixtures::create_work_schedule_group;
     use crate::fixtures::simple_paced_train_changeset;
 
-    use editoast_models::prelude::*;
-
     use super::*;
     use chrono::DateTime;
     use chrono::Utc;

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -275,7 +275,8 @@ pub(in crate::views) async fn users_info(
         if !missing_identities.is_empty() {
             return Err(AuthzError::UnknownIdentities {
                 identities: missing_identities,
-            })?;
+            }
+            .into());
         }
     }
 

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -273,7 +273,7 @@ pub(in crate::views) async fn get_routes_nodes(
         filtered_routes
             .iter()
             .fold(HashMap::new(), |mut acc, route| {
-                for (node_id, _) in node_states.iter() {
+                for node_id in node_states.keys() {
                     let node_direction = route
                         .switches_directions
                         .get(&node_id.clone().into())

--- a/editoast/src/views/server/openapi.rs
+++ b/editoast/src/views/server/openapi.rs
@@ -242,7 +242,7 @@ impl OpenApiRoot {
     // Remove the operation_id that defaults to the endpoint function name
     // so that it doesn't override the RTK methods names.
     fn remove_operation_id(openapi: &mut utoipa::openapi::OpenApi) {
-        for (_, endpoint) in openapi.paths.paths.iter_mut() {
+        for endpoint in openapi.paths.paths.values_mut() {
             for operation in path_item_operations_mut(endpoint) {
                 operation.operation_id = None;
             }

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -217,7 +217,7 @@ impl TestAppBuilder {
         );
 
         let store_name =
-            fga::test_utilities::sanitize_store_name_length(&format!("authz@{}", &self.test_name));
+            fga::test_utilities::sanitize_store_name_length(&format!("authz@{}", self.test_name));
         let fga_connection_settings = fga::client::ConnectionSettings::new(
             Url::parse("http://localhost:8091").unwrap(),
             Limits::default(),

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1785,7 +1785,7 @@ mod tests {
     use core_client::simulation::SpeedLimitProperties;
     use database::DbConnectionPoolV2;
     use editoast_models::TrainScheduleException;
-    use editoast_models::prelude::*;
+
     use editoast_models::rolling_stock::TrainMainCategory;
     use editoast_models::timetable::Timetable;
     use pretty_assertions::assert_eq;


### PR DESCRIPTION
Ran `cargo clippy --workspace --all-targets --all-features --fix`.

Turns out all the lints were autofixable.