### PR TITLE
editoast: rename round trips endpoints and fix documentation

### DIFF
--- a/editoast/editoast_models/src/round_trips.rs
+++ b/editoast/editoast_models/src/round_trips.rs
@@ -13,9 +13,9 @@ use crate::pagination::load_for_pagination;
 #[model(gen(batch_ops = cd))]
 pub struct TrainScheduleRoundTrips {
     pub id: i64,
-    /// First ID of the paced train of this round trip
+    /// ID of the first train schedule of this round trip
     pub left_id: i64,
-    /// Paced train ID of the paced train of this round trip
+    /// ID of the second train schedule of this round trip
     /// This is `None` for one-way trains
     pub right_id: Option<i64>,
 }
@@ -54,9 +54,9 @@ impl TrainScheduleRoundTrips {
         Ok((results.into_iter().map_into().collect(), count))
     }
 
-    /// Deletes a batch of paced train round trips given a list of paced train IDs
+    /// Deletes a batch of train schedule round trips given a list of train schedule IDs
     ///
-    /// **IMPORTANT**: This function does not take ids of round trips, but rather the IDs of the paced trains
+    /// **IMPORTANT**: This function does not take ids of round trips, but rather the IDs of the train schedules
     #[tracing::instrument(
         name = "delete_batch_train_ids<TrainScheduleRoundTrips>",
         skip_all,
@@ -72,7 +72,7 @@ impl TrainScheduleRoundTrips {
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
 
-        let ids = train_schedule_ids.into_iter().collect::<Vec<_>>();
+        let ids = train_schedule_ids.into_iter().collect_vec();
         let nb = diesel::delete(
             database::tables::train_schedule_round_trips::table
                 .filter(dsl::left_id.eq_any(&ids).or(dsl::right_id.eq_any(&ids))),
@@ -82,19 +82,19 @@ impl TrainScheduleRoundTrips {
         Ok(nb)
     }
 
-    /// Retrieves a batch of paced train round trips given a list of paced train IDs
+    /// Retrieves a batch of train schedule round trips given a list of train schedule IDs
     ///
-    /// **IMPORTANT**: This function does not take ids of round trips, but rather the IDs of the paced trains
+    /// **IMPORTANT**: This function does not take ids of round trips, but rather the IDs of the train schedules
     pub async fn retrieve_from_train_schedule_ids<I: IntoIterator<Item = i64> + Send>(
         conn: &mut DbConnection,
-        paced_train_ids: I,
+        train_schedule_ids: I,
     ) -> Result<Vec<Self>, database::DatabaseError> {
         use database::tables::train_schedule_round_trips::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
 
-        let ids = paced_train_ids.into_iter().collect::<Vec<_>>();
+        let ids = train_schedule_ids.into_iter().collect_vec();
         let results = database::tables::train_schedule_round_trips::table
             .filter(dsl::left_id.eq_any(&ids).or(dsl::right_id.eq_any(&ids)))
             .load::<TrainScheduleRoundTripsRow>(conn.write().await.deref_mut())

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2562,7 +2562,7 @@ paths:
                   $ref: '#/components/schemas/ScenarioReference'
         '404':
           description: The requested rolling stock was not found
-  /round_trips/train_schedules:
+  /round_trips:
     post:
       tags:
       - round_trips
@@ -2576,7 +2576,7 @@ paths:
       responses:
         '204':
           description: Round trips were successfully upserted
-  /round_trips/train_schedules/delete:
+  /round_trips/delete:
     post:
       tags:
       - round_trips
@@ -2590,7 +2590,6 @@ paths:
               items:
                 type: integer
                 format: int64
-                minimum: 0
         required: true
       responses:
         '204':
@@ -3462,12 +3461,12 @@ paths:
                       type: array
                       items:
                         $ref: '#/components/schemas/CoreTrainRequirementsById'
-  /timetable/{id}/round_trips/train_schedules:
+  /timetable/{id}/round_trips:
     get:
       tags:
       - timetable
       - round_trips
-      summary: Upsert a list of round trips / one-way of train schedules
+      summary: Paginated list of round trips / one-way of train schedules
       parameters:
       - name: id
         in: path
@@ -3495,7 +3494,7 @@ paths:
           minimum: 1
       responses:
         '200':
-          description: ''
+          description: The paginated list of round trips / one-ways
           content:
             application/json:
               schema:

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -202,15 +202,13 @@ fn service_router() -> server::router::DocumentedRouter {
                             )
                             .route("/conflicts", get!(timetable::conflicts))
                             .route("/requirements", get!(timetable::requirements))
+                            .route("/round_trips", get!(round_trips::list))
                             .route("/stdcm", post!(timetable::stdcm::stdcm))
                             .nests("/train_schedules", |path| {
                                 path.route("/", get!(timetable::get_train_schedules))
                             })
                             .nests("/path_steps", |path| {
                                 path.route("/local_track_names", post!(timetable::get_local_track_names))
-                            })
-                            .nests("/round_trips", |path| {
-                                path.route("/train_schedules", get!(round_trips::list_train_schedules))
                             })
                     })
             })
