### PR TITLE
[WIP] core, editoast: add topologic to geometric offset projection on /path endpoint

### DIFF
--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/implementations/TrainPathImpl.kt
@@ -320,7 +320,7 @@ data class TrainPathImpl(
         return distanceRangeMapOf(entries)
     }
 
-    private fun getTrackRanges(): List<DirTrackRange> {
+    override fun getTrackRanges(): List<DirTrackRange> {
         val partialTrackRanges = mutableListOf<PartialDirTrackRange>()
         for (chunkRange in chunks) {
             val dirChunkId = chunkRange.value

--- a/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
+++ b/core/kt-osrd-path/src/main/kotlin/fr/sncf/osrd/path/interfaces/TrainPath.kt
@@ -56,6 +56,8 @@ interface TrainPath : PhysicsPath, PathProperties {
     fun getZonePaths(): List<ZonePathRange>
 
     fun getZoneRanges(): List<ZoneRange>
+
+    fun getTrackRanges(): List<DirTrackRange>
     // To be expanded as needed with other linear objects
 }
 

--- a/core/osrd-geom/src/main/kotlin/fr/sncf/osrd/geom/Point.kt
+++ b/core/osrd-geom/src/main/kotlin/fr/sncf/osrd/geom/Point.kt
@@ -1,7 +1,12 @@
 package fr.sncf.osrd.geom
 
+import kotlin.math.atan2
 import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
 import kotlin.math.sqrt
+
+const val AVERAGE_EARTH_RADIUS = 6371008.8
 
 @JvmRecord
 data class Point(@JvmField val lat: Double, @JvmField val lon: Double) {
@@ -17,6 +22,17 @@ data class Point(@JvmField val lat: Double, @JvmField val lon: Double) {
         val xDiff = (lon1 - lon2) * cos(0.5 * (lat1 + lat2))
         val yDiff = lat1 - lat2
         return WGS84Interpolator.EARTH_RADIUS * sqrt(xDiff * xDiff + yDiff * yDiff)
+    }
+
+    fun haversineDistanceAsMeters(other: Point): Double {
+        val dLon = Math.toRadians(other.lon - lon)
+        val dLat = Math.toRadians(other.lat - lat)
+        val lat1 = Math.toRadians(lat)
+        val lat2 = Math.toRadians(other.lat)
+
+        val a = sin(dLat / 2).pow(2) + sin(dLon / 2).pow(2) * cos(lat1) * cos(lat2)
+        val theta = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return theta * AVERAGE_EARTH_RADIUS
     }
 
     override fun toString(): String {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
+import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 
 class PathPropResponse(
@@ -64,7 +65,7 @@ data class GeometricProjection(
         // and at least two of each (the beginning and the end)
         assert(topoOffsets.size == geomOffsets.size && topoOffsets.size >= 2)
         // Each list must start by 0
-        assert(topoOffsets[0].equals(0) && geomOffsets[0].equals(0))
+        assert(topoOffsets[0].distance == Distance.ZERO && geomOffsets[0].distance == Distance.ZERO)
         // Each list must be increasing (not strictly)
         for (i in 0..<(topoOffsets.size - 1)) {
             assert(topoOffsets[i] <= topoOffsets[i + 1])

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
@@ -18,6 +18,7 @@ class PathPropResponse(
     val geometry: RJSLineString,
     @Json(name = "operational_points") val operationalPoints: List<OperationalPointResponse>,
     val zones: RangeValues<String>,
+    @Json(name = "geom_projection") val geomProjection: GeometricProjection,
 )
 
 interface Electrification
@@ -53,6 +54,17 @@ data class OperationalPointPartResponse(
 data class OperationalPointPartExtension(val sncf: OperationalPointPartSncfExtension?)
 
 data class OperationalPointPartSncfExtension(val kp: String)
+
+data class GeometricProjection(
+    @Json(name = "topo_offsets") val topoOffsets: List<Long>,
+    @Json(name = "geom_offsets") val geomOffsets: List<Long>,
+) {
+    init {
+        // There must be the same number of topologic boundaries and geometric boundaries
+        // and at least two of each (the beginning and the end)
+        require(topoOffsets.size == geomOffsets.size && topoOffsets.size >= 2)
+    }
+}
 
 val polymorphicElectrificationAdapter: PolymorphicJsonAdapterFactory<Electrification> =
     PolymorphicJsonAdapterFactory.of(Electrification::class.java, "type")

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponse.kt
@@ -56,13 +56,20 @@ data class OperationalPointPartExtension(val sncf: OperationalPointPartSncfExten
 data class OperationalPointPartSncfExtension(val kp: String)
 
 data class GeometricProjection(
-    @Json(name = "topo_offsets") val topoOffsets: List<Long>,
-    @Json(name = "geom_offsets") val geomOffsets: List<Long>,
+    @Json(name = "topo_offsets") val topoOffsets: List<Offset<PhysicsPath>>,
+    @Json(name = "geom_offsets") val geomOffsets: List<Offset<RJSLineString>>,
 ) {
     init {
-        // There must be the same number of topologic boundaries and geometric boundaries
+        // There must be the same number of topological boundaries and geometric boundaries
         // and at least two of each (the beginning and the end)
-        require(topoOffsets.size == geomOffsets.size && topoOffsets.size >= 2)
+        assert(topoOffsets.size == geomOffsets.size && topoOffsets.size >= 2)
+        // Each list must start by 0
+        assert(topoOffsets[0].equals(0) && geomOffsets[0].equals(0))
+        // Each list must be increasing (not strictly)
+        for (i in 0..<(topoOffsets.size - 1)) {
+            assert(topoOffsets[i] <= topoOffsets[i + 1])
+            assert(geomOffsets[i] <= geomOffsets[i + 1])
+        }
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -12,6 +12,8 @@ import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DistanceRangeMapImpl
 import fr.sncf.osrd.utils.from
 import fr.sncf.osrd.utils.toRangeMap
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 
 fun makePathPropResponse(pathProperties: TrainPath, rawInfra: RawSignalingInfra): PathPropResponse {
@@ -155,31 +157,28 @@ private fun makeGeometricProjection(
     pathProperties: TrainPath,
     rawInfra: RawSignalingInfra,
 ): GeometricProjection {
-    val trackSections = pathProperties.getTrackRanges()
-    println(trackSections)
-    trackSections.forEach { println(rawInfra.getTrackSectionName(it.value.value)) }
+    val trackRanges = pathProperties.getTrackRanges()
 
-    fun getTrackSectionGeometricLength(trackSection: TrackSectionId): Double {
+    fun getTrackSectionGeometricLength(trackSection: TrackSectionId): Length<RJSLineString> {
         val chunks = rawInfra.getTrackSectionChunks(trackSection)
         return chunks
-            .map { rawInfra.getTrackChunkGeom(it).length }
-            .reduce { acc, length -> acc + length }
+            .map {
+                Length<RJSLineString>(Distance.fromMeters(rawInfra.getTrackChunkGeom(it).length))
+            }
+            .reduce { acc, length -> acc + length.distance }
     }
 
-    val trackSectionsLengths = trackSections.map { it.objectLength }
-    val trackSectionGeomLengths = trackSections.map {
-        getTrackSectionGeometricLength(it.value.value)
-    }
-    val geomOffsets = mutableListOf<Long>(0)
-    val topoOffsets = mutableListOf<Long>(0)
+    val geomOffsets = mutableListOf<Offset<RJSLineString>>(Offset.zero())
+    val topoOffsets = mutableListOf<Offset<PhysicsPath>>(Offset.zero())
 
-    trackSections.forEachIndexed { i, range ->
-        val topoDistance = range.length
-        topoOffsets.addLast(topoOffsets.last() + topoDistance.millimeters)
-        val geomDistanceInMillimeters =
-            (topoDistance / trackSectionsLengths[i].distance * trackSectionGeomLengths[i] * 1000)
-                .toInt()
-        geomOffsets.addLast(geomOffsets.last() + geomDistanceInMillimeters)
+    trackRanges.forEachIndexed { i, range ->
+        val rangeTopoLength = range.length
+        val trackSectionTopoLength = range.objectLength
+        val trackSectionGeomLength = getTrackSectionGeometricLength(range.value.value)
+        topoOffsets.addLast(topoOffsets.last() + rangeTopoLength)
+        val proportion = rangeTopoLength / trackSectionTopoLength.distance
+        val rangeGeomLength = trackSectionGeomLength.distance * proportion
+        geomOffsets.addLast(geomOffsets.last() + rangeGeomLength)
     }
 
     return GeometricProjection(topoOffsets, geomOffsets)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropResponseConverter.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.NeutralSection
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
+import fr.sncf.osrd.sim_infra.api.TrackSectionId
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DistanceRangeMapImpl
 import fr.sncf.osrd.utils.from
@@ -21,6 +22,7 @@ fun makePathPropResponse(pathProperties: TrainPath, rawInfra: RawSignalingInfra)
         makeGeographic(pathProperties),
         makeOperationalPoints(pathProperties, rawInfra),
         makeZones(pathProperties, rawInfra),
+        makeGeometricProjection(pathProperties, rawInfra),
     )
 }
 
@@ -147,4 +149,38 @@ private fun makeElectrificationMap(
         }
     }
     return res
+}
+
+private fun makeGeometricProjection(
+    pathProperties: TrainPath,
+    rawInfra: RawSignalingInfra,
+): GeometricProjection {
+    val trackSections = pathProperties.getTrackRanges()
+    println(trackSections)
+    trackSections.forEach { println(rawInfra.getTrackSectionName(it.value.value)) }
+
+    fun getTrackSectionGeometricLength(trackSection: TrackSectionId): Double {
+        val chunks = rawInfra.getTrackSectionChunks(trackSection)
+        return chunks
+            .map { rawInfra.getTrackChunkGeom(it).length }
+            .reduce { acc, length -> acc + length }
+    }
+
+    val trackSectionsLengths = trackSections.map { it.objectLength }
+    val trackSectionGeomLengths = trackSections.map {
+        getTrackSectionGeometricLength(it.value.value)
+    }
+    val geomOffsets = mutableListOf<Long>(0)
+    val topoOffsets = mutableListOf<Long>(0)
+
+    trackSections.forEachIndexed { i, range ->
+        val topoDistance = range.length
+        topoOffsets.addLast(topoOffsets.last() + topoDistance.millimeters)
+        val geomDistanceInMillimeters =
+            (topoDistance / trackSectionsLengths[i].distance * trackSectionGeomLengths[i] * 1000)
+                .toInt()
+        geomOffsets.addLast(geomOffsets.last() + geomDistanceInMillimeters)
+    }
+
+    return GeometricProjection(topoOffsets, geomOffsets)
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.api.path_properties.*
 import fr.sncf.osrd.cli.RqFake
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
+import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.assertEquals
@@ -87,21 +88,27 @@ class PathPropEndpointTest : ApiTest() {
                 ),
             )
         assertEquals(parsed.operationalPoints, oPs)
-        // Check topological distance to geometrical distance projection
+        // Check topological distance to geometric distance projection
         val trackTA0GeoLength = Point(49.5, -0.4).distanceAsMeters(Point(49.5, -0.365)) * 1000
         val trackTA1GeoLength = Point(49.4999, -0.4).distanceAsMeters(Point(49.4999, -0.37)) * 1000
-        val firstTrackRangeLength = (1950.0 / 2000.0 * trackTA0GeoLength).toLong()
+        val firstTrackRangeProportion = 1950.0 / 2000.0
+        val firstTrackRangeLength = (firstTrackRangeProportion * trackTA0GeoLength).toLong()
         val secondTrackRangeLength = trackTA1GeoLength.toLong()
         // The repetition of the last two values is because of a null-length range
         // on the TA3 track section
         val geomProjection =
             GeometricProjection(
-                listOf(0, 1_950_000, 3_900_000, 3_900_000),
                 listOf(
-                    0,
-                    firstTrackRangeLength,
-                    firstTrackRangeLength + secondTrackRangeLength,
-                    firstTrackRangeLength + secondTrackRangeLength,
+                    Offset.zero(),
+                    Offset(1_950.meters),
+                    Offset(3_900.meters),
+                    Offset(3_900.meters),
+                ),
+                listOf(
+                    Offset.zero(),
+                    Offset(Distance(firstTrackRangeLength)),
+                    Offset(Distance(firstTrackRangeLength + secondTrackRangeLength)),
+                    Offset(Distance(firstTrackRangeLength + secondTrackRangeLength)),
                 ),
             )
         assertEquals(geomProjection, parsed.geomProjection)

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.api.DirectionalTrackRange
 import fr.sncf.osrd.api.RangeValues
 import fr.sncf.osrd.api.path_properties.*
 import fr.sncf.osrd.cli.RqFake
+import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -86,6 +87,24 @@ class PathPropEndpointTest : ApiTest() {
                 ),
             )
         assertEquals(parsed.operationalPoints, oPs)
+        // Check topological distance to geometrical distance projection
+        val trackTA0GeoLength = Point(49.5, -0.4).distanceAsMeters(Point(49.5, -0.365)) * 1000
+        val trackTA1GeoLength = Point(49.4999, -0.4).distanceAsMeters(Point(49.4999, -0.37)) * 1000
+        val firstTrackRangeLength = (1950.0 / 2000.0 * trackTA0GeoLength).toLong()
+        val secondTrackRangeLength = trackTA1GeoLength.toLong()
+        // The repetition of the last two values is because of a null-length range
+        // on the TA3 track section
+        val geomProjection =
+            GeometricProjection(
+                listOf(0, 1_950_000, 3_900_000, 3_900_000),
+                listOf(
+                    0,
+                    firstTrackRangeLength,
+                    firstTrackRangeLength + secondTrackRangeLength,
+                    firstTrackRangeLength + secondTrackRangeLength,
+                ),
+            )
+        assertEquals(geomProjection, parsed.geomProjection)
     }
 
     @Test

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -35,6 +35,8 @@ pub struct PathPropertiesResponse {
     pub operational_points: Vec<OperationalPointOnPath>,
     /// Zones along the path
     pub zones: PropertyZoneValues,
+    // Projection from topologic offset to geometric offset
+    pub geom_projection: GeometryProjection,
 }
 
 /// Property f64 values along a path. Each value is associated to a range of the path.
@@ -160,6 +162,29 @@ impl PropertyZoneValues {
     pub fn new(boundaries: Vec<u64>, values: Vec<String>) -> Self {
         assert!(boundaries.len() == values.len() + 1);
         Self { boundaries, values }
+    }
+}
+
+/// Projection to map topologic offset to geometric offset
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = CorePropertyGeometryProjection)]
+pub struct GeometryProjection {
+    /// Topologic offsets in millimeters
+    #[schema(min_items = 2)]
+    topo_offsets: Vec<u64>,
+    /// Geometric offsets in millimeters
+    #[schema(min_items = 2)]
+    geom_offsets: Vec<u64>,
+}
+
+impl GeometryProjection {
+    pub fn new(topo_offsets: Vec<u64>, geom_offsets: Vec<u64>) -> Self {
+        assert_eq!(topo_offsets.len(), geom_offsets.len());
+        assert!(topo_offsets.len() >= 2);
+        Self {
+            topo_offsets,
+            geom_offsets,
+        }
     }
 }
 

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -165,14 +165,17 @@ impl PropertyZoneValues {
     }
 }
 
-/// Projection to map topologic offset to geometric offset
+/// Projection to map topologic offset to geometric offset.
+/// Both arrays are the same size
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[schema(as = CorePropertyGeometryProjection)]
 pub struct GeometryProjection {
-    /// Topologic offsets in millimeters
+    /// Topologic offsets in millimeters.
+    /// Starts with 0 and is increasing.
     #[schema(min_items = 2)]
     topo_offsets: Vec<u64>,
-    /// Geometric offsets in millimeters
+    /// Geometric offsets in millimeters.
+    /// Starts with 0 and is increasing.
     #[schema(min_items = 2)]
     geom_offsets: Vec<u64>,
 }

--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -165,12 +165,12 @@ impl PropertyZoneValues {
     }
 }
 
-/// Projection to map topologic offset to geometric offset.
-/// Both arrays are the same size
+/// Projection to map topological offset to geometric offset (or reversed).
+/// topo_offsets and geom_offsets are the same size
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[schema(as = CorePropertyGeometryProjection)]
 pub struct GeometryProjection {
-    /// Topologic offsets in millimeters.
+    /// Topological offsets in millimeters.
     /// Starts with 0 and is increasing.
     #[schema(min_items = 2)]
     topo_offsets: Vec<u64>,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5727,6 +5727,29 @@ components:
           description: |-
             The path offset in mm of each path item given as input of the pathfinding
             The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
+    CorePropertyGeometryProjection:
+      type: object
+      description: Projection to map topologic offset to geometric offset
+      required:
+      - topo_offsets
+      - geom_offsets
+      properties:
+        geom_offsets:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: Geometric offsets in millimeters
+          minItems: 2
+        topo_offsets:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: Topologic offsets in millimeters
+          minItems: 2
     CoreReportTrain:
       type: object
       required:
@@ -12056,6 +12079,7 @@ components:
       - geometry
       - operational_points
       - zones
+      - geom_projection
       properties:
         curves:
           oneOf:
@@ -12140,6 +12164,9 @@ components:
                         - non_electrified
                 description: List of `n+1` values associated to the ranges
           description: Electrification modes and neutral section along the path
+        geom_projection:
+          $ref: '#/components/schemas/CorePropertyGeometryProjection'
+          description: Curve to map topologic offset to geometric offset on the path
         geometry:
           $ref: '#/components/schemas/GeoJsonLineString'
           description: Geometry of the path

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5729,7 +5729,9 @@ components:
             The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
     CorePropertyGeometryProjection:
       type: object
-      description: Projection to map topologic offset to geometric offset
+      description: |-
+        Projection to map topologic offset to geometric offset.
+        Both arrays are the same size
       required:
       - topo_offsets
       - geom_offsets
@@ -5740,7 +5742,9 @@ components:
             type: integer
             format: int64
             minimum: 0
-          description: Geometric offsets in millimeters
+          description: |-
+            Geometric offsets in millimeters.
+            Starts with 0 and is increasing.
           minItems: 2
         topo_offsets:
           type: array
@@ -5748,7 +5752,9 @@ components:
             type: integer
             format: int64
             minimum: 0
-          description: Topologic offsets in millimeters
+          description: |-
+            Topologic offsets in millimeters.
+            Starts with 0 and is increasing.
           minItems: 2
     CoreReportTrain:
       type: object

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5730,8 +5730,8 @@ components:
     CorePropertyGeometryProjection:
       type: object
       description: |-
-        Projection to map topologic offset to geometric offset.
-        Both arrays are the same size
+        Projection to map topological offset to geometric offset (or reversed).
+        topo_offsets and geom_offsets are the same size
       required:
       - topo_offsets
       - geom_offsets
@@ -5753,7 +5753,7 @@ components:
             format: int64
             minimum: 0
           description: |-
-            Topologic offsets in millimeters.
+            Topological offsets in millimeters.
             Starts with 0 and is increasing.
           minItems: 2
     CoreReportTrain:

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -11,6 +11,7 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
 use common::geometry::GeoJsonLineString;
+use core_client::path_properties::GeometryProjection;
 use core_client::path_properties::OperationalPointOnPath;
 use core_client::path_properties::PathPropertiesRequest;
 use core_client::path_properties::PropertyElectrificationValues;
@@ -55,6 +56,8 @@ pub(in crate::views) struct PathProperties {
     /// Zones along the path
     #[schema(inline)]
     zones: PropertyZoneValues,
+    /// Curve to map topologic offset to geometric offset on the path
+    geom_projection: GeometryProjection,
 }
 
 impl From<core_client::path_properties::PathPropertiesResponse> for PathProperties {
@@ -66,6 +69,7 @@ impl From<core_client::path_properties::PathPropertiesResponse> for PathProperti
             geometry: response.geometry,
             operational_points: response.operational_points,
             zones: response.zones,
+            geom_projection: response.geom_projection,
         }
     }
 }
@@ -123,6 +127,7 @@ pub(in crate::views) async fn post(
 mod tests {
     use axum::http::StatusCode;
     use core_client::mocking::MockingClient;
+    use core_client::path_properties::GeometryProjection;
     use core_client::path_properties::OperationalPointOnPath;
     use core_client::path_properties::PropertyElectrificationValue;
     use core_client::path_properties::PropertyElectrificationValues;
@@ -150,6 +155,7 @@ mod tests {
             ]])),
             operational_points: vec![OperationalPointOnPath::new_test("1", 0, "1")],
             zones: PropertyZoneValues::new(vec![0, 1], vec!["Zone 1".into()]),
+            geom_projection: GeometryProjection::new(vec![0, 1], vec![0, 0]),
         }
     }
 

--- a/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
@@ -105,6 +105,7 @@ describe('useSimulationResults', () => {
     geometry: { type: 'LineString', coordinates: [] },
     operational_points: [],
     slopes: { boundaries: [], values: [0] },
+    geom_projection: { topo_offsets: [0, 1000], geom_offsets: [0, 0] },
   } as unknown as PathProperties;
 
   const preparedPathPropertiesBase = {

--- a/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
@@ -105,7 +105,7 @@ describe('useSimulationResults', () => {
     geometry: { type: 'LineString', coordinates: [] },
     operational_points: [],
     slopes: { boundaries: [], values: [0] },
-    geom_projection: { topo_offsets: [0, 1000], geom_offsets: [0, 0] },
+    geom_projection: { topo_offsets: [0, 1000], geom_offsets: [0, 900] },
   } as unknown as PathProperties;
 
   const preparedPathPropertiesBase = {

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -79,6 +79,7 @@ const fetchPathProperties = async (
       curves: result.curves,
       electrifications: result.electrifications,
       operational_points: result.operational_points,
+      geom_projection: result.geom_projection,
     };
   } catch (error) {
     console.error('Error fetching path properties:', error);

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3562,7 +3562,7 @@ export type CorePropertyGeometryProjection = {
   /** Geometric offsets in millimeters.
     Starts with 0 and is increasing. */
   geom_offsets: number[];
-  /** Topologic offsets in millimeters.
+  /** Topological offsets in millimeters.
     Starts with 0 and is increasing. */
   topo_offsets: number[];
 };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3558,6 +3558,12 @@ export type InfraObjectWithGeometry = {
   obj_id: string;
   railjson: object;
 };
+export type CorePropertyGeometryProjection = {
+  /** Geometric offsets in millimeters */
+  geom_offsets: number[];
+  /** Topologic offsets in millimeters */
+  topo_offsets: number[];
+};
 export type CoreOperationalPointOnPath = {
   country_code: string;
   /** Id of the operational point */
@@ -3606,6 +3612,8 @@ export type PathProperties = {
         }
     )[];
   };
+  /** Curve to map topologic offset to geometric offset on the path */
+  geom_projection: CorePropertyGeometryProjection;
   /** Geometry of the path */
   geometry: GeoJsonLineString;
   /** Operational points along the path */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3559,9 +3559,11 @@ export type InfraObjectWithGeometry = {
   railjson: object;
 };
 export type CorePropertyGeometryProjection = {
-  /** Geometric offsets in millimeters */
+  /** Geometric offsets in millimeters.
+    Starts with 0 and is increasing. */
   geom_offsets: number[];
-  /** Topologic offsets in millimeters */
+  /** Topologic offsets in millimeters.
+    Starts with 0 and is increasing. */
   topo_offsets: number[];
 };
 export type CoreOperationalPointOnPath = {

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -234,6 +234,29 @@ class PathItemPosition(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
 
+class GeomOffset(RootModel[int]):
+    root: Annotated[int, Field(ge=0)]
+
+
+class TopoOffset(RootModel[int]):
+    root: Annotated[int, Field(ge=0)]
+
+
+class CorePropertyGeometryProjection(BaseModel):
+    """
+    Projection to map topologic offset to geometric offset
+    """
+
+    geom_offsets: Annotated[list[GeomOffset], Field(min_length=2)]
+    """
+    Geometric offsets in millimeters
+    """
+    topo_offsets: Annotated[list[TopoOffset], Field(min_length=2)]
+    """
+    Topologic offsets in millimeters
+    """
+
+
 class PathItemTime(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
@@ -6590,6 +6613,10 @@ class PathProperties(BaseModel):
     electrifications: Electrifications
     """
     Electrification modes and neutral section along the path
+    """
+    geom_projection: CorePropertyGeometryProjection
+    """
+    Curve to map topologic offset to geometric offset on the path
     """
     geometry: GeoJsonLineString
     """

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -244,16 +244,19 @@ class TopoOffset(RootModel[int]):
 
 class CorePropertyGeometryProjection(BaseModel):
     """
-    Projection to map topologic offset to geometric offset
+    Projection to map topologic offset to geometric offset.
+    Both arrays are the same size
     """
 
     geom_offsets: Annotated[list[GeomOffset], Field(min_length=2)]
     """
-    Geometric offsets in millimeters
+    Geometric offsets in millimeters.
+    Starts with 0 and is increasing.
     """
     topo_offsets: Annotated[list[TopoOffset], Field(min_length=2)]
     """
-    Topologic offsets in millimeters
+    Topologic offsets in millimeters.
+    Starts with 0 and is increasing.
     """
 
 

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -244,8 +244,8 @@ class TopoOffset(RootModel[int]):
 
 class CorePropertyGeometryProjection(BaseModel):
     """
-    Projection to map topologic offset to geometric offset.
-    Both arrays are the same size
+    Projection to map topological offset to geometric offset (or reversed).
+    topo_offsets and geom_offsets are the same size
     """
 
     geom_offsets: Annotated[list[GeomOffset], Field(min_length=2)]
@@ -255,7 +255,7 @@ class CorePropertyGeometryProjection(BaseModel):
     """
     topo_offsets: Annotated[list[TopoOffset], Field(min_length=2)]
     """
-    Topologic offsets in millimeters.
+    Topological offsets in millimeters.
     Starts with 0 and is increasing.
     """
 

--- a/tests/tests/test_pathfinding.py
+++ b/tests/tests/test_pathfinding.py
@@ -279,4 +279,5 @@ def test_start_ws_v1_path(session: Session, small_infra: Infra):
             "boundaries": [],
             "values": ["zone.[DA2:DECREASING, buffer_stop.0:INCREASING]"],
         },
+        "geom_projection": {"topo_offsets": [0, 300000], "geom_offsets": [0, 379556]},
     }


### PR DESCRIPTION
- Change `TrainPath` interface in core to access the path's partial track sections
- Add property `geom_projection` to core and editoast APIs
- Test the computing of `geom_projection` in core

fix https://github.com/OpenRailAssociation/osrd/issues/9372

> [!IMPORTANT]
> The length computed in core for the `LineString` geometry is not exact, so it differs from the one we compute in the front (which is exact, using `@turf/length` package, implementing [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula)).

So we decided to implement the same formula in core, only for the loading of the infra, and being careful as to where we also have to make corresponding changes.