### PR TITLE
core: scripts: adapt editoast url to demo gateway url

### DIFF
--- a/core/scripts/download-stdcm-requirements.py
+++ b/core/scripts/download-stdcm-requirements.py
@@ -15,7 +15,7 @@ Generates a json that can be used in core to run stdcm requests,
 through the `JsonTimetableProvider` class.
 """
 )
-@click.option("--editoast-url", "-e", default="https://dev-osrd.reseau.sncf.fr/")
+@click.option("--gateway-url", "-u", default="https://demo.osrd.fr/")
 @click.option("--timetable-id", "-t", required=True, type=int)
 @click.option("--infra-id", "-i", required=True, type=int)
 @click.option("--path", "-p", default="requirements.json")
@@ -26,9 +26,9 @@ def main(*args, **kwargs):
 
 
 async def async_main(
-    editoast_url, timetable_id, infra_id, path, gateway_cookie, page_size
+    gateway_url, timetable_id, infra_id, path, gateway_cookie, page_size
 ):
-    url = f"{editoast_url}api/timetable/{timetable_id}/requirements/?page=$page&{page_size=}&{infra_id=}"
+    url = f"{gateway_url}api/timetable/{timetable_id}/requirements/?page=$page&{page_size=}&{infra_id=}"
     cookies, connector = make_connector(gateway_cookie)
     async with aiohttp.ClientSession(
         trust_env=True, raise_for_status=True, cookies=cookies, connector=connector

--- a/core/scripts/download-timetable.py
+++ b/core/scripts/download-timetable.py
@@ -12,12 +12,12 @@ from common import get_paginated, make_connector
 
 async def download_timetable(
     timetable_id: int,
-    editoast_url: str,
+    gateway_url: str,
     page_size: int,
     gateway_cookie: str,
     max_train_count: int,
 ) -> Dict:
-    paced_trains_url = f"{editoast_url}api/timetable/{timetable_id}/train_schedules/?page=$page&{page_size=}"
+    paced_trains_url = f"{gateway_url}api/timetable/{timetable_id}/train_schedules/?page=$page&{page_size=}"
     cookies, connector = make_connector(gateway_cookie)
     async with aiohttp.ClientSession(
         trust_env=True, raise_for_status=True, cookies=cookies, connector=connector
@@ -42,7 +42,7 @@ async def download_timetable(
 Downloads a full timetable into a json file that can be reimported in OSRD operational studies.
 """
 )
-@click.option("--editoast-url", "-e", default="https://dev-osrd.reseau.sncf.fr/")
+@click.option("--gateway-url", "-u", default="https://demo.osrd.fr/")
 @click.option("--timetable-id", "-t", required=True, type=int)
 @click.option("--path", "-p", default="timetable.json")
 @click.option("--gateway-cookie", "-c", envvar="GATEWAY_COOKIE")
@@ -56,10 +56,10 @@ Maximum number of train to export, to avoid issues with uploading large files.
 Trains are sorted by departure time before being trimmed (earliest ones are kept).
 """,
 )
-def main(editoast_url, timetable_id, path, gateway_cookie, page_size, max_train_count):
+def main(gateway_url, timetable_id, path, gateway_cookie, page_size, max_train_count):
     trains = asyncio.run(
         download_timetable(
-            timetable_id, editoast_url, page_size, gateway_cookie, max_train_count
+            timetable_id, gateway_url, page_size, gateway_cookie, max_train_count
         )
     )
     with open(path, "w", encoding="utf-8") as jsonfile:

--- a/core/scripts/download-work-schedules.py
+++ b/core/scripts/download-work-schedules.py
@@ -12,11 +12,11 @@ from common import get_paginated, make_connector
 
 async def download_work_schedules(
     group_id: int,
-    editoast_url: str,
+    gateway_url: str,
     page_size: int,
     gateway_cookie: str,
 ) -> List[Dict]:
-    url = f"{editoast_url}api/work_schedules/group/{group_id}/?page=$page&{page_size=}"
+    url = f"{gateway_url}api/work_schedules/group/{group_id}/?page=$page&{page_size=}"
     cookies, connector = make_connector(gateway_cookie)
     async with aiohttp.ClientSession(
         trust_env=True, raise_for_status=True, cookies=cookies, connector=connector
@@ -29,14 +29,14 @@ async def download_work_schedules(
 Downloads a full work schedule group.
 """
 )
-@click.option("--editoast-url", "-e", default="https://dev-osrd.reseau.sncf.fr/")
+@click.option("--gateway-url", "-u", default="https://demo.osrd.fr/")
 @click.option("--group-id", "-g", required=True, type=int)
 @click.option("--path", "-p", default="work_schedules.json")
 @click.option("--gateway-cookie", "-c", envvar="GATEWAY_COOKIE")
 @click.option("--page-size", "-s", default=100)
-def main(editoast_url, group_id, path, gateway_cookie, page_size):
+def main(gateway_url, group_id, path, gateway_cookie, page_size):
     work_schedules = asyncio.run(
-        download_work_schedules(group_id, editoast_url, page_size, gateway_cookie)
+        download_work_schedules(group_id, gateway_url, page_size, gateway_cookie)
     )
     with open(path, "w", encoding="utf-8") as jsonfile:
         json.dump(work_schedules, jsonfile, ensure_ascii=False, indent=4)


### PR DESCRIPTION
Adapt the URL to the public demo env.
Also rename editoast-url into gateway-url since it's what it expects (without the `/api`).
I changed the options (long and short) for consistency. Hopefully it does not break external scripts :crossed_fingers: 