@@ -266,10 +264,8 @@ fn service_router() -> server::router::DocumentedRouter {
                 })
             })
             .nests("/round_trips", |path| {
-                path.nests("/train_schedules", |path| {
-                    path.route("/", post!(round_trips::post_train_schedules))
-                        .route("/delete", post!(round_trips::delete_train_schedules))
-                })
+                path.route("/", post!(round_trips::upsert))
+                    .route("/delete", post!(round_trips::delete))
             })
             .nests("/sub_category", |path| {
                 path.route("/", get!(sub_categories::get_sub_categories))

--- a/editoast/src/views/round_trips.rs
+++ b/editoast/src/views/round_trips.rs
@@ -95,7 +95,7 @@ fn schema_round_trips() -> RefOr<Schema> {
     request_body = RoundTrips,
     responses((status = 204, description = "Round trips were successfully upserted"))
 )]
-pub(in crate::views) async fn post_train_schedules(
+pub(in crate::views) async fn upsert(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Json(round_trips): Json<RoundTrips>,
 ) -> Result<impl IntoResponse> {
@@ -143,12 +143,12 @@ pub(in crate::views) async fn post_train_schedules(
     post, path = "",
     tag = "round_trips",
     request_body(
-        content = Vec<u64>,
+        content = Vec<i64>,
         description = "IDs of train schedules to remove from round trips or one-way."
     ),
     responses((status = 204, description = "Round trips were successfully deleted"))
 )]
-pub(in crate::views) async fn delete_train_schedules(
+pub(in crate::views) async fn delete(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Json(train_schedule_ids): Json<HashSet<i64>>,
 ) -> Result<impl IntoResponse> {
@@ -166,15 +166,15 @@ pub(in crate::views) struct RoundTripsPage {
     results: RoundTrips,
 }
 
-/// Upsert a list of round trips / one-way of train schedules
+/// Paginated list of round trips / one-way of train schedules
 #[editoast_derive::route(authz::Role::OperationalStudies)]
 #[utoipa::path(
     get, path = "",
     tags = ["timetable", "round_trips"],
     params(TimetableIdParam, PaginationQueryParams<1000>),
-    responses((status = 200, body = inline(RoundTripsPage)))
+    responses((status = 200, body = inline(RoundTripsPage), description = "The paginated list of round trips / one-ways"))
 )]
-pub(in crate::views) async fn list_train_schedules(
+pub(in crate::views) async fn list(
     State(db_pool): State<Arc<DbConnectionPoolV2>>,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<1000>>,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/helpers/postPayloads.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/helpers/postPayloads.ts
@@ -32,9 +32,7 @@ const postRoundTrips = async (
       roundTrips,
       formattedPacedTrains.map(({ id }) => ({ id }))
     );
-    await dispatch(
-      osrdEditoastApi.endpoints.postRoundTripsTrainSchedules.initiate(payload)
-    ).unwrap();
+    await dispatch(osrdEditoastApi.endpoints.postRoundTrips.initiate(payload)).unwrap();
   }
 };
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -755,7 +755,7 @@ export const loadNgeDto = async (
   );
 
   const pacedTrainRoundTripsPromise = dispatch(
-    osrdEditoastApi.endpoints.getTimetableByIdRoundTripsTrainSchedules.initiate(
+    osrdEditoastApi.endpoints.getTimetableByIdRoundTrips.initiate(
       { id: timetableId },
       { subscribe: false }
     )

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/utils.ts
@@ -103,7 +103,7 @@ export const storeRoundTrip = async (
     };
   }
   await dispatch(
-    osrdEditoastApi.endpoints.postRoundTripsTrainSchedules.initiate({
+    osrdEditoastApi.endpoints.postRoundTrips.initiate({
       roundTrips,
     })
   ).unwrap();

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModal.tsx
@@ -53,14 +53,12 @@ const RoundTripsModal = ({
   const subCategories = useSubCategoryContext();
 
   const { data: { results: pacedTrainRoundtrips } = { results: undefined } } =
-    osrdEditoastApi.endpoints.getTimetableByIdRoundTripsTrainSchedules.useQuery({
+    osrdEditoastApi.endpoints.getTimetableByIdRoundTrips.useQuery({
       id: timetableId,
     });
 
-  const [postRoundTripsTrainSchedules] =
-    osrdEditoastApi.endpoints.postRoundTripsTrainSchedules.useMutation();
-  const [deleteRoundTripsTrainSchedules] =
-    osrdEditoastApi.endpoints.postRoundTripsTrainSchedulesDelete.useMutation();
+  const [postRoundTrips] = osrdEditoastApi.endpoints.postRoundTrips.useMutation();
+  const [deleteRoundTrips] = osrdEditoastApi.endpoints.postRoundTripsDelete.useMutation();
 
   const trainSchedulesWithOps = useTrainSchedulesWithPathOps(infraId, trainSchedules);
 
@@ -136,11 +134,11 @@ const RoundTripsModal = ({
 
     const apiCalls = [];
     if (idsToDelete.length > 0) {
-      apiCalls.push(deleteRoundTripsTrainSchedules({ body: idsToDelete }));
+      apiCalls.push(deleteRoundTrips({ body: idsToDelete }));
     }
     if (roundTripsIds.length > 0 || oneWaysIds.length > 0) {
       apiCalls.push(
-        postRoundTripsTrainSchedules({
+        postRoundTrips({
           roundTrips: { round_trips: roundTripsIds, one_ways: oneWaysIds },
         })
       );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
@@ -75,7 +75,7 @@ const TimetableToolbar = ({
 
   const { infraId, timetableId } = useScenarioContext();
   const { data: pacedTrainRoundTripsData } =
-    osrdEditoastApi.endpoints.getTimetableByIdRoundTripsTrainSchedules.useQuery({
+    osrdEditoastApi.endpoints.getTimetableByIdRoundTrips.useQuery({
       id: timetableId,
     });
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -838,23 +838,20 @@ const injectedRtkApi = api
         }),
         providesTags: ['rolling_stock'],
       }),
-      postRoundTripsTrainSchedules: build.mutation<
-        PostRoundTripsTrainSchedulesApiResponse,
-        PostRoundTripsTrainSchedulesApiArg
-      >({
+      postRoundTrips: build.mutation<PostRoundTripsApiResponse, PostRoundTripsApiArg>({
         query: (queryArg) => ({
-          url: `/round_trips/train_schedules`,
+          url: `/round_trips`,
           method: 'POST',
           body: queryArg.roundTrips,
         }),
         invalidatesTags: ['round_trips'],
       }),
-      postRoundTripsTrainSchedulesDelete: build.mutation<
-        PostRoundTripsTrainSchedulesDeleteApiResponse,
-        PostRoundTripsTrainSchedulesDeleteApiArg
+      postRoundTripsDelete: build.mutation<
+        PostRoundTripsDeleteApiResponse,
+        PostRoundTripsDeleteApiArg
       >({
         query: (queryArg) => ({
-          url: `/round_trips/train_schedules/delete`,
+          url: `/round_trips/delete`,
           method: 'POST',
           body: queryArg.body,
         }),
@@ -1133,12 +1130,12 @@ const injectedRtkApi = api
         }),
         providesTags: ['timetable'],
       }),
-      getTimetableByIdRoundTripsTrainSchedules: build.query<
-        GetTimetableByIdRoundTripsTrainSchedulesApiResponse,
-        GetTimetableByIdRoundTripsTrainSchedulesApiArg
+      getTimetableByIdRoundTrips: build.query<
+        GetTimetableByIdRoundTripsApiResponse,
+        GetTimetableByIdRoundTripsApiArg
       >({
         query: (queryArg) => ({
-          url: `/timetable/${queryArg.id}/round_trips/train_schedules`,
+          url: `/timetable/${queryArg.id}/round_trips`,
           params: {
             page: queryArg.page,
             page_size: queryArg.pageSize,
@@ -2250,12 +2247,12 @@ export type GetRollingStockByRollingStockIdUsageApiResponse =
 export type GetRollingStockByRollingStockIdUsageApiArg = {
   rollingStockId: number;
 };
-export type PostRoundTripsTrainSchedulesApiResponse = unknown;
-export type PostRoundTripsTrainSchedulesApiArg = {
+export type PostRoundTripsApiResponse = unknown;
+export type PostRoundTripsApiArg = {
   roundTrips: RoundTrips;
 };
-export type PostRoundTripsTrainSchedulesDeleteApiResponse = unknown;
-export type PostRoundTripsTrainSchedulesDeleteApiArg = {
+export type PostRoundTripsDeleteApiResponse = unknown;
+export type PostRoundTripsDeleteApiArg = {
   /** IDs of train schedules to remove from round trips or one-way. */
   body: number[];
 };
@@ -2471,11 +2468,11 @@ export type GetTimetableByIdRequirementsApiArg = {
   infraId: number;
   electricalProfileSetId?: number;
 };
-export type GetTimetableByIdRoundTripsTrainSchedulesApiResponse =
-  /** status 200  */ PaginationStats & {
+export type GetTimetableByIdRoundTripsApiResponse =
+  /** status 200 The paginated list of round trips / one-ways */ PaginationStats & {
     results: RoundTrips;
   };
-export type GetTimetableByIdRoundTripsTrainSchedulesApiArg = {
+export type GetTimetableByIdRoundTripsApiArg = {
   /** A timetable ID */
   id: number;
   page?: number;


### PR DESCRIPTION
This PR simplify the round trips endpoints and make naming more consistent. It also corrects the related documentation.