### PR TITLE
front: check train header's service-related fields only when they exists

### DIFF
--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -374,14 +374,16 @@ const ExpandedTrainForm = ({
     [fields.initial_speed, selectedRollingStock, computeInitialSpeedError]
   );
 
+  const isPacedTrain = !!pacedTrain;
+
   const serviceCadenceError = useMemo(
-    () => computeServiceTimingError(fields.service_cadence),
-    [fields.service_cadence]
+    () => (isPacedTrain ? computeServiceTimingError(fields.service_cadence) : null),
+    [isPacedTrain, fields.service_cadence]
   );
 
   const serviceWindowError = useMemo(
-    () => computeServiceTimingError(fields.service_window),
-    [fields.service_window]
+    () => (isPacedTrain ? computeServiceTimingError(fields.service_window) : null),
+    [isPacedTrain, fields.service_window]
   );
 
   const erroneousFields = useMemo(


### PR DESCRIPTION
Fixes #17618.

To make sure users do not collapse the train headers when there are errors in the form they may not have spot, we disable currently the button. It just so happen that we also think of empty service-related fields (cadence and time window) as erroneous… even on unique trains. Oops!

This pull request basically fixes this; we cast `pacedTrain` as a boolean in `isPacedTrain` to make sure we don't recompute those fields on every change in `pacedTrain` (we only care about it being set or not).