### PR TITLE
editoast: fix track occupancy retrieve local track name

### DIFF
--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -32,7 +32,8 @@ pub struct OperationalPointCache {
     /// Maps obj_id to index in the ops Vec
     obj_id_to_index: HashMap<String, usize>,
     track_ids: HashSet<String>,
-    track_ids_to_local_track_name: HashMap<String, NonBlankString>,
+    /// For each operational point, map track section to local track name
+    track_ids_to_local_track_name: Vec<HashMap<String, NonBlankString>>,
 }
 
 impl OperationalPointCache {
@@ -93,8 +94,12 @@ impl OperationalPointCache {
         let track_ids_to_local_track_name = op_cache
             .ops
             .iter()
-            .flat_map(|op| &op.parts)
-            .map(|part| (part.track.0.clone(), part.local_track_name.clone()))
+            .map(|op| {
+                op.parts
+                    .iter()
+                    .map(|part| (part.track.0.clone(), part.local_track_name.clone()))
+                    .collect()
+            })
             .collect();
 
         op_cache.track_ids_to_local_track_name = track_ids_to_local_track_name;
@@ -137,8 +142,6 @@ impl OperationalPointCache {
         let mut obj_id_to_index: HashMap<String, usize> = HashMap::new();
         let mut uic_to_indices: HashMap<u32, Vec<usize>> = HashMap::new();
         let mut trigram_to_indices: HashMap<NonBlankString, Vec<usize>> = HashMap::new();
-        let track_ids_to_local_track_name: HashMap<String, NonBlankString> = HashMap::new();
-        let track_ids: HashSet<String> = HashSet::new();
 
         for (index, op) in ops.iter().enumerate() {
             // Build ID index
@@ -161,8 +164,8 @@ impl OperationalPointCache {
             uic_to_indices,
             trigram_to_indices,
             obj_id_to_index,
-            track_ids,
-            track_ids_to_local_track_name,
+            track_ids: Default::default(),
+            track_ids_to_local_track_name: Default::default(),
         })
     }
 
@@ -189,8 +192,9 @@ impl OperationalPointCache {
     }
 
     /// Get the track name by track id
-    pub fn get_name_by_track(&self, track_id: &str) -> Option<&NonBlankString> {
-        self.track_ids_to_local_track_name.get(track_id)
+    pub fn get_name_by_track(&self, op_id: String, track_id: &str) -> Option<&NonBlankString> {
+        let op_index = self.obj_id_to_index.get(&op_id)?;
+        self.track_ids_to_local_track_name[*op_index].get(track_id)
     }
 
     /// Check if a track exists
@@ -343,7 +347,7 @@ impl OperationalPointCache {
         trigram_to_indices: HashMap<NonBlankString, Vec<usize>>,
         obj_id_to_index: HashMap<String, usize>,
         track_ids: HashSet<String>,
-        track_ids_to_local_track_name: HashMap<String, NonBlankString>,
+        track_ids_to_local_track_name: Vec<HashMap<String, NonBlankString>>,
     ) -> Self {
         Self {
             ops,

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -22,6 +22,7 @@ pub(super) struct TrackOccupancy {
 
 /// Structure holding extracted data needed for track occupancy computation
 struct OccupancyContext<'a> {
+    op_id: &'a str,
     report_train: Option<&'a ReportTrain>,
     pathfinding_success: Option<&'a PathfindingResultSuccess>,
     matching_index: Option<usize>,
@@ -47,7 +48,7 @@ fn find_matching_path_item_index(
 
 /// Extracts all context needed for track occupancy computation
 fn extract_occupancy_context<'a>(
-    operational_point_id: &str,
+    operational_point_id: &'a str,
     op_cache: &OperationalPointCache,
     simulation: &'a simulation::Response,
     pathfinding: &'a PathfindingResult,
@@ -70,6 +71,7 @@ fn extract_occupancy_context<'a>(
     };
 
     OccupancyContext {
+        op_id: operational_point_id,
         report_train,
         pathfinding_success,
         ..extract_occupancy_context_without_simulation(
@@ -81,7 +83,7 @@ fn extract_occupancy_context<'a>(
 }
 
 fn extract_occupancy_context_without_simulation<'a>(
-    operational_point_id: &str,
+    operational_point_id: &'a str,
     op_cache: &OperationalPointCache,
     train_schedule: &'a schemas::TrainOccurrence,
 ) -> OccupancyContext<'a> {
@@ -96,6 +98,7 @@ fn extract_occupancy_context_without_simulation<'a>(
     });
 
     OccupancyContext {
+        op_id: operational_point_id,
         report_train: None,
         pathfinding_success: None,
         matching_index,
@@ -156,16 +159,14 @@ fn get_local_track_name(
         }
     }
 
-    if let Some(pathfinding_success) = context.pathfinding_success {
-        let path_projection = PathProjection::new(&pathfinding_success.path.track_section_ranges);
-        return operational_point_track_offsets
-            .iter()
-            .find(|to| path_projection.get_position(to).is_some())
-            .and_then(|to| op_cache.get_name_by_track(to.track.as_str()))
-            .cloned();
-    }
+    let pathfinding_success = context.pathfinding_success?;
 
-    None
+    let path_projection = PathProjection::new(&pathfinding_success.path.track_section_ranges);
+    operational_point_track_offsets
+        .iter()
+        .find(|to| path_projection.get_position(to).is_some())
+        .and_then(|to| op_cache.get_name_by_track(context.op_id.to_string(), to.track.as_str()))
+        .cloned()
 }
 
 /// Find track occupancies for a train at an operational point
@@ -336,13 +337,17 @@ pub mod tests {
             Vec::new(),
             HashMap::new(),
             HashMap::new(),
-            HashMap::new(),
-            HashSet::new(),
             HashMap::from([
+                ("op_1".to_string(), 0),
+                ("op_2".to_string(), 0),
+                ("op_3".to_string(), 0),
+            ]),
+            HashSet::new(),
+            vec![HashMap::from([
                 ("T1".into(), "V1".into()),
                 ("T2".into(), "V2".into()),
                 ("T3".into(), "V3".into()),
-            ]),
+            ])],
         );
 
         let operational_point_track_offsets = vec![TrackOffset {
@@ -544,9 +549,9 @@ pub mod tests {
             Vec::new(),
             HashMap::new(),
             HashMap::new(),
-            HashMap::new(),
+            HashMap::from([("op_2".to_string(), 0)]),
             HashSet::new(),
-            HashMap::from([("T2".into(), "V2".into())]),
+            vec![HashMap::from([("T2".into(), "V2".into())])],
         );
 
         let operational_point_track_offsets = vec![TrackOffset {


### PR DESCRIPTION
The operational status was not taken into account when determining the name of the local track when a train did not have an assigned track.


You can use this [timetable.json](https://github.com/user-attachments/files/29638135/timetable.json) on a french infra.

**Before**

Track occupancy at `Menton 00` was random; it could contain track `1 2 3` the right ones or `1 2 3 V1`.

<img width="1500" height="538" alt="image" src="https://github.com/user-attachments/assets/612316b4-52b7-4eb8-a311-71e78126bd39" />


**After**

<img width="1500" height="538" alt="image" src="https://github.com/user-attachments/assets/ecba0298-f2e3-41a6-914f-1eb85d4e0119" />


> [!NOTE]
> The bug appears for this operational point because another operational point `Menton VS` is located on the same track sections with local_track_name `V1` and `V2`. Since the backend had a map from track sections to local track names, the retrieved name was random.