### PR TITLE
Add tests to the useOccurrenceActions hook

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/consts.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/consts.ts
@@ -1,0 +1,150 @@
+import type { LightRollingStockWithLiveries, TrainMainCategory } from 'common/api/osrdEditoastApi';
+import type { Occurrence, PacedTrainWithDetails } from 'modules/trainSchedule/types';
+import type { OccurrenceId } from 'reducers/osrdconf/types';
+import { Duration } from 'utils/duration';
+
+const ROLLING_STOCK_NAME = 'fast-rs';
+const PACED_INTERVAL = Duration.parse('PT45M');
+const PACED_TIME_WINDOW = Duration.parse('PT2H');
+
+export const rollingStock = {
+  name: ROLLING_STOCK_NAME,
+  effort_curves: { modes: {} },
+} as LightRollingStockWithLiveries;
+
+export const pacedTrainSchedule: PacedTrainWithDetails = {
+  stopsCount: 5,
+  category: { main_category: 'HIGH_SPEED_TRAIN' },
+  rollingStock,
+  id: 1,
+  name: 'Paced Train 1',
+  startTime: new Date('2026-06-09T08:00:00Z'),
+  rollingStockName: ROLLING_STOCK_NAME,
+  paced: {
+    timeWindow: PACED_TIME_WINDOW,
+    interval: PACED_INTERVAL,
+    exceptions: [],
+  },
+  constraint_distribution: 'STANDARD',
+  path: [],
+  train_schedule_set_id: 0,
+  labels: [],
+  speedLimitTag: null,
+};
+
+export const pacedTrainWithExceptions: PacedTrainWithDetails = {
+  ...pacedTrainSchedule,
+  paced: {
+    ...pacedTrainSchedule.paced,
+    exceptions: [
+      {
+        key: 'occurrence_1_0',
+        id: 42,
+        occurrence_index: 0,
+        train_name: { value: 'Exception Train 1' },
+        start_time: { value: new Date('2026-06-09T08:05:00Z').getTime() },
+        disabled: false,
+      },
+    ],
+  },
+};
+
+export const pacedTrainWithDisabledOccurrence: PacedTrainWithDetails = {
+  ...pacedTrainSchedule,
+  paced: {
+    ...pacedTrainSchedule.paced,
+    exceptions: [
+      {
+        key: 'occurrence_1_0',
+        id: 42,
+        occurrence_index: 0,
+        disabled: true,
+      },
+    ],
+  },
+};
+
+export const peacedTrainWithExceptionsRollingStock: PacedTrainWithDetails = {
+  ...pacedTrainSchedule,
+  paced: {
+    ...pacedTrainSchedule.paced,
+    exceptions: [
+      {
+        key: 'occurrence_1_1',
+        id: 42,
+        occurrence_index: 1,
+        train_name: { value: 'Exception Train RS 1' },
+        rolling_stock: {
+          rolling_stock_name: 'low-rs',
+          comfort: 'STANDARD',
+        },
+      },
+    ],
+  },
+};
+
+export const BASE_OCCURRENCE = {
+  stopsCount: 5,
+  category: { main_category: 'HIGH_SPEED_TRAIN' as TrainMainCategory },
+  rollingStock,
+  disabled: false,
+  exception: undefined,
+  summary: undefined,
+};
+
+export const occurrence1: Occurrence = {
+  ...BASE_OCCURRENCE,
+  id: 'indexedoccurrence_1_0' as OccurrenceId,
+  trainName: 'Paced Train 1',
+  startTime: new Date('2026-06-09T08:00:00.000Z'),
+  occurrenceIndex: 0,
+};
+
+export const occurrence2 = {
+  ...BASE_OCCURRENCE,
+  id: 'indexedoccurrence_1_1' as OccurrenceId,
+  trainName: 'Paced Train 3',
+  startTime: new Date('2026-06-09T08:45:00.000Z'),
+  occurrenceIndex: 1,
+};
+
+export const occurrence3 = {
+  ...BASE_OCCURRENCE,
+  id: 'indexedoccurrence_1_2',
+  trainName: 'Paced Train 5',
+  startTime: new Date('2026-06-09T09:30:00.000Z'),
+  occurrenceIndex: 2,
+};
+
+export const addedExceptionOccurrence = {
+  ...BASE_OCCURRENCE,
+  id: 'exception_1_0' as OccurrenceId,
+  trainName: 'Added Exception Train',
+  startTime: new Date('2026-06-09T10:00:00Z'),
+  exception: {
+    exceptionChangeGroups: {
+      start_time: {
+        value: new Date('2026-06-09T10:00:00Z').getTime(),
+      },
+      train_name: {
+        value: 'Added Exception Train',
+      },
+    },
+    id: 0,
+  },
+};
+
+export const pacedTrainWithAddedException: PacedTrainWithDetails = {
+  ...pacedTrainSchedule,
+  paced: {
+    ...pacedTrainSchedule.paced,
+    exceptions: [
+      {
+        key: addedExceptionOccurrence.id,
+        id: addedExceptionOccurrence.exception.id,
+        ...addedExceptionOccurrence.exception.exceptionChangeGroups,
+        disabled: false,
+      },
+    ],
+  },
+};

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrenceActions.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrenceActions.spec.ts
@@ -1,0 +1,520 @@
+import { getTestStore, renderHookWithStore } from 'store/__tests__';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockOsrdEditoastEndpoints } from 'common/api/__mocks__/osrdEditoastApi';
+
+import { formatTrainScheduleWithDetailsToTrainSchedule } from '../../../../ManageTrainSchedule/helpers/formatTrainSchedulePayload';
+import useOccurrenceActions from '../useOccurrenceActions';
+import {
+  addedExceptionOccurrence,
+  occurrence1,
+  occurrence2,
+  pacedTrainSchedule,
+  pacedTrainWithAddedException,
+  pacedTrainWithExceptions,
+  rollingStock,
+} from './consts';
+
+const {
+  putTrainScheduleExceptionById,
+  postTimetableByIdTrainScheduleException,
+  postTrainScheduleExceptionsDelete,
+} = mockOsrdEditoastEndpoints;
+
+const mockSelectPacedTrainToEdit = vi.fn();
+const mockUpsertTrainSchedules = vi.fn();
+
+const buildOccurrenceActionsArgs = (
+  pacedTrain = { ...pacedTrainSchedule },
+  occurrences = [{ ...occurrence1 }]
+) => ({
+  pacedTrain,
+  occurrences,
+  selectPacedTrainToEdit: mockSelectPacedTrainToEdit,
+  upsertTrainSchedules: mockUpsertTrainSchedules,
+  timetableId: 1,
+});
+
+describe('useOccurrenceActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should correctly toggle the selection of one occurrence', () => {
+    const { result, rerender } = renderHookWithStore(() =>
+      useOccurrenceActions(buildOccurrenceActionsArgs())
+    );
+    const store = getTestStore();
+
+    expect(store.getState().simulation.selectedTrain).toStrictEqual(undefined);
+
+    result.current.toggleOccurrenceSelection(occurrence1.id);
+
+    expect(store.getState().simulation.selectedTrain).toStrictEqual({
+      id: occurrence1.id,
+      by: 'timetable',
+    });
+
+    rerender();
+
+    result.current.toggleOccurrenceSelection(occurrence1.id);
+
+    expect(store.getState().simulation.selectedTrain).toStrictEqual(undefined);
+  });
+
+  it('should select occurrence for projection', () => {
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(buildOccurrenceActionsArgs())
+    );
+    const store = getTestStore();
+
+    expect(store.getState().simulation.trainIdUsedForProjection).toBe(undefined);
+
+    result.current.selectOccurrenceForProjection(occurrence1.id);
+
+    expect(store.getState().simulation.trainIdUsedForProjection).toBe(occurrence1.id);
+  });
+
+  it('should edit paced train', () => {
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(buildOccurrenceActionsArgs())
+    );
+
+    result.current.editOccurrence({
+      ...occurrence1,
+      ...{
+        trainName: 'New Cool Train',
+        rollingStock: {
+          ...rollingStock,
+          name: 'Thomas',
+        },
+        startTime: new Date('27/07/2026'),
+      },
+    });
+
+    expect(mockSelectPacedTrainToEdit).toHaveBeenCalledExactlyOnceWith(
+      {
+        ...pacedTrainSchedule,
+        name: 'New Cool Train',
+        rollingStock: {
+          ...occurrence1.rollingStock,
+          name: 'Thomas',
+        },
+        startTime: new Date('27/07/2026'),
+      },
+      pacedTrainSchedule,
+      occurrence1.id
+    );
+  });
+
+  it('should edit paced train with exceptions', () => {
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(buildOccurrenceActionsArgs({ ...pacedTrainWithExceptions }))
+    );
+
+    result.current.editOccurrence({
+      ...occurrence1,
+      ...{
+        trainName: 'New Cool Train',
+        rollingStock: {
+          ...rollingStock,
+          name: 'Thomas',
+        },
+        startTime: new Date('27/07/2026'),
+      },
+    });
+
+    const [exception1] = pacedTrainWithExceptions.paced.exceptions;
+
+    expect(mockSelectPacedTrainToEdit).toHaveBeenCalledExactlyOnceWith(
+      {
+        ...pacedTrainWithExceptions,
+        name: exception1.train_name?.value,
+        rollingStock: {
+          ...occurrence1.rollingStock,
+          name: 'Thomas',
+        },
+        startTime: new Date(exception1.start_time!.value),
+      },
+      pacedTrainWithExceptions,
+      occurrence1.id
+    );
+  });
+
+  it('should not enable an occurrence which was not disabled', async () => {
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(buildOccurrenceActionsArgs())
+    );
+
+    await expect(result.current.updateOccurrenceStatus(occurrence1, 'enable')).rejects.toThrow();
+  });
+
+  it('should create an exception if disabling an occurrence with none', async () => {
+    postTimetableByIdTrainScheduleException.mockResolvedValue({
+      data: {
+        change_groups: {},
+        disabled: false,
+        id: 1002020,
+        timetable_id: 1,
+        train_schedule_id: 1,
+      },
+    });
+
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(buildOccurrenceActionsArgs())
+    );
+
+    await result.current.updateOccurrenceStatus(occurrence1, 'disabled');
+
+    const formattedPacedTrain = formatTrainScheduleWithDetailsToTrainSchedule(pacedTrainSchedule);
+
+    expect(mockUpsertTrainSchedules).toHaveBeenCalledWith([
+      {
+        ...formattedPacedTrain,
+        id: pacedTrainSchedule.id,
+        train_schedule_set_id: pacedTrainSchedule.train_schedule_set_id,
+        paced: {
+          ...formattedPacedTrain.paced,
+          exceptions: [
+            {
+              disabled: true,
+              id: 1002020,
+              occurrence_index: occurrence1.occurrenceIndex,
+              key: '',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('should disable an occurrence with an exception', async () => {
+    putTrainScheduleExceptionById.mockResolvedValue({
+      data: [],
+    });
+
+    const [exception1] = pacedTrainWithExceptions.paced.exceptions;
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(
+        buildOccurrenceActionsArgs({
+          ...pacedTrainWithExceptions,
+          paced: {
+            ...pacedTrainWithExceptions.paced,
+            exceptions: [
+              {
+                ...exception1,
+                id: 100,
+              },
+            ],
+          },
+        })
+      )
+    );
+
+    await result.current.updateOccurrenceStatus(occurrence1, 'disabled');
+    const exception1WithId = {
+      ...exception1,
+      id: 100,
+    };
+
+    const formattedPacedTrain = formatTrainScheduleWithDetailsToTrainSchedule({
+      ...pacedTrainWithExceptions,
+      paced: {
+        ...pacedTrainWithExceptions.paced,
+        exceptions: [exception1WithId],
+      },
+    });
+
+    expect(mockUpsertTrainSchedules).toHaveBeenCalledWith([
+      {
+        ...formattedPacedTrain,
+        id: pacedTrainWithExceptions.id,
+        train_schedule_set_id: pacedTrainWithExceptions.train_schedule_set_id,
+        paced: {
+          ...formattedPacedTrain.paced,
+          exceptions: [
+            {
+              ...exception1WithId,
+              disabled: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(putTrainScheduleExceptionById).toHaveBeenCalledWith({
+      body: {
+        change_groups: {
+          start_time: exception1.start_time,
+          train_name: exception1.train_name,
+        },
+        disabled: true,
+        occurrence_index: occurrence1.occurrenceIndex,
+        train_schedule_id: pacedTrainWithExceptions.id,
+      },
+      id: 100,
+    });
+  });
+
+  it('should delete exception with no change group when updating occurrence status', async () => {
+    postTrainScheduleExceptionsDelete.mockResolvedValue({
+      data: [],
+    });
+
+    const noChangeException = {
+      id: 200,
+      key: 'occurrence_1_0',
+      occurrence_index: 0,
+      disabled: false,
+    };
+
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(
+        buildOccurrenceActionsArgs({
+          ...pacedTrainSchedule,
+          paced: {
+            ...pacedTrainSchedule.paced,
+            exceptions: [noChangeException],
+          },
+        })
+      )
+    );
+
+    await result.current.updateOccurrenceStatus(occurrence1, 'disabled');
+
+    const formattedPacedTrain = formatTrainScheduleWithDetailsToTrainSchedule(pacedTrainSchedule);
+
+    expect(mockUpsertTrainSchedules).toHaveBeenCalledWith([
+      {
+        ...formattedPacedTrain,
+        id: pacedTrainSchedule.id,
+        train_schedule_set_id: pacedTrainSchedule.train_schedule_set_id,
+        paced: {
+          ...formattedPacedTrain.paced,
+          exceptions: [
+            {
+              ...noChangeException,
+              disabled: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(postTrainScheduleExceptionsDelete).toHaveBeenCalledWith({
+      body: {
+        ids: [200],
+      },
+    });
+  });
+
+  it('should update selected train if we disable the selected occurrence', async () => {
+    postTimetableByIdTrainScheduleException.mockResolvedValue({
+      data: {
+        change_groups: {},
+        disabled: false,
+        id: 1002020,
+        timetable_id: 1,
+        train_schedule_id: 1,
+      },
+    });
+
+    const { result, rerender } = renderHookWithStore(() =>
+      useOccurrenceActions({
+        pacedTrain: { ...pacedTrainSchedule },
+        occurrences: [{ ...occurrence1 }, { ...occurrence2 }],
+        selectPacedTrainToEdit: mockSelectPacedTrainToEdit,
+        upsertTrainSchedules: mockUpsertTrainSchedules,
+        timetableId: 1,
+      })
+    );
+    const store = getTestStore();
+
+    result.current.toggleOccurrenceSelection(occurrence1.id);
+
+    expect(store.getState().simulation.selectedTrain).toStrictEqual({
+      by: 'timetable',
+      id: occurrence1.id,
+    });
+
+    rerender();
+
+    await result.current.updateOccurrenceStatus(occurrence1, 'disabled');
+
+    expect(store.getState().simulation.selectedTrain).toStrictEqual({
+      by: 'timetable',
+      id: occurrence2.id,
+    });
+  });
+
+  it('should remove indexed occurrence exceptions', async () => {
+    postTrainScheduleExceptionsDelete.mockResolvedValue({
+      data: [],
+    });
+
+    const [exception1] = pacedTrainWithExceptions.paced.exceptions;
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(
+        buildOccurrenceActionsArgs({
+          ...pacedTrainWithExceptions,
+          paced: {
+            ...pacedTrainWithExceptions.paced,
+            exceptions: [
+              {
+                ...exception1,
+                id: 100,
+              },
+            ],
+          },
+        })
+      )
+    );
+
+    await result.current.resetOccurrenceExceptions(occurrence1.id);
+
+    expect(postTrainScheduleExceptionsDelete).toHaveBeenCalledWith({
+      body: {
+        ids: [100],
+      },
+    });
+
+    const formattedPacedTrain =
+      formatTrainScheduleWithDetailsToTrainSchedule(pacedTrainWithExceptions);
+
+    expect(mockUpsertTrainSchedules).toHaveBeenCalledWith([
+      {
+        ...formattedPacedTrain,
+        id: pacedTrainWithExceptions.id,
+        train_schedule_set_id: pacedTrainWithExceptions.train_schedule_set_id,
+        paced: {
+          ...formattedPacedTrain.paced,
+          exceptions: [],
+        },
+      },
+    ]);
+  });
+
+  it('should remove change groups for added exceptions (except for start time)', async () => {
+    putTrainScheduleExceptionById.mockResolvedValue({
+      data: [],
+    });
+
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(
+        buildOccurrenceActionsArgs({ ...pacedTrainWithAddedException }, [
+          { ...addedExceptionOccurrence },
+        ])
+      )
+    );
+
+    const [addedException] = pacedTrainWithAddedException.paced.exceptions;
+    await result.current.resetOccurrenceExceptions(addedExceptionOccurrence.id);
+
+    expect(putTrainScheduleExceptionById).toHaveBeenCalledWith({
+      body: {
+        change_groups: {
+          start_time: addedException.start_time,
+        },
+        disabled: false,
+        occurrence_index: undefined,
+        train_schedule_id: pacedTrainWithAddedException.id,
+      },
+      id: addedException.id,
+    });
+
+    const formattedPacedTrain = formatTrainScheduleWithDetailsToTrainSchedule(
+      pacedTrainWithAddedException
+    );
+
+    expect(mockUpsertTrainSchedules).toHaveBeenCalledWith([
+      {
+        ...formattedPacedTrain,
+        id: pacedTrainWithAddedException.id,
+        train_schedule_set_id: pacedTrainWithAddedException.train_schedule_set_id,
+        paced: {
+          ...formattedPacedTrain.paced,
+          exceptions: [
+            {
+              id: addedException.id,
+              key: '',
+              start_time: addedException.start_time,
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('should not delete inexistent exceptions', async () => {
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(buildOccurrenceActionsArgs())
+    );
+
+    await expect(
+      result.current.deleteAddedException(addedExceptionOccurrence.id)
+    ).rejects.toThrow();
+  });
+
+  it('should filter out deleted exception', async () => {
+    postTrainScheduleExceptionsDelete.mockResolvedValue({
+      data: [],
+    });
+
+    const { result } = renderHookWithStore(() =>
+      useOccurrenceActions(
+        buildOccurrenceActionsArgs({ ...pacedTrainWithAddedException }, [
+          { ...addedExceptionOccurrence },
+        ])
+      )
+    );
+
+    await result.current.deleteAddedException(addedExceptionOccurrence.id);
+
+    expect(postTrainScheduleExceptionsDelete).toHaveBeenCalledWith({
+      body: {
+        ids: [0],
+      },
+    });
+
+    const formattedPacedTrain = formatTrainScheduleWithDetailsToTrainSchedule(
+      pacedTrainWithAddedException
+    );
+
+    expect(mockUpsertTrainSchedules).toHaveBeenCalledWith([
+      {
+        ...formattedPacedTrain,
+        id: pacedTrainWithAddedException.id,
+        train_schedule_set_id: pacedTrainWithAddedException.train_schedule_set_id,
+        paced: {
+          ...formattedPacedTrain.paced,
+          exceptions: [],
+        },
+      },
+    ]);
+  });
+
+  it('should not select deleted exception', async () => {
+    postTrainScheduleExceptionsDelete.mockResolvedValue({
+      data: [],
+    });
+
+    const { result, rerender } = renderHookWithStore(() =>
+      useOccurrenceActions(
+        buildOccurrenceActionsArgs({ ...pacedTrainWithAddedException }, [
+          { ...addedExceptionOccurrence },
+        ])
+      )
+    );
+    const store = getTestStore();
+
+    result.current.toggleOccurrenceSelection(addedExceptionOccurrence.id);
+
+    rerender();
+
+    await result.current.deleteAddedException(addedExceptionOccurrence.id);
+
+    rerender();
+
+    expect(store.getState().simulation.selectedTrain).toStrictEqual(undefined);
+  });
+});

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
@@ -1,73 +1,19 @@
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
-import type { LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
-import type { PacedTrainWithDetails } from 'modules/trainSchedule/types';
-import { Duration } from 'utils/duration';
-
 import useOccurrences from '../useOccurrences';
-
-const ROLLING_STOCK_NAME = 'fast-rs';
-const PACED_INTERVAL = Duration.parse('PT45M');
-const PACED_TIME_WINDOW = Duration.parse('PT2H');
-
-const rollingStock = {
-  name: ROLLING_STOCK_NAME,
-  effort_curves: { modes: {} },
-} as LightRollingStockWithLiveries;
-
-const pacedTrainSchedule: PacedTrainWithDetails = {
-  stopsCount: 5,
-  category: { main_category: 'HIGH_SPEED_TRAIN' },
+import {
+  BASE_OCCURRENCE,
+  occurrence1,
+  occurrence2,
+  occurrence3,
+  pacedTrainSchedule,
+  pacedTrainWithAddedException,
+  pacedTrainWithDisabledOccurrence,
+  pacedTrainWithExceptions,
+  peacedTrainWithExceptionsRollingStock,
   rollingStock,
-  id: 1,
-  name: 'Paced Train 1',
-  startTime: new Date('2026-06-09T08:00:00Z'),
-  rollingStockName: ROLLING_STOCK_NAME,
-  paced: {
-    timeWindow: PACED_TIME_WINDOW,
-    interval: PACED_INTERVAL,
-    exceptions: [],
-  },
-  constraint_distribution: 'STANDARD',
-  path: [],
-  train_schedule_set_id: 0,
-  labels: [],
-  speedLimitTag: null,
-};
-
-const BASE_OCCURRENCE = {
-  stopsCount: 5,
-  category: { main_category: 'HIGH_SPEED_TRAIN' },
-  rollingStock,
-  disabled: false,
-  exception: undefined,
-  summary: undefined,
-};
-
-const occurrence1 = {
-  ...BASE_OCCURRENCE,
-  id: 'indexedoccurrence_1_0',
-  trainName: 'Paced Train 1',
-  startTime: new Date('2026-06-09T08:00:00.000Z'),
-  occurrenceIndex: 0,
-};
-
-const occurrence2 = {
-  ...BASE_OCCURRENCE,
-  id: 'indexedoccurrence_1_1',
-  trainName: 'Paced Train 3',
-  startTime: new Date('2026-06-09T08:45:00.000Z'),
-  occurrenceIndex: 1,
-};
-
-const occurrence3 = {
-  ...BASE_OCCURRENCE,
-  id: 'indexedoccurrence_1_2',
-  trainName: 'Paced Train 5',
-  startTime: new Date('2026-06-09T09:30:00.000Z'),
-  occurrenceIndex: 2,
-};
+} from './consts';
 
 describe('useOccurrences', () => {
   it('should return occurrences based on paced train', () => {
@@ -81,23 +27,6 @@ describe('useOccurrences', () => {
 
   it('should return occurrences with exceptions (occurrence modified)', () => {
     const rollingStockList = [rollingStock];
-
-    const pacedTrainWithExceptions: PacedTrainWithDetails = {
-      ...pacedTrainSchedule,
-      paced: {
-        ...pacedTrainSchedule.paced,
-        exceptions: [
-          {
-            key: 'occurrence_1_0',
-            id: 42,
-            occurrence_index: 0,
-            train_name: { value: 'Exception Train 1' },
-            start_time: { value: new Date('2026-06-09T08:05:00Z').getTime() },
-            disabled: false,
-          },
-        ],
-      },
-    };
 
     const { result } = renderHook(() => useOccurrences(pacedTrainWithExceptions, rollingStockList));
 
@@ -125,22 +54,6 @@ describe('useOccurrences', () => {
 
   it('should return occurrences with exceptions (exception added)', () => {
     const rollingStockList = [rollingStock];
-
-    const pacedTrainWithAddedException: PacedTrainWithDetails = {
-      ...pacedTrainSchedule,
-      paced: {
-        ...pacedTrainSchedule.paced,
-        exceptions: [
-          {
-            key: 'exception_1_0',
-            id: 0,
-            train_name: { value: 'Added Exception Train' },
-            start_time: { value: new Date('2026-06-09T10:00:00Z').getTime() },
-            disabled: false,
-          },
-        ],
-      },
-    };
 
     const { result } = renderHook(() =>
       useOccurrences(pacedTrainWithAddedException, rollingStockList)
@@ -177,21 +90,6 @@ describe('useOccurrences', () => {
   it('should update count if an occurrence is disabled', () => {
     const rollingStockList = [rollingStock];
 
-    const pacedTrainWithDisabledOccurrence: PacedTrainWithDetails = {
-      ...pacedTrainSchedule,
-      paced: {
-        ...pacedTrainSchedule.paced,
-        exceptions: [
-          {
-            key: 'occurrence_1_0',
-            id: 42,
-            occurrence_index: 0,
-            disabled: true,
-          },
-        ],
-      },
-    };
-
     const { result } = renderHook(() =>
       useOccurrences(pacedTrainWithDisabledOccurrence, rollingStockList)
     );
@@ -207,24 +105,6 @@ describe('useOccurrences', () => {
   });
 
   it('should return occurrence with peaced train rolling stock if rolling stock list is null', () => {
-    const peacedTrainWithExceptionsRollingStock: PacedTrainWithDetails = {
-      ...pacedTrainSchedule,
-      paced: {
-        ...pacedTrainSchedule.paced,
-        exceptions: [
-          {
-            key: 'occurrence_1_1',
-            id: 42,
-            occurrence_index: 1,
-            train_name: { value: 'Exception Train RS 1' },
-            rolling_stock: {
-              rolling_stock_name: 'low-rs',
-              comfort: 'STANDARD',
-            },
-          },
-        ],
-      },
-    };
     const { result } = renderHook(() =>
       useOccurrences(peacedTrainWithExceptionsRollingStock, null)
     );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -253,7 +253,7 @@ const useOccurrenceActions = ({
       const newExceptions = pacedTrain.paced.exceptions.filter((ex) => ex.id !== id);
       const exceptionToDelete = pacedTrain.paced.exceptions.find((ex) => ex.id === id);
 
-      if (!exceptionToDelete?.id) {
+      if (exceptionToDelete?.id === undefined || exceptionToDelete?.id === null) {
         throw new Error('Cannot delete an exception which was not found');
       }
       await deleteExceptions(dispatch, [exceptionToDelete.id]);

--- a/front/src/store/__tests__/index.tsx
+++ b/front/src/store/__tests__/index.tsx
@@ -15,6 +15,10 @@ beforeEach(() => {
   store = createStore();
 });
 
+export function getTestStore(): Store {
+  return store;
+}
+
 /**
  * Renders a hook for test purposes with the Redux store in the context.
  *


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/16669

First commit is a factorization of existing fixtures we could use to test both `useOccurrence` and `useOccurrenceActions` hooks.
Second commit introduces the tests.