### PR TITLE
editoast, front: pass allowed track sections when running pathfinding

### DIFF
--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -40,6 +40,8 @@ pub struct PathfindingRequest {
     /// Stops the train at a new stop position: near next block-delimiting signal,
     /// staying in the same block and keeping the tail on the initial position
     pub stops_at_end_of_block: Option<bool>,
+    /// Set of authorized track section ids, empty means no restriction
+    pub allowed_track_sections: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema, Hash)]

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -174,6 +174,8 @@ pub struct PathfindingConsist {
 pub struct PathfindingConstraints {
     /// An ordered list of waypoints the resulting path must pass through
     pub path_items: Vec<PathItemAlternatives>,
+    /// Set of authorized track section ids, empty means no restriction
+    pub allowed_track_sections: BTreeSet<String>,
 }
 
 /// A set of [TrackOffset]
@@ -396,6 +398,7 @@ fn build_request(
         rolling_stock_length: consist.length,
         speed_limit_tag: consist.speed_limit_tag.clone(),
         stops_at_end_of_block: Some(false),
+        allowed_track_sections: constraints.allowed_track_sections.clone(),
     }
 }
 
@@ -449,6 +452,7 @@ pub(crate) mod test_data {
                 ]),
                 PathItemAlternatives::from_iter([TrackOffset::new("tr2", 200)]),
             ],
+            allowed_track_sections: BTreeSet::new(),
         }
     }
 

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -9,6 +9,7 @@ use schemas::train_schedule::TrainScheduleOptions;
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -194,6 +195,7 @@ impl SimulationTrain {
             parameters,
             path_constraints: PathfindingConstraints {
                 path_items: Vec::new(),
+                allowed_track_sections: BTreeSet::new(),
             },
             schedule_item_to_index: HashMap::default(),
         }

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -144,6 +144,7 @@ impl Task for core_client::simulation::Request {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use core_client::mocking::MockingClient;
@@ -184,6 +185,7 @@ mod tests {
             Arc::new(pathfinding::test_data::consist(1)),
             Arc::new(crate::PathfindingConstraints {
                 path_items: path_items.clone(),
+                allowed_track_sections: BTreeSet::new(),
             }),
         );
 
@@ -287,6 +289,7 @@ mod tests {
             Arc::new(pathfinding::test_data::consist(1)),
             Arc::new(crate::PathfindingConstraints {
                 path_items: path_items.clone(),
+                allowed_track_sections: BTreeSet::new(),
             }),
         );
 
@@ -425,7 +428,10 @@ mod tests {
         let core_env = CoreEnv::new_mock(MockingClient::new());
         let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
-            Arc::new(crate::PathfindingConstraints { path_items: vec![] }),
+            Arc::new(crate::PathfindingConstraints {
+                path_items: vec![],
+                allowed_track_sections: BTreeSet::new(),
+            }),
         );
 
         let mut builder = SimulationTrain::new(

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12242,6 +12242,12 @@ components:
       - rolling_stock_maximum_speed
       - rolling_stock_length
       properties:
+        allowed_track_sections:
+          type: array
+          items:
+            type: string
+          description: Set of authorized track section ids, empty means no restriction
+          uniqueItems: true
         path_items:
           type: array
           items:

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -68,6 +68,9 @@ pub(in crate::views) struct PathfindingInput {
     /// Stop the train at the next block-delimiting signal,
     /// staying in the same block and keeping the tail on the initial position
     stops_at_end_of_block: Option<bool>,
+    /// Set of authorized track section ids, empty means no restriction
+    #[serde(default)]
+    allowed_track_sections: BTreeSet<String>,
 }
 
 impl PathfindingInput {
@@ -96,6 +99,7 @@ impl PathfindingInput {
                 .collect(),
             speed_limit_tag: train_schedule.speed_limit_tag().cloned(),
             stops_at_end_of_block: Some(train_schedule.options().stops_at_end_of_block()),
+            allowed_track_sections: BTreeSet::new(),
         }
     }
 
@@ -415,6 +419,7 @@ fn build_pathfinding_request(
         rolling_stock_length: pathfinding_input.rolling_stock_length,
         speed_limit_tag: pathfinding_input.speed_limit_tag.clone(),
         stops_at_end_of_block: pathfinding_input.stops_at_end_of_block,
+        allowed_track_sections: pathfinding_input.allowed_track_sections.clone(),
     })
 }
 
