### PR TITLE
front: add RC name on gesico modal

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SendToRailwayManagerModal.tsx
@@ -12,7 +12,7 @@ import type {
   StdcmPathProperties,
 } from 'applications/stdcm/types';
 import { StdcmStopTypes } from 'applications/stdcm/types';
-import type { SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type SimulationResponseSuccess } from 'common/api/osrdEditoastApi';
 import {
   osrdRailwayManagerApi,
   type RmiLoadingGaugeType,
@@ -118,6 +118,9 @@ const SendToRailwayManagerModal = ({
   const dateTimeLocale = useDateTimeLocale();
   const railwayManagerUrl = useSelector(getRailwayManagerInterfaceUrl);
   const dispatch = useAppDispatch();
+
+  const { data: userGroups } = osrdEditoastApi.endpoints.getAuthzMeGroups.useQuery();
+  const railwayCompanyName = userGroups?.[0]?.name;
 
   const DEFAULT_TRAIN_CATEGORY = { value: '', label: t('modal.noCategory') };
   const stdcmData = stdcmResults.results;
@@ -367,7 +370,10 @@ const SendToRailwayManagerModal = ({
 
   return (
     <div className="send-to-railway-manager">
-      <h2>{t('modal.newRailManagerRequest')}</h2>
+      <header className="modal-header">
+        <h2>{t('modal.newRailManagerRequest')}</h2>
+        {railwayCompanyName && <span className="railway-company-name">{railwayCompanyName}</span>}
+      </header>
       <div className="modal-contents">
         <p>{t('modal.verifyParameters')}</p>
         <section className="convoy-section">

--- a/front/src/applications/stdcm/styles/_railwayManagerModal.scss
+++ b/front/src/applications/stdcm/styles/_railwayManagerModal.scss
@@ -1,13 +1,25 @@
 .send-to-railway-manager {
   font-family: 'IBM Plex Sans', sans-serif;
 
-  h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    padding: 24px 32px 20px;
+  .modal-header {
+    padding: 24px 24px 20px 32px;
     box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.25);
     background-color: var(--white);
     margin-bottom: 1px;
+
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+    }
+
+    .railway-company-name {
+      font-size: 1.5rem;
+      font-weight: 600;
+      line-height: 2rem;
+      letter-spacing: -0.2px;
+      color: var(--info60);
+      text-align: right;
+    }
   }
 
   /* override style from ui-core input */


### PR DESCRIPTION
closes https://github.com/osrd-project/osrd-confidential/issues/1449

mock-up: https://www.sketch.com/s/15e0909c-f17d-4200-a770-b9fc1154fa7e/p/2ECA4B4E-5CB5-418E-AB67-A7236153AA8E/canvas#Inspect

To test: 

` SendToRailwayManagerModal.tsx` : l.122 : 
const userGroups = [{ id: 1, name: 'Super Fret' }]; 
// const { data: userGroups } = osrdEditoastApi.endpoints.getAuthzMeGroups.useQuery();

`StdcmResults.tsx` : l.87 : 
const sendLMRAuthorizedResponse = { authorized: true };
  // const { data: sendLMRAuthorizedResponse } =
  //   osrdRailwayManagerApi.endpoints.getSendLastMinuteRequestAuthorized.useQuery(
  //     railwayManagerUrl ? undefined : skipToken
  //   );
