### PR TITLE
front, ui-charts: fix train header labels not updated when resetting …

### DIFF
--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -706,7 +706,7 @@ const ExpandedTrainForm = ({
           <TokenInput
             small
             label={t('manageTrainSchedule.trainHeader.form.tags')}
-            tokens={train?.labels ?? []}
+            tokens={fields.labels}
             onChange={(tokens) => {
               onFieldImmediateChange('labels', tokens);
             }}

--- a/front/ui/ui-core/src/components/TokenInput.tsx
+++ b/front/ui/ui-core/src/components/TokenInput.tsx
@@ -13,6 +13,15 @@ export type TokenInputProps = {
 
 const TokenInput = ({ label, tokens: initialTokens, small, onChange, onBlur }: TokenInputProps) => {
   const [tokens, setTokens] = useState(initialTokens);
+
+  // Allow to update the tokens state when an update comes from outside the component
+  // See react docs: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevInitialTokens, setPrevInitialTokens] = useState(initialTokens);
+  if (initialTokens !== prevInitialTokens) {
+    setPrevInitialTokens(initialTokens);
+    setTokens(initialTokens);
+  }
+
   const [newToken, setNewToken] = useState('');
   const [selectedToken, setSelectedToken] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
…an exception

The TokenInput component did not have a way to update its internal state when the update came from outside.

fix #17517 