### PR TITLE
editoast: fix valkey query timeout using spawn_blocking for cpu bound

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -640,6 +640,7 @@ dependencies = [
  "arcstr",
  "deadpool-redis",
  "futures 0.3.32",
+ "itertools 0.15.0",
  "rand 0.10.2",
  "redis-test",
  "serde",

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "redis-test",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "url",
  "zstd",

--- a/editoast/cache/Cargo.toml
+++ b/editoast/cache/Cargo.toml
@@ -11,6 +11,7 @@ mock = ["redis-test"]
 arcstr.workspace = true
 deadpool-redis.workspace = true
 futures.workspace = true
+itertools.workspace = true
 rand.workspace = true
 redis-test = { version = "1.0.3", optional = true } # /!\ latest version's 'redis' dependency may not compatible with deadpool-redis re-export
 serde.workspace = true

--- a/editoast/cache/Cargo.toml
+++ b/editoast/cache/Cargo.toml
@@ -16,6 +16,7 @@ rand.workspace = true
 redis-test = { version = "1.0.3", optional = true } # /!\ latest version's 'redis' dependency may not compatible with deadpool-redis re-export
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 zstd.workspace = true

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -165,52 +165,50 @@ impl Connection {
 
     /// Set a serializable value to valkey with expiry time
     #[tracing::instrument(name = "cache:json_set", skip(self, value), err)]
-    pub async fn json_set<K: Debug + ToSingleRedisArg + Send + Sync, T: Serialize>(
+    pub async fn json_set<
+        K: Debug + ToSingleRedisArg + Send + Sync + 'static,
+        T: Serialize + Send + Sync + 'static,
+    >(
         &mut self,
         key: K,
-        value: &T,
+        value: T,
     ) -> Result<(), RedisError> {
-        self.json_set_bulk(&[(key, value)]).await
+        self.json_set_bulk(vec![(key, value)]).await
     }
 
     /// Set a list of serializable values to valkey
     #[tracing::instrument(name = "cache:json_set_bulk", skip(self, items), err)]
-    pub async fn json_set_bulk<K: Debug + ToRedisArgs + Send + Sync, T: Serialize>(
+    pub async fn json_set_bulk<
+        K: Debug + ToRedisArgs + Send + Sync + 'static,
+        T: Serialize + Send + Sync + 'static,
+    >(
         &mut self,
-        items: &[(K, T)],
+        items: Vec<(K, T)>,
     ) -> Result<(), RedisError> {
         // Avoid mset to fail if keys is empty
         if items.is_empty() {
             return Ok(());
         }
 
-        let compressed_items = span!(Level::INFO, "Compressing data").in_scope(|| {
-            items
-                .iter()
-                .filter_map(|(key, value)| {
-                    let mut encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
-                    // Serialize the `value` into JSON format and write it to the encoder (which compresses it).
-                    if let Err(e) = serde_json::to_writer(&mut encoder, value) {
-                        tracing::warn!(
-                            "failed to serialize value to JSON for type '{}': {e}",
-                            std::any::type_name::<T>()
-                        );
-                        return None;
-                    }
-                    // Finalize the compression process and retrieve the compressed data.
-                    match encoder.finish() {
-                        Ok(compressed_value) => Some((key, compressed_value)),
-                        Err(e) => {
-                            tracing::warn!(
-                                "failed to compress value for type '{}': {e}",
-                                std::any::type_name::<T>()
-                            );
-                            None
-                        }
-                    }
+        let handles = items
+            .into_iter()
+            .map(|(key, value)| {
+                tokio::task::spawn_blocking(move || {
+                    // Serialization and compression in two steps to avoid perf issues.
+                    // TODO: Investigate why using Streaming is slower even with BufReader in the middle.
+                    let serialized_value =
+                        serde_json::to_vec(&value).expect("Failed to serialize value to JSON");
+                    let compressed_value = zstd::encode_all(&serialized_value[..], 1)
+                        .expect("Failed to compress value with zstd");
+                    (key, compressed_value)
                 })
-                .collect::<Vec<_>>()
-        });
+                .instrument(info_span!("Serializing data"))
+            })
+            .collect_vec();
+
+        let compressed_items: Vec<(K, Vec<u8>)> = future::try_join_all(handles)
+            .await
+            .expect("Failed to join the serialization task");
 
         // Store the compressed values using mset
         if !compressed_items.is_empty() {

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -150,7 +150,7 @@ impl Connection {
 
     /// Get a deserializable value from valkey
     #[tracing::instrument(name = "cache:json_get", skip(self), err)]
-    pub async fn json_get<T: DeserializeOwned, K: Debug + ToSingleRedisArg + Send + Sync>(
+    pub async fn json_get<K: Debug + ToSingleRedisArg + Send + Sync, T: DeserializeOwned>(
         &mut self,
         key: K,
     ) -> Result<Option<T>, RedisError> {
@@ -217,7 +217,7 @@ impl Connection {
 
     /// Get a list of deserializable value from valkey
     #[tracing::instrument(name = "cache:json_get_bulk", skip(self), err)]
-    pub async fn json_get_bulk<T: DeserializeOwned, K: Debug + ToRedisArgs + Send + Sync>(
+    pub async fn json_get_bulk<K: Debug + ToRedisArgs + Send + Sync, T: DeserializeOwned>(
         &mut self,
         keys: &[K],
     ) -> Result<impl Iterator<Item = Option<T>>, RedisError> {

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -14,6 +14,7 @@ use deadpool_redis::redis::Value;
 use deadpool_redis::redis::aio::ConnectionLike;
 use futures::FutureExt;
 use futures::future;
+use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -154,7 +155,7 @@ impl Connection {
         &mut self,
         key: K,
     ) -> Result<Option<T>, RedisError> {
-        Ok(self.json_get_bulk(&[key]).await?.next().unwrap())
+        Ok(self.json_get_bulk(&[key]).await?.pop().unwrap())
     }
 
     /// Set a serializable value to valkey with expiry time
@@ -220,7 +221,7 @@ impl Connection {
     pub async fn json_get_bulk<K: Debug + ToRedisArgs + Send + Sync, T: DeserializeOwned>(
         &mut self,
         keys: &[K],
-    ) -> Result<impl Iterator<Item = Option<T>>, RedisError> {
+    ) -> Result<Vec<Option<T>>, RedisError> {
         debug!(nb_keys = keys.len());
 
         // Fetch the values from Redis
@@ -253,6 +254,7 @@ impl Connection {
                         }
                     })
                 })
+                .collect_vec()
         });
         Ok(cached_values)
     }

--- a/editoast/cache/src/connection.rs
+++ b/editoast/cache/src/connection.rs
@@ -18,8 +18,10 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use tracing::Instrument;
 use tracing::Level;
 use tracing::debug;
+use tracing::info_span;
 use tracing::span;
 
 pub struct Connection {
@@ -151,7 +153,10 @@ impl Connection {
 
     /// Get a deserializable value from valkey
     #[tracing::instrument(name = "cache:json_get", skip(self), err)]
-    pub async fn json_get<K: Debug + ToSingleRedisArg + Send + Sync, T: DeserializeOwned>(
+    pub async fn json_get<
+        K: Debug + ToSingleRedisArg + Send + Sync,
+        T: DeserializeOwned + Send + 'static,
+    >(
         &mut self,
         key: K,
     ) -> Result<Option<T>, RedisError> {
@@ -218,14 +223,17 @@ impl Connection {
 
     /// Get a list of deserializable value from valkey
     #[tracing::instrument(name = "cache:json_get_bulk", skip(self), err)]
-    pub async fn json_get_bulk<K: Debug + ToRedisArgs + Send + Sync, T: DeserializeOwned>(
+    pub async fn json_get_bulk<
+        K: Debug + ToRedisArgs + Send + Sync,
+        T: DeserializeOwned + Send + 'static,
+    >(
         &mut self,
         keys: &[K],
     ) -> Result<Vec<Option<T>>, RedisError> {
         debug!(nb_keys = keys.len());
 
         // Fetch the values from Redis
-        let values = if !keys.is_empty() {
+        let compressed_values = if !keys.is_empty() {
             span!(Level::INFO, "Fetching values from Valkey")
                 .in_scope(async || self.mget::<_, Vec<Option<Vec<u8>>>>(keys).await)
                 .await?
@@ -234,29 +242,36 @@ impl Connection {
             vec![]
         };
 
-        // Decompress each value if it exists
-        let cached_values = span!(Level::INFO, "Decompressing data").in_scope(|| {
-            values
-                .into_iter()
-                .map(|value| {
-                    value.and_then(|compressed_data| {
-                        let mut decoder = zstd::Decoder::new(&compressed_data[..]).unwrap();
-
-                        match serde_json::from_reader(&mut decoder) {
-                            Ok(deserialized) => Some(deserialized),
-                            Err(e) => {
-                                tracing::warn!(
-                                    "the cached value is not a valid compressed JSON data for type '{}': {e}",
-                                    std::any::type_name::<T>()
-                                );
-                                None
-                            }
-                        }
+        let handles = compressed_values
+            .into_iter()
+            .map(|v| {
+                v.map(|v| {
+                    tokio::task::spawn_blocking(move || {
+                        // Decompress and deserialize in two steps to avoid buffering issue.
+                        // TODO: Investigate why using Streaming is slower even with BufReader in the middle.
+                        let decompressed_data = zstd::decode_all(&v[..])
+                            .expect("Failed to decompress data from Valkey");
+                        serde_json::from_slice::<T>(&decompressed_data)
+                            .expect("Failed to deserialize JSON data from Valkey")
                     })
+                    .instrument(info_span!("Decompressing + Deserializing data"))
                 })
-                .collect_vec()
-        });
-        Ok(cached_values)
+            })
+            .collect_vec();
+
+        let mut results = Vec::with_capacity(handles.len());
+        for handle in handles {
+            match handle {
+                Some(handle) => {
+                    let result = handle
+                        .await
+                        .expect("Failed to join the decompression + deserialization task");
+                    results.push(Some(result));
+                }
+                None => results.push(None),
+            }
+        }
+        Ok(results)
     }
 
     /// Add one serializable member to a sorted set, or update its score if it already exists.

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -41,7 +41,7 @@ impl<T> TrainKey for T where T: Clone + Hash + Eq + Send + Sync {}
 /// - [trait TaskStreamExt] to batch tasks (requires additional [type Task::Context] bounds)
 pub trait Task: Sized + Send {
     /// Task output
-    type Output: DeserializeOwned + Serialize + Send;
+    type Output: DeserializeOwned + Serialize + Send + 'static;
     /// Computation error when running a task for cache misses
     type Error: std::error::Error + Send;
     /// Context required for task

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -219,7 +219,7 @@ where
                 async move {
                     while let Some((key, value)) = cache_write_rx.recv().await {
                         let mut vkconn = vk_client.get_connection().await.unwrap();
-                        if let Err(e) = vkconn.json_set(key.clone(), &value).await {
+                        if let Err(e) = vkconn.json_set(key.clone(), value).await {
                             tracing::error!(?e, key, "task stream: cache write failure")
                         }
                     }

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -84,7 +84,7 @@ pub trait Task: Sized + Send {
         let key = self.key(vk_client.app_version());
         let cache_entry = match vk_client.get_connection().await {
             Ok(mut vkconn) => vkconn
-                .json_get::<Self::Output, _>(&key)
+                .json_get::<_, Self::Output>(&key)
                 .await
                 .map_err(|e| e.into()),
             Err(e) => Err(e),
@@ -272,7 +272,7 @@ where
                         // Fetch from valkey or compute and write to valkey
 
                         let mut vkconn = vk_client.get_connection().await.unwrap();
-                        match vkconn.json_get_bulk::<T::Output, _>(keys.as_slice()).await {
+                        match vkconn.json_get_bulk::<_, T::Output>(keys.as_slice()).await {
                             Ok(cached_values) => {
                                 for (value, correlation, key, input) in
                                     izip!(cached_values, correlation_keys, cache_keys, inputs)

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -41,7 +41,7 @@ impl<T> TrainKey for T where T: Clone + Hash + Eq + Send + Sync {}
 /// - [trait TaskStreamExt] to batch tasks (requires additional [type Task::Context] bounds)
 pub trait Task: Sized + Send {
     /// Task output
-    type Output: DeserializeOwned + Serialize + Send + 'static;
+    type Output: DeserializeOwned + Serialize + Clone + Send + Sync + 'static;
     /// Computation error when running a task for cache misses
     type Error: std::error::Error + Send;
     /// Context required for task
@@ -100,27 +100,18 @@ pub trait Task: Sized + Send {
             None => {
                 tracing::trace!(key, "cache miss");
                 let value = self.compute(ctx).await?;
-                match serde_json::to_string(&value) {
-                    Err(e) => {
-                        tracing::error!(
-                            ?e,
-                            key,
-                            "serialization error before cache write — skipping cache write"
-                        );
-                    }
-                    Ok(serialized) => {
-                        tokio::spawn(
-                            async move {
-                                use deadpool_redis::redis::AsyncCommands as _;
-                                let mut vkconn = vk_client.get_connection().await.unwrap();
-                                if let Err(e) = vkconn.set::<_, _, ()>(&key, serialized).await {
-                                    tracing::error!(?e, key, "cache write error");
-                                }
+                {
+                    let value = value.clone();
+                    tokio::spawn(
+                        async move {
+                            let mut vkconn = vk_client.get_connection().await.unwrap();
+                            if let Err(e) = vkconn.json_set(key.clone(), value).await {
+                                tracing::error!(?e, key, "cache write error");
                             }
-                            .in_current_span(),
-                        );
-                    }
-                };
+                        }
+                        .in_current_span(),
+                    );
+                }
                 Ok(value)
             }
         }

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -303,6 +303,7 @@ async fn pathfinding_blocks_batch(
     let pathfinding_cached_results: Vec<Option<Arc<PathfindingResult>>> = valkey_conn
         .json_get_bulk(&hashes)
         .await?
+        .into_iter()
         .map(|result| result.map(Arc::new))
         .collect();
     let pathfinding_cached_results: HashMap<_, _> =

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -348,7 +348,7 @@ async fn pathfinding_blocks_batch(
                 hash_to_path_indexes[hash]
                     .iter()
                     .for_each(|index| pathfinding_results[*index] = arc_result.clone());
-                to_cache.push((hash, result));
+                to_cache.push((hash.to_string(), result));
             }
         }
     }
@@ -368,7 +368,7 @@ async fn pathfinding_blocks_batch(
 
     for (path_result, hash) in computed_paths.into_iter().zip(to_compute_hashes) {
         let path = path_result?;
-        to_cache.push((hash, Box::new(path.clone().into())));
+        to_cache.push((hash.to_string(), Box::new(path.clone().into())));
         let result: Arc<PathfindingResult> = Arc::new(path.into());
         hash_to_path_indexes[hash]
             .iter()
@@ -376,7 +376,7 @@ async fn pathfinding_blocks_batch(
     }
 
     debug!(nb_cached = to_cache.len(), "Caching pathfinding response");
-    valkey_conn.json_set_bulk(&to_cache).await?;
+    valkey_conn.json_set_bulk(to_cache).await?;
 
     Ok(pathfinding_results)
 }

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -391,9 +391,8 @@ pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
     // 3. Retrieve cached projection
 
     let cached_projections = valkey_conn
-        .json_get_bulk(&train_hashes)
-        .await?
-        .collect::<Vec<Option<Vec<SpaceTimeCurve>>>>();
+        .json_get_bulk::<_, Vec<SpaceTimeCurve>>(&train_hashes)
+        .await?;
 
     let mut projection_request_map: HashMap<String, TrainSimulationDetails> = HashMap::new();
     let mut project_path_result: Vec<Arc<Vec<SpaceTimeCurve>>> =

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -430,7 +430,7 @@ pub async fn compute_projected_train_paths<T: TrainScheduleLike>(
         .collect::<Vec<_>>();
 
     // 5. Store the projection in the cache
-    valkey_conn.json_set_bulk(&space_time_curves).await?;
+    valkey_conn.json_set_bulk(space_time_curves.clone()).await?;
 
     // 6. Build the projection response
     for (hash, space_time_curve) in space_time_curves.into_iter() {

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -179,9 +179,8 @@ pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
 
     // 3. Retrieve cached occupancy blocks
     let cached_blocks = valkey_conn
-        .json_get_bulk(&train_hashes)
-        .await?
-        .collect::<Vec<Option<OccupancyBlocks>>>();
+        .json_get_bulk::<_, OccupancyBlocks>(&train_hashes)
+        .await?;
 
     let mut occupancy_blocks_result = vec![Arc::default(); trains_schedules.len()];
     let mut occupancy_block_requests = vec![];

--- a/editoast/src/views/timetable/occupancy_blocks.rs
+++ b/editoast/src/views/timetable/occupancy_blocks.rs
@@ -220,14 +220,14 @@ pub(super) async fn compute_occupancy_blocks<T: TrainScheduleLike>(
     // 5. Store block occupancies in the cache
     let occupancy_blocks: Vec<_> = occupancy_block_requests
         .iter()
-        .map(|(hash, _)| hash)
+        .map(|(hash, _)| hash.to_string())
         .zip(signal_updates.clone())
         .collect();
-    valkey_conn.json_set_bulk(&occupancy_blocks).await?;
+    valkey_conn.json_set_bulk(occupancy_blocks.clone()).await?;
 
     // 6. Build block occupancy response
     for (hash, occupancy_blocks) in occupancy_blocks.into_iter() {
-        let indexes = &train_hashes_to_idx[hash];
+        let indexes = &train_hashes_to_idx[&hash];
         let occupancy_blocks = Arc::new(occupancy_blocks);
         for index in indexes {
             occupancy_blocks_result[*index] = occupancy_blocks.clone();

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -567,6 +567,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     let cached_results: Vec<Option<Arc<simulation::Response>>> = valkey_conn
         .json_get_bulk(&cached_simulation_hash)
         .await?
+        .into_iter()
         .map(|simulation| simulation.map(Arc::new))
         .collect();
 

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -598,7 +598,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
         let train_indexes = &to_sim[train_hash];
         match sim_res {
             Ok(sim_res) => {
-                to_cache.push((train_hash, sim_res.clone()));
+                to_cache.push((train_hash.to_string(), sim_res.clone()));
                 let sim_res = Arc::new(simulation::Response::from(sim_res));
                 train_indexes
                     .iter()
@@ -618,7 +618,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
     }
 
     // Cache the simulation response
-    valkey_conn.json_set_bulk(&to_cache).await?;
+    valkey_conn.json_set_bulk(to_cache).await?;
 
     // Return the response
     Ok(simulation_results


### PR DESCRIPTION
### Root issue

When *core* loads its requirements, editoast do a lot of work with the cache. It can lead to timeouts (>1s). This leads to retries from core and can fail the full loading.

Note: This is more difficult to reproduce locally.

### Cause

The issue comes from editoast and not the valkey/elasticache server 😨 .
We're doing decompression after retrieving values from valkey. This decompression uses the CPU heavily, which can lead to cpu bounds issue. 
Tokio task can take more time to be handled, leading to timeouts.

### What is done

1. Adapt signature of `json_get_bulk` (for consistency)
2. Stop streaming response from `json_get_bulk` return a `Vec` instead. This allows us to have better tracing and it's also required for the 3rd step
3. Run decompression and deserialization in separated `tokio::task::spawn_blocking`
  - Don't block the main event loop
  - Run concurrently the decompression / deserialization
4. Run compression and serialization in a separated `tokio::task::spawn_blocking`
5. Fix @hhirtz caught bug. Path properties did not work properly, but with this PR it panicked.

> [!TIP]
> I observed that doing decompression and deserialization without using stream is faster 🤔 
> I tried adding intermediate buffering (having a 100KiB buffer is a little bit better). 

### Benchmark (hot cache)

**Before:**

<img width="1680" height="838" alt="image" src="https://github.com/user-attachments/assets/4822f887-6d09-4ac3-88f0-f5e630c6b153" />

Full trace: [before.json](https://github.com/user-attachments/files/30053022/before.json)
Time: ~1800ms

**After:**

<img width="1680" height="840" alt="image" src="https://github.com/user-attachments/assets/db106599-9c9d-4e43-abeb-01b5ddc382cb" />


Full trace: [after.json](https://github.com/user-attachments/files/30053135/after.json)
Time: ~530ms
