### PR TITLE
front: introduce getTrainScheduleRepeatOffsets()

### DIFF
--- a/front/src/modules/simulationResult/helpers/__tests__/getTrainScheduleRepeatOffsets.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getTrainScheduleRepeatOffsets.spec.ts
@@ -1,13 +1,26 @@
 import { describe, it, expect } from 'vitest';
 
+import type { BaseTrainProjection } from 'modules/simulationResult/types';
 import { Duration } from 'utils/duration';
 
 import getTrainScheduleRepeatOffsets, { type TimeRange } from '../getTrainScheduleRepeatOffsets';
 
+function buildProjection(duration: Duration): BaseTrainProjection {
+  return {
+    spaceTimeCurves: [
+      {
+        positions: [0, 500, 1000],
+        times: [0, duration.ms / 2, duration.ms],
+      },
+    ],
+    signalUpdates: [],
+  };
+}
+
 describe('getTrainScheduleRepeatOffsets', () => {
   it('should handle unique trains', () => {
     const result = getTrainScheduleRepeatOffsets(
-      { paced: undefined },
+      { ...buildProjection(new Duration({ minutes: 64 })), paced: undefined },
       { start: new Duration({ minutes: -10 }), end: new Duration({ minutes: 85 }) }
     );
     expect(result).toEqual([Duration.zero]);
@@ -17,55 +30,120 @@ describe('getTrainScheduleRepeatOffsets', () => {
     name: string;
     range: TimeRange;
     pacedTrainTimeWindow: Duration;
+    pacedTrainTravelTime: Duration;
+    exceptionTravelTime?: Duration;
     instanceOffsets: Duration[];
   }[] = [
     {
       name: 'range exactly the same as paced train time window',
       range: { start: new Duration({ minutes: 0 }), end: new Duration({ minutes: 60 }) },
       pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: Duration.zero,
       instanceOffsets: [Duration.zero],
     },
     {
       name: 'range smaller than paced train time window with no offset',
       range: { start: new Duration({ minutes: 10 }), end: new Duration({ minutes: 20 }) },
       pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: Duration.zero,
       instanceOffsets: [Duration.zero],
     },
     {
       name: 'range smaller than paced train time window with positive offset',
       range: { start: new Duration({ minutes: 75 }), end: new Duration({ minutes: 80 }) },
       pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: Duration.zero,
       instanceOffsets: [new Duration({ minutes: 60 })],
     },
     {
       name: 'range smaller than paced train time window with negative offset',
       range: { start: new Duration({ minutes: -10 }), end: new Duration({ minutes: 0 }) },
       pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: Duration.zero,
       instanceOffsets: [new Duration({ minutes: -60 })],
     },
     {
       name: 'range larger than paced train time window',
       range: { start: new Duration({ minutes: -10 }), end: new Duration({ minutes: 85 }) },
       pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: Duration.zero,
       instanceOffsets: [
         new Duration({ minutes: -60 }),
         new Duration({ minutes: 0 }),
         new Duration({ minutes: 60 }),
       ],
     },
+    {
+      name: 'paced train travel time smaller than paced train time window',
+      range: { start: new Duration({ minutes: -50 }), end: new Duration({ minutes: 85 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: new Duration({ minutes: 12 }),
+      instanceOffsets: [
+        new Duration({ minutes: -120 }),
+        new Duration({ minutes: -60 }),
+        new Duration({ minutes: 0 }),
+        new Duration({ minutes: 60 }),
+      ],
+    },
+    {
+      name: 'paced train travel time larger than paced train time window',
+      range: { start: new Duration({ minutes: -50 }), end: new Duration({ minutes: 85 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: new Duration({ minutes: 90 }),
+      instanceOffsets: [
+        new Duration({ minutes: -180 }),
+        new Duration({ minutes: -120 }),
+        new Duration({ minutes: -60 }),
+        new Duration({ minutes: 0 }),
+        new Duration({ minutes: 60 }),
+      ],
+    },
+    {
+      name: 'exception travel time',
+      range: { start: new Duration({ minutes: -50 }), end: new Duration({ minutes: 85 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      pacedTrainTravelTime: new Duration({ minutes: 1 }),
+      exceptionTravelTime: new Duration({ minutes: 32 }),
+      instanceOffsets: [
+        new Duration({ minutes: -120 }),
+        new Duration({ minutes: -60 }),
+        new Duration({ minutes: 0 }),
+        new Duration({ minutes: 60 }),
+      ],
+    },
   ];
-  it.for(testCases)('should handle $name', ({ range, pacedTrainTimeWindow, instanceOffsets }) => {
-    const result = getTrainScheduleRepeatOffsets(
-      {
-        paced: {
-          timeWindow: pacedTrainTimeWindow,
-          interval: new Duration({ minutes: 15 }),
-          exceptions: [],
-          exceptionProjections: new Map(),
+  it.for(testCases)(
+    'should handle $name',
+    ({
+      range,
+      pacedTrainTimeWindow,
+      pacedTrainTravelTime,
+      exceptionTravelTime,
+      instanceOffsets,
+    }) => {
+      const exceptionId = 20;
+      const result = getTrainScheduleRepeatOffsets(
+        {
+          ...buildProjection(pacedTrainTravelTime),
+          paced: {
+            timeWindow: pacedTrainTimeWindow,
+            interval: new Duration({ minutes: 15 }),
+            exceptions: exceptionTravelTime
+              ? [
+                  {
+                    id: exceptionId,
+                    key: 'foo',
+                  },
+                ]
+              : [],
+            exceptionProjections: new Map(
+              exceptionTravelTime ? [[exceptionId, buildProjection(exceptionTravelTime)]] : []
+            ),
+          },
         },
-      },
-      range
-    );
-    expect(result).toEqual(instanceOffsets);
-  });
+        range
+      );
+      expect(result).toEqual(instanceOffsets);
+    }
+  );
 });

--- a/front/src/modules/simulationResult/helpers/__tests__/getTrainScheduleRepeatOffsets.spec.ts
+++ b/front/src/modules/simulationResult/helpers/__tests__/getTrainScheduleRepeatOffsets.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+
+import { Duration } from 'utils/duration';
+
+import getTrainScheduleRepeatOffsets, { type TimeRange } from '../getTrainScheduleRepeatOffsets';
+
+describe('getTrainScheduleRepeatOffsets', () => {
+  it('should handle unique trains', () => {
+    const result = getTrainScheduleRepeatOffsets(
+      { paced: undefined },
+      { start: new Duration({ minutes: -10 }), end: new Duration({ minutes: 85 }) }
+    );
+    expect(result).toEqual([Duration.zero]);
+  });
+
+  const testCases: {
+    name: string;
+    range: TimeRange;
+    pacedTrainTimeWindow: Duration;
+    instanceOffsets: Duration[];
+  }[] = [
+    {
+      name: 'range exactly the same as paced train time window',
+      range: { start: new Duration({ minutes: 0 }), end: new Duration({ minutes: 60 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      instanceOffsets: [Duration.zero],
+    },
+    {
+      name: 'range smaller than paced train time window with no offset',
+      range: { start: new Duration({ minutes: 10 }), end: new Duration({ minutes: 20 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      instanceOffsets: [Duration.zero],
+    },
+    {
+      name: 'range smaller than paced train time window with positive offset',
+      range: { start: new Duration({ minutes: 75 }), end: new Duration({ minutes: 80 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      instanceOffsets: [new Duration({ minutes: 60 })],
+    },
+    {
+      name: 'range smaller than paced train time window with negative offset',
+      range: { start: new Duration({ minutes: -10 }), end: new Duration({ minutes: 0 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      instanceOffsets: [new Duration({ minutes: -60 })],
+    },
+    {
+      name: 'range larger than paced train time window',
+      range: { start: new Duration({ minutes: -10 }), end: new Duration({ minutes: 85 }) },
+      pacedTrainTimeWindow: new Duration({ minutes: 60 }),
+      instanceOffsets: [
+        new Duration({ minutes: -60 }),
+        new Duration({ minutes: 0 }),
+        new Duration({ minutes: 60 }),
+      ],
+    },
+  ];
+  it.for(testCases)('should handle $name', ({ range, pacedTrainTimeWindow, instanceOffsets }) => {
+    const result = getTrainScheduleRepeatOffsets(
+      {
+        paced: {
+          timeWindow: pacedTrainTimeWindow,
+          interval: new Duration({ minutes: 15 }),
+          exceptions: [],
+          exceptionProjections: new Map(),
+        },
+      },
+      range
+    );
+    expect(result).toEqual(instanceOffsets);
+  });
+});

--- a/front/src/modules/simulationResult/helpers/getTrainScheduleRepeatOffsets.ts
+++ b/front/src/modules/simulationResult/helpers/getTrainScheduleRepeatOffsets.ts
@@ -1,4 +1,4 @@
-import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
+import type { TrainSpaceTimeData, BaseTrainProjection } from 'modules/simulationResult/types';
 import { Duration } from 'utils/duration';
 
 /**
@@ -10,6 +10,11 @@ export type TimeRange = {
   start: Duration;
   end: Duration;
 };
+
+function getProjectionTravelTime(curves: BaseTrainProjection['spaceTimeCurves']): Duration {
+  const times = curves.flatMap((curve) => curve.times);
+  return new Duration({ milliseconds: Math.max(...times) - Math.min(...times) });
+}
 
 /**
  * Compute a list of time offsets a train schedule needs to be repeated on to
@@ -23,14 +28,24 @@ export type TimeRange = {
  * element, shifting the train schedule by the time offset each time.
  */
 export default function getTrainScheduleRepeatOffsets(
-  trainSchedule: Pick<TrainSpaceTimeData, 'paced'>,
+  trainSchedule: Pick<TrainSpaceTimeData, 'paced' | 'spaceTimeCurves'>,
   range: TimeRange
 ): Duration[] {
   if (!trainSchedule.paced) {
     return [Duration.zero];
   }
 
-  const effectiveRangeStart = range.start; // TODO: take travel time into account
+  let maxTravelTime = getProjectionTravelTime(trainSchedule.spaceTimeCurves);
+  for (const exceptionProjection of trainSchedule.paced.exceptionProjections.values()) {
+    const travelTime = getProjectionTravelTime(exceptionProjection.spaceTimeCurves);
+    if (travelTime > maxTravelTime) {
+      maxTravelTime = travelTime;
+    }
+  }
+
+  // Expand the range on the left side to ensure an occurrence starting before
+  // but arriving after range.start is visible
+  const effectiveRangeStart = range.start.sub(maxTravelTime);
 
   const timeWindow = trainSchedule.paced.timeWindow;
   const repeatStartIndex = Math.floor(effectiveRangeStart.ms / timeWindow.ms);

--- a/front/src/modules/simulationResult/helpers/getTrainScheduleRepeatOffsets.ts
+++ b/front/src/modules/simulationResult/helpers/getTrainScheduleRepeatOffsets.ts
@@ -1,0 +1,45 @@
+import type { TrainSpaceTimeData } from 'modules/simulationResult/types';
+import { Duration } from 'utils/duration';
+
+/**
+ * A relative time range.
+ *
+ * end is an exclusive bound.
+ */
+export type TimeRange = {
+  start: Duration;
+  end: Duration;
+};
+
+/**
+ * Compute a list of time offsets a train schedule needs to be repeated on to
+ * fill a time range.
+ *
+ * This helper can be used to repeat a paced train related pattern within the
+ * space time chart (curves, occupancy blocks, and so on) for hourly
+ * timetables.
+ *
+ * The caller is expected to repeat the train schedule once per returned array
+ * element, shifting the train schedule by the time offset each time.
+ */
+export default function getTrainScheduleRepeatOffsets(
+  trainSchedule: Pick<TrainSpaceTimeData, 'paced'>,
+  range: TimeRange
+): Duration[] {
+  if (!trainSchedule.paced) {
+    return [Duration.zero];
+  }
+
+  const effectiveRangeStart = range.start; // TODO: take travel time into account
+
+  const timeWindow = trainSchedule.paced.timeWindow;
+  const repeatStartIndex = Math.floor(effectiveRangeStart.ms / timeWindow.ms);
+  const repeatEndIndex = Math.ceil(range.end.ms / timeWindow.ms);
+
+  const offsets: Duration[] = [];
+  for (let i = repeatStartIndex; i < repeatEndIndex; i++) {
+    offsets.push(new Duration({ milliseconds: i * timeWindow.ms }));
+  }
+
+  return offsets;
+}


### PR DESCRIPTION
_See individual commits._

This approach has been field-tested in https://github.com/OpenRailAssociation/osrd/pull/17747.

Closes https://github.com/OpenRailAssociation/osrd/issues/17628 (function has been renamed from `getTrainScheduleInstanceIndexRange()` and adjusted to return time offsets rather than indices)  
~~Depends on https://github.com/OpenRailAssociation/osrd/pull/17660~~