### PR TITLE
python: use `models` instead of `infra` for `TrackRange` and `SwitchType`

### DIFF
--- a/osrd_schemas_auto/osrd_schemas_auto/external_generated_inputs.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/external_generated_inputs.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Field
 
-from .infra import TrackRange
+from .models import TrackRange
 
 
 class ElectricalProfile(BaseModel):

--- a/osrd_schemas_auto/osrd_schemas_auto/switch_type.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/switch_type.py
@@ -1,49 +1,63 @@
-from .infra import SwitchPortConnection, SwitchType
+from .models import Port, SwitchPortConnection, SwitchType
 
-_spc = SwitchPortConnection.from_strs
-
-
-POINT_SWITCH: SwitchType = SwitchType.from_strs(
-    "point_switch",
-    ["A", "B1", "B2"],
-    {"A_B2": [_spc("A", "B2")], "A_B1": [_spc("A", "B1")]},
-)
-
-LINK: SwitchType = SwitchType.from_strs(
-    "link", ["A", "B"], {"STATIC": [_spc("A", "B")]}
-)
-CROSSING: SwitchType = SwitchType.from_strs(
-    "crossing",
-    ["A1", "B1", "A2", "B2"],
-    {"STATIC": [_spc("A1", "B1"), _spc("A2", "B2")]},
-)
-
-SINGLE_SLIP_SWITCH: SwitchType = SwitchType.from_strs(
-    "single_slip_switch",
-    ["A1", "B1", "A2", "B2"],
-    {
-        "STATIC": [_spc("A1", "B1"), _spc("A2", "B2")],
-        "A1_B2": [_spc("A1", "B2")],
+POINT_SWITCH: SwitchType = SwitchType(
+    id="point_switch",
+    ports=[Port("A"), Port("B1"), Port("B2")],
+    groups={
+        "A_B2": [SwitchPortConnection(src="A", dst="B2")],
+        "A_B1": [SwitchPortConnection(src="A", dst="B1")],
     },
 )
 
-DOUBLE_SLIP_SWITCH: SwitchType = SwitchType.from_strs(
-    "double_slip_switch",
-    ["A1", "B1", "A2", "B2"],
-    {
-        "A1_B1": [_spc("A1", "B1")],
-        "A1_B2": [_spc("A1", "B2")],
-        "A2_B1": [_spc("A2", "B1")],
-        "A2_B2": [_spc("A2", "B2")],
+LINK: SwitchType = SwitchType(
+    id="link",
+    ports=[Port("A"), Port("B")],
+    groups={"STATIC": [SwitchPortConnection(src="A", dst="B")]},
+)
+
+CROSSING: SwitchType = SwitchType(
+    id="crossing",
+    ports=[Port("A1"), Port("B1"), Port("A2"), Port("B2")],
+    groups={
+        "STATIC": [
+            SwitchPortConnection(src="A1", dst="B1"),
+            SwitchPortConnection(src="A2", dst="B2"),
+        ]
+    },
+)
+
+SINGLE_SLIP_SWITCH: SwitchType = SwitchType(
+    id="single_slip_switch",
+    ports=[Port("A1"), Port("B1"), Port("A2"), Port("B2")],
+    groups={
+        "STATIC": [
+            SwitchPortConnection(src="A1", dst="B1"),
+            SwitchPortConnection(src="A2", dst="B2"),
+        ],
+        "A1_B2": [SwitchPortConnection(src="A1", dst="B2")],
+    },
+)
+
+DOUBLE_SLIP_SWITCH: SwitchType = SwitchType(
+    id="double_slip_switch",
+    ports=[Port("A1"), Port("B1"), Port("A2"), Port("B2")],
+    groups={
+        "A1_B1": [SwitchPortConnection(src="A1", dst="B1")],
+        "A1_B2": [SwitchPortConnection(src="A1", dst="B2")],
+        "A2_B1": [SwitchPortConnection(src="A2", dst="B1")],
+        "A2_B2": [SwitchPortConnection(src="A2", dst="B2")],
     },
 )
 
 
 def builtin_node_types():
-    return {
-        **LINK.to_dict(),
-        **POINT_SWITCH.to_dict(),
-        **SINGLE_SLIP_SWITCH.to_dict(),
-        **DOUBLE_SLIP_SWITCH.to_dict(),
-        **CROSSING.to_dict(),
-    }
+    result = {}
+    for sw in [LINK, POINT_SWITCH, CROSSING, SINGLE_SLIP_SWITCH, DOUBLE_SLIP_SWITCH]:
+        result[sw.id] = {
+            "ports": [p.root for p in sw.ports],
+            "groups": {
+                gid: [{"src": c.src, "dst": c.dst} for c in conns]
+                for gid, conns in sw.groups.items()
+            },
+        }
+    return result

--- a/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from osrd_schemas_auto import infra, models
+from osrd_schemas_auto import models
 
 from .direction import ApplicableDirection, Direction
 
@@ -65,7 +65,7 @@ class TrackRange(RangeElement):
     track: "TrackSection"
 
     def to_rjs(self):
-        return infra.TrackRange(track=self.track.id, begin=self.begin, end=self.end)
+        return models.TrackRange(track=self.track.id, begin=self.begin, end=self.end)
 
 
 @dataclass

--- a/python/railjson_generator/railjson_generator/schema/infra/switch.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/switch.py
@@ -98,7 +98,7 @@ class Link(Switch):
     A: Optional[TrackEndpoint] = None
     B: Optional[TrackEndpoint] = None
 
-    PORT_NAMES = LINK.ports
+    PORT_NAMES = [p.root for p in LINK.ports]
     SWITCH_TYPE = LINK.id
 
 
@@ -108,7 +108,7 @@ class PointSwitch(Switch):
     B1: Optional[TrackEndpoint] = None
     B2: Optional[TrackEndpoint] = None
 
-    PORT_NAMES = POINT_SWITCH.ports
+    PORT_NAMES = [p.root for p in POINT_SWITCH.ports]
     SWITCH_TYPE = POINT_SWITCH.id
 
 
@@ -119,7 +119,7 @@ class Crossing(Switch):
     A2: Optional[TrackEndpoint] = None
     B2: Optional[TrackEndpoint] = None
 
-    PORT_NAMES = CROSSING.ports
+    PORT_NAMES = [p.root for p in CROSSING.ports]
     SWITCH_TYPE = CROSSING.id
 
 
@@ -130,7 +130,7 @@ class DoubleSlipSwitch(Switch):
     B1: Optional[TrackEndpoint] = None
     B2: Optional[TrackEndpoint] = None
 
-    PORT_NAMES = DOUBLE_SLIP_SWITCH.ports
+    PORT_NAMES = [p.root for p in DOUBLE_SLIP_SWITCH.ports]
     SWITCH_TYPE = DOUBLE_SLIP_SWITCH.id
 
 
@@ -141,5 +141,5 @@ class SingleSlipSwitch(Switch):
     B1: Optional[TrackEndpoint] = None
     B2: Optional[TrackEndpoint] = None
 
-    PORT_NAMES = SINGLE_SLIP_SWITCH.ports
+    PORT_NAMES = [p.root for p in SINGLE_SLIP_SWITCH.ports]
     SWITCH_TYPE = SINGLE_SLIP_SWITCH.id

--- a/python/railjson_generator/railjson_generator/test_external_generated_inputs.py
+++ b/python/railjson_generator/railjson_generator/test_external_generated_inputs.py
@@ -1,4 +1,4 @@
-from osrd_schemas_auto import external_generated_inputs, infra
+from osrd_schemas_auto import external_generated_inputs, models
 
 from railjson_generator.external_generated_inputs import (
     ElectricalProfile,
@@ -26,7 +26,7 @@ class TestElectricalProfile:
         assert ep.to_rjs() == external_generated_inputs.ElectricalProfile(
             value="value",
             power_class="power_class",
-            track_ranges=[infra.TrackRange(track=track.id, begin=0, end=1)],
+            track_ranges=[models.TrackRange(track=track.id, begin=0, end=1)],
         )
 
 
@@ -52,7 +52,7 @@ class TestExternalGeneratedInputs:
                 external_generated_inputs.ElectricalProfile(
                     value="value",
                     power_class="power_class",
-                    track_ranges=[infra.TrackRange(track=track.id, begin=0, end=1)],
+                    track_ranges=[models.TrackRange(track=track.id, begin=0, end=1)],
                 )
             ],
             level_order={"25000V": ["25000V", "22500V", "20000V"]},

--- a/tests/data/infras/etcs_infra/external_generated_inputs.json
+++ b/tests/data/infras/etcs_infra/external_generated_inputs.json
@@ -5,9 +5,9 @@
             "power_class": "1",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -16,9 +16,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -27,9 +27,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 4000.0,
-                    "end": 6000.0
+                    "end": 6000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -38,9 +38,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 6000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -49,9 +49,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -60,9 +60,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 3000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -71,9 +71,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 7000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -82,9 +82,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -93,9 +93,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 2000.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -104,9 +104,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 4000.0,
-                    "end": 6000.0
+                    "end": 6000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -115,9 +115,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 6000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -126,9 +126,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 8000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -137,9 +137,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -148,9 +148,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 1000.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -159,9 +159,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 3000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -170,9 +170,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 7000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -181,9 +181,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 9000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -192,9 +192,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA0",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TA0"
                 }
             ]
         },
@@ -203,144 +203,144 @@
             "power_class": "1",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -349,144 +349,144 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -495,144 +495,144 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -641,144 +641,144 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -787,144 +787,144 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         }

