### PR TITLE
editoast: allow querying a portion of a train schedule path

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4692,7 +4692,7 @@ paths:
       tags:
       - train_schedule
       - pathfinding
-      summary: Get a path from a paced train given an infrastructure id and a paced train id
+      summary: Get a path from a train schedule given an infrastructure id and a train schedule id
       parameters:
       - name: id
         in: path
@@ -4712,6 +4712,20 @@ paths:
         schema:
           type: integer
           format: int64
+      - name: begin_index
+        in: query
+        description: Index of the first path item of the portion to include. Defaults to the path’s first item.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: end_index
+        in: query
+        description: Index of the last path item of the portion to include. Defaults to the path’s last item.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
       responses:
         '200':
           description: The path
@@ -4719,6 +4733,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PathfindingResult'
+        '400':
+          description: Invalid path portion queried
         '404':
           description: Infrastructure or Train schedule not found
   /train_schedules/{id}/simulation:
@@ -7270,6 +7286,7 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorDatabase'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorExceptionNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleErrorInvalidPathPortion'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorPathfindingFailed'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorRollingStockNotFound'
@@ -9810,6 +9827,37 @@ components:
           type: string
           enum:
           - editoast:train_schedule:InfraNotFound
+    EditoastTrainScheduleErrorInvalidPathPortion:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastTrainScheduleErrorInvalidPathPortionContext
+          required:
+          - begin
+          - end
+          - path_items_count
+          properties:
+            begin:
+              type: integer
+            end:
+              type: integer
+            path_items_count:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule:InvalidPathPortion
     EditoastTrainScheduleErrorNotFound:
       type: object
       required:

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -109,6 +109,15 @@ enum TrainScheduleError {
     #[error("Train schedule set '{train_schedule_set_id}', could not be found")]
     #[editoast_error(status = 404)]
     TrainScheduleSetNotFound { train_schedule_set_id: i64 },
+    #[error(
+        "Invalid path portion: start index '{begin}' and end index '{end}' are inconsistent with the path items count ('{path_items_count}')"
+    )]
+    #[editoast_error(status = 400)]
+    InvalidPathPortion {
+        begin: usize,
+        end: usize,
+        path_items_count: usize,
+    },
 
     #[error(transparent)]
     #[editoast_error(status = 500)]
@@ -557,15 +566,26 @@ pub(in crate::views) struct ExceptionQueryParam {
     exception_id: Option<i64>,
 }
 
-/// Get a path from a paced train given an infrastructure id and a paced train id
+/// Selects a portion of a train schedule’s path.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct PathPortionQueryParam {
+    /// Index of the first path item of the portion to include. Defaults to the path’s first item.
+    begin_index: Option<usize>,
+    /// Index of the last path item of the portion to include. Defaults to the path’s last item.
+    end_index: Option<usize>,
+}
+
+/// Get a path from a train schedule given an infrastructure id and a train schedule id
 #[editoast_derive::route]
 #[utoipa::path(
     get, path = "",
     tags = ["train_schedule", "pathfinding"],
-    params(TrainScheduleIdParam, InfraIdQueryParam, ExceptionQueryParam),
+    params(TrainScheduleIdParam, InfraIdQueryParam, ExceptionQueryParam, PathPortionQueryParam),
     responses(
         (status = 200, description = "The path", body = PathfindingResult),
-        (status = 404, description = "Infrastructure or Train schedule not found")
+        (status = 404, description = "Infrastructure or Train schedule not found"),
+        (status = 400, description = "Invalid path portion queried")
     )
 )]
 pub(in crate::views) async fn get_path(
@@ -581,6 +601,10 @@ pub(in crate::views) async fn get_path(
     }): Path<TrainScheduleIdParam>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
     Query(ExceptionQueryParam { exception_id }): Query<ExceptionQueryParam>,
+    Query(PathPortionQueryParam {
+        begin_index,
+        end_index,
+    }): Query<PathPortionQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
     let conn = db_pool.get().await?;
 
