### PR TITLE
railway_manager_interface: add `folder_url` endpoint

### DIFF
--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -27,6 +27,13 @@ const injectedRtkApi = api
         query: () => ({ url: `/send_last_minute_request/authorized` }),
         providesTags: ['lmr'],
       }),
+      getSendLastMinuteRequestFolderUrl: build.query<
+        GetSendLastMinuteRequestFolderUrlApiResponse,
+        GetSendLastMinuteRequestFolderUrlApiArg
+      >({
+        query: () => ({ url: `/send_last_minute_request/folder_url` }),
+        providesTags: ['lmr'],
+      }),
       postSendLastMinuteRequest: build.mutation<
         PostSendLastMinuteRequestApiResponse,
         PostSendLastMinuteRequestApiArg
@@ -56,6 +63,12 @@ export type GetSendLastMinuteRequestAuthorizedApiResponse =
     authorized: boolean;
   };
 export type GetSendLastMinuteRequestAuthorizedApiArg = void;
+export type GetSendLastMinuteRequestFolderUrlApiResponse =
+  /** status 200 The URL where the logged in user can find the requests they sent */ {
+    /** The url of the folder */
+    url: string;
+  };
+export type GetSendLastMinuteRequestFolderUrlApiArg = void;
 export type PostSendLastMinuteRequestApiResponse =
   /** status 200 User successfully identified, the last-minute request has been formatted and transferred. */ SendLastMinuteRequestResponse;
 export type PostSendLastMinuteRequestApiArg = {

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -4260,6 +4260,13 @@ class SendLastMinuteRequestAuthorizedGetResponse(BaseModel):
     """
 
 
+class SendLastMinuteRequestFolderUrlGetResponse(BaseModel):
+    url: str
+    """
+    The url of the folder
+    """
+
+
 class SendLastMinuteRequestPostRequest(BaseModel):
     simulation_report: SimulationReport
     simulation_report_sheet: bytes

--- a/railway_manager_interface/openapi.yaml
+++ b/railway_manager_interface/openapi.yaml
@@ -64,6 +64,24 @@ paths:
                     description: Whether the user is authenticated and authorized to send last-minute requests
                 required:
                   - authorized
+  /send_last_minute_request/folder_url:
+    get:
+      tags:
+        - lmr
+      summary: Returns the url of a folder containing the user's requests
+      responses:
+        '200':
+          description: The URL where the logged in user can find the requests they sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    description: The url of the folder
+                required:
+                  - url
   /send_last_minute_request:
     post:
       tags:


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/17537

The payload is a bit different from what was planned because I couldn't get rtk query to generate the correct endpoint response type (which was supposed to be `string`). It is also more consistent with how the other endpoints work so I'd argue this way is a bit better