--- a/tests/data/infras/medium_infra/external_generated_inputs.json
+++ b/tests/data/infras/medium_infra/external_generated_inputs.json
@@ -5,9 +5,9 @@
             "power_class": "1",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -16,9 +16,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -27,9 +27,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 4000.0,
-                    "end": 6000.0
+                    "end": 6000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -38,9 +38,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 6000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -49,9 +49,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -60,9 +60,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 3000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -71,9 +71,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 7000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -82,9 +82,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -93,9 +93,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 2000.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -104,9 +104,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 4000.0,
-                    "end": 6000.0
+                    "end": 6000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -115,9 +115,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 6000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -126,9 +126,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 8000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -137,9 +137,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -148,9 +148,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 1000.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -159,9 +159,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 3000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -170,9 +170,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 7000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -181,9 +181,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 9000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -192,9 +192,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA0",
                     "begin": 0.0,
-                    "end": 1750.0
+                    "end": 1750.0,
+                    "track": "TA0"
                 }
             ]
         },
@@ -203,159 +203,159 @@
             "power_class": "1",
             "track_ranges": [
                 {
-                    "track": "TI0",
                     "begin": 0.0,
-                    "end": 750.0
+                    "end": 750.0,
+                    "track": "TI0"
                 },
                 {
-                    "track": "TI1",
                     "begin": 0.0,
-                    "end": 650.0
+                    "end": 650.0,
+                    "track": "TI1"
                 },
                 {
-                    "track": "TI2",
                     "begin": 0.0,
-                    "end": 2350.0
+                    "end": 2350.0,
+                    "track": "TI2"
                 },
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -364,159 +364,159 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TI0",
                     "begin": 0.0,
-                    "end": 750.0
+                    "end": 750.0,
+                    "track": "TI0"
                 },
                 {
-                    "track": "TI1",
                     "begin": 0.0,
-                    "end": 650.0
+                    "end": 650.0,
+                    "track": "TI1"
                 },
                 {
-                    "track": "TI2",
                     "begin": 0.0,
-                    "end": 2350.0
+                    "end": 2350.0,
+                    "track": "TI2"
                 },
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -525,159 +525,159 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TI0",
                     "begin": 0.0,
