### PR TITLE
editoast: views: `POST:/timetable/{id}/stdcm` endpoint: add authorization for the rolling stocks used in the query

### DIFF
--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -173,6 +173,12 @@ impl<T> Protected<T> {
     }
 }
 
+impl Protected<()> {
+    pub fn check(check: Check) -> Self {
+        Protected::<()>::default().with_check_iter([check])
+    }
+}
+
 impl<T: Send + 'static> Protected<T> {
     /// A [Protected] value that always succeeds with the provided value
     pub fn value(t: T) -> Self {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -1,6 +1,11 @@
 pub(crate) mod request;
 
 use authz;
+use authz::RollingStockPrivilege;
+use authz::v2::Actor;
+use authz::v2::Authorizer as _;
+use authz::v2::Check;
+use authz::v2::Protected;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -53,9 +58,11 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authorizers::impossible;
 use crate::error::InternalError;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::TrainScheduleWithConsist;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::simulation;
@@ -142,6 +149,10 @@ enum StdcmError {
         expected_max: f64,
     },
     #[error(transparent)]
+    #[editoast_error(forward)]
+    #[serde(skip)]
+    Authorization(AuthorizationError),
+    #[error(transparent)]
     #[from(forward)]
     #[serde(skip)]
     Database(editoast_models::Error),
@@ -191,13 +202,41 @@ pub(in crate::views) async fn stdcm(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Extension(auth): AuthenticationExt,
     Path(id): Path<i64>,
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
 ) -> Result<Response> {
+    let consist_schedule_values = &request.consist_schedule.values;
+    if authn_state.regular_user().is_some() {
+        let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+        let checks = consist_schedule_values
+            .iter()
+            .map(|consist| {
+                Check::HasRollingStockPrivilege(
+                    Actor::Issuer,
+                    RollingStockPrivilege::CanRead,
+                    authz::RollingStock(consist.rolling_stock_id),
+                )
+            })
+            .map(Protected::check);
+        let protected = Protected::from_iter(checks);
+        authz::v2::Access::access(authorizer.authorize(protected).await?)
+            .await?
+            .map_err(|check| match check {
+                authz::v2::Check::HasRollingStockPrivilege(
+                    Actor::Issuer,
+                    RollingStockPrivilege::CanRead,
+                    _,
+                ) => StdcmError::Authorization(AuthorizationError::Forbidden),
+                check => impossible!(check),
+            })?;
+    }
+
     let mut conn = db_pool.get().await?;
 
     let timetable_id = id;
@@ -228,9 +267,7 @@ pub(in crate::views) async fn stdcm(
     let work_schedules = request.get_work_schedules(&mut conn).await?;
 
     // 3. Get RollingStock
-    let rolling_stock_ids: Vec<i64> = request
-        .consist_schedule
-        .values
+    let rolling_stock_ids: Vec<i64> = consist_schedule_values
         .iter()
         .map(|consist_config| consist_config.rolling_stock_id)
         .collect();
@@ -566,6 +603,9 @@ pub fn as_core_work_schedule(
 
 #[cfg(test)]
 mod tests {
+    use authz::InfraGrant;
+    use authz::Role;
+    use authz::RollingStockGrant;
     use axum::http::StatusCode;
     use chrono::DateTime;
     use common::units;
@@ -603,6 +643,7 @@ mod tests {
     use crate::fixtures::create_timetable;
     use crate::fixtures::create_towed_rolling_stock;
     use crate::views::path::pathfinding::PathfindingResult;
+    use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::TestResponseExt as _;
     use crate::views::test_app::test_app;
     use crate::views::timetable::stdcm::Request;
@@ -972,12 +1013,19 @@ mod tests {
             core
         };
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             Some(mass.get::<kilogram>()),
@@ -989,7 +1037,8 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
-            .json(&get_stdcm_payload(None, consist_schedule))
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule.clone()))
             .await
             .assert_status_ok()
             .last_jsonl();
@@ -1054,12 +1103,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             total_mass,
@@ -1071,6 +1127,7 @@ mod tests {
 
         let stdcm_response: InternalError = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_bad_request()
@@ -1095,12 +1152,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1112,6 +1176,7 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1146,12 +1211,17 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("admin", "identity")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1163,6 +1233,7 @@ mod tests {
 
         let stdcm_response: Vec<StdcmProgression> = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1216,12 +1287,19 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let consist_schedule = build_single_consist(build_consist_config(
             rolling_stock.id,
             None,
@@ -1233,6 +1311,7 @@ mod tests {
 
         let stdcm_response: Vec<StdcmProgression> = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1402,7 +1481,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1448,9 +1527,19 @@ mod tests {
         // WS -> MWS
         // Consist change
         // MWS -> SS
+        //
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&payload)
             .await
             .assert_status_ok()
@@ -1499,7 +1588,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1509,6 +1598,15 @@ mod tests {
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
         let third_rolling_stock =
             create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(third_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let mut payload = get_stdcm_payload(
             None,
@@ -1534,6 +1632,7 @@ mod tests {
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&payload)
             .await
             .assert_status_ok()
@@ -1623,7 +1722,7 @@ mod tests {
             })
             .finish();
 
-        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let app = test_app!().core_client(core.into()).build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
@@ -1640,8 +1739,16 @@ mod tests {
             Some(towed_rolling_stock.id),
         ));
 
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&get_stdcm_payload(None, consist_schedule))
             .await
             .assert_status_ok()
@@ -1656,5 +1763,147 @@ mod tests {
                     .expect("Failed to parse datetime"),
             })
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_with_no_grant_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_without_stdcm_role_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn user_without_infra_grant_is_forbidden() {
+        let mass = Mass::<SI<_>, f64>::new::<kilogram>(1000000.0);
+        let length = Length::<SI<_>, f64>::new::<meter>(400.0);
+        let maximum_speed = Velocity::<SI<_>, f64>::new::<kilometer_per_hour>(30.0);
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let consist_schedule = build_single_consist(build_consist_config(
+            rolling_stock.id,
+            Some(mass.get::<kilogram>()),
+            Some(length.get::<meter>()),
+            Some(maximum_speed.get::<kilometer_per_hour>()),
+            Some(LoadingGaugeType::Glott),
+            None,
+        ));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&get_stdcm_payload(None, consist_schedule))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn multiple_consist_one_missing_grant_makes_request_forbidden() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
+        let first_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let second_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        let third_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), &Uuid::new_v4().to_string()).await;
+        // User missing the Reader privilege on one of the request rolling stocks
+        let user = app
+            .user("user", "identity")
+            .with_roles([Role::Stdcm])
+            .with_rolling_stock_grant(first_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(second_rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+
+        let mut payload = get_stdcm_payload(
+            None,
+            ConsistSchedule {
+                boundaries: vec![1, 2],
+                values: vec![
+                    build_consist_config(first_rolling_stock.id, None, None, None, None, None),
+                    build_consist_config(second_rolling_stock.id, None, None, None, None, None),
+                    build_consist_config(third_rolling_stock.id, None, None, None, None, None),
+                ],
+            },
+        );
+
+        payload.steps.push(build_step("MES"));
+        payload.steps.push(build_step("SES"));
+
+        app.post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&payload)
+            .await
+            .assert_status_forbidden();
     }
 }


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/pull/17364 / https://github.com/osrd-project/osrd-confidential/issues/1064.

> [!NOTE]
The authorization tests might need some refactoring to be more concise (?)

Authorization rules:
- Users must have the Reader grant on every rolling stock.
- Users must have the `Stdcm` role.

The endpoint tests now also take into account infra permissions.