### PR TITLE
github: remove codeowner of osrdRailwayManagerApi.ts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@
 /front                                                   @openrailassociation/OSRD-Front
 /front/src/common/api/generatedEditoastApi.ts
 /front/src/common/api/osrdMiddlewareApi.ts
+/front/src/common/api/osrdRailwayManagerApi.ts
 /front/src/reducers/osrdconf/infra_schema.json
 
 # --- EDITOAST ---


### PR DESCRIPTION
We do this for generatedEditoastApi and osrdMiddlewareApi, we should stay consistent.