### PR TITLE
front: move stdcm contact info to `overrides.json`

### DIFF
--- a/front/public/locales/en/stdcm-help-section.json
+++ b/front/public/locales/en/stdcm-help-section.json
@@ -1,42 +1,6 @@
 {
-  "asu": [
-    {
-      "title": "Application name",
-      "value": "OSRD"
-    },
-    {
-      "title": "Assistance",
-      "value": "Support applicatif ASU"
-    },
-    {
-      "title": "Phone",
-      "value": "70 70 70 (ou 09 72 72 12 70)"
-    },
-    {
-      "title": "Application Code (AVAYA)",
-      "value": "176"
-    }
-  ],
-  "asuLink": "ASU support link",
   "backToIndex": "help index",
-  "externalContact": "Contact (Clients and partners)",
-  "externalSupport": [
-    {
-      "title": "Application name",
-      "value": "OSRD"
-    },
-    {
-      "title": "Assistance",
-      "value": "External support email"
-    },
-    {
-      "title": "Phone",
-      "value": "09 72 72 27 29"
-    }
-  ],
-  "externalSupportEmail": "External support email",
   "help": "Help",
-  "internalContact": "Contact (SNCF Réseau)",
   "sections": {
     "application": {
       "content": [

--- a/front/public/locales/fr/stdcm-help-section.json
+++ b/front/public/locales/fr/stdcm-help-section.json
@@ -1,42 +1,6 @@
 {
-  "asu": [
-    {
-      "title": "Nom de l'application",
-      "value": "OSRD"
-    },
-    {
-      "title": "Assistance",
-      "value": "Support applicatif ASU"
-    },
-    {
-      "title": "Téléphone",
-      "value": "70 70 70 (ou 09 72 72 12 70)"
-    },
-    {
-      "title": "Code Application (AVAYA)",
-      "value": "176"
-    }
-  ],
-  "asuLink": "Lien vers le support ASU",
   "backToIndex": "index de l'aide",
-  "externalContact": "Contact (Clients et partenaires)",
-  "externalSupport": [
-    {
-      "title": "Nom de l'application",
-      "value": "OSRD"
-    },
-    {
-      "title": "Assistance",
-      "value": "Support email externe"
-    },
-    {
-      "title": "Téléphone",
-      "value": "09 72 72 27 29"
-    }
-  ],
-  "externalSupportEmail": "Email support externe",
   "help": "Aide",
-  "internalContact": "Contact (SNCF Réseau)",
   "sections": {
     "application": {
       "content": [

--- a/front/src/applications/stdcm/components/StdcmHelpModule/StdcmHelpModule.tsx
+++ b/front/src/applications/stdcm/components/StdcmHelpModule/StdcmHelpModule.tsx
@@ -4,6 +4,8 @@ import { ChevronRight, X } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
+import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
+
 import HelpSection from './HelpSection';
 
 type StdcmHelpSectionProps = {
@@ -12,20 +14,20 @@ type StdcmHelpSectionProps = {
 };
 
 const StdcmHelpModule = ({ toggleHelpModule, showHelpModule }: StdcmHelpSectionProps) => {
-  const { t } = useTranslation('stdcm-help-section');
+  const { t, i18n } = useTranslation('stdcm-help-section');
 
   const [activeSection, setActiveSection] = useState<string | null>(null);
+
+  const allContactSections = useDeploymentSettings()?.stdcmContactSections;
+  const contactSections =
+    allContactSections &&
+    (allContactSections[i18n.language] ?? allContactSections.en ?? allContactSections.fr);
 
   const closeHelpModule = () => {
     setActiveSection(null);
     toggleHelpModule();
   };
   const closeHelpSection = () => setActiveSection(null);
-  const support = t('asu', { returnObjects: true }) as { title: string; value: string }[];
-  const externalSupport = t('externalSupport', { returnObjects: true }) as {
-    title: string;
-    value: string;
-  }[];
   const sections = Object.keys(t('sections', { returnObjects: true }));
   return (
     <div className={cx('stdcm__help-module', { active: showHelpModule })}>
@@ -50,48 +52,31 @@ const StdcmHelpModule = ({ toggleHelpModule, showHelpModule }: StdcmHelpSectionP
           ))}
         </div>
       </div>
-      <footer>
-        <div className="contact">
-          <h2 className="contact_title">{t('externalContact')}</h2>
-          {Array.isArray(externalSupport) &&
-            externalSupport.map((item, index) => (
-              <div key={item.title}>
-                <div className="support-info">
-                  <div className="support-info__title">{item.title}</div>
-                  <div className="support-info__content">{item.value}</div>
+      {contactSections && contactSections.length > 0 && (
+        <footer>
+          {contactSections.map((contactSection) => (
+            <div className="contact" key={contactSection.title}>
+              <h2 className="contact_title">{contactSection.title}</h2>
+              {contactSection.items.map((item, index) => (
+                <div key={item.title}>
+                  <div className="support-info">
+                    <div className="support-info__title">{item.title}</div>
+                    <div className="support-info__content">{item.value}</div>
+                  </div>
+                  {index !== contactSection.items.length - 1 && <hr />}
                 </div>
-                {index !== externalSupport.length - 1 && <hr />}
-              </div>
-            ))}
-          <div className="support__link">
-            <a href="mailto:SupportClients.SI@reseau.sncf.fr" target="_blank" rel="noreferrer">
-              {t('externalSupportEmail')}
-            </a>
-          </div>
-        </div>
-        <div className="contact">
-          <h2 className="contact_title">{t('internalContact')}</h2>
-          {Array.isArray(support) &&
-            support.map((item, index) => (
-              <div key={item.title}>
-                <div className="support-info">
-                  <div className="support-info__title">{item.title}</div>
-                  <div className="support-info__content">{item.value}</div>
+              ))}
+              {contactSection.link && (
+                <div className="support__link">
+                  <a href={contactSection.link.url} target="_blank" rel="noreferrer">
+                    {contactSection.link.label}
+                  </a>
                 </div>
-                {index !== support.length - 1 && <hr />}
-              </div>
-            ))}
-          <div className="support__link">
-            <a
-              href="https://sncfreseau.service-now.com/support_asu"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t('asuLink')}
-            </a>
-          </div>
-        </div>
-      </footer>
+              )}
+            </div>
+          ))}
+        </footer>
+      )}
       {sections.map((section) => (
         <HelpSection
           section={section}

--- a/front/src/utils/hooks/useDeploymentSettings.tsx
+++ b/front/src/utils/hooks/useDeploymentSettings.tsx
@@ -25,6 +25,13 @@ const defaultSettings = {
   stdcmFeedbackMail: 'support_LMR@default.org',
   noInfraEdit: false,
   railwayManagerInterfaceUrl: undefined,
+  stdcmContactSections: undefined,
+};
+
+export type StdcmContactSection = {
+  title: string;
+  items: { title: string; value: string }[];
+  link?: { url: string; label: string };
 };
 
 export type DeploymentSettings = {
@@ -38,6 +45,7 @@ export type DeploymentSettings = {
   stdcmFeedbackMail?: string;
   noInfraEdit?: boolean;
   railwayManagerInterfaceUrl?: string;
+  stdcmContactSections?: Record<string, StdcmContactSection[]>;
 };
 
 type Overrides = {
@@ -47,6 +55,8 @@ type Overrides = {
   stdcm_feedback_mail?: string;
   /** Whether the options to edit the rail infrastructure should be visible to users. */
   no_infra_edit?: boolean;
+  /** Locale-keyed contact sections shown in the STDCM help module footer. */
+  stdcm_contact_sections?: Record<string, StdcmContactSection[]>;
   /** Custom names to display to users for the osrd modules. */
   names?: {
     operational_studies?: string;
@@ -114,6 +124,7 @@ export const DeploymentContextProvider = ({ children }: DeploymentContextProvide
             stdcm_feedback_mail,
             no_infra_edit,
             railway_manager_interface_url,
+            stdcm_contact_sections,
           } = overridesData;
 
           const deploySettings: DeploymentSettings = {
@@ -154,6 +165,10 @@ export const DeploymentContextProvider = ({ children }: DeploymentContextProvide
           if (railway_manager_interface_url) {
             dispatch(setRailwayManagerInterfaceUrl(railway_manager_interface_url));
             deploySettings.railwayManagerInterfaceUrl = railway_manager_interface_url;
+          }
+
+          if (stdcm_contact_sections) {
+            deploySettings.stdcmContactSections = stdcm_contact_sections;
           }
 
           setCustomizedDeploymentSetting({


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/17309

I moved the contact section data into the `overrides.json` file. Not sure its the best way to do it but in my mind, this kind of info should be set on a per-deployment basis.

Here is an example of `overrides.json` for the contact section:
```json
{
  "stdcm_contact_sections": {
    "en": [
      {
        "title": "External support",
        "items": [
          { "title": "Application", "value": "My STDCM" },
          { "title": "Phone", "value": "+1 234 567 890" }
        ],
        "link": {
          "url": "mailto:support@example.com",
          "label": "Contact external support"
        }
      },
      {
        "title": "Internal support",
        "items": [
          { "title": "Application", "value": "My STDCM" },
          { "title": "Phone", "value": "+1 234 567 891" }
        ],
        "link": {
          "url": "https://helpdesk.example.com",
          "label": "Open a support ticket"
        }
      }
    ],
    "fr": [
      {
        "title": "Support externe",
        "items": [
          { "title": "Application", "value": "My STDCM" },
          { "title": "Téléphone", "value": "+1 234 567 890" }
        ],
        "link": {
          "url": "mailto:support@example.com",
          "label": "Contacter le support externe"
        }
      },
      {
        "title": "Support interne",
        "items": [
          { "title": "Application", "value": "My STDCM" },
          { "title": "Téléphone", "value": "+1 234 567 891" }
        ],
        "link": {
          "url": "https://helpdesk.example.com",
          "label": "Ouvrir un ticket de support"
        }
      }
    ]
  }
}
```