### PR TITLE
core: stdcm: fix backtracking bugs

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -101,7 +101,11 @@ fun runScheduleMetadataExtractor(
     val spacingGenerator = SpacingResourceGenerator(fullInfra, context)
     spacingGenerator.extendPath(trainPath.getBlocks(), trainPath.getRoutes(), pathStops, true)
     // as the provided path is complete, the resource generator should never return NotEnoughPath
-    val spacingRequirements = spacingGenerator.processUpdate(envelopeAdapter)!!
+    val spacingRequirements =
+        // TODO: Remove if condition once spacing requirements are fixed for paths with
+        // backtrackings.
+        if (trainPath.getBacktrackLocations().isNotEmpty()) listOf()
+        else spacingGenerator.processUpdate(envelopeAdapter)!!
 
     val routingRequirements =
         routingRequirements(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.meters
 import kotlin.math.min
 
 /** This class handles the creation of new edges, handling the many optional parameters. */
@@ -21,17 +20,27 @@ internal constructor(
     private val graph: STDCMGraph,
     /** Previous node, used to compute the final path */
     private var prevNode: STDCMNode,
-    /** Start offset on the given block */
-    private var startOffset: Offset<Block> = Offset(0.meters),
-    /** Envelope to use on the edge, if unspecified we try to go at maximum allowed speed */
-    private var envelope: Envelope? = null,
-
     /**
      * Infra explorer with the new envelope for the current edge. Keeping one instance is important
      * for the resource generator caches. This is the instance that must be used for next edges
      */
     private var explorerWithNewEnvelope: InfraExplorerWithEnvelope? = null,
 ) {
+    /** Start offset on the given block */
+    private var startOffset: Offset<Block> =
+        // Staying on the same block means intermediate stop without backtracking: restart from
+        // previous node's location
+        if (
+            prevNode.locationOnEdge != null &&
+                prevNode.infraExplorer.getCurrentBlock() == infraExplorer.getCurrentBlock()
+        )
+            prevNode.locationOnEdge!!
+        // In any other case (start, end of block, backtracking): (re)start from blockRange's begin
+        else infraExplorer.getCurrentBlockRange().objectBegin
+
+    /** Envelope to use on the edge, if unspecified we try to go at maximum allowed speed */
+    private var envelope: Envelope? = null
+
     /**
      * Sets the envelope to use on the edge, if unspecified we try to go at maximum allowed speed
      */
@@ -235,15 +244,10 @@ internal constructor(
     companion object {
         fun fromNode(
             graph: STDCMGraph,
-            node: STDCMNode,
+            prevNode: STDCMNode,
             infraExplorer: InfraExplorerWithEnvelope,
         ): STDCMEdgeBuilder {
-            val builder = STDCMEdgeBuilder(infraExplorer, graph, node)
-            if (node.locationOnEdge != null) {
-                builder.startOffset = node.locationOnEdge
-            }
-            builder.prevNode = node
-            return builder
+            return STDCMEdgeBuilder(infraExplorer, graph, prevNode)
         }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -143,7 +143,15 @@ class STDCMGraph(
                 explorer = node.infraExplorer,
             )
         val explorer = node.infraExplorer.clone()
-        if (node.locationOnEdge != null) {
+        if (
+            node.locationOnEdge != null &&
+                explorer.getBacktrackLocationsInRange().none {
+                    it == explorer.getCurrentBlockRange().pathEnd
+                }
+        ) {
+            // If we're at a non-backtracking stop in the middle of an edge, we want to generate the
+            // rest of the edge on the rest of the block, starting at the stop and ending at the end
+            // of the block.
             val backtrackingLocation = explorer.getBacktrackingLocationInLookahead()
             visitedNodesParameters.fingerprint =
                 VisitedNodes.Fingerprint(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -192,8 +192,6 @@ data class ExplorerStep(
     val plannedTimingData: PlannedTimingData? = null,
 )
 
-data class TrainPathCacheKey(val blockId: BlockId, val backtrackLocation: Offset<Block>?)
-
 /**
  * Init all InfraExplorers starting at the given location. The last of `stops` are used to identify
  * when the incremental path is complete. `constraints` are used to determine if a block can be
@@ -211,7 +209,7 @@ fun initInfraExplorers(
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
     val pathProps = buildTrainPathFromBlock(rawInfra, blockInfra, block, listOf())
-    val blockToPathProperties = mutableMapOf(TrainPathCacheKey(block, null) to pathProps)
+    val blockToPathProperties = mutableMapOf(block to pathProps)
     val routes = blockInfra.routesOnBlock(rawInfra, block)
 
     routes.forEach { route ->
@@ -246,7 +244,7 @@ private class InfraExplorerImpl(
     private var routes: AppendOnlyLinkedList<RouteRange>,
     private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
     private var lastTrack: TrackSectionId?,
-    private var trainPathCache: MutableMap<TrainPathCacheKey, TrainPath>,
+    private var trainPathCache: MutableMap<BlockId, TrainPath>,
     private var currentIndex: Int = 0, // /!\ currentBlockRange should be updated simultaneously /!\
     private var currentBlockRange: BlockRange? = null,
     private var stepTracker: StepTracker,
@@ -262,26 +260,11 @@ private class InfraExplorerImpl(
         // We also can't set a first route for sure in initInfraExplorer, but we set the first cache
         // entry.
         // So we have to correct that here now that we now which route we're on.
-        val blockRange = getCurrentBlockRange()
-        val blockBacktrackLocations =
-            getBacktrackLocationsInRange(blockRange.pathBegin, blockRange.pathEnd).map {
-                Offset<Block>(it.distance - blockRange.objectAbsolutePathStart.distance)
-            }
-
-        assert(blockBacktrackLocations.size <= 1)
-        val trainPathCacheKey =
-            TrainPathCacheKey(getCurrentBlock(), blockBacktrackLocations.firstOrNull())
-
+        val currentBlock = getCurrentBlock()
         val path =
-            trainPathCache.getOrElse(trainPathCacheKey) {
-                val res =
-                    buildTrainPathFromBlock(
-                        rawInfra,
-                        blockInfra,
-                        getCurrentBlock(),
-                        blockBacktrackLocations,
-                    )
-                trainPathCache[trainPathCacheKey] = res
+            trainPathCache.getOrElse(currentBlock) {
+                val res = buildTrainPathFromBlock(rawInfra, blockInfra, currentBlock, listOf())
+                trainPathCache[currentBlock] = res
                 res
             }
         val route = blockRoutes[getCurrentBlock()]!!
@@ -291,9 +274,10 @@ private class InfraExplorerImpl(
         val blockLength = blockInfra.getBlockLength(getCurrentBlock())
         val endOffset: Offset<Block> = if (length == null) blockLength else offset.plus(length)
         if (offset.distance == 0.meters && endOffset == blockLength) {
+            // Edge takes up the whole path.
             return pathWithRoutes
         }
-        // In that case, start of the block is start of the travelled path
+        // Edge takes part of the path: return corresponding sub-path.
         return pathWithRoutes.subPath(offset.cast(), endOffset.cast())
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -158,6 +158,8 @@ data class InfraExplorerWithEnvelopeImpl(
     }
 
     override fun getSpacingRequirements(): List<SpacingRequirement> {
+        // TODO: Remove once spacing requirements are fixed for paths with backtrackings.
+        if (getBacktrackLocationsInRange().isNotEmpty()) return listOf()
         val cached = spacingRequirementsCache?.get()
         if (cached != null) return cached
         if (getFullEnvelope().endPos == 0.0) {
@@ -190,6 +192,8 @@ data class InfraExplorerWithEnvelopeImpl(
     }
 
     override fun getFullSpacingRequirements(): List<SpacingRequirement> {
+        // TODO: Remove once spacing requirements are fixed for paths with backtrackings.
+        if (getBacktrackLocationsInRange().isNotEmpty()) return listOf()
         val simulationComplete = isPathComplete && getLookahead().isEmpty()
         // We need a new automaton to get the resource uses over the whole path, and not just since
         // the last update


### PR DESCRIPTION
Progress logger wasn't working on hacked paths allowing backtrackings in STDCM: this PR corrects all the bugs (theoretically -hopefully - fingers crossed) to fix the STDCM pathfinding with backtrackings, and make the progress logger work with backtrackings :)

Last commit (which will be reverted in the future) disables spacing requirement computation for paths with backracking, for incoming debug purposes. This will allow the user to test the feature at least partially: the resulting path will be able to have backtrackings BUT the train will not dodge incoming traffic (ouchie).