### PR TITLE
editoast: fix clippy linting error on option filtering in main.rs

### DIFF
--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -131,7 +131,7 @@ async fn run() -> anyhow::Result<()> {
 
     let app_version = client
         .app_version
-        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+        .filter(|v| !v.is_empty())
         .or_else(|| buildid::build_id().map(to_hex_string));
 
     match client.command {


### PR DESCRIPTION
the linting error is triggered with clippy 0.1.97