### PR TITLE
editoast: fix op migration with empty main code

### DIFF
--- a/editoast/migrations/2026-07-03-152118-0000_fix_empty_main_code/down.sql
+++ b/editoast/migrations/2026-07-03-152118-0000_fix_empty_main_code/down.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+ALTER TABLE infra_object_operational_point
+DROP CONSTRAINT IF EXISTS check_main_code_not_empty;
+
+ALTER TABLE infra_object_operational_point
+DROP CONSTRAINT IF EXISTS check_secondary_code_not_empty;
+
+ALTER TABLE infra_object_operational_point
+DROP CONSTRAINT IF EXISTS check_secondary_name_not_empty;

--- a/editoast/migrations/2026-07-03-152118-0000_fix_empty_main_code/up.sql
+++ b/editoast/migrations/2026-07-03-152118-0000_fix_empty_main_code/up.sql
@@ -1,0 +1,35 @@
+-- Your SQL goes here
+UPDATE infra_object_operational_point
+SET data = jsonb_set(data, '{main_code}', data->'name')
+WHERE data->'main_code' = '""'::jsonb;
+
+
+UPDATE infra_object_operational_point
+SET data = jsonb_set(data, '{secondary_code}',  'null'::jsonb)
+WHERE data->'secondary_code' = '""'::jsonb;
+
+UPDATE infra_object_operational_point
+SET data = jsonb_set(data, '{secondary_name}',  'null'::jsonb)
+WHERE data->'secondary_name' = '""'::jsonb;
+
+-- Fix unique constraints
+
+DROP INDEX IF EXISTS uic_unique_index;
+CREATE UNIQUE INDEX uic_unique_index ON infra_object_operational_point(infra_id, (data->>'uic'), (data->>'secondary_code')) NULLS NOT DISTINCT WHERE data->>'uic' IS NOT NULL;
+
+DROP INDEX IF EXISTS plc_unique_index;
+CREATE UNIQUE INDEX plc_unique_index ON infra_object_operational_point(infra_id, (data->>'plc')) WHERE data->>'plc' IS NOT NULL;
+
+-- Add check on non blank main_code, secondary_code and secondary_name
+
+ALTER TABLE infra_object_operational_point
+ADD CONSTRAINT check_main_code_not_empty
+CHECK ((data->>'main_code') IS NOT NULL AND (data->>'main_code') != '');
+
+ALTER TABLE infra_object_operational_point
+ADD CONSTRAINT check_secondary_code_not_empty
+CHECK ((data->>'secondary_code') IS NULL OR (data->>'secondary_code') != '');
+
+ALTER TABLE infra_object_operational_point
+ADD CONSTRAINT check_secondary_name_not_empty
+CHECK ((data->>'secondary_name') IS NULL OR (data->>'secondary_name') != '');


### PR DESCRIPTION
Fix #17516 


We had issues with some infrastructure (mainly when generated from OSM).

- If `trigram` was `""` then the generated main code was empty too, which is not allowed
- Same for `secondary_code` and `secondary_name`

What is done:
- Empty main code is filled when required using the name
- The secondary code and name are set to null when empty.
- Add a constraint to enforce these fields not to be empty
- Also fix the `uic_unique_index` : 
  - It did not catch when two OPs had the same UIC and `null` as secondary code.
- I optimized the  `plc_unique_index` by skipping `null` values. This slightly reduces the size of the index.