### PR TITLE
editoast: bugfix: implement EditoastError for authz::Error so that endpoints return the correct response codes

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6262,26 +6262,6 @@ components:
           type: string
           enum:
           - editoast:attached:TrackNotFound
-    EditoastAuthorizationErrorAuthError:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          title: EditoastAuthorizationErrorAuthErrorContext
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:authz:AuthError
     EditoastAuthorizationErrorDbError:
       type: object
       required:
@@ -6427,6 +6407,46 @@ components:
           type: string
           enum:
           - editoast:authz:Database
+    EditoastAuthzErrorOpenfga:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzErrorOpenfgaContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:authz:Openfga
+    EditoastAuthzErrorStorage:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzErrorStorageContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:authz:Storage
     EditoastAuthzErrorUnknownIdentities:
       type: object
       required:
@@ -7000,7 +7020,6 @@ components:
       - $ref: '#/components/schemas/EditoastAppHealthErrorTimeout'
       - $ref: '#/components/schemas/EditoastAppHealthErrorValkey'
       - $ref: '#/components/schemas/EditoastAttachedErrorTrackNotFound'
-      - $ref: '#/components/schemas/EditoastAuthorizationErrorAuthError'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorDbError'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorForbidden'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorForbiddenImpersonation'
@@ -7008,9 +7027,14 @@ components:
       - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthenticated'
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthorizer'
       - $ref: '#/components/schemas/EditoastAuthzErrorDatabase'
+      - $ref: '#/components/schemas/EditoastAuthzErrorOpenfga'
+      - $ref: '#/components/schemas/EditoastAuthzErrorStorage'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownIdentities'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownResource'
+      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownResource'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownSubject'
+      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownSubject'
+      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownUser'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownUser'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorFixTrialFailure'

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -221,6 +221,58 @@ impl EditoastError for json_patch::PatchError {
 }
 
 inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:authz:UnknownSubject", "UnknownSubject", "AuthzError", 404u16, r#"{}"#)