@@ -633,14 +657,31 @@ pub(in crate::views) async fn get_path(
         .map(|item| &item.location)
         .collect_vec();
 
-    let track_offsets =
-        match OperationalPointCache::load_path_items(conn, infra.id, path_items.as_slice())
-            .await?
-            .extract_location_from_path_items(&path_items)
-        {
-            Ok(track_offsets) => track_offsets,
-            Err(err) => return Ok(Json(PathfindingResult::Failure(err))),
-        };
+    let path_items = match (begin_index, end_index) {
+        (None, None) => &path_items,
+        (begin_index, end_index) => {
+            let path_items_count = path_items.len();
+            let begin = begin_index.unwrap_or(0);
+            let end = end_index.unwrap_or(path_items_count.saturating_sub(1));
+            if begin > end || end >= path_items_count {
+                return Err(TrainScheduleError::InvalidPathPortion {
+                    begin,
+                    end,
+                    path_items_count,
+                }
+                .into());
+            }
+            &path_items[begin..=end]
+        }
+    };
+
+    let track_offsets = match OperationalPointCache::load_path_items(conn, infra.id, path_items)
+        .await?
+        .extract_location_from_path_items(path_items)
+    {
+        Ok(track_offsets) => track_offsets,
+        Err(err) => return Ok(Json(PathfindingResult::Failure(err))),
+    };
 
     let constraints = core_task::PathfindingConstraints {
         path_items: track_offsets
@@ -2726,6 +2767,90 @@ mod tests {
                 backtrack_path_items: Some(vec![]),
                 length: 1
             })
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_paced_train_path_with_bounds() {
+        let mut core = MockingClient::new();
+        core.stub("/pathfinding/blocks")
+            .on_body(
+                "/path_items",
+                json!([
+                    {
+                        "locations": [{ "track": "TC0", "offset": 340 }],
+                        "can_backtrack": false
+                    },
+                    {
+                        "locations": [
+                            { "track": "TC0", "offset": 550000 },
+                            { "track": "TC1", "offset": 550000 },
+                            { "track": "TC2", "offset": 450000 },
+                            { "track": "TC3", "offset": 450000 }
+                        ],
+                        "can_backtrack": false
+                    }
+                ]),
+            )
+            .response(StatusCode::OK)
+            .json(json!({
+                "path": {
+                    "blocks":[],
+                    "routes": [],
+                    "track_section_ranges": [],
+                },
+                "path_item_positions": [],
+                "backtrack_path_items": [],
+                "length": 1,
+                "status": "success"
+            }))
+            .finish();
+        let app = test_app!().skip_authz().core_client(core.into()).build();
+        let db_pool = app.db_pool();
+
+        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
+        let paced_train =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+        app.get(&format!(
+            "/train_schedules/{}/path?infra_id={}&begin_index=1&end_index=2",
+            paced_train.id, small_infra.id
+        ))
+        .await
+        .assert_status_ok();
+    }
+
+    #[rstest]
+    #[case(2, 100)] // end_index > path_items_count
+    #[case(2, 1)] // begin_index > end_index
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_paced_train_path_invalid_portion(
+        #[case] begin_index: usize,
+        #[case] end_index: usize,
+    ) {
+        let app = test_app!().skip_authz().build();
+        let db_pool = app.db_pool();
+
+        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let train_schedule_set = create_train_schedule_set(&mut db_pool.get_ok()).await;
+        let paced_train =
+            create_simple_paced_train(&mut db_pool.get_ok(), train_schedule_set.id).await;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+        let response: InternalError = app
+            .get(&format!(
+                "/train_schedules/{}/path?infra_id={}&begin_index={}&end_index={}",
+                paced_train.id, small_infra.id, begin_index, end_index
+            ))
+            .await
+            .assert_status_bad_request()
+            .json();
+
+        assert_eq!(
+            &response.error_type,
+            "editoast:train_schedule:InvalidPathPortion"
         )
     }
 

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -313,6 +313,7 @@
       "Database": "Internal error (database)",
       "ExceptionNotFound": "Exception '{{exception_id}}' could not be found",
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
+      "InvalidPathPortion": "Invalid path portion: start index '{{begin}}' and end index '{{end}}' are inconsistent with the path items count ('{{path_items_count}}')",
       "NotFound": "Train schedule '{{train_schedule_id}}' could not be found",
       "PathfindingFailed": "Pathfinding failed for train schedule '{{train_schedule_id}}'",
       "RollingStockNotFound": "Rolling Stock '{{rolling_stock_name}}' could not be found",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -313,6 +313,7 @@
       "Database": "Erreur interne (base de données)",
       "ExceptionNotFound": "Exception '{{exception_id}}' non trouvée",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
+      "InvalidPathPortion": "Portion de chemin invalide : l'index de début '{{begin}}' et l'index de fin '{{end}}' sont incohérents avec le nombre d'étapes du chemin ('{{path_items_count}}')",
       "NotFound": "Circulation '{{train_schedule_id}}' non trouvée",
       "PathfindingFailed": "La recherche de chemin n'a pas abouti pour la circulation '{{train_schedule_id}}'",
       "RollingStockNotFound": "Matériel roulant '{{rolling_stock_name}}' non trouvé",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1481,6 +1481,8 @@ const injectedRtkApi = api
           params: {
             infra_id: queryArg.infraId,
             exception_id: queryArg.exceptionId,
+            begin_index: queryArg.beginIndex,
+            end_index: queryArg.endIndex,
           },
         }),
         providesTags: ['train_schedule', 'pathfinding'],
