### PR TITLE
core, editoast: make allowedTrackSections non-nullable

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/ConsistSchedule.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/ConsistSchedule.kt
@@ -33,7 +33,7 @@ data class ConsistSchedule(
         operator fun invoke(
             consistSchedule: RequestConsistSchedule,
             infra: FullInfra,
-            allowedTrackSections: Set<TrackSectionId>? = null,
+            allowedTrackSections: Set<TrackSectionId> = emptySet(),
             totalSteps: Int,
         ): ConsistSchedule {
             val boundaries = consistSchedule.boundaries
@@ -58,7 +58,7 @@ data class ConsistSchedule(
             rollingStocks: List<RollingStock>,
             boundaries: List<Int>,
             infra: FullInfra,
-            allowedTrackSections: Set<TrackSectionId>? = null,
+            allowedTrackSections: Set<TrackSectionId> = emptySet(),
             totalSteps: Int,
         ): ConsistSchedule {
             // Input validation:

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -598,11 +598,8 @@ private fun parseSimulationScheduleItems(
     )
 }
 
-fun parseTrackSectionIds(infra: FullInfra, trackSectionNames: Set<String>?): Set<TrackSectionId>? {
-    return trackSectionNames
-        ?.mapNotNull { infra.rawInfra.getTrackSectionFromName(it) }
-        ?.toSet()
-        ?.takeIf { it.isNotEmpty() }
+fun parseTrackSectionIds(infra: FullInfra, trackSectionNames: Set<String>): Set<TrackSectionId> {
+    return trackSectionNames.mapNotNull { infra.rawInfra.getTrackSectionFromName(it) }.toSet()
 }
 
 private fun progressCallback(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMRequest.kt
@@ -57,7 +57,7 @@ class STDCMRequest(
     @Json(name = "temporary_speed_limits")
     val temporarySpeedLimits: Collection<STDCMTemporarySpeedLimit>,
     @Json(name = "work_schedules") val workSchedules: Collection<WorkSchedule> = listOf(),
-    @Json(name = "allowed_track_sections") val allowedTrackSections: Set<String>?,
+    @Json(name = "allowed_track_sections") val allowedTrackSections: Set<String> = emptySet(),
 )
 
 data class STDCMTemporarySpeedLimit(

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/CachedBlockConstraintCombiner.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/constraints/CachedBlockConstraintCombiner.kt
@@ -59,7 +59,7 @@ class CachedBlockConstraintCombiner(val functions: List<PathfindingConstraint> =
 fun initConstraints(
     fullInfra: FullInfra,
     rollingStock: RollingStock,
-    allowedTrackSections: Set<TrackSectionId>? = null,
+    allowedTrackSections: Set<TrackSectionId> = emptySet(),
 ): List<PathfindingConstraint> {
     return initConstraintsFromRSProps(
         fullInfra,
@@ -77,7 +77,7 @@ fun initConstraintsFromRSProps(
     rollingStockLoadingGauge: RJSLoadingGaugeType,
     rollingStockSupportedElectrification: List<String>,
     rollingStockSupportedSignalingSystems: List<String>,
-    allowedTrackSections: Set<TrackSectionId>? = null,
+    allowedTrackSections: Set<TrackSectionId> = emptySet(),
 ): List<PathfindingConstraint> {
     val res = mutableListOf<PathfindingConstraint>()
     if (!rollingStockIsThermal) {
@@ -95,7 +95,7 @@ fun initConstraintsFromRSProps(
             infra.signalingSimulator.sigModuleManager.findSignalingSystem(it)
         }
     res.add(SignalingSystemConstraints(infra.blockInfra, listOf(sigSystemIds)))
-    if (allowedTrackSections != null)
+    if (allowedTrackSections.isNotEmpty())
         res.add(TrackSectionConstraints(infra.blockInfra, infra.rawInfra, allowedTrackSections))
     return res
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -195,7 +195,8 @@ data class STDCMPathfindingBuilder(
         }
         val blockAvailabilityAdapter =
             blockAvailability ?: DummyBlockAvailability(infra!!.blockInfra, unavailableTimes)
-        val consistSchedule = ConsistSchedule(rollingStocks, boundaries, infra!!, null, steps.size)
+        val consistSchedule =
+            ConsistSchedule(rollingStocks, boundaries, infra!!, emptySet(), steps.size)
         return findPath(
             infra!!,
             consistSchedule,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
@@ -50,7 +50,7 @@ class InfraExplorerWithEnvelopeTests {
                         listOf(REALISTIC_FAST_TRAIN),
                         listOf(),
                         fullInfra,
-                        null,
+                        emptySet(),
                         nbSteps,
                     ),
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
@@ -127,7 +127,7 @@ class BlockAvailabilityTests {
             initInfraExplorerWithEnvelope(
                     infra,
                     BlockLocation(blocks[0], startOffset),
-                    ConsistSchedule(listOf(rollingStock), listOf(), infra, null, totalSteps),
+                    ConsistSchedule(listOf(rollingStock), listOf(), infra, emptySet(), totalSteps),
                     steps,
                 )
                 .find { filterExplorer(it) }!!

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/ConsistChangeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/ConsistChangeTests.kt
@@ -321,7 +321,7 @@ class ConsistChangeTests {
         val requestConsistSchedule =
             RequestConsistSchedule(listOf(1, 3, 6), listOf(consist1, consist2, consist1, consist3))
         val infra = Helpers.fullInfraFromFile("small_infra/infra.json")
-        val consistSchedule = ConsistSchedule(requestConsistSchedule, infra, null, nbSteps)
+        val consistSchedule = ConsistSchedule(requestConsistSchedule, infra, emptySet(), nbSteps)
         val expected = listOf(100.0, 200.0, 200.0, 100.0, 100.0, 100.0, 300.0, 300.0)
         assertEquals(expected, consistSchedule.rollingStocks.map { it.length })
     }
@@ -359,7 +359,8 @@ class ConsistChangeTests {
                 listOf(shorterConsist, longerConsist, shorterConsist),
             )
         val infra = Helpers.fullInfraFromFile("small_infra/infra.json")
-        val consistShortLongShort = ConsistSchedule(requestShortLongShort, infra, null, nbSteps)
+        val consistShortLongShort =
+            ConsistSchedule(requestShortLongShort, infra, emptySet(), nbSteps)
         val pathItems =
             listOf(
                 STDCMPathItem(
@@ -391,7 +392,8 @@ class ConsistChangeTests {
                 consistShortLongShort.rollingStocks.map { it.length },
             )
         val requestSingleShortTrain = RequestConsistSchedule(emptyList(), listOf(shorterConsist))
-        val consistSingleShortTrain = ConsistSchedule(requestSingleShortTrain, infra, null, nbSteps)
+        val consistSingleShortTrain =
+            ConsistSchedule(requestSingleShortTrain, infra, emptySet(), nbSteps)
         val stepsSingleShortTrain =
             parseSteps(
                 infra,

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -32,8 +32,8 @@ pub struct Request {
     // Pathfinding inputs
     /// List of waypoints. Each waypoint is a list of track offset.
     pub path_items: Vec<STDCMPathItem>,
-    /// Set of authorized track section ids for the current request
-    pub allowed_track_sections: Option<HashSet<String>>,
+    /// Set of authorized track section ids, empty means no restriction
+    pub allowed_track_sections: HashSet<String>,
 
     // Simulation inputs
     /// The comfort of the train

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3539,14 +3539,10 @@ paths:
               - consist_schedule
               properties:
                 allowed_track_sections:
-                  type:
-                  - array
-                  - 'null'
+                  type: array
                   items:
                     type: string
-                  description: |-
-                    Set of authorized track section ids for the current loading gauge,
-                    None value means no zone restriction.
+                  description: Set of authorized track section ids, empty means no restriction
                   uniqueItems: true
                 comfort:
                   $ref: '#/components/schemas/Comfort'

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -667,7 +667,7 @@ mod tests {
             time_gap_before: 35000,
             time_gap_after: 35000,
             margin: Some(MarginValue::MinPer100Km(4.5)),
-            allowed_track_sections: None,
+            allowed_track_sections: HashSet::new(),
             consist_schedule,
         }
     }

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -126,9 +126,9 @@ pub(crate) struct Request {
     #[serde(default)]
     #[schema(value_type = Option<String>, example = json!(["5%", "2min/100km"]))]
     pub(crate) margin: Option<MarginValue>,
-    /// Set of authorized track section ids for the current loading gauge,
-    /// None value means no zone restriction.
-    pub(crate) allowed_track_sections: Option<HashSet<String>>,
+    /// Set of authorized track section ids, empty means no restriction
+    #[serde(default)]
+    pub(crate) allowed_track_sections: HashSet<String>,
     pub(crate) consist_schedule: ConsistSchedule,
 }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2490,9 +2490,8 @@ export type PostTimetableByIdStdcmApiArg = {
   /** The infra id */
   infra: number;
   body: {
-    /** Set of authorized track section ids for the current loading gauge,
-        None value means no zone restriction. */
-    allowed_track_sections?: string[] | null;
+    /** Set of authorized track section ids, empty means no restriction */
+    allowed_track_sections?: string[];
     comfort: Comfort;
     consist_schedule: ConsistSchedule;
     electrical_profile_set_id?: number | null;


### PR DESCRIPTION
Previously, `null` and empty set both used to have the same meaning. The field now being non-nullable, empty set means no track section restriction.

This comes from a [discussion](https://github.com/OpenRailAssociation/osrd/pull/17372#discussion_r3468053379) in a previous PR.

You can test by making sure nothing is broken, the change should be transparent