@@ -436,6 +441,7 @@ fn build_pathfinding_train(
             .into_iter()
             .map(core_task::PathItemAlternatives::from_iter)
             .collect(),
+        allowed_track_sections: pathfinding_input.allowed_track_sections.clone(),
     };
 
     Ok(core_task::PathfindingTrain {
@@ -552,6 +558,7 @@ pub mod tests {
             rolling_stock_length: 26.0.into(),
             speed_limit_tag: None,
             stops_at_end_of_block: None,
+            allowed_track_sections: BTreeSet::new(),
             path_items,
         }
     }

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::iter::Extend as _;
@@ -647,6 +648,7 @@ pub(in crate::views) async fn get_path(
             .into_iter()
             .map(core_task::PathItemAlternatives::from_iter)
             .collect(),
+        allowed_track_sections: BTreeSet::new(),
     };
 
     let pathfinding_train = core_task::PathfindingTrain {

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -15,6 +15,7 @@ import {
   getStdcmPathSteps,
   getLoadingGauge,
   getStdcmSpeedLimitByTag,
+  getTrackSectionIdsByLoadingGauge,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 
@@ -41,6 +42,7 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
   const speedLimitByTag = useSelector(getStdcmSpeedLimitByTag);
   const rollingStock = useStdcmLightRollingStock();
   const loadingGauge = useSelector(getLoadingGauge);
+  const trackSectionIdsByLoadingGauge = useSelector(getTrackSectionIdsByLoadingGauge);
 
   const [pathfinding, setPathfinding] = useState<PathfindingResult>();
   const [showPathfindingStatusMessage, setShowPathfindingStatusMessage] = useState(false);
@@ -93,6 +95,11 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
 
       setShowPathfindingStatusMessage(true);
 
+      const allowedTrackSections =
+        trackSectionIdsByLoadingGauge && loadingGauge
+          ? trackSectionIdsByLoadingGauge[loadingGauge]
+          : undefined;
+
       const pathfindingResult = await launchSegmentedPathfinding({
         pathSegmentsIndexes,
         stdcmPathSteps,
@@ -103,6 +110,7 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
         rollingStock,
         loadingGauge,
         speedLimitByTag,
+        allowedTrackSections,
       });
 
       setPathfinding(pathfindingResult);
@@ -118,6 +126,7 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
     rollingStock,
     speedLimitByTag,
     loadingGauge,
+    trackSectionIdsByLoadingGauge,
     infra,
     workerStatus,
     consistChanges,

--- a/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
+++ b/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
@@ -40,6 +40,7 @@ type LaunchSegmentedPathfindingOptions = {
   rollingStock: LightRollingStock;
   loadingGauge?: LoadingGaugeType;
   speedLimitByTag?: string | null;
+  allowedTrackSections?: string[];
 };
 
 type GetLightRollingStockById = ReturnType<
@@ -113,6 +114,7 @@ export const launchSegmentedPathfinding = async ({
   rollingStock,
   loadingGauge,
   speedLimitByTag,
+  allowedTrackSections,
 }: LaunchSegmentedPathfindingOptions): Promise<PathfindingResult | undefined> => {
   let pathfindingResult: PathfindingResult | undefined;
 
@@ -137,6 +139,7 @@ export const launchSegmentedPathfinding = async ({
       pathSteps: segmentSteps,
       loadingGauge: segmentLoadingGauge,
       speedLimitByTag: segmentSpeedLimitByTag,
+      allowedTrackSections,
     });
 
     if (payload === null) {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3770,6 +3770,8 @@ export type PathfindingResult =
       status: 'failure';
     });
 export type PathfindingInput = {
+  /** Set of authorized track section ids, empty means no restriction */
+  allowed_track_sections?: string[];
   /** List of waypoints given to the pathfinding */
   path_items: PathItemLocation[];
   /** Can the rolling stock run on non-electrified tracks */

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -70,6 +70,7 @@ export const getPathfindingQuery = ({
   pathSteps,
   loadingGauge,
   speedLimitByTag,
+  allowedTrackSections,
 }: {
   infraId?: number;
   rollingStock?: Pick<
@@ -79,6 +80,7 @@ export const getPathfindingQuery = ({
   pathSteps: (PathItemLocation | null)[];
   loadingGauge?: LoadingGaugeType;
   speedLimitByTag?: string | null;
+  allowedTrackSections?: string[];
 }): PostInfraByInfraIdPathfindingBlocksApiArg | null => {
   const origin = pathSteps.at(0);
   const destination = pathSteps.at(-1);
@@ -101,6 +103,7 @@ export const getPathfindingQuery = ({
         rolling_stock_maximum_speed: rollingStock.max_speed,
         rolling_stock_length: rollingStock.length,
         speed_limit_tag: speedLimitByTag,
+        allowed_track_sections: allowedTrackSections,
       },
     };
   }

--- a/osrd_schemas_auto/osrd_schemas_auto/models.py
+++ b/osrd_schemas_auto/osrd_schemas_auto/models.py
@@ -4934,6 +4934,10 @@ class PathfindingInput(BaseModel):
     and a list of path waypoints
     """
 
+    allowed_track_sections: list[str] | None = None
+    """
+    Set of authorized track section ids, empty means no restriction
+    """
     path_items: list[
         PathItemLocationTrackOffset | PathItemLocationOperationalPointPartReference
     ]


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/16699, follow up of https://github.com/OpenRailAssociation/osrd/pull/17372

Forwards the track section (gabarit) constraint to the core pathfinding engine.

# Test

You need a search env with allowed track sections in it
Then, run a query that passes through an OP that is not in the allowed perimeter (on a grey track) and see that the form can't be submitted (no path should be found)