### PR TITLE
front: add a banner in train header on path change

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -539,6 +539,7 @@
         "trainName": "Train name"
       },
       "itinerary": "Itinerary",
+      "pathChanged": "The itinerary has been changed following a modification",
       "serviceChangeWarning": {
         "cancel": "Cancel",
         "confirm": "Confirm",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -539,6 +539,7 @@
         "trainName": "Nom du train"
       },
       "itinerary": "Itinéraire",
+      "pathChanged": "L’itinéraire a été modifié suite à une modification",
       "serviceChangeWarning": {
         "cancel": "Annuler",
         "confirm": "Confirmer",

--- a/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
@@ -232,17 +232,32 @@ describe('useSimulationResults', () => {
         case: 'rolling stock is missing',
         arrange: () =>
           getRollingStockNameByRollingStockName.mockResolvedValue({ error: notFoundError }),
-        expectedResults: { isValid: false, train: expectedTrain, rollingStock: undefined },
+        expectedResults: {
+          isValid: false,
+          train: expectedTrain,
+          path: pathfindingSuccess,
+          rollingStock: undefined,
+        },
       },
       {
         case: 'path properties are missing',
         arrange: () => postInfraByInfraIdPathProperties.mockResolvedValue({ error: notFoundError }),
-        expectedResults: { isValid: false, train: expectedTrain, rollingStock },
+        expectedResults: {
+          isValid: false,
+          train: expectedTrain,
+          path: pathfindingSuccess,
+          rollingStock,
+        },
       },
       {
         case: 'pathfinding has failed',
         arrange: () => getTrainPath.mockResolvedValue({ error: notFoundError }),
-        expectedResults: { isValid: false, train: expectedTrain, rollingStock },
+        expectedResults: {
+          isValid: false,
+          train: expectedTrain,
+          path: undefined,
+          rollingStock,
+        },
       },
       {
         case: 'simulation is not successful',
@@ -250,6 +265,7 @@ describe('useSimulationResults', () => {
         expectedResults: {
           isValid: false,
           train: expectedTrain,
+          path: pathfindingSuccess,
           rollingStock,
           pathProperties: preparedPathProperties,
         },

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -141,7 +141,7 @@ const useSimulationResults = (
 
   if (pathfinding?.status !== 'success' || !rawPathProperties || !rollingStock) {
     return {
-      results: { isValid: false, train, rollingStock },
+      results: { isValid: false, train, path: pathfinding, rollingStock },
       isSimulationDataLoading,
     };
   }
@@ -160,6 +160,7 @@ const useSimulationResults = (
         isValid: false,
         train,
         rollingStock,
+        path: pathfinding,
         pathProperties,
       },
       isSimulationDataLoading,

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -18,6 +18,7 @@ import type {
   OperationalPointReference,
   MacroNoteForm,
   TrainScheduleResponse,
+  PathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
 import type { PathOperationalPoint } from 'modules/simulationResult/types';
@@ -135,6 +136,7 @@ export type SimulationResults =
       isValid: false;
       train: Train;
       rollingStock?: RollingStockWithLiveries;
+      path?: PathfindingResult;
       pathProperties?: PathPropertiesFormatted;
     }
   | {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -663,6 +663,10 @@ const ItineraryModal = ({
     frameAllPathSteps();
   }, [pathStepsMetadataById, hasInvalidPathStep]);
 
+  const resetCategoryWarning = useCallback(() => {
+    setCategoryWarning(undefined);
+  }, [setCategoryWarning]);
+
   return (
     <dialog ref={modalRef} className="itinerary-modal" data-testid="itinerary-modal">
       <div
@@ -685,7 +689,7 @@ const ItineraryModal = ({
           />
         </div>
         <div className="itinerary-modal-form-body" data-testid="itinerary-modal-form-body">
-          {categoryWarning && <Banner message={categoryWarning} closeable />}
+          {categoryWarning && <Banner message={categoryWarning} onClose={resetCategoryWarning} />}
           {rollingStockMessage && <Banner type="info" message={rollingStockMessage} />}
           {(hasInvalidPathStepDisplay || invalidTrackSteps.length > 0) && (
             <div key={`invalid-op-${bannerWiggle}`}>

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
@@ -125,18 +125,6 @@ const ItineraryModalFormHeader = ({
     };
   }, [isNameBlurred, submitAttempted, isNameEmpty, t]);
 
-  // Category warning
-  const categoryWarningMessage = useMemo(() => {
-    if (!rollingStock || !modalFormState.category) return undefined;
-
-    const isMismatch = isMainCategory(modalFormState.category)
-      ? modalFormState.category.main_category !== rollingStock.primary_category &&
-        !rollingStock.other_categories.includes(modalFormState.category.main_category)
-      : currentSubCategory?.main_category !== rollingStock.primary_category;
-
-    return isMismatch ? t('categoryMismatch') : undefined;
-  }, [rollingStock, modalFormState.category, currentSubCategory, t]);
-
   const rollingStockMessage = useMemo(() => {
     if (!rollingStockValue) {
       return t('noRollingStock');
@@ -147,9 +135,20 @@ const ItineraryModalFormHeader = ({
     return isValid ? undefined : t('unknownRollingStock');
   }, [rollingStockValue, fullRollingStockList, t]);
 
+  // Category warning
   useEffect(() => {
-    onCategoryWarningChange(categoryWarningMessage);
-  }, [categoryWarningMessage]);
+    if (!rollingStock || !modalFormState.category) {
+      onCategoryWarningChange(undefined);
+      return;
+    }
+
+    const isMismatch = isMainCategory(modalFormState.category)
+      ? modalFormState.category.main_category !== rollingStock.primary_category &&
+        !rollingStock.other_categories.includes(modalFormState.category.main_category)
+      : currentSubCategory?.main_category !== rollingStock.primary_category;
+
+    onCategoryWarningChange(isMismatch ? t('categoryMismatch') : undefined);
+  }, [rollingStock, modalFormState.category, currentSubCategory, t]);
 
   useEffect(() => {
     onRollingStockMessageChange(rollingStockMessage);

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -333,6 +333,7 @@ const SimulationResults = ({
           customHeader={
             <TrainHeader
               train={simulationResults.train}
+              path={simulationResults.path}
               trainSchedulesWithDetails={trainSchedulesWithDetails}
               upsertTrainSchedules={upsertTrainSchedules}
               setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}

--- a/front/src/common/Banner.tsx
+++ b/front/src/common/Banner.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { Alert, Info, Blocked, X } from '@osrd-project/ui-icons';
 
 type BannerType = 'warning' | 'error' | 'info';
@@ -7,7 +5,7 @@ type BannerType = 'warning' | 'error' | 'info';
 type BannerProps = {
   type?: BannerType;
   message?: string;
-  closeable?: boolean;
+  onClose?: () => void;
 };
 
 const iconByType = {
@@ -16,22 +14,15 @@ const iconByType = {
   info: <Info variant="fill" size="lg" className="banner-icon info" />,
 };
 
-const Banner = ({ type = 'warning', message, closeable }: BannerProps) => {
-  const [visible, setVisible] = useState(true);
+const Banner = ({ type = 'warning', message, onClose }: BannerProps) => {
   const icon = iconByType[type];
-
-  if (!visible) return null;
 
   return (
     <div className={`banner ${type}`}>
       {icon}
       <span className={`banner-text ${type}`}>{message}</span>
-      {closeable && (
-        <button
-          className={`banner-close-button ${type}`}
-          onClick={() => setVisible(false)}
-          type="button"
-        >
+      {onClose && (
+        <button className={`banner-close-button ${type}`} onClick={onClose} type="button">
           <X />
         </button>
       )}

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -13,10 +13,15 @@ import {
   type CalendarSlot,
 } from '@osrd-project/ui-core';
 import { ChevronUp } from '@osrd-project/ui-icons';
+import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import type { PacedTrainWithPaced } from 'applications/operationalStudies/types';
-import type { LightRollingStockWithLiveries, TrainCategory } from 'common/api/osrdEditoastApi';
+import type {
+  LightRollingStockWithLiveries,
+  PathfindingResult,
+  TrainCategory,
+} from 'common/api/osrdEditoastApi';
 import type { Comfort, ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
 import Banner from 'common/Banner';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
@@ -44,6 +49,7 @@ export const ANY_DATE_SLOT: CalendarSlot = { start: new Date(0), end: null };
 
 export type ExpandedTrainFormProps = {
   train: Train;
+  path?: Omit<PathfindingResult, 'status'>;
   onCollapse: () => void;
   onPersistTrain: (
     updatedTrain: Train,
@@ -183,6 +189,7 @@ function extractChangesInFields(
  */
 const ExpandedTrainForm = ({
   train,
+  path,
   onCollapse,
   onPersistTrain,
   onItineraryOpened,
@@ -227,6 +234,7 @@ const ExpandedTrainForm = ({
   // NOTE: The setter is called outside a useEffect purposefully, as suggested in React's
   // documentation: https://react.dev/reference/react/useState#storing-information-from-previous-renders
   const originalFields = usePrevious(fieldsFromTrain);
+  const previousPath = usePrevious(path);
   if (originalFields) {
     const changes = extractChangesInFields(originalFields, fieldsFromTrain, fields);
 
@@ -234,6 +242,15 @@ const ExpandedTrainForm = ({
       setFields({ ...fields, ...changes });
     }
   }
+
+  const [pathChanged, setPathChanged] = useState(false);
+  if (!pathChanged && previousPath !== null && !isEqual(previousPath, path)) {
+    setPathChanged(true);
+  }
+
+  const resetPathJustChanged = useCallback(() => {
+    setPathChanged(false);
+  }, [setPathChanged]);
 
   const onFieldChange = useCallback(
     (fieldName: keyof TrainFieldsState, newValue: TrainFieldsState[typeof fieldName]) => {
@@ -659,6 +676,13 @@ const ExpandedTrainForm = ({
           />
         </div>
       </div>
+      {pathChanged && (
+        <Banner
+          message={t('manageTrainSchedule.trainHeader.pathChanged')}
+          type="info"
+          onClose={resetPathJustChanged}
+        />
+      )}
       {categoryWarning && <Banner message={categoryWarning} />}
       {isServiceChangeWarningDialogVisible && (
         <ServiceChangeWarningDialog

--- a/front/src/modules/trainHeader/TrainHeader.tsx
+++ b/front/src/modules/trainHeader/TrainHeader.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import { updateTrainSchedule } from 'applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule';
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/views/Scenario/consts';
-import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import type { PathfindingResult, TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 import type { PacedTrainWithDetails } from 'modules/trainSchedule/types';
 import { setFailure } from 'reducers/main';
 import { selectTrainToEdit } from 'reducers/osrdconf/operationalStudiesConf';
@@ -19,6 +19,7 @@ import { applyOccurrenceOnPacedTrain } from './utils/applyOccurrenceOnPacedTrain
 
 export type TrainHeaderProps = {
   train: Train;
+  path?: Omit<PathfindingResult, 'status'>;
   trainSchedulesWithDetails: PacedTrainWithDetails[];
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
   setDisplayTrainScheduleManagement: (type: string) => void;
@@ -37,6 +38,7 @@ export type ExtraOccurrencesChanges = {
  */
 const TrainHeader = ({
   train,
+  path,
   trainSchedulesWithDetails,
   upsertTrainSchedules,
   setDisplayTrainScheduleManagement,
@@ -115,6 +117,7 @@ const TrainHeader = ({
       <ExpandedTrainForm
         key={`form-${train.id}` /* Invalidate the form's state if we select another train */}
         train={train}
+        path={path}
         onCollapse={() => {
           setExpanded(false);
         }}


### PR DESCRIPTION
We missed this AC from our task breakdown in https://github.com/osrd-project/osrd-confidential/issues/1315:

> If the user changes the rolling stock (and only if the pathfinding changes), an information message (with a blue background, as in LMR for mass/length/speed) appears as a banner with the message "The itinerary has been changed following a modification"

This pull request does this; it's fortunately quite easy to do. I just had to fix `Banner` to remove its inner state to let us reset that warning.
