### PR TITLE
front: parse start_time as Date or Duration based on timetable type

### DIFF
--- a/front/src/applications/operationalStudies/helpers/generateBareOccurrences.ts
+++ b/front/src/applications/operationalStudies/helpers/generateBareOccurrences.ts
@@ -2,22 +2,50 @@ import {
   getOccurrencesNb,
   computeIndexedOccurrenceStartTime,
 } from 'modules/trainSchedule/helpers/pacedTrain';
-import type { PacedTrainWithDetails, SimulatedException } from 'modules/trainSchedule/types';
+import type {
+  PacedDetails,
+  PacedTrainWithDetails,
+  SimulatedException,
+} from 'modules/trainSchedule/types';
 import type { OccurrenceId } from 'reducers/osrdconf/types';
+import { msToStartTime, type Duration, type StartTime } from 'utils/duration';
 import {
   formatEditoastIdToIndexedOccurrenceId,
   formatEditoastIdToExceptionId,
 } from 'utils/trainId';
 
-export type BareOccurrence = {
+export type BareOccurrence<T extends StartTime = StartTime> = {
   id: OccurrenceId;
-  startTime: Date;
+  startTime: T;
   exception: SimulatedException | undefined;
 };
 
 /**
  * Given a paced train, generate basic details for all occurrences.
+ *
+ * Overloaded on the paced train's start time type so that callers still working with a
+ * plain Date (e.g. TrainSpaceTimeData.departureTime, not yet adapted for hourly
+ * timetables) get back a Date, while callers holding a StartTime (Date | Duration) get
+ * back a StartTime.
+ *
+ * TODO Hourly timetables: this overload only exists for the migration. Once
+ * TrainSpaceTimeData.departureTime (and the rest of the STD) is adapted to StartTime,
+ * drop the Date-only overload and the BareOccurrence<T> generic, and type this function
+ * with StartTime only.
  */
+export function generateBareOccurrences(pacedTrain: {
+  id: number;
+  startTime: Date;
+  paced: PacedDetails;
+}): BareOccurrence<Date>[];
+export function generateBareOccurrences(pacedTrain: {
+  id: number;
+  startTime: Duration;
+  paced: PacedDetails;
+}): BareOccurrence<Duration>[];
+export function generateBareOccurrences(
+  pacedTrain: Pick<PacedTrainWithDetails, 'id' | 'startTime' | 'paced'>
+): BareOccurrence[];
 export function generateBareOccurrences(
   pacedTrain: Pick<PacedTrainWithDetails, 'id' | 'startTime' | 'paced'>
 ): BareOccurrence[] {
@@ -26,7 +54,7 @@ export function generateBareOccurrences(
   for (let i = 0; i < occurrencesCount; i++) {
     const exception = pacedTrain.paced.exceptions.find((ex) => ex.occurrence_index === i);
     const startTime = exception?.start_time
-      ? new Date(exception.start_time.value)
+      ? msToStartTime(exception.start_time.value, pacedTrain.startTime)
       : computeIndexedOccurrenceStartTime(pacedTrain.startTime, pacedTrain.paced.interval, i);
 
     occurrences.push({
@@ -55,7 +83,7 @@ export function generateBareOccurrences(
         trainScheduleId: pacedTrain.id,
         exceptionId: exception.id,
       }),
-      startTime: new Date(exception.start_time.value),
+      startTime: msToStartTime(exception.start_time.value, pacedTrain.startTime),
       exception,
     });
   }

--- a/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazySimulateTrains.ts
@@ -3,6 +3,7 @@ import { useRef, useEffect, useCallback, useState } from 'react';
 import type {
   LightRollingStockWithLiveries,
   PacedTrainException,
+  TimetableType,
   TrainScheduleSimulationSummaryResult,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
@@ -16,6 +17,7 @@ import TrainSimulationLazyLoader from '../helpers/TrainSimulationLazyLoader';
 type UseLazySimulateTrainsOptions = {
   infraId: number;
   timetableId: number;
+  timetableType: TimetableType;
   electricalProfileSetId: number | undefined;
   rollingStocks: LightRollingStockWithLiveries[] | null;
   onProgress?: (results: Map<number, TrainScheduleWithDetails>) => void;
@@ -39,6 +41,7 @@ type UseLazySimulateTrainsOptions = {
 export default function useLazySimulateTrains({
   infraId,
   timetableId,
+  timetableType,
   electricalProfileSetId,
   rollingStocks,
   onProgress,
@@ -66,7 +69,8 @@ export default function useLazySimulateTrains({
         const summaries = formatTrainScheduleSummaries(
           trainScheduleSummaries,
           trainSchedulesByIdRef.current,
-          rollingStocks
+          rollingStocks,
+          timetableType
         );
         setSimulatedTrainsById((prev) => new Map([...prev.entries(), ...summaries.entries()]));
         if (onProgressRef.current) onProgressRef.current(summaries);

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -135,6 +135,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
   } = useLazySimulateTrains({
     infraId,
     timetableId,
+    timetableType: scenario.timetable_type,
     electricalProfileSetId: scenario.electrical_profile_set_id,
     rollingStocks,
     onProgress: (summaries) => {
@@ -164,10 +165,10 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
       const simulatedTrain = simulatedTrainsById.get(trainSchedule.id);
       if (simulatedTrain) return simulatedTrain;
       const rollingStock = rollingStocksByName.get(trainSchedule.rolling_stock_name);
-      return formatTrainScheduleWithDetails(trainSchedule, rollingStock);
+      return formatTrainScheduleWithDetails(trainSchedule, scenario.timetable_type, rollingStock);
     });
     return sortBy(trains, ['startTime', 'name', 'id']);
-  }, [trainSchedules, rollingStocksByName, simulatedTrainsById]);
+  }, [trainSchedules, rollingStocksByName, simulatedTrainsById, scenario.timetable_type]);
 
   const projectedTrains = useMemo(
     () => Array.from(projectedTrainsById.values()),

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
@@ -4,6 +4,7 @@ import type { PacedTrainException, TrainSchedule } from 'common/api/osrdEditoast
 import { isPacedTrainBase } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { PacedTrainWithDetails, TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import type { OperationalStudiesConfState, OccurrenceId, PathStep } from 'reducers/osrdconf/types';
+import { startTimeToMs } from 'utils/duration';
 import { kmhToMs } from 'utils/physics';
 import { extractOccurrenceIndexFromOccurrenceId, isIndexedOccurrenceId } from 'utils/trainId';
 
@@ -102,7 +103,7 @@ export function formatTrainScheduleWithDetailsToTrainSchedule(
     rolling_stock_name: trainScheduleWithDetails.rollingStock?.name ?? '',
     schedule: trainScheduleWithDetails.schedule,
     speed_limit_tag: trainScheduleWithDetails.speed_limit_tag,
-    start_time: trainScheduleWithDetails.startTime.getTime(),
+    start_time: startTimeToMs(trainScheduleWithDetails.startTime),
     train_name: trainScheduleWithDetails.name,
   };
 }

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -30,7 +30,7 @@ import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selector
 import { useAppDispatch } from 'store';
 import { addElementAtIndex } from 'utils/array';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
-import { addDurationToDate } from 'utils/duration';
+import { addDurationToDate, startTimeToDate } from 'utils/duration';
 import {
   getExceptionType,
   isExceptionFromPathOrSimulation,
@@ -93,7 +93,9 @@ const OccurrenceItem = ({
 
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
-  const { trainName, rollingStock, startTime, disabled, exception, summary } = occurrence;
+  const { trainName, rollingStock, disabled, exception, summary } = occurrence;
+  // TODO Hourly timetables: display the actual start time instead of a fictive date
+  const startTime = startTimeToDate(occurrence.startTime);
   const exceptionChangeGroups = exception?.exceptionChangeGroups;
 
   let arrivalTime: Date | undefined;
@@ -103,7 +105,7 @@ const OccurrenceItem = ({
     isAfterMidnight = dayjs(arrivalTime).isAfter(startTime, 'day');
   }
   const isNextAfterMidnight =
-    !!nextOccurrence && dayjs(nextOccurrence.startTime).isAfter(startTime, 'day');
+    !!nextOccurrence && dayjs(startTimeToDate(nextOccurrence.startTime)).isAfter(startTime, 'day');
   const isStartTimeException = !!exceptionChangeGroups?.start_time;
 
   const closeMenu = () => {
@@ -278,7 +280,8 @@ const OccurrenceItem = ({
         {nextOccurrence && isNextAfterMidnight && (
           <ConsecutiveDayDateDisplay
             departureTime={startTime}
-            nextDepartureTime={nextOccurrence?.startTime}
+            // TODO Hourly timetables: display the actual start time instead of a fictive date
+            nextDepartureTime={startTimeToDate(nextOccurrence.startTime)}
           />
         )}
       </div>

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/useOccurrenceActions.ts
@@ -28,6 +28,7 @@ import type { OccurrenceId } from 'reducers/osrdconf/types';
 import { updateSelectedTrain, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import { getSelectedTrain } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
+import { msToStartTime, startTimeToMs } from 'utils/duration';
 import { extractExceptionIdFromOccurrenceId, isIndexedOccurrenceId } from 'utils/trainId';
 
 type OccurrenceActionsParams = {
@@ -102,7 +103,7 @@ const useOccurrenceActions = ({
         train_name: editedOccurrence.trainName,
         speed_limit_tag: pacedTrain.speedLimitTag,
         rolling_stock_name: editedOccurrence.rollingStock?.name || '',
-        start_time: editedOccurrence.startTime.getTime(),
+        start_time: startTimeToMs(editedOccurrence.startTime),
       };
 
       const {
@@ -117,7 +118,7 @@ const useOccurrenceActions = ({
         ...pacedTrain,
         ...occurrenceProps,
         name: train_name,
-        startTime: new Date(start_time),
+        startTime: msToStartTime(start_time, pacedTrain.startTime),
         speedLimitTag: speed_limit_tag ?? null,
         rollingStock: editedOccurrence.rollingStock,
       };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
@@ -21,6 +21,7 @@ import {
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
+import { startTimeToDate } from 'utils/duration';
 import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
 
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from '../../consts';
@@ -118,7 +119,8 @@ const TrainList = ({
   const currentDepartureDates = useMemo(
     () =>
       trainSchedulesWithDetails.map((train) =>
-        formatDepartureDate(train.startTime, dateTimeLocale)
+        // TODO Hourly timetables: display the actual start time instead of a fictive date
+        formatDepartureDate(startTimeToDate(train.startTime), dateTimeLocale)
       ),
     [trainSchedulesWithDetails, dateTimeLocale]
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -31,7 +31,7 @@ import {
 } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
-import { addDurationToDate, Duration } from 'utils/duration';
+import { addDurationToDate, Duration, startTimeToDate } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
 
@@ -153,11 +153,14 @@ const UniqueTrainItem = ({
     if (!summary?.isValid) dispatch(updateProjectionType('operationalPointProjection'));
   };
 
+  // TODO Hourly timetables: display the actual start time instead of a fictive date
+  const trainStartTime = startTimeToDate(train.startTime);
+
   const arrivalTime = summary?.isValid
-    ? addDurationToDate(train.startTime, summary.duration)
+    ? addDurationToDate(trainStartTime, summary.duration)
     : undefined;
   const isAfterMidnight = arrivalTime
-    ? dayjs(arrivalTime).isAfter(train.startTime, 'day')
+    ? dayjs(arrivalTime).isAfter(trainStartTime, 'day')
     : undefined;
 
   const { category } = train;
@@ -239,9 +242,9 @@ const UniqueTrainItem = ({
               <div className="status-icon after-midnight">{isAfterMidnight && <Moon />}</div>
               <div
                 className="scenario-timetable-train-times"
-                title={train.startTime.toLocaleString(dateTimeLocale)}
+                title={trainStartTime.toLocaleString(dateTimeLocale)}
               >
-                {timeToLocaleStringRounded(train.startTime, dateTimeLocale)}
+                {timeToLocaleStringRounded(trainStartTime, dateTimeLocale)}
               </div>
               <div
                 className={cx('status-icon', {

--- a/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
@@ -23,7 +23,7 @@ import type {
 } from 'modules/trainSchedule/types';
 import type { TrainId } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
-import { Duration } from 'utils/duration';
+import { Duration, startTimeToDate } from 'utils/duration';
 
 /**
  * Insert or update a path step to go through a specific track.
@@ -196,7 +196,8 @@ export default function useOccupancyZoneDrop({
       const simulationSummary = exception?.summary ?? trainSchedule.summary;
       const occupancyZoneStartOffset = Duration.subtractDate(
         occupancyZoneStartTime,
-        trainSchedule.startTime
+        // TODO Hourly timetables: use the actual start time instead of a fictive date
+        startTimeToDate(trainSchedule.startTime)
       );
       const newPath = upsertPathStepTrack(
         path,

--- a/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
+++ b/front/src/modules/simulationResult/components/Chronogram/useLevelCrossingsWithChronogram.ts
@@ -7,6 +7,7 @@ import { useInfraID } from 'common/osrdContext';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
+import { startTimeToDate } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 
 import { formatLevelCrossingOccupanciesForChronogram } from './buildOccupancyBlocks';
@@ -22,7 +23,8 @@ const useLevelCrossingsWithChronogram = (
   const infraId = useInfraID();
   const dispatch = useAppDispatch();
 
-  const timeOrigin = useMemo(() => new Date(trains[0].startTime).getTime(), [trains]);
+  // TODO Hourly timetables: use the actual start time instead of a fictive date
+  const timeOrigin = useMemo(() => startTimeToDate(trains[0].startTime).getTime(), [trains]);
 
   const trainIds = useMemo(() => trains.map((train) => train.id), [trains]);
 

--- a/front/src/modules/simulationResult/helpers/formatTrainScheduleSummaries.ts
+++ b/front/src/modules/simulationResult/helpers/formatTrainScheduleSummaries.ts
@@ -1,5 +1,6 @@
 import type {
   LightRollingStockWithLiveries,
+  TimetableType,
   TrainScheduleSimulationSummaryResult,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
@@ -11,7 +12,8 @@ import { mapBy } from 'utils/types';
 const formatTrainScheduleSummaries = (
   rawTrainScheduleSummaries: Map<number, TrainScheduleSimulationSummaryResult>,
   rawTrainSchedules: Map<number, TrainScheduleResponse>,
-  rollingStocks: LightRollingStockWithLiveries[]
+  rollingStocks: LightRollingStockWithLiveries[],
+  timetableType: TimetableType
 ): Map<number, TrainScheduleWithDetails> => {
   const trainSchedules: TrainScheduleWithDetails[] = [...rawTrainScheduleSummaries].map(
     ([id, trainScheduleSummary]) => {
@@ -20,7 +22,12 @@ const formatTrainScheduleSummaries = (
         throw new Error('Missing train schedule');
       }
       const rollingStock = rollingStocks.find((rs) => rs.name === trainSchedule.rolling_stock_name);
-      return formatTrainScheduleWithDetails(trainSchedule, rollingStock, trainScheduleSummary);
+      return formatTrainScheduleWithDetails(
+        trainSchedule,
+        timetableType,
+        rollingStock,
+        trainScheduleSummary
+      );
     }
   );
   return mapBy(trainSchedules, 'id');

--- a/front/src/modules/trainHeader/utils/applyOccurrenceOnPacedTrain.ts
+++ b/front/src/modules/trainHeader/utils/applyOccurrenceOnPacedTrain.ts
@@ -5,6 +5,7 @@ import {
 } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import type { OccurrenceId, Train } from 'reducers/osrdconf/types';
+import { msToStartTime } from 'utils/duration';
 
 /**
  * Apply occurrence-related properties to a paced train, so that the resulting paced train
@@ -47,7 +48,7 @@ export function applyOccurrenceOnPacedTrain(
     ...originalTrainSchedule,
     ...occurrenceProps,
     name: train_name,
-    startTime: new Date(start_time),
+    startTime: msToStartTime(start_time, originalTrainSchedule.startTime),
     speedLimitTag: speed_limit_tag ?? null,
     rollingStockName,
   };

--- a/front/src/modules/trainSchedule/helpers/__tests__/pacedTrain.spec.ts
+++ b/front/src/modules/trainSchedule/helpers/__tests__/pacedTrain.spec.ts
@@ -15,6 +15,7 @@ import {
 } from 'utils/trainId';
 
 import {
+  computeIndexedOccurrenceStartTime,
   extractOccurrenceDetailsFromPacedTrain,
   getFirstActiveOccurrenceId,
   getOccurrencesNb,
@@ -51,6 +52,31 @@ describe('getOccurrencesNb', () => {
     expect(() =>
       getOccurrencesNb({ timeWindow: Duration.parse('PT2H'), interval: Duration.parse('PT0S') })
     ).toThrow('Interval cannot be 0');
+  });
+});
+
+describe('computeIndexedOccurrenceStartTime', () => {
+  it('should return a Date shifted by index × interval for a Date start time (calendar)', () => {
+    expect(
+      computeIndexedOccurrenceStartTime(
+        new Date('2024-10-15T03:00:00Z'),
+        Duration.parse('PT30M'),
+        2
+      )
+    ).toEqual(new Date('2024-10-15T04:00:00Z'));
+  });
+
+  it('should return a Duration shifted by index × interval for a Duration start time (trame)', () => {
+    expect(
+      computeIndexedOccurrenceStartTime(new Duration({ hours: 3 }), Duration.parse('PT30M'), 2)
+    ).toEqual(new Duration({ hours: 4 }));
+  });
+
+  it('should return the start time unchanged for index 0', () => {
+    const startTime = new Duration({ hours: 3 });
+    expect(computeIndexedOccurrenceStartTime(startTime, Duration.parse('PT30M'), 0)).toEqual(
+      startTime
+    );
   });
 });
 

--- a/front/src/modules/trainSchedule/helpers/formatTrainScheduleWithDetails.ts
+++ b/front/src/modules/trainSchedule/helpers/formatTrainScheduleWithDetails.ts
@@ -6,6 +6,7 @@ import {
 import type {
   LightRollingStockWithLiveries,
   SimulationSummaryResult,
+  TimetableType,
   TrainScheduleSimulationSummaryResult,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
@@ -59,9 +60,21 @@ const formatSummary = (summary?: SimulationSummaryResult): SimulationSummary | u
     : { isValid: false, invalidReason: extractInvalidReason(summary) };
 };
 
-const extractBaseTrainScheduleProps = (trainSchedule: TrainScheduleResponse) => ({
+/**
+ * Convert a start time received from the backend (a number of ms) according to the
+ * timetable type: elapsed ms since 1970-01-01T00:00:00Z (a Date) for calendar
+ * timetables, elapsed ms since the timetable start (a Duration) for hourly
+ * timetables.
+ */
+const parseStartTime = (startTime: number, timetableType: TimetableType) =>
+  timetableType === 'HOURLY' ? new Duration({ milliseconds: startTime }) : new Date(startTime);
+
+const extractBaseTrainScheduleProps = (
+  trainSchedule: TrainScheduleResponse,
+  timetableType: TimetableType
+) => ({
   name: trainSchedule.train_name,
-  startTime: new Date(trainSchedule.start_time),
+  startTime: parseStartTime(trainSchedule.start_time, timetableType),
   stopsCount: intermediateStopsCount(trainSchedule),
   rollingStockName: trainSchedule.rolling_stock_name,
   speedLimitTag: trainSchedule.speed_limit_tag ?? null,
@@ -70,6 +83,7 @@ const extractBaseTrainScheduleProps = (trainSchedule: TrainScheduleResponse) => 
 
 export const formatTrainScheduleWithDetails = (
   trainSchedule: TrainScheduleResponse,
+  timetableType: TimetableType,
   rollingStock?: LightRollingStockWithLiveries,
   trainScheduleSummary?: TrainScheduleSimulationSummaryResult
 ): TrainScheduleWithDetails => {
@@ -83,9 +97,12 @@ export const formatTrainScheduleWithDetails = (
   } = trainSchedule;
 
   if (!paced) {
+    if (timetableType === 'HOURLY') {
+      throw new Error('An hourly timetable cannot contain unique trains');
+    }
     return {
       ...trainScheduleProps,
-      ...extractBaseTrainScheduleProps(trainSchedule),
+      ...extractBaseTrainScheduleProps(trainSchedule, timetableType),
       rollingStock,
       summary: formatSummary(trainScheduleSummary?.train_schedule),
     };
@@ -116,7 +133,7 @@ export const formatTrainScheduleWithDetails = (
 
   return {
     ...trainScheduleProps,
-    ...extractBaseTrainScheduleProps(trainSchedule),
+    ...extractBaseTrainScheduleProps(trainSchedule, timetableType),
     rollingStock,
     paced: {
       timeWindow: Duration.parse(paced.time_window),

--- a/front/src/modules/trainSchedule/helpers/pacedTrain.ts
+++ b/front/src/modules/trainSchedule/helpers/pacedTrain.ts
@@ -5,7 +5,7 @@ import type {
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import type { OccurrenceId, TrainScheduleId, TrainId } from 'reducers/osrdconf/types';
-import { Duration, addDurationToDate } from 'utils/duration';
+import { Duration, addDurationToDate, startTimeToMs, type StartTime } from 'utils/duration';
 import {
   extractEditoastIdFromTrainScheduleId,
   extractEditoastIdFromTrainId,
@@ -85,11 +85,31 @@ export const getOccurrencesNb = ({
 };
 
 /** startTime + index × interval */
-export const computeIndexedOccurrenceStartTime = (
+export function computeIndexedOccurrenceStartTime(
   pacedTrainStartTime: Date,
   interval: Duration,
   index: number
-) => addDurationToDate(pacedTrainStartTime, new Duration({ milliseconds: index * interval.ms }));
+): Date;
+export function computeIndexedOccurrenceStartTime(
+  pacedTrainStartTime: Duration,
+  interval: Duration,
+  index: number
+): Duration;
+export function computeIndexedOccurrenceStartTime(
+  pacedTrainStartTime: StartTime,
+  interval: Duration,
+  index: number
+): StartTime;
+export function computeIndexedOccurrenceStartTime(
+  pacedTrainStartTime: StartTime,
+  interval: Duration,
+  index: number
+): StartTime {
+  const offset = new Duration({ milliseconds: index * interval.ms });
+  return pacedTrainStartTime instanceof Duration
+    ? pacedTrainStartTime.add(offset)
+    : addDurationToDate(pacedTrainStartTime, offset);
+}
 
 /**
  * Based on an exception list and an occurrence id, find the corresponding exception
@@ -350,7 +370,7 @@ export const getFirstActiveOccurrenceId = (
   trainScheduleId: TrainScheduleId
 ): OccurrenceId | undefined => {
   const { paced } = pacedTrain;
-  const startTimeMs = pacedTrain.startTime.getTime();
+  const startTimeMs = startTimeToMs(pacedTrain.startTime);
   const intervalMs = paced.interval.ms;
 
   let bestId: OccurrenceId | undefined;

--- a/front/src/modules/trainSchedule/types.ts
+++ b/front/src/modules/trainSchedule/types.ts
@@ -11,7 +11,7 @@ import type {
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import type { OccurrenceId } from 'reducers/osrdconf/types';
-import type { Duration } from 'utils/duration';
+import type { Duration, StartTime } from 'utils/duration';
 
 export type SuggestedOP = {
   pathStepId: string | undefined;
@@ -71,7 +71,8 @@ type TrainScheduleWithSummaries = Omit<
   'train_name' | 'rolling_stock_name' | 'start_time' | 'paced'
 > & {
   name: string;
-  startTime: Date;
+  /** Date for a calendar timetable, Duration (offset from the timetable start) for a hourly timetable */
+  startTime: StartTime;
   stopsCount: number;
   rollingStockName: string;
   rollingStock?: LightRollingStockWithLiveries;
@@ -117,7 +118,8 @@ export type Occurrence = {
   occurrenceIndex?: number; // Optional, only if not created
   trainName: string;
   rollingStock?: LightRollingStockWithLiveries;
-  startTime: Date;
+  /** Date for a calendar timetable, Duration (offset from the timetable start) for a hourly timetable */
+  startTime: StartTime;
   stopsCount: number;
   exception?: { id: number; exceptionChangeGroups: ExceptionChangeGroups };
   summary?: SimulationSummary;

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -6,7 +6,7 @@ import type { SuggestedOP, TrainScheduleWithDetails } from 'modules/trainSchedul
 import { buildMapStateReducer } from 'reducers/commonMap';
 import { defaultCommonConf, buildCommonConfReducers } from 'reducers/osrdconf/osrdConfCommon';
 import type { OperationalStudiesConfState } from 'reducers/osrdconf/types';
-import { Duration } from 'utils/duration';
+import { Duration, startTimeToDate } from 'utils/duration';
 import { msToKmh } from 'utils/physics';
 
 import { upsertPathStep } from '../helpers';
@@ -73,7 +73,8 @@ export const operationalStudiesConfSlice = createSlice({
       state.pathSteps = path.map((_, index) =>
         computeBasePathStep(action.payload.trainSchedule, index)
       );
-      state.startTime = startTime;
+      // TODO Hourly timetables: keep the Duration start time in the conf state instead of a fictive date
+      state.startTime = startTimeToDate(startTime);
 
       state.name = name;
       state.category = category ?? null;

--- a/front/src/utils/__tests__/duration.spec.ts
+++ b/front/src/utils/__tests__/duration.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { Duration, msToStartTime, startTimeToDate, startTimeToMs } from 'utils/duration';
+
+describe('startTimeToMs', () => {
+  it('should return the epoch timestamp for a Date start time', () => {
+    expect(startTimeToMs(new Date('2024-01-01T08:37:12.250Z'))).toEqual(1704098232250);
+  });
+
+  it('should return the offset in ms for a Duration start time', () => {
+    expect(
+      startTimeToMs(new Duration({ hours: 8, minutes: 37, seconds: 12, milliseconds: 250 }))
+    ).toEqual(31032250);
+  });
+});
+
+describe('startTimeToDate', () => {
+  it('should return the same Date for a Date start time', () => {
+    const startTime = new Date('2024-01-01T08:00:00Z');
+    expect(startTimeToDate(startTime)).toEqual(startTime);
+  });
+});
+
+describe('msToStartTime', () => {
+  it('should return a Date when the reference is a Date', () => {
+    expect(msToStartTime(1704098232250, new Date(0))).toEqual(new Date('2024-01-01T08:37:12.250Z'));
+  });
+
+  it('should return a Duration when the reference is a Duration', () => {
+    expect(msToStartTime(31032250, Duration.zero)).toEqual(
+      new Duration({ hours: 8, minutes: 37, seconds: 12, milliseconds: 250 })
+    );
+  });
+});

--- a/front/src/utils/duration.ts
+++ b/front/src/utils/duration.ts
@@ -98,6 +98,40 @@ export class Duration {
   }
 }
 
+/**
+ * A start time received from the backend, converted according to the timetable type:
+ * a Date for calendar timetables, a Duration (offset from the timetable start) for
+ * hourly timetables.
+ */
+export type StartTime = Date | Duration;
+
+/**
+ * Number of ms represented by a start time: elapsed ms since 1970-01-01T00:00:00Z for
+ * calendar timetables (Date), elapsed ms since the timetable start for hourly
+ * timetables (Duration). This is the value expected by the backend in `start_time`.
+ */
+export const startTimeToMs = (startTime: StartTime): number =>
+  startTime instanceof Duration ? startTime.ms : startTime.getTime();
+
+/**
+ * Convert a number of ms expressed in the same hourly timetable as `reference` into a StartTime:
+ * a Duration (offset from the timetable start) if the reference is a Duration (hourly timetable),
+ * a Date (ms since epoch) otherwise.
+ */
+export const msToStartTime = (ms: number, reference: StartTime): StartTime =>
+  reference instanceof Duration ? new Duration({ milliseconds: ms }) : new Date(ms);
+
+/**
+ * TODO Hourly timetables: temporary helper, remove once components handle Duration start times.
+ *
+ * Components are not adapted to hourly timetables yet but still expect a Date. Since no
+ * Date is meaningful for an offset from the timetable start, deliberately return the
+ * epoch as an obviously fictive placeholder instead of a value that could pass for a
+ * real date. Each call site marks a component to migrate in a follow-up PR.
+ */
+export const startTimeToDate = (startTime: StartTime): Date =>
+  startTime instanceof Duration ? new Date(0) : startTime;
+
 export const addDurationToDate = (date: Date, dur: Duration) => new Date(date.getTime() + dur.ms);
 
 export const subtractDurationFromDate = (date: Date, dur: Duration) =>


### PR DESCRIPTION
closes #17590 

In this PR, we are only adapting the data structures, not the components; use a placeholder date for now, that's why we have some `// TODO : Hourly timetable`

To create a hourly timetable: https://github.com/osrd-project/osrd-confidential/issues/1430#issuecomment-5003557783