### PR TITLE
editoast: add project fga model

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -215,6 +215,9 @@ impl fga::model::Type for Role {
     }
 }
 
+#[derive(fga::Type, fga::Object, derive_more::FromStr, Debug)]
+pub struct Project(pub i64);
+
 fga::relations! {
     User {
         role: Role,
@@ -249,6 +252,11 @@ fga::relations! {
         can_share_write: User,
         can_share_ownership: User,
         can_revoke: User
+    },
+    Project {
+        owner: User,
+        // Computed
+        has_access: User
     }
 }
 

--- a/editoast/fga_migrations/migrations/3_project_model.fga
+++ b/editoast/fga_migrations/migrations/3_project_model.fga
@@ -1,0 +1,52 @@
+model
+  schema 1.1
+
+type role # 3 roles in DB: role:OperationalStudies, role:Stdcm, role:Admin
+
+type user
+  relations
+    define role: [role] or role from group
+    define group: [group]
+    define manager: manager from group
+
+type group
+  relations
+    define role: [role]
+    define manager: [user]
+    define member: [user]
+
+type infra
+  relations
+    define reader: [user, group#member, group#manager, user#manager]
+    define writer: [user, group#member, group#manager, user#manager]
+    define owner: [user, group#member, group#manager, user#manager]
+
+    define can_read: reader or can_write
+    define can_write: writer or can_delete
+    define can_delete: owner
+
+    define can_share_read: can_read
+    define can_share_write: can_write
+    define can_share_ownership: owner
+    define can_revoke: owner
+
+type rolling_stock
+  relations
+    define reader: [user, group#member, group#manager, user#manager]
+    define writer: [user, group#member, group#manager, user#manager]
+    define owner: [user, group#member, group#manager, user#manager]
+
+    define can_read: reader or can_write
+    define can_write: writer or can_delete
+    define can_delete: owner
+
+    define can_share_read: can_read
+    define can_share_write: can_write
+    define can_share_ownership: owner
+    define can_revoke: owner
+
+type project
+  relations
+    define owner: [user, group#member, group#manager, user#manager]
+
+    define has_access: owner


### PR DESCRIPTION
## Context

See #17546

## Goals

- Add `project` object to fga migration
```
type project
  relations
    define owner: [user, group#member, group#manager, user#manager]

    define has_access: owner
```
- Add model in `authz::model.rs`