@@ -2808,6 +2810,10 @@ export type GetTrainSchedulesByIdPathApiArg = {
   id: number;
   infraId: number;
   exceptionId?: number;
+  /** Index of the first path item of the portion to include. Defaults to the path’s first item. */
+  beginIndex?: number;
+  /** Index of the last path item of the portion to include. Defaults to the path’s last item. */
+  endIndex?: number;
 };
 export type GetTrainSchedulesByIdSimulationApiResponse =
   /** status 200 Simulation Output */ SimulationResponse;

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -2242,6 +2242,22 @@ class EditoastTrainScheduleErrorInfraNotFound(BaseModel):
     type: Literal["editoast:train_schedule:InfraNotFound"]
 
 
+class EditoastTrainScheduleErrorInvalidPathPortionContext(BaseModel):
+    begin: int
+    end: int
+    path_items_count: int
+
+
+class EditoastTrainScheduleErrorInvalidPathPortion(BaseModel):
+    context: Annotated[
+        EditoastTrainScheduleErrorInvalidPathPortionContext | None,
+        Field(title="EditoastTrainScheduleErrorInvalidPathPortionContext"),
+    ] = None
+    message: str
+    status: Literal[400]
+    type: Literal["editoast:train_schedule:InvalidPathPortion"]
+
+
 class EditoastTrainScheduleErrorNotFoundContext(BaseModel):
     train_schedule_id: int
 
@@ -4715,6 +4731,7 @@ class EditoastError(
         | EditoastTrainScheduleErrorDatabase
         | EditoastTrainScheduleErrorExceptionNotFound
         | EditoastTrainScheduleErrorInfraNotFound
+        | EditoastTrainScheduleErrorInvalidPathPortion
         | EditoastTrainScheduleErrorNotFound
         | EditoastTrainScheduleErrorPathfindingFailed
         | EditoastTrainScheduleErrorRollingStockNotFound
@@ -4891,6 +4908,7 @@ class EditoastError(
         | EditoastTrainScheduleErrorDatabase
         | EditoastTrainScheduleErrorExceptionNotFound
         | EditoastTrainScheduleErrorInfraNotFound
+        | EditoastTrainScheduleErrorInvalidPathPortion
         | EditoastTrainScheduleErrorNotFound
         | EditoastTrainScheduleErrorPathfindingFailed
         | EditoastTrainScheduleErrorRollingStockNotFound


### PR DESCRIPTION
Allow querying a specific portion of a train schedule's path by introducing optional `begin_index` and `end_index` parameters to the /train_schedules/{id}/path endpoint.
Frontend needs to get path portion to display the result of `/search_journey` that is a list of them.