### PR TITLE
Display confirmation popup on cadence change

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/buildPacedTrainException.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/buildPacedTrainException.ts
@@ -328,10 +328,10 @@ export function checkChangeGroups(
 
       // If the exception is now empty, we don't want to keep it anymore in the list
       // We check explicitly for change group keys to avoid false positives from
-      // metadata fields like 'id', 'disabled', 'summary', etc.
+      // metadata fields like 'id', 'summary', etc.
       const hasChangedGroup = CHANGE_GROUP_KEYS.some((key) => key in updatedException);
 
-      if (hasChangedGroup) {
+      if (hasChangedGroup || updatedException.disabled) {
         acc.exceptions.push(updatedException);
         if (!isEqual(updatedException, exception)) {
           acc.modifiedExceptions.push(updatedException);


### PR DESCRIPTION
Fixes the bug described in #16535 (see issue [comment](https://github.com/OpenRailAssociation/osrd/issues/16535#issuecomment-4799281560)): changing the cadence now waits for the user's confirmation before applying any changes. Cancelling preserves both the original cadence and the exceptions, while confirming updates the cadence and removes the exceptions.
