### PR TITLE
docker: use empty OSRD_GIT_DESCRIBE by default in Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
         test_data: tests/data
         static_assets: assets
       args:
-        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE-}
     environment:
       # Actual values in ./docker/osrdyne.yml (please maintain consistency)
       # Provided here only for reuse in compose layers and doc
@@ -174,7 +174,7 @@ services:
         static_assets: assets
       args:
         CARGO_PROFILE: dev
-        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE-}
     restart: unless-stopped
     ports: [ "8090:80" ]
     environment:
@@ -212,7 +212,7 @@ services:
       context: gateway
       dockerfile: Dockerfile
       args:
-        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE-}
         CARGO_PROFILE: dev
       additional_contexts:
         front_src: front
@@ -234,7 +234,7 @@ services:
       dockerfile: Dockerfile
       args:
         CARGO_PROFILE: dev
-        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
+        OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE-}
     restart: unless-stopped
     ports: [ "4242:4242" ]
     environment:


### PR DESCRIPTION
Makes it clear that it's fine to leave this variable unset.

Fixes this Podman warning:

    WARN[0000] The "OSRD_GIT_DESCRIBE" variable is not set. Defaulting to a blank string.