+}
+
+inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:authz:UnknownResource", "UnknownResource", "AuthzError", 404u16, r#"{}"#)
+}
+
+inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:authz:UnknownUser", "UnknownUser", "AuthzError", 401u16, r#"{}"#)
+}
+
+inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:authz:Openfga", "Openfga", "AuthzError", 500u16, r#"{}"#)
+}
+
+inventory::submit! {
+    crate::error::ErrorDefinition::new("editoast:authz:Storage", "Storage", "AuthzError", 500u16, r#"{}"#)
+}
+impl<StorageError: std::error::Error + Send + Sync> EditoastError for authz::Error<StorageError> {
+    fn get_status(&self) -> StatusCode {
+        match self {
+            authz::Error::UnknownSubject(_) | authz::Error::UnknownResource(_) => {
+                StatusCode::NOT_FOUND
+            }
+            authz::Error::UnknownUser { .. } => StatusCode::UNAUTHORIZED,
+            authz::Error::OpenFga(_) | authz::Error::Storage(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        }
+    }
+
+    fn get_type(&self) -> &str {
+        match self {
+            authz::Error::UnknownSubject(_) => "editoast:authz:UnknownSubject",
+            authz::Error::UnknownResource(_) => "editoast:authz:UnknownResource",
+            authz::Error::UnknownUser { .. } => "editoast:authz:UnknownUser",
+            authz::Error::OpenFga(_) => "editoast:authz:Openfga",
+            authz::Error::Storage(_) => "editoast:authz:Storage",
+        }
+    }
+
+    fn context(&self) -> HashMap<String, Value> {
+        match self {
+            authz::Error::UnknownUser { identity } => {
+                HashMap::from([("id".to_string(), json!(identity))])
+            }
+            _ => HashMap::new(),
+        }
+    }
+}
+
+inventory::submit! {
     crate::error::ErrorDefinition::new("editoast:geometry:UnexpectedGeometry", "UnexpectedGeometry", "GeometryError", 404u16, r#"{"expected":"String","actual":"String"}"#)
 }
 impl EditoastError for schemas::errors::GeometryError {
@@ -312,12 +364,6 @@ impl From<authz::Unauthorized> for InternalError {
     fn from(authz::Unauthorized { reason }: authz::Unauthorized) -> Self {
         tracing::error!(reason, "Unauthorized operation");
         crate::views::AuthorizationError::Forbidden.into()
-    }
-}
-
-impl From<crate::views::AuthorizerError> for InternalError {
-    fn from(value: crate::views::AuthorizerError) -> Self {
-        crate::views::AuthorizationError::from(value).into()
     }
 }
 

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -503,7 +503,7 @@ pub enum AuthorizationError {
     #[editoast_error(status = 404)]
     ImpersonatedUserNotFound { identity: String },
     #[error(transparent)]
-    #[editoast_error(status = 500)]
+    #[editoast_error(forward)]
     #[from(AuthorizerError, fga::client::Error)]
     AuthError(AuthorizerError),
     #[error(transparent)]

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -868,18 +868,11 @@ pub mod tests {
     use crate::generated_data;
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::views::test_app;
-    use crate::views::test_app::TestApp;
     use crate::views::test_app::TestRequestExt as _;
     use editoast_models::infra::DEFAULT_INFRA_VERSION;
     use editoast_models::infra_objects::get_geometry_layer_table;
     use editoast_models::infra_objects::get_table;
     use schemas::train_schedule::OperationalPointReference;
-
-    impl TestApp {
-        fn delete_infra_request(&self, infra_id: i64) -> axum_test::TestRequest {
-            self.delete(format!("/infra/{infra_id}").as_str())
-        }
-    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_clone_empty() {
@@ -981,18 +974,26 @@ pub mod tests {
     async fn infra_delete() {
         let pool = DbConnectionPoolV2::for_tests();
         let app = test_app!()
-            .skip_authz()
             .db_pool(pool)
             .core_client(CoreClient::Mocked(MockingClient::default()))
             .build();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
 
-        app.delete_infra_request(empty_infra.id)
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_id, InfraGrant::Owner)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.delete(&format!("/infra/{infra_id}"))
+            .by_user(user.as_ref())
             .await
             .assert_status_no_content();
 
-        app.delete_infra_request(empty_infra.id)
+        app.delete(&format!("/infra/{infra_id}"))
+            .by_user(user.as_ref())
             .await
             .assert_status_not_found();
     }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -35,6 +35,8 @@
       "GrantsApiMisuse": "Improper API usage",
       "ImpersonatedUserNotFound": "Unknown impersonated user",
       "NoSuchUser": "Unknown user",
+      "Openfga": "Internal error",
+      "Storage": "Internal error",
       "Unauthenticated": "Unauthenticated user",
       "UnknownIdentities": "Unknown identities '{{identities}}'",
       "UnknownResource": "Unknown resource",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -35,6 +35,8 @@
       "GrantsApiMisuse": "Mauvaise utilisation de l'API d'autorisation",
       "ImpersonatedUserNotFound": "Utilisateur usurpé inconnu",
       "NoSuchUser": "Utilisateur inconnu",
+      "Openfga": "Erreur interne",
+      "Storage": "Erreur interne",
       "Unauthenticated": "Utilisateur non authentifié",
       "UnknownIdentities": "Identités inconnues '{{identities}}'",
       "UnknownResource": "Ressource inconnue",

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -477,15 +477,6 @@ class EditoastAttachedErrorTrackNotFound(BaseModel):
     type: Literal["editoast:attached:TrackNotFound"]
 
 
-class EditoastAuthorizationErrorAuthError(BaseModel):
-    context: Annotated[
-        dict[str, Any] | None, Field(title="EditoastAuthorizationErrorAuthErrorContext")
-    ] = None
-    message: str
-    status: Literal[500]
-    type: Literal["editoast:authz:AuthError"]
-
-
 class EditoastAuthorizationErrorDbError(BaseModel):
     context: Annotated[
         dict[str, Any] | None, Field(title="EditoastAuthorizationErrorDbErrorContext")
@@ -554,6 +545,24 @@ class EditoastAuthzErrorDatabase(BaseModel):
     message: str
     status: Literal[500]
     type: Literal["editoast:authz:Database"]
+
+
+class EditoastAuthzErrorOpenfga(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastAuthzErrorOpenfgaContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:authz:Openfga"]
+
+
+class EditoastAuthzErrorStorage(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastAuthzErrorStorageContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:authz:Storage"]
 
 
 class EditoastAuthzErrorUnknownIdentitiesContext(BaseModel):
@@ -4464,7 +4473,6 @@ class EditoastError(
         | EditoastAppHealthErrorTimeout
         | EditoastAppHealthErrorValkey
         | EditoastAttachedErrorTrackNotFound
-        | EditoastAuthorizationErrorAuthError
         | EditoastAuthorizationErrorDbError
         | EditoastAuthorizationErrorForbidden
         | EditoastAuthorizationErrorForbiddenImpersonation
@@ -4472,6 +4480,8 @@ class EditoastError(
         | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorAuthorizer
         | EditoastAuthzErrorDatabase
+        | EditoastAuthzErrorOpenfga
+        | EditoastAuthzErrorStorage
         | EditoastAuthzErrorUnknownIdentities
         | EditoastAuthzErrorUnknownResource
         | EditoastAuthzErrorUnknownSubject
@@ -4630,7 +4640,6 @@ class EditoastError(
         | EditoastAppHealthErrorTimeout
         | EditoastAppHealthErrorValkey
         | EditoastAttachedErrorTrackNotFound
-        | EditoastAuthorizationErrorAuthError
         | EditoastAuthorizationErrorDbError
         | EditoastAuthorizationErrorForbidden
         | EditoastAuthorizationErrorForbiddenImpersonation
@@ -4638,6 +4647,8 @@ class EditoastError(
         | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorAuthorizer
         | EditoastAuthzErrorDatabase
+        | EditoastAuthzErrorOpenfga
+        | EditoastAuthzErrorStorage
         | EditoastAuthzErrorUnknownIdentities
         | EditoastAuthzErrorUnknownResource
         | EditoastAuthzErrorUnknownSubject


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/issues/17127.

Implement EditoastError for `authz::Error` and forward error codes resolution to it in AuthorizationError. The authz::Error variant needs to be able to return several error codes depending on auhtz::Error.

The old version always converted authz errors to 500 internal errors instead, which led endpoints performing authorization to return internal errors on an unknown resource instead of a 404 not found when authorization was not skipped.

>[!NOTE]
The commits will be squashed before merging. The second commit is not important (it's just a odd way of abusing of `#[editoast_error]` that apparently works).