### PR TITLE
front: introduce generateBareOccurrences()

### DIFF
--- a/front/src/applications/operationalStudies/helpers/__tests__/generateBareOccurrences.spec.ts
+++ b/front/src/applications/operationalStudies/helpers/__tests__/generateBareOccurrences.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+
+import type { PacedTrainWithDetails, SimulatedException } from 'modules/trainSchedule/types';
+import { Duration } from 'utils/duration';
+import {
+  formatEditoastIdToIndexedOccurrenceId,
+  formatEditoastIdToExceptionId,
+} from 'utils/trainId';
+
+import { generateBareOccurrences, type BareOccurrence } from '../generateBareOccurrences';
+
+const pacedTrain: Pick<PacedTrainWithDetails, 'id' | 'startTime' | 'paced'> = {
+  id: 6,
+  startTime: new Date('1996-05-28T09:10:00Z'),
+  paced: {
+    timeWindow: new Duration({ hours: 2 }),
+    interval: new Duration({ minutes: 42 }),
+    exceptions: [],
+  },
+};
+
+const baseOccurrences: BareOccurrence[] = [
+  {
+    id: formatEditoastIdToIndexedOccurrenceId({ trainScheduleId: 6, occurrenceIndex: 0 }),
+    startTime: new Date('1996-05-28T09:10:00Z'),
+    exception: undefined,
+  },
+  {
+    id: formatEditoastIdToIndexedOccurrenceId({ trainScheduleId: 6, occurrenceIndex: 1 }),
+    startTime: new Date('1996-05-28T09:52:00Z'),
+    exception: undefined,
+  },
+  {
+    id: formatEditoastIdToIndexedOccurrenceId({ trainScheduleId: 6, occurrenceIndex: 2 }),
+    startTime: new Date('1996-05-28T10:34:00Z'),
+    exception: undefined,
+  },
+];
+
+describe('generateBareOccurrences', () => {
+  it('should generate occurrences without exceptions', () => {
+    const occurrences = generateBareOccurrences(pacedTrain);
+    expect(occurrences).toEqual(baseOccurrences);
+  });
+
+  it('should generate occurrences with an added exception', () => {
+    const exceptionStartTime = new Date('1996-05-28T10:01:00Z');
+    const exception: SimulatedException = {
+      id: 60,
+      key: 'foo',
+      start_time: { value: exceptionStartTime.getTime() },
+    };
+    const occurrences = generateBareOccurrences({
+      ...pacedTrain,
+      paced: {
+        ...pacedTrain.paced,
+        exceptions: [exception],
+      },
+    });
+    expect(occurrences).toEqual([
+      ...baseOccurrences,
+      {
+        id: formatEditoastIdToExceptionId({ trainScheduleId: 6, exceptionId: 60 }),
+        startTime: exceptionStartTime,
+        exception,
+      },
+    ]);
+  });
+
+  it('should generate occurrences with a modified exception for start time', () => {
+    const exceptionStartTime = new Date('1996-05-28T10:01:00Z');
+    const exception: SimulatedException = {
+      id: 60,
+      key: 'foo',
+      occurrence_index: 2,
+      start_time: { value: exceptionStartTime.getTime() },
+    };
+    const occurrences = generateBareOccurrences({
+      ...pacedTrain,
+      paced: {
+        ...pacedTrain.paced,
+        exceptions: [exception],
+      },
+    });
+    expect(occurrences).toEqual([
+      baseOccurrences[0],
+      baseOccurrences[1],
+      {
+        id: baseOccurrences[2].id,
+        startTime: exceptionStartTime,
+        exception,
+      },
+    ]);
+  });
+
+  it('should generate occurrences with a disabled exception', () => {
+    const exception: SimulatedException = {
+      id: 60,
+      key: 'foo',
+      occurrence_index: 1,
+      disabled: true,
+    };
+    const occurrences = generateBareOccurrences({
+      ...pacedTrain,
+      paced: {
+        ...pacedTrain.paced,
+        exceptions: [exception],
+      },
+    });
+    expect(occurrences).toEqual([
+      baseOccurrences[0],
+      {
+        ...baseOccurrences[1],
+        exception,
+      },
+      baseOccurrences[2],
+    ]);
+  });
+});

