### PR TITLE
front: fix compo code field alignment in stdcm consist selection

### DIFF
--- a/front/src/common/SpeedLimitTagSelector/SpeedLimitTagSelector.tsx
+++ b/front/src/common/SpeedLimitTagSelector/SpeedLimitTagSelector.tsx
@@ -31,7 +31,7 @@ const SpeedLimitTagSelector = ({
   return (
     <div className="osrd-config-item">
       <div
-        className={cx('osrd-config-item-container', className, {
+        className={cx(className, {
           'd-flex align-items-center gap-10': condensed,
         })}
       >


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/17503