### PR TITLE
front: compute hourly timetable duration from paced train

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -18,6 +18,7 @@ import { useRollingStockContext } from 'common/RollingStockContext';
 import type { PanelSelectionMode } from 'modules/simulationResult/components/SpaceTimeChartWrapper/CurveSelectionSidePanel';
 import useLazyProjectTrains from 'modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains';
 import { formatPacedTrainWithDetails } from 'modules/trainSchedule/helpers/formatTrainScheduleWithDetails';
+import { computeHourlyTimetableDuration } from 'modules/trainSchedule/helpers/hourlyTimetable';
 import {
   extractOccurrenceDetailsFromPacedTrain,
   findExceptionWithOccurrenceId,
@@ -172,6 +173,14 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
   const projectedTrains = useMemo(
     () => Array.from(projectedTrainsById.values()),
     [projectedTrainsById]
+  );
+
+  const hourlyTimetableDuration = useMemo(
+    () =>
+      scenario.timetable_type === 'HOURLY'
+        ? computeHourlyTimetableDuration(trainSchedules ?? [])
+        : undefined,
+    [scenario.timetable_type, trainSchedules]
   );
 
   useAutoSelectTrainIds(trainSchedules ? trainSchedulesWithDetails : undefined);
@@ -442,6 +451,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
         : undefined,
       conflicts,
       isConflictsLoading,
+      hourlyTimetableDuration,
       removeTrainSchedules: removeTrainSchedulesWithBroadcast,
       upsertTrainSchedules: upsertTrainSchedulesWithBroadcast,
       updateTrainScheduleDepartureTime: updateTrainScheduleDepartureTimeWithBroadcast,
@@ -457,6 +467,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
       trainSchedules?.length ?? 0,
       conflicts,
       isConflictsLoading,
+      hourlyTimetableDuration,
       rollingStocks,
       removeTrainSchedulesWithBroadcast,
       upsertTrainSchedulesWithBroadcast,

--- a/front/src/modules/trainSchedule/helpers/__tests__/hourlyTimetable.spec.ts
+++ b/front/src/modules/trainSchedule/helpers/__tests__/hourlyTimetable.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+
+import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import { Duration } from 'utils/duration';
+
+import {
+  computeHourlyTimetableDuration,
+  DEFAULT_HOURLY_TIMETABLE_DURATION,
+} from '../hourlyTimetable';
+
+const baseTrainSchedule: TrainScheduleResponse = {
+  id: 0,
+  train_schedule_set_id: 0,
+  train_name: 'test',
+  rolling_stock_name: 'test',
+  constraint_distribution: 'STANDARD',
+  start_time: 0,
+  path: [],
+};
+
+const buildPacedTrain = (timeWindow: string): TrainScheduleResponse => ({
+  ...baseTrainSchedule,
+  id: 1,
+  paced: {
+    exceptions: [],
+    interval: 'PT30M',
+    time_window: timeWindow,
+  },
+});
+
+const buildUniqueTrain = (): TrainScheduleResponse => ({
+  ...baseTrainSchedule,
+  id: 2,
+});
+
+describe('computeHourlyTimetableDuration', () => {
+  it('should return the default duration for an empty timetable', () => {
+    expect(computeHourlyTimetableDuration([])).toEqual(DEFAULT_HOURLY_TIMETABLE_DURATION);
+  });
+
+  it('should return the paced train duration when there is a single paced train', () => {
+    expect(computeHourlyTimetableDuration([buildPacedTrain('PT2H')])).toEqual(
+      new Duration({ hours: 2 })
+    );
+  });
+
+  it('should compute the LCM of the paced train durations (2h and 3h -> 6h)', () => {
+    expect(
+      computeHourlyTimetableDuration([buildPacedTrain('PT2H'), buildPacedTrain('PT3H')])
+    ).toEqual(new Duration({ hours: 6 }));
+  });
+
+  it('should compute the LCM of several paced train durations (2h, 3h and 4h -> 12h)', () => {
+    expect(
+      computeHourlyTimetableDuration([
+        buildPacedTrain('PT2H'),
+        buildPacedTrain('PT3H'),
+        buildPacedTrain('PT4H'),
+      ])
+    ).toEqual(new Duration({ hours: 12 }));
+  });
+
+  it('should ignore unique (non-paced) train schedules', () => {
+    expect(computeHourlyTimetableDuration([buildPacedTrain('PT2H'), buildUniqueTrain()])).toEqual(
+      new Duration({ hours: 2 })
+    );
+  });
+
+  it('should return the default duration when there is no paced train', () => {
+    expect(computeHourlyTimetableDuration([buildUniqueTrain()])).toEqual(
+      DEFAULT_HOURLY_TIMETABLE_DURATION
+    );
+  });
+
+  it('should accept a resulting duration of exactly 24h', () => {
+    expect(
+      computeHourlyTimetableDuration([buildPacedTrain('PT8H'), buildPacedTrain('PT12H')])
+    ).toEqual(new Duration({ hours: 24 }));
+  });
+
+  it('should return the resulting duration even when it exceeds 24h (5h and 7h -> 35h)', () => {
+    expect(
+      computeHourlyTimetableDuration([buildPacedTrain('PT5H'), buildPacedTrain('PT7H')])
+    ).toEqual(new Duration({ hours: 35 }));
+  });
+});

--- a/front/src/modules/trainSchedule/helpers/hourlyTimetable.ts
+++ b/front/src/modules/trainSchedule/helpers/hourlyTimetable.ts
@@ -1,0 +1,34 @@
+import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import { Duration } from 'utils/duration';
+import { lcm } from 'utils/numbers';
+
+import { isPacedTrain } from './pacedTrain';
+
+/**
+ * Default duration for an hourly timetable, used when it contains no paced trains.
+ */
+export const DEFAULT_HOURLY_TIMETABLE_DURATION = new Duration({ hours: 2 });
+
+/**
+ * Compute the hourly timetable duration from the paced trains it contains.
+ *
+ * The duration is the least common multiple (LCM) of the paced train durations (their
+ * `time_window`): the minimal duration needed to have a repeating pattern. For example, a 2h
+ * paced train and a 3h paced train give a 6h hourly timetable.
+ *
+ * When there is no paced train, the duration defaults to `DEFAULT_HOURLY_TIMETABLE_DURATION`.
+ *
+ */
+export function computeHourlyTimetableDuration(trainSchedules: TrainScheduleResponse[]): Duration {
+  const pacedTrainDurationsMs = trainSchedules
+    .filter(isPacedTrain)
+    .map((trainSchedule) => Duration.parse(trainSchedule.paced.time_window).ms);
+
+  if (pacedTrainDurationsMs.length === 0) {
+    return DEFAULT_HOURLY_TIMETABLE_DURATION;
+  }
+
+  return new Duration({
+    milliseconds: pacedTrainDurationsMs.reduce((acc, ms) => lcm(acc, ms)),
+  });
+}

--- a/front/src/utils/__tests__/numbers.spec.ts
+++ b/front/src/utils/__tests__/numbers.spec.ts
@@ -4,6 +4,7 @@ import {
   budgetFormat,
   isFloat,
   isInvalidFloatNumber,
+  lcm,
   linearScaleInterpolation,
 } from 'utils/numbers';
 import { NARROW_NO_BREAK_SPACE, NO_BREAK_SPACE } from 'utils/strings';
@@ -37,6 +38,23 @@ describe('isFloat', () => {
   it('should return false if the number is infinite', () => {
     expect(isFloat(Infinity)).toBe(false);
     expect(isFloat(-Infinity)).toBe(false);
+  });
+});
+
+describe('lcm', () => {
+  it('should compute the least common multiple of two integers', () => {
+    expect(lcm(4, 6)).toBe(12);
+    expect(lcm(3, 5)).toBe(15);
+    expect(lcm(2, 3)).toBe(6);
+  });
+
+  it('should return 0 when either operand is 0', () => {
+    expect(lcm(0, 5)).toBe(0);
+    expect(lcm(5, 0)).toBe(0);
+  });
+
+  it('should return the number itself when both operands are equal', () => {
+    expect(lcm(7, 7)).toBe(7);
   });
 });
 

--- a/front/src/utils/numbers.ts
+++ b/front/src/utils/numbers.ts
@@ -28,6 +28,26 @@ export function isFloat(n: number) {
   return Number.isFinite(n) && !Number.isInteger(n);
 }
 
+/** Greatest common divisor of two integers (Euclid's algorithm). */
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y) {
+    [x, y] = [y, x % y];
+  }
+  return x;
+}
+
+/**
+ * Least common multiple of two integers.
+ * Returns 0 when either operand is 0.
+ * Uses `(a / gcd) * b` to limit the risk of intermediate overflow.
+ */
+export function lcm(a: number, b: number): number {
+  if (a === 0 || b === 0) return 0;
+  return (Math.abs(a) / gcd(a, b)) * Math.abs(b);
+}
+
 /**
  * Checks if a floating-point number has more decimal places than specified.
  * @param value the floating-point number to check.


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/17608

to create scenario : `curl --request POST \ --url http://localhost:4000/timetable \ --header 'content-type: application/json' \ --data '{ "timetable_type": "HOURLY" }'`