### PR TITLE
front: fix train header's rolling stock selector behaviour

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
@@ -82,12 +82,12 @@ const ItineraryModalFormHeader = ({
     : modalFormState.rollingStockName;
 
   // When user types or clears input
-  const handleRollingStockInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onRollingStockQueryChange(e);
+  const handleRollingStockInputChange = (newValue: string) => {
+    onRollingStockQueryChange(newValue);
     onModalFormStateChange({
       ...modalFormState,
       rollingStockId: undefined,
-      rollingStockName: e.target.value,
+      rollingStockName: newValue,
     });
   };
 
@@ -189,7 +189,7 @@ const ItineraryModalFormHeader = ({
             narrow
             small
             autoComplete="off"
-            value={rollingStockValue || undefined}
+            value={rollingStockValue ?? ''}
             suggestions={rollingStockSuggestions.map(getRollingStockLabel)}
             getSuggestionLabel={(s) => s}
             onSelectSuggestion={handleRollingStockSelect}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
@@ -490,7 +490,7 @@ const PathStepItem = ({
                 narrow
                 onFocusCapture={onOpFocus}
                 onBlurCapture={onOpBlur}
-                onChange={(e) => onOpInputChange(e.target.value)}
+                onChange={onOpInputChange}
               />
             </div>
             {isTrackOffset ? (
@@ -507,7 +507,7 @@ const PathStepItem = ({
                   value={selectedTrackNameOption}
                   suggestions={filteredTrackSuggestions}
                   getSuggestionLabel={(option) => option.label}
-                  onChange={(e) => setTrackNameQuery(e.target.value)}
+                  onChange={setTrackNameQuery}
                   onSelectSuggestion={(option) => onTrackNameChange(option?.label ?? '')}
                   resetSuggestions={() => setTrackNameQuery('')}
                   allowCustomValue

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
@@ -100,7 +100,8 @@ export function formatTrainScheduleWithDetailsToTrainSchedule(
     path: trainScheduleWithDetails.path,
     power_restrictions: trainScheduleWithDetails.power_restrictions,
     // Rollingstock is missing when just created a train from nge or with import
-    rolling_stock_name: trainScheduleWithDetails.rollingStock?.name ?? '',
+    rolling_stock_name:
+      trainScheduleWithDetails.rollingStock?.name ?? trainScheduleWithDetails.rollingStockName,
     schedule: trainScheduleWithDetails.schedule,
     speed_limit_tag: trainScheduleWithDetails.speed_limit_tag,
     start_time: startTimeToMs(trainScheduleWithDetails.startTime),

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
@@ -116,10 +116,6 @@ const StdcmOperationalPoint = ({
     }
   };
 
-  const handleCiInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTerm(e.target.value);
-  };
-
   const resetSuggestions = () => {
     if (searchTerm !== '' && !operationalPoint) {
       setSearchTerm('');
@@ -163,7 +159,7 @@ const StdcmOperationalPoint = ({
           label={t('trainPath.ci')}
           value={operationalPoint}
           suggestions={ciSuggestions}
-          onChange={handleCiInputChange}
+          onChange={setSearchTerm}
           getSuggestionLabel={(option) => [option.mainCode, option.name].join(' ')}
           onSelectSuggestion={handleCiSelect}
           resetSuggestions={resetSuggestions}

--- a/front/src/common/NavBar/UserSettings.tsx
+++ b/front/src/common/NavBar/UserSettings.tsx
@@ -133,9 +133,7 @@ const UserSettings = () => {
               {...userComboBoxDefaultProps}
               autoComplete="off"
               narrow
-              onChange={(e) => {
-                setInputValue(e.target.value);
-              }}
+              onChange={setInputValue}
             />
           </>
         )}

--- a/front/src/common/authorization/components/GrantManagerAddSubjectForm.tsx
+++ b/front/src/common/authorization/components/GrantManagerAddSubjectForm.tsx
@@ -57,7 +57,7 @@ const GrantManagerAddSubjectForm = ({
             value={addUserForm.user}
             suggestions={searchedUsers}
             getSuggestionLabel={(option) => option.name}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={setSearchTerm}
             onSelectSuggestion={(suggestion) => {
               setAddUserForm((prev) => ({ ...prev, user: suggestion }));
             }}

--- a/front/src/modules/rollingStock/helpers/category.ts
+++ b/front/src/modules/rollingStock/helpers/category.ts
@@ -13,11 +13,11 @@ export const findSubCategory = (
     : subCategories.find((option) => option.code === category.sub_category_code);
 
 export function checkCategoryWarning(
-  rollingStock: LightRollingStock | undefined,
+  rollingStock: LightRollingStock | string | undefined,
   currentCategory: TrainCategory | null,
   currentSubCategory?: SubCategory
 ): boolean {
-  if (!rollingStock || !currentCategory) return false;
+  if (!rollingStock || typeof rollingStock === 'string' || !currentCategory) return false;
 
   if (isMainCategory(currentCategory)) {
     return (

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -2,13 +2,11 @@ import { useCallback, useMemo, useState } from 'react';
 
 import {
   Button,
-  ComboBox,
   DatePicker,
   Input,
   Select,
   Switch,
   TokenInput,
-  useDefaultComboBox,
   type CalendarSlot,
 } from '@osrd-project/ui-core';
 import { isEqual } from 'lodash';
@@ -36,6 +34,7 @@ import { kmhToMs } from 'utils/physics';
 import { isOccurrenceId } from 'utils/trainId';
 import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
+import RollingStockField from './RollingStockField';
 import type { ExtraOccurrencesChanges } from './TrainHeader';
 import TrainServiceForm, { computeServiceTimingError } from './TrainServiceForm';
 
@@ -68,7 +67,7 @@ export type TrainFieldsState = {
   use_electrical_profiles: boolean | null;
   labels: string[];
   added_exception_date: Date;
-  rolling_stock_name: string;
+  rolling_stock: LightRollingStockWithLiveries | string;
   departure_date: Date;
   initial_speed: string | null;
   service_changed_confirmed: boolean;
@@ -78,17 +77,27 @@ export type InitialSpeedError = 'INVALID_NUMBER' | 'ROUNDING' | 'TOO_HIGH' | nul
 
 function computeInitialSpeedError(
   initialSpeed: string | null,
-  rollingStock?: LightRollingStockWithLiveries
+  rollingStock?: LightRollingStockWithLiveries | string
 ): InitialSpeedError {
   if (!initialSpeed) return 'INVALID_NUMBER';
   const floatInitialSpeed = Number.parseFloat(initialSpeed);
   if (!isFinite(floatInitialSpeed) || floatInitialSpeed < 0) return 'INVALID_NUMBER';
   if (Math.round(floatInitialSpeed * 10) / 10 !== floatInitialSpeed) return 'ROUNDING';
-  if (rollingStock && kmhToMs(floatInitialSpeed) > rollingStock.max_speed) return 'TOO_HIGH';
+  if (
+    rollingStock &&
+    typeof rollingStock !== 'string' &&
+    kmhToMs(floatInitialSpeed) > rollingStock.max_speed
+  )
+    return 'TOO_HIGH';
   return null;
 }
 
-function getFieldsFromTrain(train: Train): TrainFieldsState {
+function getFieldsFromTrain(
+  train: Train,
+  rollingStocks: LightRollingStockWithLiveries[]
+): TrainFieldsState {
+  const rollingStock = rollingStocks.find((rs) => rs.name === train.rolling_stock_name);
+
   return {
     train_name: train.train_name,
     speed_limit_tag: train.speed_limit_tag ?? null,
@@ -101,7 +110,7 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     use_electrical_profiles: train?.options?.use_electrical_profiles ?? null,
     labels: train.labels ?? [],
     added_exception_date: new Date(train.start_time),
-    rolling_stock_name: train.rolling_stock_name,
+    rolling_stock: rollingStock ?? train.rolling_stock_name,
     departure_date: new Date(train.start_time),
     initial_speed:
       train.initial_speed === undefined ? null : String(Math.round(train.initial_speed * 36) / 10),
@@ -137,11 +146,10 @@ function applyFieldsToPaced(fields: TrainFieldsState, train: Train): Train['pace
     : undefined;
 }
 
-function applyFieldsToTrain(
-  fields: TrainFieldsState,
-  train: Train,
-  rollingStock?: LightRollingStockWithLiveries
-): Train {
+function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
+  const rollingStock = typeof fields.rolling_stock === 'object' ? fields.rolling_stock : undefined;
+  const customRollingStock = typeof fields.rolling_stock === 'string' ? fields.rolling_stock : '';
+
   return {
     ...train,
     train_name: fields.train_name || train.train_name,
@@ -150,8 +158,8 @@ function applyFieldsToTrain(
     comfort: fields.comfort === null ? undefined : fields.comfort,
     category: fields.category === null ? undefined : fields.category,
     labels: fields.labels,
-    rolling_stock_name: fields.rolling_stock_name,
     paced: applyFieldsToPaced(fields, train),
+    rolling_stock_name: rollingStock ? rollingStock.name : customRollingStock,
     options: {
       ...train.options,
       use_electrical_profiles:
@@ -224,24 +232,11 @@ const ExpandedTrainForm = ({
 
   const { filteredRollingStockList: rollingStocks } = useFilterRollingStock();
 
-  const getRollingStockLabel = useCallback((rs: LightRollingStockWithLiveries) => {
-    const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
-    return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
-  }, []);
-
-  const {
-    suggestions: rollingStockSuggestions,
-    onChange: onRollingStockQueryChange,
-    resetSuggestions: resetRollingStockSuggestions,
-  } = useDefaultComboBox(rollingStocks, getRollingStockLabel);
-
-  const fieldsFromTrain = useMemo(() => getFieldsFromTrain(train), [train]);
-  const [fields, setFields] = useState<TrainFieldsState>(fieldsFromTrain);
-
-  const selectedRollingStock = useMemo(
-    () => rollingStocks.find((rs) => rs.name === fields.rolling_stock_name),
-    [fields.rolling_stock_name, rollingStocks]
+  const fieldsFromTrain = useMemo(
+    () => getFieldsFromTrain(train, rollingStocks),
+    [train, rollingStocks]
   );
+  const [fields, setFields] = useState<TrainFieldsState>(fieldsFromTrain);
 
   // Reset fields values if they changed outside of the form (e.g., because it was an
   // exception and the user reverted it back to an occurrence through the train list)
@@ -268,13 +263,13 @@ const ExpandedTrainForm = ({
 
   const persistTrainIfNeeded = useCallback(
     (newFields: TrainFieldsState) => {
-      const updatedTrain = applyFieldsToTrain(newFields, train, selectedRollingStock);
+      const updatedTrain = applyFieldsToTrain(newFields, train);
 
       if (trainPayloadChanged(updatedTrain, train)) {
         onPersistTrain(updatedTrain);
       }
     },
-    [train, selectedRollingStock, onPersistTrain]
+    [train, onPersistTrain]
   );
 
   const onFieldChange = useCallback(
@@ -358,7 +353,7 @@ const ExpandedTrainForm = ({
     [fields.category, subCategories]
   );
   const isCategoryWarning = checkCategoryWarning(
-    selectedRollingStock,
+    fields.rolling_stock,
     fields.category,
     currentSubCategory
   );
@@ -367,8 +362,8 @@ const ExpandedTrainForm = ({
     : undefined;
 
   const initialSpeedError = useMemo(
-    () => computeInitialSpeedError(fields.initial_speed, selectedRollingStock),
-    [fields.initial_speed, selectedRollingStock, computeInitialSpeedError]
+    () => computeInitialSpeedError(fields.initial_speed, fields.rolling_stock),
+    [fields.initial_speed, fields.rolling_stock, computeInitialSpeedError]
   );
 
   const revertServiceChange = useCallback(() => {
@@ -483,27 +478,10 @@ const ExpandedTrainForm = ({
           />
         </div>
         <div className="train-rolling-stock">
-          <ComboBox
-            id="train-header-rolling-stock-input"
-            label={t('manageTrainSchedule.trainHeader.form.rollingStock')}
-            small
-            autoComplete="off"
-            value={
-              selectedRollingStock
-                ? getRollingStockLabel(selectedRollingStock)
-                : fields.rolling_stock_name
-            }
-            suggestions={rollingStockSuggestions.map(getRollingStockLabel)}
-            getSuggestionLabel={(s) => s}
-            onSelectSuggestion={(label) => {
-              const rs = rollingStocks.find((r) => getRollingStockLabel(r) === label);
-              if (rs) onFieldImmediateChange('rolling_stock_name', rs.name);
-            }}
-            resetSuggestions={resetRollingStockSuggestions}
-            onChange={(e) => {
-              onRollingStockQueryChange(e);
-              onFieldChange('rolling_stock_name', e.target.value);
-            }}
+          <RollingStockField
+            value={fields.rolling_stock}
+            rollingStocks={rollingStocks}
+            onFieldImmediateChange={onFieldImmediateChange}
           />
         </div>
         <div className="train-composition-code">

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -150,13 +150,18 @@ function applyFieldsToTrain(fields: TrainFieldsState, train: Train): Train {
   const rollingStock = typeof fields.rolling_stock === 'object' ? fields.rolling_stock : undefined;
   const customRollingStock = typeof fields.rolling_stock === 'string' ? fields.rolling_stock : '';
 
+  const suggestedCategory =
+    rollingStock && rollingStock.name !== train.rolling_stock_name && rollingStock.primary_category
+      ? { main_category: rollingStock.primary_category }
+      : undefined;
+
   return {
     ...train,
     train_name: fields.train_name || train.train_name,
     speed_limit_tag: fields.speed_limit_tag,
     constraint_distribution: fields.constraint_distribution,
     comfort: fields.comfort === null ? undefined : fields.comfort,
-    category: fields.category === null ? undefined : fields.category,
+    category: fields.category === null ? suggestedCategory : fields.category,
     labels: fields.labels,
     paced: applyFieldsToPaced(fields, train),
     rolling_stock_name: rollingStock ? rollingStock.name : customRollingStock,

--- a/front/src/modules/trainHeader/RollingStockField.tsx
+++ b/front/src/modules/trainHeader/RollingStockField.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+
+import { ComboBox, useDefaultComboBox } from '@osrd-project/ui-core';
+import { useTranslation } from 'react-i18next';
+
+import type { LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
+
+import type { TrainFieldsState } from './ExpandedTrainForm';
+
+type RollingStockFieldProps = {
+  rollingStocks: LightRollingStockWithLiveries[];
+  value: LightRollingStockWithLiveries | string;
+  onFieldImmediateChange: (
+    fieldName: keyof TrainFieldsState,
+    value: TrainFieldsState[typeof fieldName]
+  ) => void;
+};
+
+export default function RollingStockField({
+  rollingStocks,
+  value,
+  onFieldImmediateChange,
+}: RollingStockFieldProps) {
+  const { t } = useTranslation(['operational-studies', 'translation']);
+
+  const getRollingStockLabel = useCallback((rs: LightRollingStockWithLiveries) => {
+    const secondPart = rs.metadata?.series || rs.metadata?.reference || '';
+    return secondPart ? `${rs.name} - ${secondPart}` : rs.name;
+  }, []);
+
+  const {
+    suggestions: rollingStockSuggestions,
+    onChange: onRollingStockQueryChange,
+    resetSuggestions: resetRollingStockSuggestions,
+  } = useDefaultComboBox(rollingStocks, getRollingStockLabel);
+
+  return (
+    <ComboBox
+      id="train-header-rolling-stock-input"
+      label={t('manageTrainSchedule.trainHeader.form.rollingStock')}
+      small
+      autoComplete="off"
+      value={typeof value === 'object' ? getRollingStockLabel(value) : value}
+      suggestions={rollingStockSuggestions.map(getRollingStockLabel)}
+      getSuggestionLabel={(s) => s}
+      onSelectSuggestion={(label) => {
+        const rs = rollingStocks.find((r) => getRollingStockLabel(r) === label);
+        if (rs) onFieldImmediateChange('rolling_stock', rs);
+      }}
+      resetSuggestions={resetRollingStockSuggestions}
+      onChange={(e) => {
+        onRollingStockQueryChange(e);
+      }}
+      onBlur={() => {
+        const rs = rollingStocks.find((r) => getRollingStockLabel(r) === value);
+        const newValue = rs ?? value ?? '';
+
+        if (newValue !== value) {
+          onFieldImmediateChange('rolling_stock', newValue);
+        }
+      }}
+    />
+  );
+}

--- a/front/src/modules/trainHeader/RollingStockField.tsx
+++ b/front/src/modules/trainHeader/RollingStockField.tsx
@@ -45,19 +45,14 @@ export default function RollingStockField({
       getSuggestionLabel={(s) => s}
       onSelectSuggestion={(label) => {
         const rs = rollingStocks.find((r) => getRollingStockLabel(r) === label);
-        if (rs) onFieldImmediateChange('rolling_stock', rs);
+        onFieldImmediateChange('rolling_stock', rs ?? label);
       }}
       resetSuggestions={resetRollingStockSuggestions}
       onChange={(e) => {
         onRollingStockQueryChange(e);
       }}
-      onBlur={() => {
-        const rs = rollingStocks.find((r) => getRollingStockLabel(r) === value);
-        const newValue = rs ?? value ?? '';
-
-        if (newValue !== value) {
-          onFieldImmediateChange('rolling_stock', newValue);
-        }
+      onAddCustomValue={(label) => {
+        onFieldImmediateChange('rolling_stock', label);
       }}
     />
   );

--- a/front/src/modules/trainHeader/TrainHeader.tsx
+++ b/front/src/modules/trainHeader/TrainHeader.tsx
@@ -6,6 +6,7 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import { updateTrainSchedule } from 'applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule';
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/views/Scenario/consts';
 import type { PathfindingResult, TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 import type { TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import { setFailure } from 'reducers/main';
 import { selectTrainToEdit } from 'reducers/osrdconf/operationalStudiesConf';
@@ -51,6 +52,7 @@ const TrainHeader = ({
   const { timetableId } = useScenarioContext();
   const occurrenceId = isOccurrenceId(train.id) ? train.id : undefined;
   const trainScheduleId = extractEditoastIdFromTrainId(train.id);
+  const { filteredRollingStockList: rollingStocks } = useFilterRollingStock();
 
   // TODO: As soon as we ditch the old train edition modal, we should switch to a TrainSchedule instead
   //       of a TrainScheduleWithDetails as we have no need for the "details" in this form.
@@ -91,7 +93,7 @@ const TrainHeader = ({
     dispatch(
       selectTrainToEdit({
         trainSchedule: occurrenceId
-          ? applyOccurrenceOnPacedTrain(originalTrainSchedule, train, occurrenceId)
+          ? applyOccurrenceOnPacedTrain(originalTrainSchedule, train, occurrenceId, rollingStocks)
           : originalTrainSchedule,
         isOccurrence: !!occurrenceId,
       })
@@ -107,6 +109,7 @@ const TrainHeader = ({
     originalTrainSchedule,
     trainScheduleId,
     occurrenceId,
+    rollingStocks,
     dispatch,
     setDisplayTrainScheduleManagement,
     setTrainScheduleToEditData,

--- a/front/src/modules/trainHeader/utils/applyOccurrenceOnPacedTrain.ts
+++ b/front/src/modules/trainHeader/utils/applyOccurrenceOnPacedTrain.ts
@@ -1,4 +1,4 @@
-import type { TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { LightRollingStockWithLiveries, TrainSchedule } from 'common/api/osrdEditoastApi';
 import {
   extractOccurrenceDetailsFromPacedTrain,
   findExceptionWithOccurrenceId,
@@ -19,7 +19,8 @@ import { msToStartTime } from 'utils/duration';
 export function applyOccurrenceOnPacedTrain(
   originalTrainSchedule: TrainScheduleWithDetails,
   train: Train,
-  occurrenceId: OccurrenceId
+  occurrenceId: OccurrenceId,
+  rollingStocks: LightRollingStockWithLiveries[]
 ): TrainScheduleWithDetails {
   if (!originalTrainSchedule.paced) return originalTrainSchedule;
 
@@ -44,12 +45,15 @@ export function applyOccurrenceOnPacedTrain(
     ...occurrenceProps
   } = extractOccurrenceDetailsFromPacedTrain(rawPacedTrain, occurrenceToUpdateException);
 
+  const rollingStock = rollingStocks.find((rs) => rs.name === rollingStockName);
+
   return {
     ...originalTrainSchedule,
     ...occurrenceProps,
     name: train_name,
     startTime: msToStartTime(start_time, originalTrainSchedule.startTime),
     speedLimitTag: speed_limit_tag ?? null,
+    rollingStock,
     rollingStockName,
   };
 }

--- a/front/ui/storybook/stories/ui-core/ComboBoxCustom.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/ComboBoxCustom.stories.tsx
@@ -35,8 +35,8 @@ const ComboBoxStory = () => {
     setValue(suggestion);
   };
 
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const inputValue = e.target.value.toLowerCase();
+  const onChange = (newValue: string) => {
+    const inputValue = newValue.toLowerCase();
     if (!inputValue) {
       setFilteredSuggestions(suggestions);
       return;

--- a/front/ui/storybook/stories/ui-core/ComboBoxCustomSuggestions.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/ComboBoxCustomSuggestions.stories.tsx
@@ -376,8 +376,7 @@ const ComboBoxStory = (props: { small?: boolean; disabled?: boolean; readOnly?: 
     valueRef.current = suggestion;
   };
 
-  const onChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    const newValue = e.target.value;
+  const onChange = (newValue: string) => {
     setFilteredSuggestions(filterAndMarkSuggestions(ALL_SUGGESTIONS, newValue));
   };
 

--- a/front/ui/storybook/stories/ui-core/Form.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/Form.stories.tsx
@@ -77,7 +77,7 @@ const FormComponent = (fieldProps: {
         id="combobox"
         label="Combo box"
         value={data.combobox}
-        onChange={(e) => setData((prev) => ({ ...prev, combobox: e.target.value }))}
+        onChange={(newValue) => setData((prev) => ({ ...prev, combobox: newValue }))}
         suggestions={['Group DDDEEEFFF', 'Group AAABBBCCC', 'Group GGGHHHIII']}
         getSuggestionLabel={(e) => e}
         onSelectSuggestion={noop}

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -99,12 +99,21 @@ const ComboBox = <T,>({
     }
   }, [inputRef, isInputFocused]);
 
+  const normalizedInputValue = useMemo(() => inputValue.trim().toLowerCase(), [inputValue]);
+
+  const suggestionsByLabel = useMemo(() => {
+    const map = new Map<string, T>();
+    for (const suggestion of suggestions) {
+      map.set(getSuggestionLabel(suggestion).trim().toLowerCase(), suggestion);
+    }
+    return map;
+  }, [suggestions, getSuggestionLabel]);
+
   const showAddCustomValue = useMemo(() => {
-    if (!allowCustomValue || !inputValue.trim()) return false;
-    return !suggestions.some(
-      (s) => getSuggestionLabel(s).toLowerCase() === inputValue.trim().toLowerCase()
-    );
-  }, [allowCustomValue, inputValue, suggestions, getSuggestionLabel]);
+    if (!allowCustomValue || !normalizedInputValue) return false;
+
+    return !suggestionsByLabel.has(normalizedInputValue);
+  }, [allowCustomValue, normalizedInputValue, suggestionsByLabel]);
 
   const showSuggestions = useMemo(
     () => isInputFocused && (suggestions.length > 0 || showAddCustomValue) && !inputProps.disabled,
@@ -117,8 +126,7 @@ const ComboBox = <T,>({
     setInputValue(e.currentTarget.value);
   };
 
-  const selectSuggestion = (index: number) => {
-    const selectedSuggestion = suggestions.at(index)!;
+  const selectSuggestion = (selectedSuggestion: T) => {
     onSelectSuggestion(selectedSuggestion);
     setInputValue(getSuggestionLabel(selectedSuggestion));
     removeFocus();
@@ -136,10 +144,33 @@ const ComboBox = <T,>({
     removeFocus();
   };
 
+  const onFieldBlur = () => {
+    const exactSuggestion = suggestionsByLabel.get(normalizedInputValue);
+    if (activeSuggestionIndex === -1 && !showAddCustomValue) {
+      if (exactSuggestion) {
+        onSelectSuggestion(exactSuggestion);
+      } else {
+        onAddCustomValue?.(inputValue);
+      }
+    }
+    closeSuggestions();
+  };
+
   const totalItems = suggestions.length + (showAddCustomValue ? 1 : 0);
   const customValueIndex = showAddCustomValue ? suggestions.length : -1;
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    const confirmSelected = () => {
+      if (showAddCustomValue && activeSuggestionIndex === customValueIndex) {
+        confirmCustomValue();
+      }
+
+      const suggestion = suggestions.at(activeSuggestionIndex);
+      if (suggestion) {
+        selectSuggestion(suggestion);
+      }
+    };
+
     switch (e.key) {
       case 'ArrowDown': {
         setActiveSuggestionIndex((prev) => {
@@ -159,25 +190,40 @@ const ComboBox = <T,>({
       }
       case 'Enter': {
         e.preventDefault();
-        if (activeSuggestionIndex === customValueIndex) {
-          confirmCustomValue();
-        } else if (activeSuggestionIndex >= 0) {
-          selectSuggestion(activeSuggestionIndex);
-        } else if (suggestions.length === 1) {
-          selectSuggestion(0);
+
+        if (activeSuggestionIndex >= 0) {
+          confirmSelected();
+        } else {
+          // No item selected
+
+          const exactSuggestion = suggestionsByLabel.get(normalizedInputValue);
+          if (exactSuggestion) {
+            selectSuggestion(exactSuggestion);
+          } else if (
+            suggestions.length === 1 &&
+            getSuggestionLabel(suggestions[0]).startsWith(inputValue)
+          ) {
+            selectSuggestion(suggestions[0]);
+          } else {
+            if (showAddCustomValue) {
+              confirmCustomValue();
+            } else {
+              onAddCustomValue?.(inputValue);
+            }
+          }
         }
         break;
       }
       case 'Tab': {
-        if (activeSuggestionIndex === customValueIndex) {
-          confirmCustomValue();
-        } else if (activeSuggestionIndex >= 0) {
-          selectSuggestion(activeSuggestionIndex);
+        if (activeSuggestionIndex >= 0) {
+          confirmSelected();
         }
+        onFieldBlur();
+
         break;
       }
       case 'Escape': {
-        closeSuggestions();
+        onFieldBlur();
         break;
       }
       default:
@@ -192,15 +238,11 @@ const ComboBox = <T,>({
 
   const clearInput = () => {
     setInputValue('');
-    onSelectSuggestion(undefined);
     resetSuggestions();
     focusInput();
   };
 
-  useOutsideClick(
-    showSuggestions ? wrapperRef : null, // Only trigger when the suggestions are displayed
-    closeSuggestions
-  );
+  useOutsideClick(showSuggestions || isInputFocused ? wrapperRef : null, onFieldBlur);
 
   const inputIcons = useMemo(() => {
     if (inputProps.readOnly || inputProps.disabled) return undefined;
@@ -260,6 +302,7 @@ const ComboBox = <T,>({
           className="suggestions-list"
           data-testid={testIdPrefix ? `${testIdPrefix}-list` : undefined}
           onMouseLeave={() => setActiveSuggestionIndex(-1)}
+          tabIndex={-1}
         >
           {suggestions.map((suggestion, index) => (
             <li
@@ -276,7 +319,7 @@ const ComboBox = <T,>({
                 small,
                 'suggestion-item--custom': renderListElementComponent,
               })}
-              onClick={() => selectSuggestion(index)}
+              onClick={() => selectSuggestion(suggestion)}
               onMouseEnter={() => setActiveSuggestionIndex(index)}
             >
               {renderListElementComponent

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -202,11 +202,6 @@ const ComboBox = <T,>({
           const exactSuggestion = suggestionsByLabel.get(normalizedInputValue);
           if (exactSuggestion) {
             selectSuggestion(exactSuggestion);
-          } else if (
-            suggestions.length === 1 &&
-            getSuggestionLabel(suggestions[0]).startsWith(inputValue)
-          ) {
-            selectSuggestion(suggestions[0]);
           } else {
             if (showAddCustomValue) {
               confirmCustomValue();

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -148,7 +148,9 @@ const ComboBox = <T,>({
   const onFieldBlur = () => {
     const exactSuggestion = suggestionsByLabel.get(normalizedInputValue);
     if (activeSuggestionIndex === -1 && !showAddCustomValue) {
-      if (exactSuggestion) {
+      if (normalizedInputValue === '') {
+        onSelectSuggestion(undefined);
+      } else if (exactSuggestion) {
         onSelectSuggestion(exactSuggestion);
       } else {
         onAddCustomValue?.(inputValue);

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -15,7 +15,7 @@ import cx from 'classnames';
 import useOutsideClick from '../../hooks/useOutsideClick';
 import Input, { type InputProps } from '../Input';
 
-export type ComboBoxProps<T> = Omit<InputProps, 'value'> & {
+export type ComboBoxProps<T> = Omit<InputProps, 'value' | 'onChange'> & {
   value?: T;
   suggestions: Array<T>;
   customLabel?: ReactNode;
@@ -31,6 +31,7 @@ export type ComboBoxProps<T> = Omit<InputProps, 'value'> & {
     isSelected: boolean;
   }) => ReactNode;
   renderFooterItem?: () => ReactNode;
+  onChange: (inputValue: string) => void;
 
   allowCustomValue?: boolean;
   onAddCustomValue?: (value: string) => void;
@@ -122,7 +123,7 @@ const ComboBox = <T,>({
 
   // behavior
   const handleInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    onChange?.(e);
+    onChange?.(e.currentTarget.value);
     setInputValue(e.currentTarget.value);
   };
 
@@ -238,6 +239,7 @@ const ComboBox = <T,>({
 
   const clearInput = () => {
     setInputValue('');
+    onChange?.('');
     resetSuggestions();
     focusInput();
   };

--- a/front/ui/ui-core/src/components/ComboBox/__tests__/useDefaultComboBox.spec.ts
+++ b/front/ui/ui-core/src/components/ComboBox/__tests__/useDefaultComboBox.spec.ts
@@ -1,7 +1,5 @@
-import type { ChangeEvent } from 'react';
-
 import { act, renderHook } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 import useDefaultComboBox, {
   defaultFilterSuggestions,
@@ -75,10 +73,6 @@ describe('defaultFilterSuggestions', () => {
   });
 });
 
-function mockChangeEvent(value: string): ChangeEvent<HTMLInputElement> {
-  return vi.mockObject({ target: { value } }) as ChangeEvent<HTMLInputElement>;
-}
-
 describe('useDefaultComboBox', () => {
   const GREEN = { id: '1-green', label: 'Green' };
   const RED = { id: '2-red', label: 'Red' };
@@ -92,31 +86,31 @@ describe('useDefaultComboBox', () => {
     expect(result.current.suggestions).toEqual([GREEN, RED, ORANGE]);
 
     act(() => {
-      result.current.onChange(mockChangeEvent('re'));
+      result.current.onChange('re');
     });
 
     expect(result.current.suggestions).toEqual([RED, GREEN]);
 
     act(() => {
-      result.current.onChange(mockChangeEvent('red'));
+      result.current.onChange('red');
     });
 
     expect(result.current.suggestions).toEqual([RED]);
 
     act(() => {
-      result.current.onChange(mockChangeEvent(' ang '));
+      result.current.onChange(' ang');
     });
 
     expect(result.current.suggestions).toEqual([ORANGE]);
 
     act(() => {
-      result.current.onChange(mockChangeEvent('blu'));
+      result.current.onChange('blu');
     });
 
     expect(result.current.suggestions).toEqual([]);
 
     act(() => {
-      result.current.onChange(mockChangeEvent(' '));
+      result.current.onChange(' ');
     });
 
     expect(result.current.suggestions).toEqual([GREEN, RED, ORANGE]);
@@ -126,7 +120,7 @@ describe('useDefaultComboBox', () => {
     const { result } = renderHook(() => useDefaultComboBox(SUGGESTIONS, (color) => color.label));
 
     act(() => {
-      result.current.onChange(mockChangeEvent('red'));
+      result.current.onChange('red');
     });
 
     expect(result.current.suggestions).toEqual([RED]);

--- a/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
+++ b/front/ui/ui-core/src/components/ComboBox/useDefaultComboBox.ts
@@ -68,8 +68,8 @@ const useDefaultComboBox = <T>(suggestions: T[], getSuggestionLabel: (suggestion
     [labels, query]
   );
 
-  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setQuery(e.target.value);
+  const onChange = useCallback((newValue: string) => {
+    setQuery(newValue);
   }, []);
 
   const resetSuggestions = useCallback(() => {


### PR DESCRIPTION
Fixes #17633, #17639 and #17509.
Superseeds @Caracol3's attempt in #17692.

This pull request:
- Allows users to actually unset the rolling stock, i.e. to put an empty value inside that field if they choose to do so;
- Allows users to set an unknown, arbitrary rolling stock as a value, to align the behaviour with the one from the itinerary modal;
- Selects the category automatically if there was none selected based on the newly selected rolling stock (fixing #17509).