### PR TITLE
ci: check versions of playwright

### DIFF
--- a/.github/scripts/check-playwright-version.sh
+++ b/.github/scripts/check-playwright-version.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script checks that the version of the Playwright driver available in nix,
+# is coherent with the version of playwright in `front`.
+
+set -e
+
+PLAYWRIGHT_NPM_VERSION=$(cd front/ && npm ls "@playwright/test" --json --package-lock-only | jq --raw-output '.. | .version? // empty')
+echo "Version of Playwright in \`package-lock.json\` is '${PLAYWRIGHT_NPM_VERSION}'"
+PLAYWRIGHT_NIX_VERSION=$(nix eval --raw '.#playwright-driver.version')
+echo "Version of Playwright in the nix flake is '${PLAYWRIGHT_NIX_VERSION}'"
+
+if [ "${PLAYWRIGHT_NPM_VERSION}" = "${PLAYWRIGHT_NIX_VERSION}" ]
+then
+    echo "Versions of Playwright are the same in \`package-lock.json\` and in the nix flake"
+    exit 0
+else
+    echo "Version of playwright in \`package-lock.json\` (${PLAYWRIGHT_NPM_VERSION}) is incompatible with version of the playwright driver in the nix flake (${PLAYWRIGHT_NIX_VERSION})"
+    exit 1
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -838,6 +838,17 @@ jobs:
           ./scripts/load-railjson-rolling-stock.sh tests/data/rolling_stocks/realistic/*.json --force
           ./scripts/load-railjson-rolling-stock.sh tests/data/rolling_stocks/*.json
 
+  check_playwright_version:
+    runs-on: ubuntu-latest
+    name: Check Playwright version for nix
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Check versions of playwright
+        run: .github/scripts/check-playwright-version.sh
+
   end_to_end_tests:
     runs-on: ubuntu-latest
     name: End to end tests

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1781527054,
-        "narHash": "sha256-1fX9ev2Fh5QoKQ41G9dYutjo5j/jywu6tZse5Eb1Ck4=",
+        "lastModified": 1782732035,
+        "narHash": "sha256-oREqdReAdtbMW5WFcVFDg7NM4b6rmJQglZ+sxC+CwDs=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8c2e51dffefc040a21975da7abf6f252c8c9b783",
+        "rev": "1748a8592edbdcbe8a2317ddc237b47a27932578",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1781453968,
-        "narHash": "sha256-+V3nK4pCngbmgyVGXY6Kkrlevp4ocPkJJLf2aqwkDNA=",
+        "lastModified": 1782691063,
+        "narHash": "sha256-qtAe8z4KKLIe/oKu4tc2bmaB+wEG/jjPrebR34WY0zg=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "cc272809a173c2c11d0e479d639c811c1eacf049",
+        "rev": "972c4e7bee140acd27e26b3e04673bfd05302f89",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
       in
       with pkgs;
       {
+        packages.playwright-driver = playwright-driver;
         devShells.default = mkShell {
           buildInputs = [
             # Rust


### PR DESCRIPTION
When using nix to install the playwright driver, it only works when the driver is in a compatible version with the library installed in the `package-lock.json`. This adds a CI checks to ensure versions are not bumped without consideration.