### PR TITLE
core: ensure path item times have the same length as simulation input

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/SimulationParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/SimulationParser.kt
@@ -24,7 +24,7 @@ val simulationScheduleItemParserLogger = KotlinLogging.logger {}
  * - receptionSignal is the most constrained of all schedule item's receptionSignal
  * - isBacktracking is true if at least one of the items is backtracking
  */
-fun parseRawSimulationScheduleItems(
+fun dedupScheduleItems(
     rawSimulationScheduleItems: List<SimulationScheduleItem>
 ): List<SimulationScheduleItem> {
     val simulationScheduleItems = mutableListOf<SimulationScheduleItem>()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/etcs/ETCSBrakingCurvesEndpoint.kt
@@ -77,7 +77,7 @@ class ETCSBrakingCurvesEndpoint(
             val curvesAndConditions =
                 rollingStock.mapTractiveEffortCurves(electrificationMap, request.comfort)
             val signalingRanges = buildSignalingRanges(infra, trainPath)
-            val stops = getSimStops(parseRawSimulationScheduleItems(request.schedule))
+            val stops = getSimStops(dedupScheduleItems(request.schedule))
             val context =
                 EnvelopeSimContext(
                     rollingStock,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -77,7 +77,7 @@ class SimulationEndpoint(
                     request.options.useElectricalProfiles,
                     request.options.useSpeedLimits ?: true,
                     2.0,
-                    dedupScheduleItems(request.schedule),
+                    request.schedule,
                     request.initialSpeed,
                     request.margins,
                 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -77,7 +77,7 @@ class SimulationEndpoint(
                     request.options.useElectricalProfiles,
                     request.options.useSpeedLimits ?: true,
                     2.0,
-                    parseRawSimulationScheduleItems(request.schedule),
+                    dedupScheduleItems(request.schedule),
                     request.initialSpeed,
                     request.margins,
                 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationResponse.kt
@@ -71,6 +71,16 @@ open class ReportTrain(
     val times: List<TimeDelta>,
     val speeds: List<Double>,
     @Json(name = "energy_consumption") val energyConsumption: Double,
+    /**
+     * Times at which the train *arrives* at each path item.
+     *
+     * If two path items have the same position, but the first one has a stop duration, the second
+     * path item time will be offset by the stop duration of the first.
+     *
+     * For example, in a simulation going through four path items A, B, B' and C. If B and B' are at
+     * the same position, then the path item time of B' will be equal to the path item time of B
+     * plus the stop duration of B.
+     */
     @Json(name = "path_item_times") val pathItemTimes: List<TimeDelta>,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -586,7 +586,7 @@ fun parseMarginValue(margin: MarginValue): AllowanceValue? {
 private fun parseSimulationScheduleItems(
     trainStops: List<TrainStop>
 ): List<SimulationScheduleItem> {
-    return parseRawSimulationScheduleItems(
+    return dedupScheduleItems(
         trainStops.map {
             val duration = if (it.duration > 0.0) it.duration.seconds else null
             val stopDetails =

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.standalone_sim
 
+import com.google.common.collect.Comparators.min
 import fr.sncf.osrd.api.*
 import fr.sncf.osrd.api.standalone_sim.CompleteReportTrain
 import fr.sncf.osrd.api.standalone_sim.ReportTrain
@@ -238,8 +239,19 @@ fun makeSimpleReportTrain(
             }
     val envelopeStopWrapper = EnvelopeStopWrapper(envelope, stops)
 
-    val pathItemTimes = schedule.map { item: SimulationScheduleItem ->
-        TimeDelta.fromSeconds(envelopeStopWrapper.interpolateArrivalAt((item.pathOffset.meters)))
+    val pathItemTimes = schedule.mapIndexed { i: Int, item: SimulationScheduleItem ->
+        var time =
+            TimeDelta.fromSeconds(envelopeStopWrapper.interpolateArrivalAt(item.pathOffset.meters))
+        var i = i
+        while (i > 0 && schedule[i - 1].pathOffset == item.pathOffset) {
+            time += (schedule[i - 1].stopDetails?.duration ?: Duration.ZERO)
+            i--
+        }
+        val departureTimeFromOp =
+            TimeDelta.fromSeconds(
+                envelopeStopWrapper.interpolateDepartureFrom(item.pathOffset.meters)
+            )
+        min(time, departureTimeFromOp)
     }
 
     // Iterate over the points and simplify the results

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -5,6 +5,7 @@ import com.google.common.collect.TreeRangeMap
 import fr.sncf.osrd.DriverBehaviour
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.RangeValues
+import fr.sncf.osrd.api.dedupScheduleItems
 import fr.sncf.osrd.api.standalone_sim.ElectricalProfileValue
 import fr.sncf.osrd.api.standalone_sim.MarginValue
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
@@ -69,9 +70,13 @@ fun runStandaloneSimulation(
     driverBehaviour: DriverBehaviour = DriverBehaviour(),
 ): SimulationSuccess {
     if (trainPath.getLength() == Offset.zero<TrainPath>()) throw OSRDError(ZeroLengthPath)
+
+    val scheduleDeduped = dedupScheduleItems(schedule)
+
     val signalingRanges = buildSignalingRanges(infra, trainPath)
     // MRSP & SpeedLimits
-    val safetySpeedRanges = makeSafetySpeedRanges(infra, trainPath, schedule, signalingRanges)
+    val safetySpeedRanges =
+        makeSafetySpeedRanges(infra, trainPath, scheduleDeduped, signalingRanges)
     var mrsp =
         computeMRSP(
             trainPath,
@@ -109,7 +114,7 @@ fun runStandaloneSimulation(
         )
 
     // Max speed envelope
-    val simStops = getSimStops(schedule)
+    val simStops = getSimStops(scheduleDeduped)
     val maxSpeedEnvelope = maxSpeedEnvelopeFrom(context, simStops, mrsp)
 
     // Add neutral sections
@@ -136,7 +141,7 @@ fun runStandaloneSimulation(
             context,
             margins,
             constraintDistribution,
-            schedule,
+            scheduleDeduped,
         )
 
     // Extract all kinds of metadata from the simulation,

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/SimulationScheduleItemsParserTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/SimulationScheduleItemsParserTests.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.standalone_sim
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import fr.sncf.osrd.api.parseRawSimulationScheduleItems
+import fr.sncf.osrd.api.dedupScheduleItems
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
 import fr.sncf.osrd.api.standalone_sim.StopDetails
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
@@ -26,7 +26,7 @@ class SimulationScheduleItemsParserTests {
         simulationScheduleItems: List<SimulationScheduleItem>,
         expectedItems: List<SimulationScheduleItem>,
     ) {
-        val mergedItems = parseRawSimulationScheduleItems(simulationScheduleItems)
+        val mergedItems = dedupScheduleItems(simulationScheduleItems)
         Assertions.assertThat(mergedItems).usingRecursiveComparison().isEqualTo(expectedItems)
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -490,6 +491,65 @@ class StandaloneSimulationTest {
             val actual = mrspWithSafetySpeed.interpolateSpeedLeftDir(position, 1.0)
             assertEquals(expected, actual)
             position += 1.0
+        }
+    }
+
+    private fun testThroughDuplicateOP(): Stream<Arguments> =
+        Stream.of(
+            arguments(listOf(123, 587)),
+            arguments(listOf(8524, 7456, 2975)),
+            arguments(listOf(8524, 7456, 2975, 0)),
+        )
+
+    @ParameterizedTest
+    @MethodSource
+    fun testThroughDuplicateOP(stopDurations: List<Long>) {
+        val opOffset = Offset<PhysicsPath>(Distance(pathLength.distance.millimeters / 2))
+        val schedule = stopDurations.map { milliseconds ->
+            SimulationScheduleItem(
+                pathOffset = opOffset,
+                arrival = null,
+                stopDetails =
+                    StopDetails(
+                        duration = Duration(milliseconds),
+                        receptionSignal = OPEN,
+                        isBacktracking = false,
+                    ),
+            )
+        }
+
+        val res =
+            runStandaloneSimulation(
+                infra = infra,
+                trainPath = trainPath,
+                rollingStock = rollingStock,
+                comfort = Comfort.STANDARD,
+                constraintDistribution = RJSAllowanceDistribution.LINEAR,
+                speedLimitTag = null,
+                powerRestrictions = offsetRangeMapOf(),
+                useElectricalProfiles = false,
+                useSpeedLimits = false,
+                timeStep = 2.0,
+                schedule = schedule,
+                initialSpeed = 0.0,
+                margins = RangeValues(listOf(), listOf()),
+            )
+
+        assertDuplicateOPReport(res.base, schedule)
+        assertDuplicateOPReport(res.provisional, schedule)
+        assertDuplicateOPReport(res.finalOutput, schedule)
+    }
+
+    private fun assertDuplicateOPReport(
+        report: ReportTrain,
+        schedule: List<SimulationScheduleItem>,
+    ) {
+        assertEquals(schedule.size, report.pathItemTimes.size)
+        for (i in 0..schedule.size - 2) {
+            assertEquals(
+                report.pathItemTimes[i] + (schedule[i].stopDetails?.duration ?: Duration.ZERO),
+                report.pathItemTimes[i + 1],
+            )
         }
     }
 

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -157,8 +157,14 @@ pub struct ReportTrain {
     pub speeds: Vec<f64>,
     /// Total energy consumption
     pub energy_consumption: f64,
-    /// Time in ms of each path item given as input of the pathfinding
+    /// Time in ms at which the train *arrives* at each path item given as input of the pathfinding
     /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+    ///
+    /// In case multiple path items are at the same position, the stop duration
+    /// of the earlier ones are added to the path item time of the next. For
+    /// example, if A and B are at the same position, and A has a stop duration
+    /// of 2s, then the path item time of B will be equal to the path item time
+    /// of A plus 2s.
     pub path_item_times: Vec<u64>,
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5781,8 +5781,14 @@ components:
             format: int64
             minimum: 0
           description: |-
-            Time in ms of each path item given as input of the pathfinding
+            Time in ms at which the train *arrives* at each path item given as input of the pathfinding
             The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+
+            In case multiple path items are at the same position, the stop duration
+            of the earlier ones are added to the path item time of the next. For
+            example, if A and B are at the same position, and A has a stop duration
+            of 2s, then the path item time of B will be equal to the path item time
+            of A plus 2s.
         positions:
           type: array
           items:

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4502,8 +4502,14 @@ export type SimDebugTrainZoneRequirement = {
 export type CoreReportTrain = {
   /** Total energy consumption */
   energy_consumption: number;
-  /** Time in ms of each path item given as input of the pathfinding
-    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path) */
+  /** Time in ms at which the train *arrives* at each path item given as input of the pathfinding
+    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+    
+    In case multiple path items are at the same position, the stop duration
+    of the earlier ones are added to the path item time of the next. For
+    example, if A and B are at the same position, and A has a stop duration
+    of 2s, then the path item time of B will be equal to the path item time
+    of A plus 2s. */
   path_item_times: number[];
   /** List of positions of a train
     Both positions (in mm) and times (in ms) must have the same length */

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -253,8 +253,14 @@ class CoreReportTrain(BaseModel):
     """
     path_item_times: list[PathItemTime]
     """
-    Time in ms of each path item given as input of the pathfinding
+    Time in ms at which the train *arrives* at each path item given as input of the pathfinding
     The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+
+    In case multiple path items are at the same position, the stop duration
+    of the earlier ones are added to the path item time of the next. For
+    example, if A and B are at the same position, and A has a stop duration
+    of 2s, then the path item time of B will be equal to the path item time
+    of A plus 2s.
     """
     positions: list[Position]
     """


### PR DESCRIPTION
editoast (and the frontend before) were expecting path item time arrays to have the same length as the schedule, in order to compute whether the simulation respects input times and margins.

This patch makes it so core uses the input schedule to build the reports instead of the dedupped schedule.

Also renamed the function to make its intent clearer.

Closes #17603

# How to test

Simple case: using this patched small infra with a duplicate op at MWS  [small_dup.json](https://github.com/user-attachments/files/29851610/small_dup.json)
and this train schedule which goes through both duplicates: [timetable(31).json](https://github.com/user-attachments/files/29851644/timetable.31.json)

there shouldn't be any "index out of bounds" error in editoast logs after running the simulation.

Another example can be found in the internal backup, see the issue for the repro.