### PR TITLE
cherry-picked: implement `authorizers::require`

### DIFF
--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -209,6 +209,41 @@ macro_rules! impossible {
 }
 pub(crate) use impossible;
 
+use crate::views::AuthorizationError;
+use crate::views::AuthorizerError;
+
+/// Ensures the issuer holds a privilege satisfying `required`.
+/// `protected` is an operation yielding the set of privileges the issuer holds on a resource.
+/// Access is granted when the operation is authorized and the issuer holds a privilege equal to `required`.
+pub async fn require<T, I, U>(
+    authorizer: &U,
+    protected: Protected<I>,
+    required: &T,
+) -> Result<(), AuthorizationError>
+where
+    T: PartialEq,
+    I: IntoIterator<Item = T>,
+    U: Authorizer<Error = Error>,
+{
+    let access = authorizer.authorize(protected).await.map_err(|e| match e {
+        Error::Database(error) => {
+            AuthorizationError::AuthError(AuthorizerError::Storage(error.into()))
+        }
+        Error::OpenFga(error) => error.into(),
+    })?;
+    let Ok(privileges) = access.access().await? else {
+        return Err(AuthorizationError::Forbidden);
+    };
+    if privileges
+        .into_iter()
+        .any(|privilege| privilege == *required)
+    {
+        Ok(())
+    } else {
+        Err(AuthorizationError::Forbidden)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use authz::InfraGrant;


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/pull/17364 / https://github.com/osrd-project/osrd-confidential/issues/1064.

> [!NOTE]
Not ready for review yet, tests missing.

Authorization rules:
- Users must have the Writer grant on the rolling stock to post a livery.
- No role is required (or allows) to use the endpoint except admin.