### PR TITLE
editoast: small follow-up refactos after merging authorization middleware extensions 

### DIFF
--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -131,15 +131,12 @@ pub(in crate::views) struct WhoamiResponse {
 )]
 pub(in crate::views) async fn whoami(
     Extension(authn_state): Extension<crate::authentication::State>,
-    State(AppState { db_pool, .. }): State<AppState>,
+    Extension(user): Extension<Option<editoast_models::User>>,
 ) -> Result<Json<WhoamiResponse>> {
     match authn_state {
         crate::authentication::State::Skip => Err(AuthorizationError::Unauthenticated)?,
-        crate::authentication::State::Authenticated { user, roles } => {
-            let conn = db_pool.get().await?;
-            let user = editoast_models::User::retrieve(conn, user.0)
-                .await?
-                .expect("user stored in the authorization middleware extension should exist");
+        crate::authentication::State::Authenticated { roles, .. } => {
+            let user = user.expect("the user was authenticated and should therefore exist");
             let roles = HashSet::from_iter(roles);
             Ok(Json(WhoamiResponse {
                 id: user.id,

--- a/editoast/src/views/server/middlewares.rs
+++ b/editoast/src/views/server/middlewares.rs
@@ -232,7 +232,9 @@ pub(in crate::views) async fn authentication_validation_middleware(
     span.record("user.roles", tracing::field::debug(&roles));
     span.record("user.is_admin", roles.contains(&Role::Admin));
 
-    let authz_user = user.iter().map(|user| authz::User(user.id)).next();
+    let authz_user = user
+        .as_ref()
+        .map(|editoast_models::User { id, .. }| ::authz::User(*id));
     let state = crate::authentication::State::try_new(authn, authz_user, roles.clone())?;
     span.record("authz.state", tracing::field::debug(&state));
     req.extensions_mut().insert(state);


### PR DESCRIPTION
Follow-up on https://github.com/OpenRailAssociation/osrd/pull/17362, (https://github.com/OpenRailAssociation/osrd/pull/17362#discussion_r3492177613 and https://github.com/OpenRailAssociation/osrd/pull/17362#discussion_r3492174339), some review comments arrived after the PR was merged on `dev`.