-                    "end": 750.0
+                    "end": 750.0,
+                    "track": "TI0"
                 },
                 {
-                    "track": "TI1",
                     "begin": 0.0,
-                    "end": 650.0
+                    "end": 650.0,
+                    "track": "TI1"
                 },
                 {
-                    "track": "TI2",
                     "begin": 0.0,
-                    "end": 2350.0
+                    "end": 2350.0,
+                    "track": "TI2"
                 },
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -686,159 +686,159 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TI0",
                     "begin": 0.0,
-                    "end": 750.0
+                    "end": 750.0,
+                    "track": "TI0"
                 },
                 {
-                    "track": "TI1",
                     "begin": 0.0,
-                    "end": 650.0
+                    "end": 650.0,
+                    "track": "TI1"
                 },
                 {
-                    "track": "TI2",
                     "begin": 0.0,
-                    "end": 2350.0
+                    "end": 2350.0,
+                    "track": "TI2"
                 },
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -847,159 +847,159 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TI0",
                     "begin": 0.0,
-                    "end": 750.0
+                    "end": 750.0,
+                    "track": "TI0"
                 },
                 {
-                    "track": "TI1",
                     "begin": 0.0,
-                    "end": 650.0
+                    "end": 650.0,
+                    "track": "TI1"
                 },
                 {
-                    "track": "TI2",
                     "begin": 0.0,
-                    "end": 2350.0
+                    "end": 2350.0,
+                    "track": "TI2"
                 },
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         }

--- a/tests/data/infras/small_infra/external_generated_inputs.json
+++ b/tests/data/infras/small_infra/external_generated_inputs.json
@@ -5,9 +5,9 @@
             "power_class": "1",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -16,9 +16,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -27,9 +27,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 4000.0,