--- a/front/src/applications/operationalStudies/helpers/generateBareOccurrences.ts
+++ b/front/src/applications/operationalStudies/helpers/generateBareOccurrences.ts
@@ -1,0 +1,64 @@
+import {
+  getOccurrencesNb,
+  computeIndexedOccurrenceStartTime,
+} from 'modules/trainSchedule/helpers/pacedTrain';
+import type { PacedTrainWithDetails, SimulatedException } from 'modules/trainSchedule/types';
+import type { OccurrenceId } from 'reducers/osrdconf/types';
+import {
+  formatEditoastIdToIndexedOccurrenceId,
+  formatEditoastIdToExceptionId,
+} from 'utils/trainId';
+
+export type BareOccurrence = {
+  id: OccurrenceId;
+  startTime: Date;
+  exception: SimulatedException | undefined;
+};
+
+/**
+ * Given a paced train, generate basic details for all occurrences.
+ */
+export function generateBareOccurrences(
+  pacedTrain: Pick<PacedTrainWithDetails, 'id' | 'startTime' | 'paced'>
+): BareOccurrence[] {
+  const occurrencesCount = getOccurrencesNb(pacedTrain.paced);
+  const occurrences: BareOccurrence[] = [];
+  for (let i = 0; i < occurrencesCount; i++) {
+    const exception = pacedTrain.paced.exceptions.find((ex) => ex.occurrence_index === i);
+    const startTime = exception?.start_time
+      ? new Date(exception.start_time.value)
+      : computeIndexedOccurrenceStartTime(pacedTrain.startTime, pacedTrain.paced.interval, i);
+
+    occurrences.push({
+      id: formatEditoastIdToIndexedOccurrenceId({
+        trainScheduleId: pacedTrain.id,
+        occurrenceIndex: i,
+      }),
+      startTime,
+      exception,
+    });
+  }
+
+  for (const exception of pacedTrain.paced.exceptions) {
+    if (exception.occurrence_index !== undefined) {
+      continue;
+    }
+    // TODO_EXCEPTION: remove this error case when ID becomes mandatory
+    if (exception.id === undefined || exception.id === null) {
+      throw new Error('Exception ID must be defined');
+    }
+    if (!exception.start_time) {
+      throw new Error('Added exception must have a start_time change group');
+    }
+    occurrences.push({
+      id: formatEditoastIdToExceptionId({
+        trainScheduleId: pacedTrain.id,
+        exceptionId: exception.id,
+      }),
+      startTime: new Date(exception.start_time.value),
+      exception,
+    });
+  }
+
+  return occurrences;
+}

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
@@ -89,6 +89,7 @@ describe('useOccurrences', () => {
         exceptions: [
           {
             key: 'occurrence_1_0',
+            id: 42,
             occurrence_index: 0,
             train_name: { value: 'Exception Train 1' },
             start_time: { value: new Date('2026-06-09T08:05:00Z').getTime() },
@@ -108,6 +109,13 @@ describe('useOccurrences', () => {
           trainName: 'Exception Train 1',
           startTime: new Date('2026-06-09T08:05:00Z'),
           disabled: false,
+          exception: {
+            id: 42,
+            exceptionChangeGroups: {
+              train_name: { value: 'Exception Train 1' },
+              start_time: { value: new Date('2026-06-09T08:05:00Z').getTime() },
+            },
+          },
         },
         occurrence2,
         occurrence3,
@@ -175,6 +183,7 @@ describe('useOccurrences', () => {
         exceptions: [
           {
             key: 'occurrence_1_0',
+            id: 42,
             occurrence_index: 0,
             disabled: true,
           },
@@ -188,7 +197,11 @@ describe('useOccurrences', () => {
 
     expect(result.current).toEqual({
       occurrencesCount: 2,
-      occurrences: [{ ...occurrence1, disabled: true }, occurrence2, occurrence3],
+      occurrences: [
+        { ...occurrence1, disabled: true, exception: { id: 42, exceptionChangeGroups: {} } },
+        occurrence2,
+        occurrence3,
+      ],
     });
   });
 
@@ -200,6 +213,7 @@ describe('useOccurrences', () => {
         exceptions: [
           {
             key: 'occurrence_1_1',
+            id: 42,
             occurrence_index: 1,
             train_name: { value: 'Exception Train RS 1' },
             rolling_stock: {
@@ -220,6 +234,16 @@ describe('useOccurrences', () => {
         {
           ...occurrence2,
           trainName: 'Exception Train RS 1',
+          exception: {
+            id: 42,
+            exceptionChangeGroups: {
+              train_name: { value: 'Exception Train RS 1' },
+              rolling_stock: {
+                rolling_stock_name: 'low-rs',
+                comfort: 'STANDARD',
+              },
+            },
+          },
         },
         occurrence3,
       ],

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
@@ -40,7 +40,7 @@ const BASE_OCCURRENCE = {
   stopsCount: 5,
   category: { main_category: 'HIGH_SPEED_TRAIN' },
   rollingStock,
-  disabled: undefined,
+  disabled: false,
   exception: undefined,
   summary: undefined,
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrences.spec.ts
@@ -157,6 +157,7 @@ describe('useOccurrences', () => {
           id: 'exception_1_0',
           trainName: 'Added Exception Train',
           startTime: new Date('2026-06-09T10:00:00Z'),
+          occurrenceIndex: undefined,
           exception: {
             exceptionChangeGroups: {
               start_time: {

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -51,7 +51,7 @@ export const returnOccurrenceExceptionRollingStock = ({
 const useOccurrences = (
   pacedTrain: PacedTrainWithDetails,
   rollingStockList: LightRollingStockWithLiveries[] | null
-) => {
+): { occurrencesCount: number; occurrences: Occurrence[] } => {
   const {
     id,
     paced,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -100,10 +100,10 @@ const useOccurrences = (
           : pacedTrainCategory,
         occurrenceIndex: i,
         exception:
-          // TODO_EXCEPTION: remove the second check when use TrainScheduleException type
-          correspondingException && correspondingException.id
+          correspondingException
             ? {
-                id: correspondingException.id,
+                // TODO_EXCEPTION: remove `!` when use TrainScheduleException type
+                id: correspondingException.id!,
                 exceptionChangeGroups: omit(correspondingException, [
                   // TODO_EXCEPTION: remove 'key' when use TrainScheduleException type
                   'key',

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -2,24 +2,16 @@ import { useMemo } from 'react';
 
 import { omit, sortBy } from 'lodash';
 
+import { generateBareOccurrences } from 'applications/operationalStudies/helpers/generateBareOccurrences';
 import { intermediateStopsCount } from 'applications/operationalStudies/utils';
 import { type LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
 import computeOccurrenceName from 'modules/trainSchedule/helpers/computeOccurrenceName';
-import {
-  findExceptionWithOccurrenceId,
-  getOccurrencesNb,
-  computeIndexedOccurrenceStartTime,
-} from 'modules/trainSchedule/helpers/pacedTrain';
 import type {
   Occurrence,
   PacedTrainWithDetails,
   SimulatedException,
 } from 'modules/trainSchedule/types';
-import {
-  formatEditoastIdToTrainScheduleId,
-  formatTrainScheduleIdToExceptionId,
-  formatTrainScheduleIdToIndexedOccurrenceId,
-} from 'utils/trainId';
+import { isIndexedOccurrenceId, extractOccurrenceIndexFromOccurrenceId } from 'utils/trainId';
 
 export const returnOccurrenceExceptionRollingStock = ({
   exception,
@@ -53,7 +45,6 @@ const useOccurrences = (
   rollingStockList: LightRollingStockWithLiveries[] | null
 ): { occurrencesCount: number; occurrences: Occurrence[] } => {
   const {
-    id,
     paced,
     name,
     rollingStock,
@@ -63,48 +54,41 @@ const useOccurrences = (
   } = pacedTrain;
   const { exceptions } = paced;
 
-  const occurrencesCount = getOccurrencesNb(paced);
-
   const occurrences = useMemo(() => {
-    const computedOccurrences: Occurrence[] = [];
-    const trainScheduleId = formatEditoastIdToTrainScheduleId(id);
+    const computedOccurrences = generateBareOccurrences(pacedTrain).map(
+      ({ id, startTime, exception }): Occurrence => {
+        let occurrenceIndex: number | undefined;
+        let trainName = exception?.train_name?.value;
+        if (isIndexedOccurrenceId(id)) {
+          occurrenceIndex = extractOccurrenceIndexFromOccurrenceId(id);
+          trainName ??= computeOccurrenceName(name, occurrenceIndex);
+        } else {
+          trainName ??= `${name}/+`;
+        }
 
-    // Handle indexed occurrences
-    for (let i = 0; i < occurrencesCount; i += 1) {
-      const occurrenceId = formatTrainScheduleIdToIndexedOccurrenceId(trainScheduleId, i);
-
-      const correspondingException = findExceptionWithOccurrenceId(exceptions, occurrenceId);
-
-      const occurrenceRollingStock = returnOccurrenceExceptionRollingStock({
-        exception: correspondingException,
-        rollingStock,
-        rollingStockList,
-      });
-
-      const startTime = correspondingException?.start_time
-        ? new Date(correspondingException.start_time.value)
-        : computeIndexedOccurrenceStartTime(pacedTrain.startTime, paced.interval, i);
-
-      computedOccurrences.push({
-        id: occurrenceId,
-        trainName: correspondingException?.train_name?.value ?? computeOccurrenceName(name, i),
-        rollingStock: occurrenceRollingStock,
-        startTime,
-        stopsCount: correspondingException?.path_and_schedule
-          ? intermediateStopsCount(correspondingException.path_and_schedule)
-          : stopsCount,
-        disabled: correspondingException?.disabled ?? false,
-        // In the model, we can currently have a null category value so we need to handle this case
-        category: correspondingException?.rolling_stock_category
-          ? correspondingException.rolling_stock_category.value
-          : pacedTrainCategory,
-        occurrenceIndex: i,
-        exception:
-          correspondingException
+        return {
+          id,
+          startTime,
+          trainName,
+          occurrenceIndex,
+          rollingStock: returnOccurrenceExceptionRollingStock({
+            exception,
+            rollingStock,
+            rollingStockList,
+          }),
+          stopsCount: exception?.path_and_schedule
+            ? intermediateStopsCount(exception.path_and_schedule)
+            : stopsCount,
+          disabled: exception?.disabled ?? false,
+          category: exception?.rolling_stock_category
+            ? exception.rolling_stock_category.value
+            : pacedTrainCategory,
+          summary: exception?.summary ?? summary,
+          exception: exception
             ? {
                 // TODO_EXCEPTION: remove `!` when use TrainScheduleException type
-                id: correspondingException.id!,
-                exceptionChangeGroups: omit(correspondingException, [
+                id: exception.id!,
+                exceptionChangeGroups: omit(exception, [
                   // TODO_EXCEPTION: remove 'key' when use TrainScheduleException type
                   'key',
                   'occurrence_index',
@@ -114,54 +98,10 @@ const useOccurrences = (
                 ]),
               }
             : undefined,
+        };
+      }
+    );
 
-        summary: correspondingException?.summary ?? summary,
-      });
-    }
-
-    // Handle added exceptions
-    exceptions.forEach((exception) => {
-      if (exception.occurrence_index !== undefined || !exception.start_time) return;
-
-      const occurrenceRollingStock = returnOccurrenceExceptionRollingStock({
-        exception,
-        rollingStock,
-        rollingStockList,
-      });
-
-      const startTime = new Date(exception.start_time.value);
-
-      computedOccurrences.push({
-        // TODO_EXCEPTION: remove `!` when use TrainScheduleException type
-        id: formatTrainScheduleIdToExceptionId(trainScheduleId, Number(exception.id!)),
-        trainName: exception.train_name?.value ?? `${name}/+`,
-        rollingStock: occurrenceRollingStock,
-        startTime,
-        stopsCount: exception.path_and_schedule
-          ? intermediateStopsCount(exception.path_and_schedule)
-          : stopsCount,
-        disabled: false,
-        // In the model, we can currently have a null category value so we need to handle this case
-        category: exception.rolling_stock_category
-          ? exception.rolling_stock_category.value
-          : pacedTrainCategory,
-
-        exception: {
-          // TODO_EXCEPTION: remove `!` when use TrainScheduleException type
-          id: exception.id!,
-          exceptionChangeGroups: omit(exception, [
-            // TODO_EXCEPTION: remove 'key' when use TrainScheduleException type
-            'key',
-            'disabled',
-            'occurrence_index',
-            'summary',
-            'id',
-          ]),
-        },
-
-        summary: exception.summary ?? summary,
-      });
-    });
     return sortBy(computedOccurrences, 'startTime');
   }, [pacedTrain, rollingStockList]);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrences.ts
@@ -93,7 +93,7 @@ const useOccurrences = (
         stopsCount: correspondingException?.path_and_schedule
           ? intermediateStopsCount(correspondingException.path_and_schedule)
           : stopsCount,
-        disabled: correspondingException?.disabled,
+        disabled: correspondingException?.disabled ?? false,
         // In the model, we can currently have a null category value so we need to handle this case
         category: correspondingException?.rolling_stock_category
           ? correspondingException.rolling_stock_category.value
@@ -140,6 +140,7 @@ const useOccurrences = (
         stopsCount: exception.path_and_schedule
           ? intermediateStopsCount(exception.path_and_schedule)
           : stopsCount,
+        disabled: false,
         // In the model, we can currently have a null category value so we need to handle this case
         category: exception.rolling_stock_category
           ? exception.rolling_stock_category.value

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
@@ -143,106 +143,113 @@ describe('makeProjectedTrains', () => {
   });
 
   describe('paced train with 1 ADDED path exception', () => {
-    const exceptionId = 2;
-    const exception: PacedTrainException = {
-      key: exceptionId.toString(),
-      id: exceptionId,
-      path_and_schedule: {
-        margins: {
-          boundaries: [],
-          values: ['0%'],
+    const basePacedTrainProjection: TrainSpaceTimeData = {
+      name: 'auie',
+      departureTime: new Date('2025-07-09T05:30:00.000Z'),
+      originPathItem: {
+        id: 'origin',
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: { type: 'id', operational_point: 'a' },
         },
-        path: [
-          {
-            id: '3e6c78c6-89a9-462f-a0b3-1e4253cb6386',
-            location: {
-              type: 'operational_point_part_reference',
-              operational_point: {
-                uic: 11,
-                secondary_code: 'BV',
-                type: 'uic',
-              },
-            },
-          },
-          {
-            id: '00fd1b82-32ca-43fd-a46e-24b5bc6f0fd3',
-            location: {
-              type: 'operational_point_part_reference',
-              operational_point: {
-                uic: 14,
-                secondary_code: 'BV',
-                type: 'uic',
-              },
-            },
-          },
-        ],
-        power_restrictions: [],
-        schedule: [
-          {
-            at: '00fd1b82-32ca-43fd-a46e-24b5bc6f0fd3',
-            stop_for: 'P0D',
-          },
-        ],
       },
-      start_time: {
-        value: new Date('2025-07-30T14:00:00.000Z').getTime(),
+      destinationPathItem: {
+        id: 'destination',
+        location: {
+          type: 'operational_point_part_reference',
+          operational_point: { type: 'id', operational_point: 'b' },
+        },
       },
-      train_name: {
-        value: 'GE VPE +',
-      },
-    };
-
-    const exceptionProjection = {
       spaceTimeCurves: [
         {
-          positions: [0, 2408, 8726, 17630, 28475],
-          times: [0, 2000, 4000, 6000, 8000],
-        },
-        {
-          positions: [3747000, 4062674, 4370040, 5094361, 5568162],
-          times: [276550, 292849, 308849, 348849, 374849],
+          positions: [0, 2408, 8726, 17630, 40899],
+          times: [0, 2000, 4000, 6000, 10000],
         },
       ],
       signalUpdates: [],
+      id: 2564,
+      paced: {
+        timeWindow: Duration.parse('PT3H'),
+        interval: Duration.parse('PT1H'),
+        exceptions: [],
+        exceptionProjections: new Map(),
+      },
     };
 
-    const trainProjections: TrainSpaceTimeData[] = [
-      {
-        name: 'auie',
-        departureTime: new Date('2025-07-09T05:30:00.000Z'),
-        originPathItem: {
-          id: 'origin',
-          location: {
-            type: 'operational_point_part_reference',
-            operational_point: { type: 'id', operational_point: 'a' },
+    test('added path exception should use its own projection', () => {
+      const exceptionId = 2;
+      const exception: PacedTrainException = {
+        key: exceptionId.toString(),
+        id: exceptionId,
+        path_and_schedule: {
+          margins: {
+            boundaries: [],
+            values: ['0%'],
           },
+          path: [
+            {
+              id: '3e6c78c6-89a9-462f-a0b3-1e4253cb6386',
+              location: {
+                type: 'operational_point_part_reference',
+                operational_point: {
+                  uic: 11,
+                  secondary_code: 'BV',
+                  type: 'uic',
+                },
+              },
+            },
+            {
+              id: '00fd1b82-32ca-43fd-a46e-24b5bc6f0fd3',
+              location: {
+                type: 'operational_point_part_reference',
+                operational_point: {
+                  uic: 14,
+                  secondary_code: 'BV',
+                  type: 'uic',
+                },
+              },
+            },
+          ],
+          power_restrictions: [],
+          schedule: [
+            {
+              at: '00fd1b82-32ca-43fd-a46e-24b5bc6f0fd3',
+              stop_for: 'P0D',
+            },
+          ],
         },
-        destinationPathItem: {
-          id: 'destination',
-          location: {
-            type: 'operational_point_part_reference',
-            operational_point: { type: 'id', operational_point: 'b' },
-          },
+        start_time: {
+          value: new Date('2025-07-30T14:00:00.000Z').getTime(),
         },
+        train_name: {
+          value: 'GE VPE +',
+        },
+      };
+
+      const exceptionProjection = {
         spaceTimeCurves: [
           {
-            positions: [0, 2408, 8726, 17630, 40899],
-            times: [0, 2000, 4000, 6000, 10000],
+            positions: [0, 2408, 8726, 17630, 28475],
+            times: [0, 2000, 4000, 6000, 8000],
+          },
+          {
+            positions: [3747000, 4062674, 4370040, 5094361, 5568162],
+            times: [276550, 292849, 308849, 348849, 374849],
           },
         ],
         signalUpdates: [],
-        id: 2564,
+      };
+
+      const pacedTrain: TrainSpaceTimeData = {
+        ...basePacedTrainProjection,
         paced: {
-          timeWindow: Duration.parse('PT3H'),
-          interval: Duration.parse('PT1H'),
+          ...basePacedTrainProjection.paced!,
           exceptions: [exception],
           exceptionProjections: new Map([[exceptionId, exceptionProjection]]),
         },
-      },
-    ];
+      };
 
-    test('added path exception should use its own projection', () => {
-      const pacedTrain = trainProjections[0];
+      const trainProjections: TrainSpaceTimeData[] = [pacedTrain];
 
       const result = makeProjectedTrains(trainProjections);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
@@ -142,7 +142,7 @@ describe('makeProjectedTrains', () => {
     });
   });
 
-  describe('paced train with 1 ADDED path exception', () => {
+  describe('paced train with 1 ADDED exception', () => {
     const basePacedTrainProjection: TrainSpaceTimeData = {
       name: 'auie',
       departureTime: new Date('2025-07-09T05:30:00.000Z'),
@@ -285,6 +285,38 @@ describe('makeProjectedTrains', () => {
         type: 'exception',
         exception,
         ...exceptionProjection,
+      });
+    });
+
+    test('added exception should generate correct name', () => {
+      const exceptionStartTime = new Date('2025-07-30T14:00:00.000Z');
+      const exception: PacedTrainException = {
+        key: 'foo',
+        id: 2,
+        start_time: {
+          value: exceptionStartTime.getTime(),
+        },
+      };
+
+      const pacedTrain: TrainSpaceTimeData = {
+        ...basePacedTrainProjection,
+        paced: {
+          ...basePacedTrainProjection.paced!,
+          exceptions: [exception],
+        },
+      };
+
+      const result = makeProjectedTrains([pacedTrain]);
+
+      expect(result.length).toBe(4);
+      expect(result[3]).toEqual({
+        id: 'exception_2564_2',
+        name: 'auie/+≠',
+        departureTime: exceptionStartTime,
+        type: 'exception',
+        exception,
+        spaceTimeCurves: basePacedTrainProjection.spaceTimeCurves,
+        signalUpdates: basePacedTrainProjection.signalUpdates,
       });
     });
   });

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
@@ -1,16 +1,12 @@
 import { pick } from 'lodash';
 
+import { generateBareOccurrences } from 'applications/operationalStudies/helpers/generateBareOccurrences';
 import type { IndividualTrainProjection, TrainSpaceTimeData } from 'modules/simulationResult/types';
 import computeOccurrenceName from 'modules/trainSchedule/helpers/computeOccurrenceName';
 import {
-  computeIndexedOccurrenceStartTime,
-  findExceptionWithOccurrenceId,
-  getOccurrencesNb,
-} from 'modules/trainSchedule/helpers/pacedTrain';
-import {
-  formatTrainScheduleIdToIndexedOccurrenceId,
-  formatEditoastIdToExceptionId,
   formatEditoastIdToTrainScheduleId,
+  isIndexedOccurrenceId,
+  extractOccurrenceIndexFromOccurrenceId,
 } from 'utils/trainId';
 
 const EXCEPTION_SUFFIX = '≠';
@@ -21,101 +17,66 @@ const EXCEPTION_SUFFIX = '≠';
  */
 const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
   trainScheduleProjections.flatMap<IndividualTrainProjection>((projectedTrain) => {
-    const trainScheduleId = formatEditoastIdToTrainScheduleId(projectedTrain.id);
-    if (!projectedTrain.paced) {
-      return { ...projectedTrain, id: trainScheduleId, type: 'trainSchedule' };
+    const { paced } = projectedTrain;
+    if (!paced) {
+      return {
+        ...projectedTrain,
+        id: formatEditoastIdToTrainScheduleId(projectedTrain.id),
+        type: 'trainSchedule',
+      };
     }
 
-    const occurrences: IndividualTrainProjection[] = [];
     const pacedTrainCurves = pick(projectedTrain, [
       'spaceTimeCurves',
       'signalUpdates',
       'isSimulated',
     ]);
 
-    // =========== indexed occurrences ===========
-    const occurrencesCount = getOccurrencesNb(projectedTrain.paced);
-    for (let i = 0; i < occurrencesCount; i += 1) {
-      const occurrenceId = formatTrainScheduleIdToIndexedOccurrenceId(trainScheduleId, i);
-      const correspondingException = findExceptionWithOccurrenceId(
-        projectedTrain.paced.exceptions,
-        occurrenceId
-      );
-
-      // Disabled occurrences should not be displayed
-      if (correspondingException?.disabled) continue;
-
-      if (!correspondingException) {
-        occurrences.push({
-          ...pacedTrainCurves,
-          id: occurrenceId,
-          type: 'occurrence',
-          name: computeOccurrenceName(projectedTrain.name, i),
-          departureTime: computeIndexedOccurrenceStartTime(
-            projectedTrain.departureTime,
-            projectedTrain.paced.interval,
-            i
-          ),
-        });
-        continue;
-      }
-
-      const exceptionProjection = projectedTrain.paced.exceptionProjections.get(
-        correspondingException.id! // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
-      );
-
-      const departureTime = correspondingException.start_time
-        ? new Date(correspondingException.start_time.value)
-        : computeIndexedOccurrenceStartTime(
-            projectedTrain.departureTime,
-            projectedTrain.paced.interval,
-            i
+    return generateBareOccurrences({
+      id: projectedTrain.id,
+      startTime: projectedTrain.departureTime,
+      paced,
+    })
+      .filter(({ exception }) => !exception?.disabled)
+      .map(({ id, startTime: departureTime, exception }): IndividualTrainProjection => {
+        let name = exception?.train_name?.value;
+        if (isIndexedOccurrenceId(id)) {
+          name ??= computeOccurrenceName(
+            projectedTrain.name,
+            extractOccurrenceIndexFromOccurrenceId(id)
           );
+        } else {
+          name ??= projectedTrain.name + '/+';
+        }
+        if (exception) {
+          name += EXCEPTION_SUFFIX;
+        }
 
-      const name = correspondingException?.train_name
-        ? `${correspondingException.train_name.value}${EXCEPTION_SUFFIX}`
-        : `${computeOccurrenceName(projectedTrain.name, i)}${EXCEPTION_SUFFIX}`;
+        if (exception) {
+          // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
+          const exceptionProjection = paced.exceptionProjections.get(exception.id!);
 
-      occurrences.push({
-        ...(exceptionProjection ?? pacedTrainCurves),
-        id: occurrenceId,
-        type: 'exception',
-        name,
-        departureTime,
-        exception: correspondingException,
+          return {
+            ...(exceptionProjection ?? pacedTrainCurves),
+            id,
+            type: 'exception',
+            name,
+            departureTime,
+            exception,
+          };
+        } else {
+          if (!isIndexedOccurrenceId(id)) {
+            throw new Error('Occurrence without exception must be indexed');
+          }
+          return {
+            ...pacedTrainCurves,
+            id,
+            type: 'occurrence',
+            name,
+            departureTime,
+          };
+        }
       });
-    }
-
-    // =========== added exceptions ===========
-    for (const exception of projectedTrain.paced.exceptions) {
-      if (Number.isInteger(exception.occurrence_index)) {
-        // already done in the indexed occurrences loop above
-        continue;
-      }
-
-      // Disabled occurrences should not be displayed
-      if (exception.disabled) continue;
-
-      if (!exception.start_time) throw new Error('added exception should have a start time');
-
-      const id = formatEditoastIdToExceptionId({
-        trainScheduleId: projectedTrain.id,
-        exceptionId: exception.id!, // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
-      });
-      const name = exception.train_name
-        ? `${exception.train_name.value}${EXCEPTION_SUFFIX}`
-        : `${projectedTrain.name}/+${EXCEPTION_SUFFIX}`;
-
-      occurrences.push({
-        ...(projectedTrain.paced.exceptionProjections.get(exception.id!) ?? pacedTrainCurves), // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
-        id,
-        type: 'exception',
-        name,
-        departureTime: new Date(exception.start_time.value),
-        exception,
-      });
-    }
-    return occurrences;
   });
 
 export default makeProjectedTrains;

--- a/front/src/modules/trainSchedule/types.ts
+++ b/front/src/modules/trainSchedule/types.ts
@@ -112,11 +112,7 @@ export type ExceptionChangeGroups = Omit<
 
 export type Occurrence = {
   id: OccurrenceId;
-  /**
-   * Field present only for a regular occurrence.
-   * An added exception can only be deleted, not disabled.
-   */
-  disabled?: boolean;
+  disabled: boolean;
   category?: TrainCategory | null;
   occurrenceIndex?: number; // Optional, only if not created
   trainName: string;


### PR DESCRIPTION
This helper generates basic occurrence skeletons. It unifies code from `useOccurrences()` and `makeProjectedTrains()`.

_See individual commits._

First part of https://github.com/OpenRailAssociation/osrd/issues/17628