### PR TITLE
editoast: add support for datetime and timestamp filtering

### DIFF
--- a/editoast/editoast_derive/src/search.rs
+++ b/editoast/editoast_derive/src/search.rs
@@ -85,6 +85,7 @@ enum ColumnType {
     TextualSearchString,
     Boolean,
     Null,
+    DateTime,
     Sequence(Box<ColumnType>),
 }
 
@@ -120,6 +121,11 @@ impl ColumnType {
             }
             "boolean" | "bool" => Some(ColumnType::Boolean),
             "null" => Some(ColumnType::Null),
+            "timestamptz"
+            | "timestamp with time zone"
+            | "timestamp"
+            | "timestamp without time zone"
+            | "datetime" => Some(ColumnType::DateTime),
             // handles VARCHAR(240), NUMERIC(4, 2), etc.
             prefix if prefix.contains('(') => {
                 let (prefix, _) = prefix.split_once('(').unwrap();
@@ -151,6 +157,9 @@ impl ColumnType {
             }
             ColumnType::Null => {
                 quote! { search::TypeSpec::Type(search::AstType::Null) }
+            }
+            ColumnType::DateTime => {
+                quote! { search::TypeSpec::Type(search::AstType::DateTime) }
             }
             ColumnType::Sequence(ct) => {
                 let ts = ct.to_type_spec();

--- a/editoast/search/src/dsl.rs
+++ b/editoast/search/src/dsl.rs
@@ -118,6 +118,8 @@ pub struct Integer;
 pub struct Float;
 /// Represents [TypedAst::String] and maps to [std::string::String]
 pub struct String;
+/// Represents a timestamptz (datetime) column.
+pub struct DateTime;
 /// Represents [TypedAst::Sql]. As an argument, checks that the value typechecks
 /// and exposes the [SqlQuery]. As a return value, wraps the [SqlQuery] into a
 /// [TypedAst::Sql] with `T::type_spec()`
@@ -229,6 +231,24 @@ impl Type for String {
 
     fn from_return(value: Self::ReturnType) -> Result<TypedAst, ProcessingError> {
         Ok(TypedAst::String(value))
+    }
+}
+
+impl Type for DateTime {
+    type ArgType = TypedAst; // NOTE: should theoretically be a chrono::DateTime
+    type ReturnType = SqlQuery; // NOTE: likewise
+
+    fn type_spec() -> TypeSpec {
+        TypeSpec::Type(AstType::DateTime)
+    }
+
+    fn into_arg(value: TypedAst) -> Result<Self::ArgType, ProcessingError> {
+        Self::typecheck(&value)?;
+        Ok(value)
+    }
+
+    fn from_return(value: Self::ReturnType) -> Result<TypedAst, ProcessingError> {
+        Ok(TypedAst::Sql(Box::new(value), Self::type_spec()))
     }
 }
 

--- a/editoast/search/src/process.rs
+++ b/editoast/search/src/process.rs
@@ -94,6 +94,15 @@ impl QueryContext {
 /// - = : (int | null) -> (int | null) -> (bool | null)
 /// - = : (float | null) -> (float | null) -> (bool | null)
 /// - = : (string | null) -> (string | null) -> (bool | null)
+/// - = : (datetime | null) -> (datetime | null) -> (bool | null)
+/// - < : (int | null) -> (int | null) -> (bool | null)
+/// - <= : (int | null) -> (int | null) -> (bool | null)
+/// - > : (int | null) -> (int | null) -> (bool | null)
+/// - >= : (int | null) -> (int | null) -> (bool | null)
+/// - < : (datetime | null) -> (datetime | null) -> (bool | null)
+/// - <= : (datetime | null) -> (datetime | null) -> (bool | null)
+/// - > : (datetime | null) -> (datetime | null) -> (bool | null)
+/// - >= : (datetime | null) -> (datetime | null) -> (bool | null)
 /// - like : string -> (string | null) -> (bool | null)
 /// - ilike : string -> (string | null) -> (bool | null)
 /// - search : string -> (string | null) -> bool
@@ -101,6 +110,7 @@ impl QueryContext {
 /// - to_string : (int | null) -> string
 /// - to_string : (float | null) -> string
 /// - to_string : (string | null) -> string
+/// - datetime : string -> datetime
 /// - list : variadic string -> string list
 /// - contains : string list -> string list -> bool
 pub fn create_processing_context() -> QueryContext {
@@ -141,8 +151,40 @@ pub fn create_processing_context() -> QueryContext {
             eq.clone(),
         );
     context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::String>>, dsl::Nullable<dsl::Ersatz<dsl::String>>, dsl::Sql<dsl::Boolean>>(
+            "=", eq.clone(),
+        );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Sql<dsl::Boolean>>(
             "=", eq,
         );
+    let cmp = |op: &'static str| {
+        Rc::new(move |left: Option<TypedAst>, right: Option<TypedAst>| {
+            Ok(SqlQuery::infix(op, left, right))
+        })
+    };
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Sql<dsl::Boolean>>(
+        "<", cmp("<"),
+    );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Sql<dsl::Boolean>>(
+        "<=", cmp("<="),
+    );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Sql<dsl::Boolean>>(
+        ">", cmp(">"),
+    );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Nullable<dsl::Ersatz<dsl::Integer>>, dsl::Sql<dsl::Boolean>>(
+        ">=", cmp(">="),
+    );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Sql<dsl::Boolean>>(
+        "<", cmp("<"),
+    );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Sql<dsl::Boolean>>(
+        "<=", cmp("<="),
+    );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Sql<dsl::Boolean>>(
+        ">", cmp(">"),
+    );
+    context.def_function_2::<dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Nullable<dsl::Ersatz<dsl::DateTime>>, dsl::Sql<dsl::Boolean>>(
+        ">=", cmp(">="),
+    );
     context.def_function_2::<dsl::Ersatz<dsl::String>, dsl::Nullable<dsl::String>, dsl::Sql<dsl::Nullable<dsl::Boolean>>>(
             "like",
             Rc::new(|string, pattern| {
@@ -199,6 +241,10 @@ pub fn create_processing_context() -> QueryContext {
     context.def_function_1::<dsl::Nullable<dsl::Ersatz<dsl::Float>>, dsl::Sql<dsl::String>>(
         "to_string",
         to_string.clone(),
+    );
+    context.def_function_1::<dsl::Ersatz<dsl::String>, dsl::Sql<dsl::DateTime>>(
+        "datetime",
+        Rc::new(|s: TypedAst| Ok(SqlQuery::cast(s, "TIMESTAMPTZ"))),
     );
     context.def_function(
         "list",
@@ -464,5 +510,102 @@ mod tests {
         assert!(try_eval(json!(["not", true, false])).is_err());
         assert!(try_eval(json!(["like", "test"])).is_err());
         assert!(try_eval(json!(["like", "test", null, null])).is_err());
+    }
+
+    #[test]
+    fn test_integer_comparisons() {
+        let mut env = create_processing_context();
+        env.columns_type
+            .insert("start_time".into(), AstType::Integer.into());
+
+        let eval_int = |q: serde_json::Value| {
+            let expr = SearchAst::build_ast(q).unwrap();
+            env.evaluate_ast(&expr).unwrap()
+        };
+
+        // Basic integer comparisons should produce SQL expressions
+        assert!(matches!(
+            eval_int(json!(["<", ["start_time"], 1000000])),
+            TypedAst::Sql(_, _)
+        ));
+        assert!(matches!(
+            eval_int(json!(["<=", ["start_time"], 1000000])),
+            TypedAst::Sql(_, _)
+        ));
+        assert!(matches!(
+            eval_int(json!([">", ["start_time"], 0])),
+            TypedAst::Sql(_, _)
+        ));
+        assert!(matches!(
+            eval_int(json!([">=", ["start_time"], 0])),
+            TypedAst::Sql(_, _)
+        ));
+
+        // Range query: start_time within [start, end]
+        let range_query = json!([
+            "and",
+            [">=", ["start_time"], 1700000000000_i64],
+            ["<", ["start_time"], 1700086400000_i64]
+        ]);
+        assert!(matches!(eval_int(range_query), TypedAst::Sql(_, _)));
+
+        // Type errors: integer comparisons should reject non-integer
+        let expr = SearchAst::build_ast(json!(["<", ["start_time"], "2024-01-01"])).unwrap();
+        assert!(env.evaluate_ast(&expr).is_err());
+    }
+
+    #[test]
+    fn test_datetime_function_and_comparisons() {
+        let mut env = create_processing_context();
+        env.columns_type
+            .insert("last_modification".into(), AstType::DateTime.into());
+
+        let eval_dt = |q: serde_json::Value| {
+            let expr = SearchAst::build_ast(q).unwrap();
+            env.evaluate_ast(&expr).unwrap()
+        };
+
+        // datetime() converts a string literal to a timestamptz cast
+        let result = eval_dt(json!(["datetime", "2024-01-01T00:00:00Z"]));
+        assert!(matches!(result, TypedAst::Sql(_, _)));
+        if let TypedAst::Sql(sql, spec) = result {
+            assert!(spec.is_supertype_spec(&AstType::DateTime.into()));
+            // Should render as a TIMESTAMPTZ cast
+            assert!(sql.to_string().contains("TIMESTAMPTZ"));
+        }
+
+        // datetime() with null → type error (non-nullable string required)
+        let null_expr = SearchAst::build_ast(json!(["datetime", null])).unwrap();
+        assert!(env.evaluate_ast(&null_expr).is_err());
+
+        // Datetime column comparisons
+        assert!(matches!(
+            eval_dt(json!([
+                "=",
+                ["last_modification"],
+                ["datetime", "2024-01-01T00:00:00Z"]
+            ])),
+            TypedAst::Sql(_, _)
+        ));
+        assert!(matches!(
+            eval_dt(json!([
+                ">=",
+                ["last_modification"],
+                ["datetime", "2024-01-01T00:00:00Z"]
+            ])),
+            TypedAst::Sql(_, _)
+        ));
+        assert!(matches!(
+            eval_dt(json!([
+                "<",
+                ["last_modification"],
+                ["datetime", "2024-02-01T00:00:00Z"]
+            ])),
+            TypedAst::Sql(_, _)
+        ));
+
+        // Type error: comparing a datetime column with a raw integer should fail
+        let expr = SearchAst::build_ast(json!(["=", ["last_modification"], 42])).unwrap();
+        assert!(env.evaluate_ast(&expr).is_err());
     }
 }

--- a/editoast/search/src/sqlquery.rs
+++ b/editoast/search/src/sqlquery.rs
@@ -130,6 +130,7 @@ fn sql_type(spec: &TypeSpec) -> Option<String> {
         TypeSpec::Type(AstType::Integer) => Some("INTEGER".to_owned()),
         TypeSpec::Type(AstType::Float) => Some("NUMERIC".to_owned()),
         TypeSpec::Type(AstType::String) => Some("TEXT".to_owned()),
+        TypeSpec::Type(AstType::DateTime) => Some("TIMESTAMPTZ".to_owned()),
         _ => None,
     }
 }

--- a/editoast/search/src/typing.rs
+++ b/editoast/search/src/typing.rs
@@ -39,6 +39,7 @@ pub enum AstType {
     Integer,
     Float,
     String,
+    DateTime,
 }
 
 /// Allows combining [AstType]s in order to express more complex types

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -742,7 +742,8 @@ pub(super) struct SearchResultItemScenario {
 #[search(
     table = "train_schedule",
     column(name = "train_schedule_set_id", data_type = "integer"),
-    column(name = "train_name", data_type = "string")
+    column(name = "train_name", data_type = "string"),
+    column(name = "start_time", data_type = "integer")
 )]
 /// A search result item for a query with `object = "trainschedule"`
 pub(super) struct SearchResultItemTrainSchedule {
@@ -861,6 +862,55 @@ pub mod tests {
                 "object": "trainschedule",
                 "query": ["and", ["=", ["train_name"], train_name],
                                  ["=", ["train_schedule_set_id"], train_schedule_set.id]],
+            }))
+            .await
+            .assert_status_ok()
+            .json();
+
+        assert_eq!(response.len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn search_trainschedule_start_time_range() {
+        let app = test_app!().skip_authz().build();
+        let pool = app.db_pool();
+
+        let train_schedule_set = create_train_schedule_set(&mut pool.get_ok()).await;
+        // Fixture train has start_time = 2023-12-21T08:51:30Z
+        let train = create_simple_paced_train(&mut pool.get_ok(), train_schedule_set.id).await;
+
+        let day_start = DateTime::parse_from_rfc3339("2023-12-21T00:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        let next_day = DateTime::parse_from_rfc3339("2023-12-22T00:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+
+        let response: Vec<SearchResultItemTrainSchedule> = app
+            .post("/search")
+            .json(&json!({
+                "object": "trainschedule",
+                "query": ["and",
+                    ["=", ["train_schedule_set_id"], train.train_schedule_set_id],
+                    [">=", ["start_time"], day_start],
+                    ["<",  ["start_time"], next_day],
+                ],
+            }))
+            .await
+            .assert_status_ok()
+            .json();
+
+        assert_eq!(response.len(), 1);
+        assert_eq!(response[0].train_name, train.train_name);
+
+        let response: Vec<SearchResultItemTrainSchedule> = app
+            .post("/search")
+            .json(&json!({
+                "object": "trainschedule",
+                "query": ["and",
+                    ["=", ["train_schedule_set_id"], train.train_schedule_set_id],
+                    [">=", ["start_time"], next_day],
+                ],
             }))
             .await
             .assert_status_ok()


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/16593

Adds support to search in the database by filtering by date (datetime) and timestamp.

No real way to test this yet since we do not use it, but the tests should be exhaustive enough