### PR TITLE
Lf/perm endpoint rs post livery

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -138,6 +138,7 @@ pub enum InfraGrant {
     Eq,
     Hash,
 )]
+#[cfg_attr(test, derive(PartialOrd, Ord))]
 #[fga(name = "rolling_stock")]
 pub struct RollingStock(pub i64);
 

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -14,6 +14,8 @@ use crate::RollingStockPrivilege;
 use crate::Subject;
 use crate::User;
 use crate::v2::Actor;
+use crate::v2::ResourcesList;
+use crate::v2::subject_roles;
 
 pub fn rolling_stock_privileges(
     user: User,
@@ -229,6 +231,58 @@ pub fn rolling_stock_granted_subjects(
         .with_check(Check::RollingStockExists(rolling_stock))
 }
 
+pub fn rolling_stock_list(
+    user: User,
+    privilege: RollingStockPrivilege,
+) -> Protected<ResourcesList<RollingStock>> {
+    subject_roles(Subject::user(user)).map(move |openfga, roles| {
+        async move {
+            if roles.contains(&Role::Admin) {
+                return Ok(ResourcesList::All);
+            }
+            let authorized_rolling_stocks = match privilege {
+                RollingStockPrivilege::CanRead => {
+                    openfga
+                        .list_objects(RollingStock::can_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareRead => {
+                    openfga
+                        .list_objects(RollingStock::can_share_read().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareWrite => {
+                    openfga
+                        .list_objects(RollingStock::can_share_write().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanDelete => {
+                    openfga
+                        .list_objects(RollingStock::can_delete().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanShareOwnership => {
+                    openfga
+                        .list_objects(RollingStock::can_share_ownership().query_objects(&user))
+                        .await?
+                }
+                RollingStockPrivilege::CanRevoke => {
+                    openfga
+                        .list_objects(RollingStock::can_revoke().query_objects(&user))
+                        .await?
+                }
+            };
+            Ok(ResourcesList::Privileged(authorized_rolling_stocks))
+        }
+        .boxed()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -376,6 +430,79 @@ mod tests {
         assert_eq!(response, expected);
     }
 
+    #[tokio::test]
+    async fn check_rolling_stock_list_no_rights_and_admin() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(3)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .write(&User::role().tuple(&Role::Admin, &User(3)))
+            .execute()
+            .await
+            .unwrap();
+        let rolling_stocks_1 = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_2 = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged()
+            .into_iter();
+        let rolling_stocks_no_rights = openfga
+            .rolling_stock_list(User(4), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        let rolling_stocks_admin = openfga
+            .rolling_stock_list(User(3), RollingStockPrivilege::CanRead)
+            .await;
+        assert_eq!(
+            rolling_stocks_1.sorted().collect_vec(),
+            vec![RollingStock(1), RollingStock(3)]
+        );
+        assert_eq!(
+            rolling_stocks_2.sorted().collect_vec(),
+            vec![RollingStock(2)]
+        );
+        assert_eq!(rolling_stocks_no_rights, vec![]);
+        assert!(matches!(rolling_stocks_admin, ResourcesList::All));
+    }
+
+    #[tokio::test]
+    async fn rolling_stock_list_only_returns_resources_with_the_queried_privilege() {
+        let openfga = crate::authz_client!();
+        openfga
+            .prepare_writes()
+            .write(&RollingStock::reader().tuple(&User(1), &RollingStock(1)))
+            .write(&RollingStock::writer().tuple(&User(2), &RollingStock(2)))
+            .execute()
+            .await
+            .unwrap();
+
+        // A reader grant grants read access and not write access
+        let reader_can_read = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanRead)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_read, vec![RollingStock(1)]);
+
+        let reader_can_write = openfga
+            .rolling_stock_list(User(1), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(reader_can_write, vec![]);
+
+        // A writer grant grants both read and write access
+        let writer_can_write = openfga
+            .rolling_stock_list(User(2), RollingStockPrivilege::CanWrite)
+            .await
+            .unwrap_privileged();
+        assert_eq!(writer_can_write, vec![RollingStock(2)]);
+    }
+
     #[rstest]
     #[case::rolling_stock_privileges(
         rolling_stock_privileges(User(1), RollingStock(1)).checks,
@@ -400,6 +527,13 @@ mod tests {
         &[
            Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
            Check::RollingStockExists(RollingStock(1))
+        ]
+    )]
+    #[rstest]
+    #[case::rolling_stock_list(
+        rolling_stock_list(User(1), RollingStockPrivilege::CanRead).checks,
+        &[
+           Check::SubjectExists(Subject::user(1)),
         ]
     )]
     fn protected_contains_expected_checks(

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -63,6 +63,11 @@ pub trait TestClientExt {
         subject: Subject,
         grant: RollingStockGrant,
     );
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock>;
 }
 
 impl TestClientExt for fga::Client {
@@ -255,6 +260,20 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(crate::v2::infra::infra_list(user, privilege))
+            .await
+            .unwrap()
+    }
+
+    async fn rolling_stock_list(
+        &self,
+        user: User,
+        privilege: RollingStockPrivilege,
+    ) -> ResourcesList<RollingStock> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(crate::v2::rolling_stock::rolling_stock_list(
+                user, privilege,
+            ))
             .await
             .unwrap()
     }

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -124,4 +124,15 @@ impl State {
             Mode::Skip { .. } => Ok(State::Skip { user, roles }),
         }
     }
+
+    /// The authenticated user if authorization is **not** skipped
+    ///
+    /// If this function returns a user, then it is subject to permissions,
+    /// otherwise they likely can be bypassed.
+    pub fn regular_user(&self) -> Option<authz::User> {
+        match self {
+            State::Authenticated { user, .. } => Some(*user),
+            State::Skip { .. } => None,
+        }
+    }
 }

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,5 +1,7 @@
 use std::convert::Infallible;
 
+use crate::views::AuthorizationError;
+use crate::views::AuthorizerError;
 use authz::v2::Access;
 use authz::v2::Actor;
 use authz::v2::Authorizer;
@@ -208,6 +210,38 @@ macro_rules! impossible {
     };
 }
 pub(crate) use impossible;
+
+/// Ensures the issuer holds a privilege satisfying `required`.
+/// `protected` is an operation yielding the set of privileges the issuer holds on a resource.
+/// Access is granted when the operation is authorized and the issuer holds a privilege equal to `required`.
+pub async fn require<I, U>(
+    authorizer: &U,
+    protected: Protected<I>,
+    required: &<I as IntoIterator>::Item,
+) -> Result<(), AuthorizationError>
+where
+    I: IntoIterator,
+    <I as IntoIterator>::Item: PartialEq,
+    U: Authorizer<Error = Error>,
+{
+    let access = authorizer.authorize(protected).await.map_err(|e| match e {
+        Error::Database(error) => {
+            AuthorizationError::AuthError(AuthorizerError::Storage(error.into()))
+        }
+        Error::OpenFga(error) => error.into(),
+    })?;
+    let Ok(privileges) = access.access().await? else {
+        return Err(AuthorizationError::Forbidden);
+    };
+    if privileges
+        .into_iter()
+        .any(|privilege| privilege == *required)
+    {
+        Ok(())
+    } else {
+        Err(AuthorizationError::Forbidden)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1017,30 +1017,39 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn infra_list_filters_authorized_infras() {
+    async fn infra_list_user_only_sees_its_related_infras() {
         let app = test_app!().build();
         let db_pool = app.db_pool();
-        let infra = create_small_infra(&mut db_pool.get_ok()).await;
-        let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
-
-        // Regular user with the correct roles should see only the infra he is associated with:
+        let infra_1 = create_small_infra(&mut db_pool.get_ok()).await;
+        let infra_2 = create_small_infra(&mut db_pool.get_ok()).await;
+        let _infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
         let user = app
             .user("user_identity", "user_name")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_infra_grant(infra_1.id, InfraGrant::Reader)
+            .with_infra_grant(infra_2.id, InfraGrant::Reader)
             .create()
             .await;
         let response: InfraListResponse = app
             .get("/infra/")
             .by_user(user.as_ref())
             .await
-            .assert_status(StatusCode::OK)
+            .assert_status_ok()
             .json();
         assert_eq!(
-            response.results.iter().map(|infra| infra.id).collect_vec(),
-            vec![infra.id]
+            response
+                .results
+                .iter()
+                .map(|infra| infra.id)
+                .collect::<Vec<_>>(),
+            vec![infra_1.id, infra_2.id]
         );
+    }
 
-        // An admin should see all the infras:
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_list_admin_can_see_unrelated_infra() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
         let admin = app
             .user("admin", "admin")
             .with_roles([Role::Admin])
@@ -1050,11 +1059,15 @@ pub mod tests {
             .get("/infra/")
             .by_user(admin.as_ref())
             .await
-            .assert_status(StatusCode::OK)
+            .assert_status_ok()
             .json();
         assert_eq!(
-            response.results.iter().map(|infra| infra.id).collect_vec(),
-            vec![infra.id, infra_no_grant.id]
+            response
+                .results
+                .iter()
+                .map(|infra| infra.id)
+                .collect::<Vec<_>>(),
+            vec![infra_no_grant.id]
         );
     }
 

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -515,10 +515,26 @@ async fn parse_multipart_content(
     )
 )]
 pub(in crate::views) async fn create_livery(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
     form: Multipart,
 ) -> Result<Json<schemas::rolling_stock::RollingStockLivery>> {
+    match &authn_state {
+        crate::authentication::State::Skip { .. } => (),
+        crate::authentication::State::Authenticated { user, .. } => {
+            let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+            crate::authorizers::require(
+                &authorizer,
+                authz::v2::rolling_stock_privileges(*user, authz::RollingStock(rolling_stock_id)),
+                &RollingStockPrivilege::CanWrite,
+            )
+            .await?;
+        }
+    };
+
     let conn = &mut db_pool.get().await?;
 
     let (name, images) = parse_multipart_content(form)
@@ -1553,5 +1569,36 @@ pub mod tests {
                 .expect("Failed to check if rolling stock exists");
 
         assert!(!rolling_stock_exists);
+    }
+
+    mod post_rolling_stock_livery {
+        mod authorization {
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn authorized_grant_levels() {
+                todo!()
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn admin_is_authorized() {
+                todo!()
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn skip_authz_is_authorized() {
+                todo!()
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn unauthorized_grant_levels() {
+                todo!()
+            }
+
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            async fn roles_dont_provide_authorization() {
+                todo!()
+            }
+        }
+
+        // TODO Add tests
     }
 }

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -1,6 +1,9 @@
 pub(in crate::views) mod light;
 pub(in crate::views) mod towed;
 
+use authz::RollingStockPrivilege;
+use authz::v2::rolling_stock_privileges;
+use axum::Extension;
 use schemas::RollingStock as RollingStockForm;
 
 use std::io::Cursor;
@@ -36,6 +39,7 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
+use crate::AppState;
 use crate::error::InternalError;
 use crate::error::Result;
 
@@ -180,9 +184,22 @@ pub struct RollingStockNameParam {
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_id): Path<i64>,
 ) -> Result<Json<RollingStockWithLiveries>> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock_id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock = retrieve_existing_rolling_stock(
         &mut db_pool.get().await?,
         RollingStockKey::Id(rolling_stock_id),
@@ -204,7 +221,10 @@ pub(in crate::views) async fn get(
     )
 )]
 pub(in crate::views) async fn get_by_name(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(rolling_stock_name): Path<String>,
 ) -> Result<Json<RollingStockWithLiveries>> {
     let rolling_stock = retrieve_existing_rolling_stock(
@@ -212,6 +232,17 @@ pub(in crate::views) async fn get_by_name(
         RollingStockKey::Name(rolling_stock_name),
     )
     .await?;
+
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock_with_liveries =
         RollingStockWithLiveries::try_fetch(&mut db_pool.get().await?, rolling_stock).await?;
     Ok(Json(rolling_stock_with_liveries))
@@ -689,6 +720,7 @@ pub mod tests {
     use crate::fixtures::simple_paced_train_changeset;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt;
     use editoast_models::rolling_stock::RollingStock;
 
     impl TestApp {
@@ -1012,21 +1044,72 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_rolling_stock_by_id() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with the role to reach the endpoint and a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_roles([Role::OperationalStudies])
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let raw_response = app
             .rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
             .await;
 
         // THEN
         let response: RollingStock = raw_response.assert_status_ok().json();
 
         assert_eq!(response, fast_rolling_stock);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_rolling_stock_by_id_with_privilege_and_no_roles() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that does not have the role to reach the endpoint but has a read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
+        app.rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_rolling_stock_by_id_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.rolling_stock_get_by_id_request(fast_rolling_stock.id)
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,3 +1,6 @@
+use authz::RollingStockPrivilege;
+use authz::v2::rolling_stock_privileges;
+use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -28,6 +31,7 @@ use super::RollingStockError;
 use super::RollingStockIdParam;
 use super::RollingStockKey;
 use super::RollingStockNameParam;
+use crate::AppState;
 use crate::error::Result;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
@@ -118,9 +122,22 @@ pub(in crate::views) async fn list(
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(light_rolling_stock_id): Path<i64>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(light_rolling_stock_id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let rolling_stock =
         RollingStock::retrieve_or_fail(db_pool.get().await?, light_rolling_stock_id, || {
             RollingStockError::KeyNotFound {
@@ -144,7 +161,10 @@ pub(in crate::views) async fn get(
     )
 )]
 pub(in crate::views) async fn get_by_name(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        regulator, db_pool, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(light_rolling_stock_name): Path<String>,
 ) -> Result<Json<LightRollingStockWithLiveries>> {
     let rolling_stock = RollingStock::retrieve_or_fail(
@@ -155,6 +175,17 @@ pub(in crate::views) async fn get_by_name(
         },
     )
     .await?;
+
+    if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        crate::authorizers::require(
+            &authorizer,
+            rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
+            &RollingStockPrivilege::CanRead,
+        )
+        .await?;
+    }
+
     let light_rolling_stock_with_liveries =
         LightRollingStockWithLiveries::try_fetch(&mut db_pool.get().await?, rolling_stock).await?;
     Ok(Json(light_rolling_stock_with_liveries))
@@ -281,6 +312,7 @@ mod tests {
     use crate::error::InternalError;
     use crate::fixtures::create_fast_rolling_stock;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt;
 
     fn is_sorted(data: &[i64]) -> bool {
         for elem in data.windows(2) {
@@ -300,15 +332,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let response: LightRollingStockWithLiveries = app
             .get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -320,15 +360,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock_by_name() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
 
         let rs_name = "fast_rolling_stock_name";
         let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
+        // a user with a read grant on the rolling stock
+        let user = app
+            .user("authorized", "Authorized")
+            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .create()
+            .await;
+
         // WHEN
         let response: LightRollingStockWithLiveries = app
             .get(format!("/light_rolling_stock/name/{rs_name}").as_str())
+            .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
@@ -345,6 +393,48 @@ mod tests {
         app.get(format!("/light_rolling_stock/{}", -1).as_str())
             .await
             .assert_status_not_found();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_light_rolling_stock_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_light_rolling_stock_by_name_without_permission() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        let rs_name = "fast_rolling_stock_name";
+        create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
+
+        // a user that has the role to reach the endpoint but no read grant on the rolling stock
+        let user = app
+            .user("unauthorized", "Unauthorized")
+            .with_roles([authz::Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(format!("/light_rolling_stock/name/{rs_name}").as_str())
+            .by_user(&user.info)
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -368,17 +368,16 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn rolling_stock_list_filters_authorized_rolling_stocks() {
+    async fn rolling_stock_list_user_only_sees_its_related_rolling_stocks() {
         let app = test_app!().build();
         let db_pool = app.db_pool();
-        let rolling_stock_grant =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_grant").await;
-        let rolling_stock_no_grant =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_no_grant").await;
-        // Regular user with the correct roles should see only the rolling stock he is associated with:
+        let rs_1 = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_1").await;
+        let rs_2 = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_2").await;
+        let _rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let user = app
             .user("user_identity", "user_name")
-            .with_rolling_stock_grant(rolling_stock_grant.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rs_1.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rs_2.id, RollingStockGrant::Reader)
             .create()
             .await;
         let response: LightRollingStockWithLiveriesCountList = app
@@ -393,10 +392,15 @@ mod tests {
                 .iter()
                 .map(|rolling_stock| rolling_stock.rolling_stock.id)
                 .collect::<Vec<_>>(),
-            vec![rolling_stock_grant.id]
+            vec![rs_1.id, rs_2.id]
         );
-        // TODO: separate in two tests (admins_can_list_all_rolling_stocks and user_can_list_their_rolling_stocks)
-        // An admin should see all the rolling stocks:
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn rolling_stock_list_admin_can_see_unrelated_rolling_stock() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let admin = app
             .user("admin", "admin")
             .with_roles([Role::Admin])
@@ -414,7 +418,7 @@ mod tests {
                 .iter()
                 .map(|rolling_stock| rolling_stock.rolling_stock.id)
                 .collect::<Vec<_>>(),
-            vec![rolling_stock_grant.id, rolling_stock_no_grant.id]
+            vec![rs_no_grant.id]
         );
     }
 

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -1,4 +1,6 @@
 use authz::RollingStockPrivilege;
+use authz::v2::Authorizer;
+use authz::v2::Check;
 use authz::v2::rolling_stock_privileges;
 use axum::Extension;
 use axum::extract::Json;
@@ -8,7 +10,6 @@ use axum::extract::State;
 use common::units;
 use common::units::quantities::Length;
 use database::DbConnection;
-use database::DbConnectionPoolV2;
 use editoast_models::prelude::*;
 use editoast_models::rolling_stock::RollingStock;
 use editoast_models::rolling_stock::TrainMainCategory;
@@ -22,7 +23,6 @@ use schemas::rolling_stock::SupportedSignalingSystem;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 use uom::si::f64::Mass;
 use uom::si::f64::Velocity;
 use utoipa::ToSchema;
@@ -32,7 +32,9 @@ use super::RollingStockIdParam;
 use super::RollingStockKey;
 use super::RollingStockNameParam;
 use crate::AppState;
+use crate::authorizers::impossible;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -88,14 +90,48 @@ pub(in crate::views) struct LightRollingStockWithLiveriesCountList {
     )
 )]
 pub(in crate::views) async fn list(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+
+    Extension(authn_state): Extension<crate::authentication::State>,
     Query(page_settings): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<LightRollingStockWithLiveriesCountList>> {
-    let settings = page_settings
-        .into_selection_settings()
-        .order_by(|| RollingStock::ID.asc());
+    let conn = &mut db_pool.get().await?;
+    let default_settings = page_settings.into_selection_settings();
+    let settings = if let Some(user) = authn_state.regular_user() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        let authorized_rolling_stocks = authorizer
+            .authorize(authz::v2::rolling_stock_list(
+                user,
+                RollingStockPrivilege::CanRead,
+            ))
+            .await?
+            .access()
+            .await?
+            .map_err(|err| match err {
+                Check::SubjectExists(_) => AuthorizationError::Forbidden,
+                check => impossible!(check),
+            })?;
+        match authorized_rolling_stocks {
+            authz::v2::ResourcesList::All => default_settings,
+            authz::v2::ResourcesList::Privileged(authorized_rolling_stocks) => default_settings
+                .filter(move || {
+                    RollingStock::ID.eq_any(
+                        authorized_rolling_stocks
+                            .iter()
+                            .map(|rolling_stock| rolling_stock.0)
+                            .collect(),
+                    )
+                }),
+        }
+    } else {
+        default_settings
+    };
+
     let (rolling_stocks, stats) =
-        RollingStock::list_paginated(&mut db_pool.get().await?, settings).await?;
+        RollingStock::list_paginated(conn, settings.order_by(move || RollingStock::ID.asc()))
+            .await?;
 
     let results = rolling_stocks.into_iter().zip(db_pool.iter_conn()).map(
         |(rolling_stock, conn)| async move {
@@ -302,6 +338,8 @@ impl From<ModeEffortCurves> for LightModeEffortCurves {
 
 #[cfg(test)]
 mod tests {
+    use authz::Role;
+    use authz::RollingStockGrant;
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -327,6 +365,57 @@ mod tests {
     async fn list_light_rolling_stock() {
         let app = test_app!().skip_authz().build();
         app.get("/light_rolling_stock").await.assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn rolling_stock_list_filters_authorized_rolling_stocks() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let rolling_stock_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_grant").await;
+        let rolling_stock_no_grant =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_no_grant").await;
+        // Regular user with the correct roles should see only the rolling stock he is associated with:
+        let user = app
+            .user("user_identity", "user_name")
+            .with_rolling_stock_grant(rolling_stock_grant.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock")
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id]
+        );
+        // TODO: separate in two tests (admins_can_list_all_rolling_stocks and user_can_list_their_rolling_stocks)
+        // An admin should see all the rolling stocks:
+        let admin = app
+            .user("admin", "admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let response: LightRollingStockWithLiveriesCountList = app
+            .get("/light_rolling_stock/")
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            response
+                .results
+                .iter()
+                .map(|rolling_stock| rolling_stock.rolling_stock.id)
+                .collect::<Vec<_>>(),
+            vec![rolling_stock_grant.id, rolling_stock_no_grant.id]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/pull/17364 / https://github.com/osrd-project/osrd-confidential/issues/1064.

> [!NOTE]
Not ready for review yet, tests missing.

Authorization rules:
- Users must have the Writer grant on the rolling stock to post a livery.
- No role is required (or allows) to use the endpoint except admin.