### PR TITLE
 front: fix repeated consist changes for duplicated steps

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useState, type JSX } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import { ArrowRight, CheckCircle, Container } from '@osrd-project/ui-icons';
@@ -7,11 +7,11 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 
 import type {
+  ConsistData,
   StdcmResultsOperationalPoint,
   StdcmSimulationInputs,
   StdcmSuccessResponse,
 } from 'applications/stdcm/types';
-import { getConsistChangesAroundStep } from 'applications/stdcm/utils/simulationOutputUtils';
 import { getStopDurationTime } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
 import { retainSimulation } from 'reducers/osrdconf/stdcmConf';
 import type { StdcmViaPathStep } from 'reducers/osrdconf/types';
@@ -45,6 +45,90 @@ const StdcmResultsTable = ({
     dispatch(retainSimulation(simulationIndex));
   };
 
+  const operationalPointRows: JSX.Element[] = [];
+
+  let currentConsist: ConsistData = {
+    totalLength: consist.totalLength!,
+    totalMass: consist.totalMass!,
+  };
+
+  for (const [index, step] of operationalPointsList.entries()) {
+    const isFirstStep = index === 0;
+    const isLastStep = index === operationalPointsList.length - 1;
+    const prevStep = operationalPointsList[index - 1];
+    const isRequestedPathStep = stdcmData.simulationPathSteps.some(
+      ({ operationalPoint }) => operationalPoint && operationalPoint.id === step.opId
+    );
+    const shouldRenderRow =
+      isFirstStep || isRequestedPathStep || isLastStep || step.duration !== null;
+    const isPathStep = isFirstStep || isLastStep || isRequestedPathStep;
+    const isNotExtremity = !isFirstStep && !isLastStep;
+
+    const extremityStepMass =
+      (isLastStep && lastDefinedConsistChange?.totalMass) || consist.totalMass!;
+    const displayedMass = isNotExtremity ? step.consistChange?.totalMass : extremityStepMass;
+
+    const extremityRollingStock =
+      (isLastStep && lastDefinedConsistChange?.rollingStockName) || consist.tractionEngine!.name;
+    const displayedRollingStock = isNotExtremity
+      ? step.consistChange?.rollingStockName
+      : extremityRollingStock;
+
+    const previousConsist = currentConsist;
+    currentConsist = step.consistChange ? step.consistChange : currentConsist;
+
+    if (showAllOP || shouldRenderRow) {
+      operationalPointRows.push(
+        <Fragment key={`op-list-row-${index}`}>
+          <tr className={cx({ isPathStep })}>
+            <td className={cx('index', { 'muted-text': !isPathStep })}>{index + 1}</td>
+            <td className="name">
+              {isNotExtremity &&
+              !isRequestedPathStep &&
+              step.name === prevStep.name &&
+              step.duration === null
+                ? '='
+                : step.name || t('reportSheet.unknown')}
+            </td>
+            <td className={cx('ch', { 'muted-text': !isPathStep })}>{step.secondaryCode}</td>
+            <td className="stop">{isLastStep || step.duration !== null ? step.time : ''}</td>
+            <td className="stop">
+              {isNotExtremity && (
+                <div className={step.duration !== null ? 'stop-with-duration ml-n2' : 'stop'}>
+                  {step.duration !== null ? getStopDurationTime(step.duration) : step.time}
+                </div>
+              )}
+            </td>
+            <td className="stop">
+              {isFirstStep || step.duration !== null ? step.stopEndTime : ''}
+            </td>
+            <td className={cx('weight', { 'muted-text': !isFirstStep })}>
+              {displayedMass ? `${displayedMass}t` : '='}
+            </td>
+            <td className={cx('ref', { 'muted-text': !isFirstStep })}>
+              {displayedRollingStock ?? '='}
+            </td>
+          </tr>
+          {step.consistChange && (
+            <tr>
+              <td className="index">
+                <Container />
+              </td>
+              <td colSpan={8} data-testid="consist-change">
+                <p className="consist-change-label">{t('consist.consistChange')}</p>
+                <p>
+                  {t('consist.tonnage')} ({previousConsist.totalMass}t <ArrowRight />{' '}
+                  {step.consistChange.totalMass}t), {t('consist.length')} (
+                  {previousConsist.totalLength}m <ArrowRight /> {step.consistChange.totalLength}m)
+                </p>
+              </td>
+            </tr>
+          )}
+        </Fragment>
+      );
+    }
+  }
+
   return (
     <div className="stdcm-result-table-container">
       <table data-testid="table-results" className="table-results">
@@ -60,99 +144,7 @@ const StdcmResultsTable = ({
             <th>{t('reportSheet.refEngine')}</th>
           </tr>
         </thead>
-        <tbody>
-          {operationalPointsList.map((step, index) => {
-            const isFirstStep = index === 0;
-            const isLastStep = index === operationalPointsList.length - 1;
-            const prevStep = operationalPointsList[index - 1];
-            const isRequestedPathStep = stdcmData.simulationPathSteps.some(
-              ({ operationalPoint }) => operationalPoint && operationalPoint.id === step.opId
-            );
-            const shouldRenderRow =
-              isFirstStep || isRequestedPathStep || isLastStep || step.duration !== null;
-            const isPathStep = isFirstStep || isLastStep || isRequestedPathStep;
-            const isNotExtremity = !isFirstStep && !isLastStep;
-
-            const consistChanges = getConsistChangesAroundStep(step.opId!, intermediatePathSteps, {
-              rollingStockName: consist.tractionEngine?.name ?? '',
-              totalMass: consist.totalMass ?? NaN,
-              totalLength: consist.totalLength ?? NaN,
-            });
-
-            const initialConsistMass = consist.totalMass ?? stdcmData.rollingStock.mass / 1000;
-            const extremityStepMass =
-              (isLastStep && lastDefinedConsistChange?.totalMass) || initialConsistMass;
-            const displayedMass = isNotExtremity
-              ? consistChanges?.updatedConsist.totalMass
-              : extremityStepMass;
-
-            const initialRollingStock = stdcmData.rollingStock.name;
-            const extremityRollingStock =
-              (isLastStep && lastDefinedConsistChange?.rollingStockName) || initialRollingStock;
-            const displayedRollingStock = isNotExtremity
-              ? consistChanges?.updatedConsist.rollingStockName
-              : extremityRollingStock;
-
-            if (showAllOP || shouldRenderRow) {
-              return (
-                <Fragment key={`op-list-row-${index}`}>
-                  <tr className={cx({ isPathStep })}>
-                    <td className={cx('index', { 'muted-text': !isPathStep })}>{index + 1}</td>
-                    <td className="name">
-                      {isNotExtremity &&
-                      !isRequestedPathStep &&
-                      step.name === prevStep.name &&
-                      step.duration === null
-                        ? '='
-                        : step.name || t('reportSheet.unknown')}
-                    </td>
-                    <td className={cx('ch', { 'muted-text': !isPathStep })}>
-                      {step.secondaryCode}
-                    </td>
-                    <td className="stop">
-                      {isLastStep || step.duration !== null ? step.time : ''}
-                    </td>
-                    <td className="stop">
-                      {isNotExtremity && (
-                        <div
-                          className={step.duration !== null ? 'stop-with-duration ml-n2' : 'stop'}
-                        >
-                          {step.duration !== null ? getStopDurationTime(step.duration) : step.time}
-                        </div>
-                      )}
-                    </td>
-                    <td className="stop">
-                      {isFirstStep || step.duration !== null ? step.stopEndTime : ''}
-                    </td>
-                    <td className={cx('weight', { 'muted-text': !isFirstStep })}>
-                      {displayedMass ? `${displayedMass}t` : '='}
-                    </td>
-                    <td className={cx('ref', { 'muted-text': !isFirstStep })}>
-                      {displayedRollingStock ?? '='}
-                    </td>
-                  </tr>
-                  {consistChanges && step.duration !== null && (
-                    <tr>
-                      <td className="index">
-                        <Container />
-                      </td>
-                      <td colSpan={8} data-testid="consist-change">
-                        <p className="consist-change-label">{t('consist.consistChange')}</p>
-                        <p>
-                          {t('consist.tonnage')} ({consistChanges.currentConsist.totalMass}t{' '}
-                          <ArrowRight /> {consistChanges.updatedConsist.totalMass}t),{' '}
-                          {t('consist.length')} ({consistChanges.currentConsist.totalLength}m{' '}
-                          <ArrowRight /> {consistChanges.updatedConsist.totalLength}m)
-                        </p>
-                      </td>
-                    </tr>
-                  )}
-                </Fragment>
-              );
-            }
-            return null;
-          })}
-        </tbody>
+        <tbody>{operationalPointRows}</tbody>
       </table>
       <div className={cx('results-buttons', { 'simulation-retained': isSimulationRetained })}>
         <div className="button-display-all-PR">

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -55,6 +55,7 @@ export type StdcmResultsOperationalPoint = {
   positionOnPath: number;
   time: string | null;
   name?: string;
+  consistChange?: ConsistData;
   secondaryCode?: string | null;
   duration: Duration | null;
   stopEndTime: string;

--- a/front/src/applications/stdcm/utils/simulationOutputUtils.ts
+++ b/front/src/applications/stdcm/utils/simulationOutputUtils.ts
@@ -9,7 +9,6 @@ import type {
 import { getStopDurationTime } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
 import { getRowStyle } from 'modules/SimulationReportSheet/utils/formatSimulationTable';
 import type { SpeedDistanceDiagramData } from 'modules/simulationResult/types';
-import type { StdcmViaPathStep } from 'reducers/osrdconf/types';
 import { capitalizeFirstLetter } from 'utils/strings';
 
 export const hasResults = (
@@ -20,18 +19,6 @@ export const hasResults = (
   speedDistanceDiagramData: SpeedDistanceDiagramData;
 } => !!outputs && 'results' in outputs;
 
-type ConsistChangeParameters = {
-  totalMass: number;
-  totalLength: number;
-  rollingStockName: string;
-  towedRollingStockName?: string;
-};
-
-type ConsistChangeContext = {
-  currentConsist: ConsistChangeParameters;
-  updatedConsist: ConsistChangeParameters;
-};
-
 type ConsistParameters = {
   /** In ton */
   mass: number;
@@ -40,57 +27,29 @@ type ConsistParameters = {
   rollingStockName: string;
 };
 
-export function getConsistChangesAroundStep(
-  opId: string,
-  simulationPathSteps: StdcmViaPathStep[],
-  initialConsist: ConsistChangeParameters
-): ConsistChangeContext | undefined {
-  const stepIndex = simulationPathSteps.findIndex((step) => step.operationalPoint?.id === opId);
-
-  if (stepIndex === -1) return undefined;
-
-  const consistChangeForThisStep = simulationPathSteps[stepIndex].consistChange;
-
-  if (!consistChangeForThisStep) return undefined;
-
-  let currentConsist: ConsistChangeParameters = initialConsist;
-  for (let i = stepIndex - 1; i >= 0; i--) {
-    if (simulationPathSteps[i].consistChange) {
-      currentConsist = simulationPathSteps[i].consistChange! as ConsistChangeParameters;
-      break;
-    }
-  }
-
-  const { totalLength, totalMass, rollingStockName, towedRollingStockName } =
-    consistChangeForThisStep;
-  const updatedConsist = {
-    totalLength: totalLength!,
-    totalMass: totalMass!,
-    rollingStockName: rollingStockName ?? currentConsist.rollingStockName,
-    towedRollingStockName,
-  };
-
-  return { currentConsist, updatedConsist };
-}
-
 export const formatStdcmDataForSimulationTable = (
   operationalPointsList: StdcmResultsOperationalPoint[],
   stdcmPathSteps: StdcmSuccessResponse['simulationPathSteps'],
   consist: ConsistParameters,
   t: TFunction<'stdcm'>
-) =>
-  operationalPointsList.map((step, index) => {
+) => {
+  let currentConsist = {
+    totalLength: `${consist.length} m`,
+    totalMass: `${consist.mass} t`,
+  };
+
+  return operationalPointsList.map((op, index) => {
     const isFirst = index === 0;
     const isLast = index === operationalPointsList.length - 1;
-    const previousStep = operationalPointsList[index - 1];
+    const previousOp = operationalPointsList[index - 1];
 
-    const isStop = step.duration !== null && !isLast;
-    const isVia = stdcmPathSteps.slice(1, -1).some((s) => s.operationalPoint!.id === step.opId);
+    const isStop = op.duration !== null && !isLast;
+    const isVia = stdcmPathSteps.slice(1, -1).some((step) => step.operationalPoint!.id === op.opId);
     const isPathStep = isFirst || isVia || isLast;
 
-    const startTime = isFirst || isStop ? step.stopEndTime : '';
-    const endTime = isLast || isStop ? step.time : '';
-    const { stopType, trackName } = step;
+    const startTime = isFirst || isStop ? op.stopEndTime : '';
+    const endTime = isLast || isStop ? op.time : '';
+    const { stopType, trackName } = op;
 
     const stopTypeLabel = stopType
       ? capitalizeFirstLetter(t(`trainPath.stopType.${stopType}`))
@@ -98,40 +57,29 @@ export const formatStdcmDataForSimulationTable = (
 
     let passageStop = '';
     if (!isFirst && !isLast) {
-      passageStop = step.duration !== null ? getStopDurationTime(step.duration) : String(step.time);
+      passageStop = op.duration !== null ? getStopDurationTime(op.duration) : String(op.time);
     }
 
-    const intermediatePathSteps: StdcmViaPathStep[] = stdcmPathSteps.filter(
-      (pathStep) => pathStep.isVia
-    );
-
-    const consistChangesData = getConsistChangesAroundStep(step.opId!, intermediatePathSteps, {
-      totalLength: consist.length,
-      totalMass: consist.mass,
-      rollingStockName: consist.rollingStockName,
-    });
-
-    const consistChanges = consistChangesData
-      ? {
-          currentConsist: {
-            totalLength: `${consistChangesData?.currentConsist.totalLength} m`,
-            totalMass: `${consistChangesData?.currentConsist.totalMass} t`,
-          },
-          updatedConsist: {
-            totalLength: `${consistChangesData.updatedConsist.totalLength} m`,
-            totalMass: `${consistChangesData.updatedConsist.totalMass} t`,
-            rollingStockName: consistChangesData.updatedConsist.rollingStockName,
-            towedRollingStockName: consistChangesData.updatedConsist.towedRollingStockName,
-          },
-        }
-      : undefined;
+    let consistChanges;
+    if (op.consistChange) {
+      consistChanges = {
+        currentConsist,
+        updatedConsist: {
+          totalLength: `${op.consistChange.totalLength} m`,
+          totalMass: `${op.consistChange.totalMass} t`,
+          rollingStockName: op.consistChange.rollingStockName!,
+          towedRollingStockName: op.consistChange.towedRollingStockName,
+        },
+      };
+      currentConsist = {
+        totalLength: `${op.consistChange.totalLength} m`,
+        totalMass: `${op.consistChange.totalMass} t`,
+      };
+    }
 
     return {
-      name:
-        !isPathStep && step.name === previousStep.name
-          ? '='
-          : step.name || t('reportSheet.unknown'),
-      ch: step.secondaryCode,
+      name: !isPathStep && op.name === previousOp.name ? '=' : op.name || t('reportSheet.unknown'),
+      ch: op.secondaryCode,
       trackName,
       endTime,
       passageStop,
@@ -146,6 +94,7 @@ export const formatStdcmDataForSimulationTable = (
       stopTypeLabel,
       stopType,
       consistChanges,
-      ...getRowStyle(step.duration, isPathStep, isFirst, isLast),
+      ...getRowStyle(op.duration, isPathStep, isFirst, isLast),
     };
   });
+};

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -261,7 +261,7 @@ export function insertMissingStopsInOperationalPointsWithTimes(
 
 // TODO : Remove this function as soon as fake takeover tracks cease to be used
 // It serves to consolidate steps of the form OVERTAKE_n_A;X, OVERTAKE_n_B;X in a single step X
-export function consolidateOvertakesToSingleSteps(
+function consolidateOvertakesToSingleSteps(
   steps: StdcmResultsOperationalPoint[]
 ): StdcmResultsOperationalPoint[] {
   function convertHHMMTimeToSeconds(time: string): number {
@@ -326,12 +326,11 @@ export function getOperationalPointsWithTimes({
     .filter((suggestedOp) => {
       // Keep if the OP is not in the exclusion list
       if (!suggestedOp.opId || !opIdsToExclude.includes(suggestedOp.opId)) return true;
-      // Keep if explicitly requested by the user (origin, destination, via point or stop)
 
+      // Keep if explicitly requested by the user (origin, destination, via point or stop)
       const isRequestedPoint = simulationPathSteps.some(
         (step) => step.operationalPoint && step.operationalPoint.id === suggestedOp.opId
       );
-
       return isRequestedPoint;
     })
     // Map operational points with their positions, times, and stop durations
@@ -354,7 +353,7 @@ export function getOperationalPointsWithTimes({
 
   return formattedConsolidatedOps.map((op) => ({
     ...op,
-    stopType: op.duration ? op.stopType : undefined,
+    stopType: op.duration || !op.stopType ? op.stopType : StdcmStopTypes.PASSAGE_TIME, // no stop duration -> stoptype = undefined or PASSAGE_TIME
     consistChange: op.duration ? op.consistChange : undefined,
   }));
 }

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -165,11 +165,13 @@ function formatOperationalPointWithTimesAndWeight(
     (step) => step.operationalPoint && step.operationalPoint.id === suggestedOp.opId
   );
   let stopType;
+  let consistChange;
   if (correspondingStep) {
     if (correspondingStep.isVia) {
       stopType = correspondingStep.consistChange
         ? StdcmStopTypes.CONSIST_CHANGE
         : correspondingStep.stopType;
+      consistChange = correspondingStep.consistChange;
     } else {
       stopType = StdcmStopTypes.SERVICE_STOP;
     }
@@ -184,6 +186,7 @@ function formatOperationalPointWithTimesAndWeight(
     name: suggestedOp.name,
     secondaryCode: suggestedOp.secondaryCode,
     trackName: suggestedOp.metadata?.trackName,
+    consistChange,
     stopType,
     stopRequested,
     weight: operationalPoints.find((op) => op.id === suggestedOp.opId)?.weight ?? null,
@@ -347,7 +350,13 @@ export function getOperationalPointsWithTimes({
     stopPositions,
     { positions, times, speeds, departureHour, departureMinute }
   );
-  return consolidateOvertakesToSingleSteps(formattedOpsWithAllStops);
+  const formattedConsolidatedOps = consolidateOvertakesToSingleSteps(formattedOpsWithAllStops);
+
+  return formattedConsolidatedOps.map((op) => ({
+    ...op,
+    stopType: op.duration ? op.stopType : undefined,
+    consistChange: op.duration ? op.consistChange : undefined,
+  }));
 }
 
 export const getArrivalTimes = (


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/17204

Last pr I made a small change to fix the symptom. Instead, this pr fixes the issue beforehand, by adding the consist change data from to the path steps into the list of ops earlier, at the same type as the stop type is added, and imposing that a stop type and consist change can only be present if there is a stop (i.e. the stop duration should be positive or 0 but not null).