-                    "end": 6000.0
+                    "end": 6000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -38,9 +38,9 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 6000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -49,9 +49,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -60,9 +60,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 3000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -71,9 +71,9 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 7000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -82,9 +82,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -93,9 +93,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 2000.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -104,9 +104,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 4000.0,
-                    "end": 6000.0
+                    "end": 6000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -115,9 +115,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 6000.0,
-                    "end": 8000.0
+                    "end": 8000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -126,9 +126,9 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 8000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -137,9 +137,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -148,9 +148,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 1000.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -159,9 +159,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 3000.0,
-                    "end": 7000.0
+                    "end": 7000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -170,9 +170,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 7000.0,
-                    "end": 9000.0
+                    "end": 9000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -181,9 +181,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA6",
                     "begin": 9000.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA6"
                 }
             ]
         },
@@ -192,9 +192,9 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA0",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TA0"
                 }
             ]
         },
@@ -203,144 +203,144 @@
             "power_class": "1",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -349,144 +349,144 @@
             "power_class": "2",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -495,144 +495,144 @@
             "power_class": "3",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -641,144 +641,144 @@
             "power_class": "4",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         },
@@ -787,144 +787,144 @@
             "power_class": "5",
             "track_ranges": [
                 {
-                    "track": "TA1",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA1"
                 },
                 {
-                    "track": "TA2",
                     "begin": 0.0,
-                    "end": 1950.0
+                    "end": 1950.0,
+                    "track": "TA2"
                 },
                 {
-                    "track": "TA3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA3"
                 },
                 {
-                    "track": "TA4",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA4"
                 },
                 {
-                    "track": "TA5",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TA5"
                 },
                 {
-                    "track": "TA7",
                     "begin": 0.0,
-                    "end": 10000.0
+                    "end": 10000.0,
+                    "track": "TA7"
                 },
                 {
-                    "track": "TB0",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TB0"
                 },
                 {
-                    "track": "TC0",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC0"
                 },
                 {
-                    "track": "TC1",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC1"
                 },
                 {
-                    "track": "TC2",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TC2"
                 },
                 {
-                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 1050.0
+                    "end": 1050.0,
+                    "track": "TC3"
                 },
                 {
-                    "track": "TD0",
                     "begin": 0.0,
-                    "end": 25000.0
+                    "end": 25000.0,
+                    "track": "TD0"
                 },
                 {
-                    "track": "TD2",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TD2"
                 },
                 {
-                    "track": "TD3",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TD3"
                 },
                 {
-                    "track": "TE0",
                     "begin": 0.0,
-                    "end": 1500.0
+                    "end": 1500.0,
+                    "track": "TE0"
                 },
                 {
-                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 3.0
+                    "end": 3.0,
+                    "track": "TF0"
                 },
                 {
-                    "track": "TF1",
                     "begin": 0.0,
-                    "end": 6500.0
+                    "end": 6500.0,
+                    "track": "TF1"
                 },
                 {
-                    "track": "TE1",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE1"
                 },
                 {
-                    "track": "TE2",
                     "begin": 0.0,
-                    "end": 2050.0
+                    "end": 2050.0,
+                    "track": "TE2"
                 },
                 {
-                    "track": "TE3",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TE3"
                 },
                 {
-                    "track": "TG0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TG0"
                 },
                 {
-                    "track": "TG1",
                     "begin": 0.0,
-                    "end": 4000.0
+                    "end": 4000.0,
+                    "track": "TG1"
                 },
                 {
-                    "track": "TG2",
                     "begin": 0.0,
-                    "end": 3000.0
+                    "end": 3000.0,
+                    "track": "TG2"
                 },
                 {
-                    "track": "TG3",
                     "begin": 0.0,
-                    "end": 50.0
+                    "end": 50.0,
+                    "track": "TG3"
                 },
                 {
-                    "track": "TG4",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG4"
                 },
                 {
-                    "track": "TG5",
                     "begin": 0.0,
-                    "end": 2000.0
+                    "end": 2000.0,
+                    "track": "TG5"
                 },
                 {
-                    "track": "TH0",
                     "begin": 0.0,
-                    "end": 1000.0
+                    "end": 1000.0,
+                    "track": "TH0"
                 },
                 {
-                    "track": "TH1",
                     "begin": 0.0,
-                    "end": 5000.0
+                    "end": 5000.0,
+                    "track": "TH1"
                 }
             ]
         }


### PR DESCRIPTION
`infra.py` is kept: `RailJsonInfra` and `Identifier` are still needed by `infra_editor.py` to generate the front editor schema correctly.