### PR TITLE
editoast: assert path item times len against train schedule path len

### DIFF
--- a/editoast/schemas/src/train_schedule.rs
+++ b/editoast/schemas/src/train_schedule.rs
@@ -225,12 +225,14 @@ impl Serialize for TrainOccurrence {
 
 #[cfg(any(test, feature = "testing"))]
 impl TrainOccurrence {
+    pub const FAKE_PATH_LEN: usize = 4;
+
     pub fn fake() -> Self {
         use crate::fixtures::ms_since_epoch;
         use crate::infra::TrackOffset;
         use crate::primitives::Identifier;
 
-        Self {
+        let fake = Self {
             train_name: "ABC3615".to_string(),
             labels: vec!["choo-choo".to_string(), "tchou-tchou".to_string()],
             rolling_stock_name: "R2D2".to_string(),
@@ -328,7 +330,11 @@ impl TrainOccurrence {
                 stops_at_end_of_block: false,
             },
             category: None,
-        }
+        };
+
+        assert_eq!(Self::FAKE_PATH_LEN, fake.path.len());
+
+        fake
     }
 }
 

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -539,7 +539,8 @@ mod tests {
         pathfinding_stub.finish();
         let mut simulation_stub = core.stub("/standalone_simulation").response(StatusCode::OK);
         for _ in 0..10 {
-            simulation_stub = simulation_stub.json(simulation_empty_response());
+            // 4 path items, same as the pathfinding stub above
+            simulation_stub = simulation_stub.json(simulation_empty_response(4));
         }
         simulation_stub.finish();
         core.stub("/signal_projection")

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1087,12 +1087,16 @@ pub(in crate::views) struct TrainScheduleSetForm {
 }
 
 #[cfg(test)]
-pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::Response {
+pub(in crate::views) fn simulation_empty_response(
+    path_len: usize,
+) -> core_client::simulation::Response {
     use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ElectricalProfiles;
     use core_client::simulation::ReportTrain;
     use core_client::simulation::SimulationSuccess;
     use core_client::simulation::SpeedLimitProperties;
+
+    let path_item_times: Vec<u64> = (0..).take(path_len).collect();
 
     core_client::simulation::Response::Success(SimulationSuccess {
         base: ReportTrain {
@@ -1100,14 +1104,14 @@ pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::
             times: vec![0, 30_000, 100_000],
             speeds: vec![],
             energy_consumption: 0.0,
-            path_item_times: vec![0, 1, 2, 3],
+            path_item_times: path_item_times.clone(),
         },
         provisional: ReportTrain {
             positions: vec![0, 500_000, 15_050_000],
             times: vec![0, 30_000, 100_000],
             speeds: vec![],
             energy_consumption: 0.0,
-            path_item_times: vec![0, 1, 2, 3],
+            path_item_times: path_item_times.clone(),
         },
         final_output: CompleteReportTrain {
             report_train: ReportTrain {
@@ -1115,7 +1119,7 @@ pub(in crate::views) fn simulation_empty_response() -> core_client::simulation::
                 times: vec![0, 30_000, 100_000],
                 speeds: vec![],
                 energy_consumption: 0.0,
-                path_item_times: vec![0, 1, 2, 3],
+                path_item_times: path_item_times.clone(),
             },
             signal_critical_positions: vec![],
             zone_updates: vec![],

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -93,6 +93,13 @@ pub fn path_item_respect_times<T: TrainScheduleLike>(
     path_item_times_final: &[u64],
     train_schedule: &T,
 ) -> Vec<bool> {
+    // Ensure we get meaningful panic messages instead of "index out of bounds"
+    assert_eq!(
+        path_item_times_final.len(),
+        train_schedule.path().len(),
+        "the number of path item times must be equal to the number of path items in the train schedule"
+    );
+
     let path_item_id_to_index: HashMap<&NonBlankString, usize> = train_schedule
         .path()
         .iter()
@@ -134,6 +141,18 @@ pub fn path_item_respect_margins<T: TrainScheduleLike>(
     path_item_times_provisional: &[u64],
     train_schedule: &T,
 ) -> Vec<bool> {
+    // Ensure we get meaningful panic messages instead of "index out of bounds"
+    assert_eq!(
+        path_item_times_final.len(),
+        train_schedule.path().len(),
+        "the number of path item times must be equal to the number of path items in the train schedule"
+    );
+    assert_eq!(
+        path_item_times_provisional.len(),
+        train_schedule.path().len(),
+        "the number of path item times must be equal to the number of path items in the train schedule"
+    );
+
     let margin_boundary_set = train_schedule.margins().boundaries.as_slice();
 
     let path_item_id_to_index: HashMap<&NonBlankString, usize> = train_schedule

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -615,7 +615,6 @@ mod tests {
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app::TestResponseExt as _;
     use crate::views::test_app::test_app;
-    use crate::views::timetable::simulation_empty_response;
     use crate::views::timetable::stdcm::Request;
     use crate::views::timetable::stdcm::request::ConsistSchedule;
     use crate::views::timetable::stdcm::request::PathfindingItem;
@@ -731,6 +730,10 @@ mod tests {
             path_item_positions: vec![0, 10],
             backtrack_path_items: Some(vec![]),
         }
+    }
+
+    fn simulation_empty_response() -> core_client::simulation::Response {
+        crate::views::timetable::simulation_empty_response(4)
     }
 
     fn core_mocking_client() -> MockingClient {

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -2181,7 +2181,10 @@ mod tests {
             .assert_status_ok()
             .json();
 
-        assert_eq!(response, simulation_empty_response());
+        assert_eq!(
+            response,
+            simulation_empty_response(TrainOccurrence::FAKE_PATH_LEN)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -3017,7 +3020,7 @@ mod tests {
             .finish();
         core.stub("/standalone_simulation")
             .response(StatusCode::OK)
-            .json(simulation_empty_response())
+            .json(simulation_empty_response(path.len()))
             .finish();
         let app = test_app!().skip_authz().core_client(core.into()).build();
         let db_pool = app.db_pool();


### PR DESCRIPTION
That would have helped with debugging #17603

Made them asserts since the function was already panicking in those cases.