### PR TITLE
front: handle templates containing only string literals in i18n-checker

### DIFF
--- a/front/scripts/i18n-checker.ts
+++ b/front/scripts/i18n-checker.ts
@@ -180,16 +180,18 @@ function visitCallExpression(
     keys = [keyNode.text];
   } else {
     const keyType = checker.getTypeAtLocation(keyNode);
-    if (!keyType.isUnion()) {
-      return;
-    }
-
-    keys = [];
-    for (const t of keyType.types) {
-      if (!t.isStringLiteral()) {
-        return;
+    if (keyType.isStringLiteral()) {
+      keys = [keyType.value];
+    } else if (keyType.isUnion()) {
+      keys = [];
+      for (const t of keyType.types) {
+        if (!t.isStringLiteral()) {
+          return;
+        }
+        keys.push(t.value);
       }
-      keys.push(t.value);
+    } else {
+      return;
     }
   }
 


### PR DESCRIPTION
Trivial templates such as `` `foo${"bar"}` `` would make the parser choke because they would pass neither ts.isStringLiteral(keyNode) (not being literals at the AST level) nor keyType.isUnion() (only a single choice is possible). Add a new case to handle these.

We could get rid of the AST-level checks if we wanted to, at the cost of more type-checking work.

This is a backport of this PR (see the new test case there): https://github.com/emersion/i18next-typescript-parser/pull/12