### PR TITLE
editoast: openapi: give different base_id values to authz error enums

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6322,7 +6322,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:authz:DbError
+          - editoast:authorization:DbError
     EditoastAuthorizationErrorForbidden:
       type: object
       required:
@@ -6342,7 +6342,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:authz:Forbidden
+          - editoast:authorization:Forbidden
     EditoastAuthorizationErrorForbiddenImpersonation:
       type: object
       required:
@@ -6362,7 +6362,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:authz:ForbiddenImpersonation
+          - editoast:authorization:ForbiddenImpersonation
     EditoastAuthorizationErrorImpersonatedUserNotFound:
       type: object
       required:
@@ -6387,7 +6387,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:authz:ImpersonatedUserNotFound
+          - editoast:authorization:ImpersonatedUserNotFound
     EditoastAuthorizationErrorUnauthenticated:
       type: object
       required:
@@ -6407,7 +6407,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:authz:Unauthenticated
+          - editoast:authorization:Unauthenticated
     EditoastAuthzErrorAuthorizer:
       type: object
       required:
@@ -6448,46 +6448,6 @@ components:
           type: string
           enum:
           - editoast:authz:Database
-    EditoastAuthzErrorOpenfga:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          title: EditoastAuthzErrorOpenfgaContext
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:authz:Openfga
-    EditoastAuthzErrorStorage:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          title: EditoastAuthzErrorStorageContext
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:authz:Storage
     EditoastAuthzErrorUnknownIdentities:
       type: object
       required:
@@ -6588,6 +6548,111 @@ components:
           type: string
           enum:
           - editoast:authz:UnknownUser
+    EditoastAuthzLegacyErrorOpenfga:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzLegacyErrorOpenfgaContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:authz_legacy:Openfga
+    EditoastAuthzLegacyErrorStorage:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzLegacyErrorStorageContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:authz_legacy:Storage
+    EditoastAuthzLegacyErrorUnknownResource:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzLegacyErrorUnknownResourceContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:authz_legacy:UnknownResource
+    EditoastAuthzLegacyErrorUnknownSubject:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzLegacyErrorUnknownSubjectContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:authz_legacy:UnknownSubject
+    EditoastAuthzLegacyErrorUnknownUser:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzLegacyErrorUnknownUserContext
+          required:
+          - id
+          properties:
+            id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 401
+        type:
+          type: string
+          enum:
+          - editoast:authz_legacy:UnknownUser
     EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject:
       type: object
       required:
@@ -7069,15 +7134,15 @@ components:
       - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthenticated'
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthorizer'
       - $ref: '#/components/schemas/EditoastAuthzErrorDatabase'
-      - $ref: '#/components/schemas/EditoastAuthzErrorOpenfga'
-      - $ref: '#/components/schemas/EditoastAuthzErrorStorage'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownIdentities'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownResource'
-      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownResource'
-      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownSubject'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownSubject'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownUser'
-      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownUser'
+      - $ref: '#/components/schemas/EditoastAuthzLegacyErrorOpenfga'
+      - $ref: '#/components/schemas/EditoastAuthzLegacyErrorStorage'
+      - $ref: '#/components/schemas/EditoastAuthzLegacyErrorUnknownResource'
+      - $ref: '#/components/schemas/EditoastAuthzLegacyErrorUnknownSubject'
+      - $ref: '#/components/schemas/EditoastAuthzLegacyErrorUnknownUser'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorFixTrialFailure'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorMaximumIterationReached'

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -246,23 +246,23 @@ impl EditoastError for json_patch::PatchError {
 }
 
 inventory::submit! {
-    crate::error::ErrorDefinition::new("editoast:authz:UnknownSubject", "UnknownSubject", "AuthzError", 404u16, r#"{}"#)
+    crate::error::ErrorDefinition::new("editoast:authz_legacy:UnknownSubject", "UnknownSubject", "AuthzLegacyError", 404u16, r#"{}"#)
 }
 
 inventory::submit! {
-    crate::error::ErrorDefinition::new("editoast:authz:UnknownResource", "UnknownResource", "AuthzError", 404u16, r#"{}"#)
+    crate::error::ErrorDefinition::new("editoast:authz_legacy:UnknownResource", "UnknownResource", "AuthzLegacyError", 404u16, r#"{}"#)
 }
 
 inventory::submit! {
-    crate::error::ErrorDefinition::new("editoast:authz:UnknownUser", "UnknownUser", "AuthzError", 401u16, r#"{}"#)
+    crate::error::ErrorDefinition::new("editoast:authz_legacy:UnknownUser", "UnknownUser", "AuthzLegacyError", 401u16, r#"{"id": "i64"}"#)
 }
 
 inventory::submit! {
-    crate::error::ErrorDefinition::new("editoast:authz:Openfga", "Openfga", "AuthzError", 500u16, r#"{}"#)
+    crate::error::ErrorDefinition::new("editoast:authz_legacy:Openfga", "Openfga", "AuthzLegacyError", 500u16, r#"{}"#)
 }
 
 inventory::submit! {
-    crate::error::ErrorDefinition::new("editoast:authz:Storage", "Storage", "AuthzError", 500u16, r#"{}"#)
+    crate::error::ErrorDefinition::new("editoast:authz_legacy:Storage", "Storage", "AuthzLegacyError", 500u16, r#"{}"#)
 }
 impl<StorageError: std::error::Error + Send + Sync> EditoastError for authz::Error<StorageError> {
     fn get_status(&self) -> StatusCode {
@@ -279,11 +279,11 @@ impl<StorageError: std::error::Error + Send + Sync> EditoastError for authz::Err
 
     fn get_type(&self) -> &str {
         match self {
-            authz::Error::UnknownSubject(_) => "editoast:authz:UnknownSubject",
-            authz::Error::UnknownResource(_) => "editoast:authz:UnknownResource",
-            authz::Error::UnknownUser { .. } => "editoast:authz:UnknownUser",
-            authz::Error::OpenFga(_) => "editoast:authz:Openfga",
-            authz::Error::Storage(_) => "editoast:authz:Storage",
+            authz::Error::UnknownSubject(_) => "editoast:authz_legacy:UnknownSubject",
+            authz::Error::UnknownResource(_) => "editoast:authz_legacy:UnknownResource",
+            authz::Error::UnknownUser { .. } => "editoast:authz_legacy:UnknownUser",
+            authz::Error::OpenFga(_) => "editoast:authz_legacy:Openfga",
+            authz::Error::Storage(_) => "editoast:authz_legacy:Storage",
         }
     }
 

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -490,7 +490,7 @@ pub use server::middlewares::AuthenticationExt;
 pub type AuthorizerError = ::authz::Error<<PgAuthDriver as ::authz::StorageDriver>::Error>;
 
 #[derive(Debug, Error, derive_more::From, EditoastError)]
-#[editoast_error(base_id = "authz")]
+#[editoast_error(base_id = "authorization")]
 pub enum AuthorizationError {
     #[error("Unauthorized (401) — user must be authenticated")]
     #[editoast_error(status = 401)]

--- a/front/public/locales/de/errors.json
+++ b/front/public/locales/de/errors.json
@@ -23,22 +23,27 @@
     "attached": {
       "TrackNotFound": "Gleisabschnitt {{track_id}} nicht gefunden"
     },
-    "authz": {
+    "authorization": {
       "AuthError": "Interner Authentifizierungs-/Autorisierungsfehler, bitte erneut versuchen oder den Support kontaktieren",
+      "DbError": "Interner Datenbankfehler, bitte erneut versuchen oder den Support kontaktieren",
+      "Forbidden": "Zugriff verweigert",
+      "ForbiddenImpersonation": "Identitätswechsel verweigert",
+      "ImpersonatedUserNotFound": "Imitierter Benutzer unbekannt"
+    },
+    "authz": {
       "Authorizer": "Interner Fehler",
       "Authz": "Interner Authentifizierungs-/Autorisierungsfehler, bitte erneut versuchen oder den Support kontaktieren",
       "Database": "Interner Datenbankfehler",
-      "DbError": "Interner Datenbankfehler, bitte erneut versuchen oder den Support kontaktieren",
       "Driver": "Interner Authentifizierungs-/Autorisierungsfehler, bitte erneut versuchen oder den Support kontaktieren",
-      "Forbidden": "Zugriff verweigert",
-      "ForbiddenImpersonation": "Identitätswechsel verweigert",
       "GrantsApiMisuse": "Fehlerhafte Nutzung der Autorisierungs-API",
-      "ImpersonatedUserNotFound": "Imitierter Benutzer unbekannt",
       "NoSuchUser": "Unbekannter Benutzer",
-      "Unauthorized": "Unauthentifizierter Benutzer",
-      "UnknownIdentity": "Unbekannte Identität '{{identity}}'",
       "UnknownResource": "Unbekannte Ressource",
       "UnknownResourceType": "Unbekannter Ressourcentyp",
+      "UnknownSubject": "Unbekanntes Subjekt",
+      "UnknownUser": "Unbekannter Benutzer '{{id}}'"
+    },
+    "authz_legacy": {
+      "UnknownResource": "Unbekannte Ressource",
       "UnknownSubject": "Unbekanntes Subjekt",
       "UnknownUser": "Unbekannter Benutzer '{{id}}'"
     },

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -28,24 +28,31 @@
     "attached": {
       "TrackNotFound": "Track {{track_id}} not found"
     },
-    "authz": {
+    "authorization": {
       "AuthError": "Authentication/authorization internal error, try again or contact support",
+      "DbError": "Database access fatal error",
+      "Forbidden": "Access denied",
+      "ForbiddenImpersonation": "Impersonation denied",
+      "ImpersonatedUserNotFound": "Unknown impersonated user",
+      "Unauthenticated": "Unauthenticated user"
+    },
+    "authz": {
       "Authorizer": "Internal error",
       "Authz": "Authentication/authorization internal error, try again or contact support",
       "Database": "Internal error (database)",
-      "DbError": "Database access fatal error",
       "Driver": "Authentication/authorization internal error, try again or contact support",
-      "Forbidden": "Access denied",
-      "ForbiddenImpersonation": "Impersonation denied",
       "GrantsApiMisuse": "Improper API usage",
-      "ImpersonatedUserNotFound": "Unknown impersonated user",
       "NoSuchUser": "Unknown user",
-      "Openfga": "Internal error",
-      "Storage": "Internal error",
-      "Unauthenticated": "Unauthenticated user",
       "UnknownIdentities": "Unknown identities '{{identities}}'",
       "UnknownResource": "Unknown resource",
       "UnknownResourceType": "Unknown resource type",
+      "UnknownSubject": "Unknown subject",
+      "UnknownUser": "Unknown user '{{id}}'"
+    },
+    "authz_legacy": {
+      "Openfga": "Internal error",
+      "Storage": "Internal error",
+      "UnknownResource": "Unknown resource",
       "UnknownSubject": "Unknown subject",
       "UnknownUser": "Unknown user '{{id}}'"
     },

--- a/front/public/locales/es/errors.json
+++ b/front/public/locales/es/errors.json
@@ -20,16 +20,20 @@
       "Timeout": "El servicio no respondió a tiempo",
       "Valkey": "Error de Valkey"
     },
-    "authz": {
+    "authorization": {
       "AuthError": "Error interno de autenticación o de autorización; vuelva a intentarlo o contacte al personal de asistencia",
+      "DbError": "Error grave de acceso a la base de datos"
+    },
+    "authz": {
       "Authorizer": "Error interno",
       "Authz": "Error interno de autenticación o de autorización; vuelva a intentarlo o contacte al personal de asistencia",
-      "DbError": "Error grave de acceso a la base de datos",
       "GrantsApiMisuse": "Uso impropio de la API",
       "NoSuchUser": "Usuario desconocido",
-      "Unauthorized": "Usuario no autenticado",
       "UnknownResource": "Recurso desconocido",
       "UnknownResourceType": "Tipo de recurso desconocido"
+    },
+    "authz_legacy": {
+      "UnknownResource": "Recurso desconocido"
     },
     "auto_fixes": {
       "MissingErrorObject": "No se pudo encontrar el objeto del error"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -28,24 +28,31 @@
     "attached": {
       "TrackNotFound": "Section de voie {{track_id}} non trouvée"
     },
-    "authz": {
+    "authorization": {
       "AuthError": "Erreur interne d'authentification ou d'autorisation, veuillez réessayer ou contacter le support",
+      "DbError": "Erreur interne de base de données, veuillez réessayer ou contacter le support",
+      "Forbidden": "Accès refusé",
+      "ForbiddenImpersonation": "Usurpation refusée",
+      "ImpersonatedUserNotFound": "Utilisateur usurpé inconnu",
+      "Unauthenticated": "Utilisateur non authentifié"
+    },
+    "authz": {
       "Authorizer": "Erreur interne",
       "Authz": "Erreur interne d'authentification ou d'autorisation, veuillez réessayer ou contacter le support",
       "Database": "Internal error (database)",
-      "DbError": "Erreur interne de base de données, veuillez réessayer ou contacter le support",
       "Driver": "Erreur interne d'authentification ou d'autorisation, veuillez réessayer ou contacter le support",
-      "Forbidden": "Accès refusé",
-      "ForbiddenImpersonation": "Usurpation refusée",
       "GrantsApiMisuse": "Mauvaise utilisation de l'API d'autorisation",
-      "ImpersonatedUserNotFound": "Utilisateur usurpé inconnu",
       "NoSuchUser": "Utilisateur inconnu",
-      "Openfga": "Erreur interne",
-      "Storage": "Erreur interne",
-      "Unauthenticated": "Utilisateur non authentifié",
       "UnknownIdentities": "Identités inconnues '{{identities}}'",
       "UnknownResource": "Ressource inconnue",
       "UnknownResourceType": "Type de ressource inconnu",
+      "UnknownSubject": "Sujet inconnu",
+      "UnknownUser": "Utilisateur inconnu '{{id}}'"
+    },
+    "authz_legacy": {
+      "Openfga": "Erreur interne",
+      "Storage": "Erreur interne",
+      "UnknownResource": "Ressource inconnue",
       "UnknownSubject": "Sujet inconnu",
       "UnknownUser": "Utilisateur inconnu '{{id}}'"
     },

--- a/front/public/locales/pl/errors.json
+++ b/front/public/locales/pl/errors.json
@@ -22,20 +22,25 @@
     "attached": {
       "TrackNotFound": "Odcinek toru {{track_id}} nie został znaleziony"
     },
-    "authz": {
+    "authorization": {
       "AuthError": "Wewnętrzny błąd autoryzacji/autentykacji. Spróbuj ponownie później lub skontaktuj się z pomocą techniczną",
-      "Authorizer": "Wewnętrzny błąd",
-      "Authz": "Wewnętrzny błąd autoryzacji/autentykacji. Spróbuj ponownie później lub skontaktuj się z pomocą techniczną",
       "DbError": "Błąd krytyczny dostępu do bazy danych",
-      "Driver": "Wewnętrzny błąd autoryzacji/autentykacji. Spróbuj ponownie później lub skontaktuj się z pomocą techniczną",
       "Forbidden": "Odmowa dostępu",
       "ForbiddenImpersonation": "Uzurpacja odrzucona",
+      "ImpersonatedUserNotFound": "Nieznany podszyty użytkownik"
+    },
+    "authz": {
+      "Authorizer": "Wewnętrzny błąd",
+      "Authz": "Wewnętrzny błąd autoryzacji/autentykacji. Spróbuj ponownie później lub skontaktuj się z pomocą techniczną",
+      "Driver": "Wewnętrzny błąd autoryzacji/autentykacji. Spróbuj ponownie później lub skontaktuj się z pomocą techniczną",
       "GrantsApiMisuse": "Nieprawidłowy sposób użycia API",
-      "ImpersonatedUserNotFound": "Nieznany podszyty użytkownik",
       "NoSuchUser": "Nieznany Użytkownik",
-      "Unauthorized": "Nieautoryzowany użytkownik",
       "UnknownResource": "Nienznany zasób",
       "UnknownResourceType": "Nieznany typ zasobu",
+      "UnknownSubject": "Nieznany Obiekt"
+    },
+    "authz_legacy": {
+      "UnknownResource": "Nienznany zasób",
       "UnknownSubject": "Nieznany Obiekt"
     },
     "auto_fixes": {

--- a/front/public/locales/pt/errors.json
+++ b/front/public/locales/pt/errors.json
@@ -23,21 +23,26 @@
     "attached": {
       "TrackNotFound": "Secção de via {{track_id}} não encontrado"
     },
-    "authz": {
+    "authorization": {
       "AuthError": "Erro interno de autenticação ou de autorização, tente novamente ou contacte o suporte",
+      "DbError": "Erro interno de base de dados, tente outra vez ou contacte o suporte",
+      "Forbidden": "Acesso recusado",
+      "ForbiddenImpersonation": "Usurpação recursa"
+    },
+    "authz": {
       "Authorizer": "Erro interno",
       "Authz": "Erro interno de autenticação ou de autorização. Tente mais tarde ou contacte o suporte",
       "Database": "Erro interno (database)",
-      "DbError": "Erro interno de base de dados, tente outra vez ou contacte o suporte",
       "Driver": "Erro interno de autenticação ou autorização. Tente novamente ou contate o suporte",
-      "Forbidden": "Acesso recusado",
-      "ForbiddenImpersonation": "Usurpação recursa",
       "GrantsApiMisuse": "Utilização incorreta da API de autorização",
       "NoSuchUser": "Utilizador desconhecido",
-      "Unauthorized": "Utilizador não autenticado",
-      "UnknownIdentity": "Identidade desconhecida '{{identity}}'",
       "UnknownResource": "Recurso desconhecido",
       "UnknownResourceType": "Tipo de recurso desconhecido",
+      "UnknownSubject": "Assunto desconhecido",
+      "UnknownUser": "Utilizador desconhecido '{{id}}'"
+    },
+    "authz_legacy": {
+      "UnknownResource": "Recurso desconhecido",
       "UnknownSubject": "Assunto desconhecido",
       "UnknownUser": "Utilizador desconhecido '{{id}}'"
     },

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -492,7 +492,7 @@ class EditoastAuthorizationErrorDbError(BaseModel):
     ] = None
     message: str
     status: Literal[500]
-    type: Literal["editoast:authz:DbError"]
+    type: Literal["editoast:authorization:DbError"]
 
 
 class EditoastAuthorizationErrorForbidden(BaseModel):
@@ -501,7 +501,7 @@ class EditoastAuthorizationErrorForbidden(BaseModel):
     ] = None
     message: str
     status: Literal[403]
-    type: Literal["editoast:authz:Forbidden"]
+    type: Literal["editoast:authorization:Forbidden"]
 
 
 class EditoastAuthorizationErrorForbiddenImpersonation(BaseModel):
@@ -511,7 +511,7 @@ class EditoastAuthorizationErrorForbiddenImpersonation(BaseModel):
     ] = None
     message: str
     status: Literal[403]
-    type: Literal["editoast:authz:ForbiddenImpersonation"]
+    type: Literal["editoast:authorization:ForbiddenImpersonation"]
 
 
 class EditoastAuthorizationErrorImpersonatedUserNotFoundContext(BaseModel):
@@ -525,7 +525,7 @@ class EditoastAuthorizationErrorImpersonatedUserNotFound(BaseModel):
     ] = None
     message: str
     status: Literal[404]
-    type: Literal["editoast:authz:ImpersonatedUserNotFound"]
+    type: Literal["editoast:authorization:ImpersonatedUserNotFound"]
 
 
 class EditoastAuthorizationErrorUnauthenticated(BaseModel):
@@ -535,7 +535,7 @@ class EditoastAuthorizationErrorUnauthenticated(BaseModel):
     ] = None
     message: str
     status: Literal[401]
-    type: Literal["editoast:authz:Unauthenticated"]
+    type: Literal["editoast:authorization:Unauthenticated"]
 
 
 class EditoastAuthzErrorAuthorizer(BaseModel):
@@ -554,24 +554,6 @@ class EditoastAuthzErrorDatabase(BaseModel):
     message: str
     status: Literal[500]
     type: Literal["editoast:authz:Database"]
-
-
-class EditoastAuthzErrorOpenfga(BaseModel):
-    context: Annotated[
-        dict[str, Any] | None, Field(title="EditoastAuthzErrorOpenfgaContext")
-    ] = None
-    message: str
-    status: Literal[500]
-    type: Literal["editoast:authz:Openfga"]
-
-
-class EditoastAuthzErrorStorage(BaseModel):
-    context: Annotated[
-        dict[str, Any] | None, Field(title="EditoastAuthzErrorStorageContext")
-    ] = None
-    message: str
-    status: Literal[500]
-    type: Literal["editoast:authz:Storage"]
 
 
 class EditoastAuthzErrorUnknownIdentitiesContext(BaseModel):
@@ -628,6 +610,58 @@ class EditoastAuthzErrorUnknownUser(BaseModel):
     message: str
     status: Literal[404]
     type: Literal["editoast:authz:UnknownUser"]
+
+
+class EditoastAuthzLegacyErrorOpenfga(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastAuthzLegacyErrorOpenfgaContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:authz_legacy:Openfga"]
+
+
+class EditoastAuthzLegacyErrorStorage(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastAuthzLegacyErrorStorageContext")
+    ] = None
+    message: str
+    status: Literal[500]
+    type: Literal["editoast:authz_legacy:Storage"]
+
+
+class EditoastAuthzLegacyErrorUnknownResource(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None,
+        Field(title="EditoastAuthzLegacyErrorUnknownResourceContext"),
+    ] = None
+    message: str
+    status: Literal[404]
+    type: Literal["editoast:authz_legacy:UnknownResource"]
+
+
+class EditoastAuthzLegacyErrorUnknownSubject(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None,
+        Field(title="EditoastAuthzLegacyErrorUnknownSubjectContext"),
+    ] = None
+    message: str
+    status: Literal[404]
+    type: Literal["editoast:authz_legacy:UnknownSubject"]
+
+
+class EditoastAuthzLegacyErrorUnknownUserContext(BaseModel):
+    id: int
+
+
+class EditoastAuthzLegacyErrorUnknownUser(BaseModel):
+    context: Annotated[
+        EditoastAuthzLegacyErrorUnknownUserContext | None,
+        Field(title="EditoastAuthzLegacyErrorUnknownUserContext"),
+    ] = None
+    message: str
+    status: Literal[401]
+    type: Literal["editoast:authz_legacy:UnknownUser"]
 
 
 class EditoastAutoFixesEditoastErrorConflictingFixesOnSameObjectContext(BaseModel):
@@ -4545,12 +4579,15 @@ class EditoastError(
         | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorAuthorizer
         | EditoastAuthzErrorDatabase
-        | EditoastAuthzErrorOpenfga
-        | EditoastAuthzErrorStorage
         | EditoastAuthzErrorUnknownIdentities
         | EditoastAuthzErrorUnknownResource
         | EditoastAuthzErrorUnknownSubject
         | EditoastAuthzErrorUnknownUser
+        | EditoastAuthzLegacyErrorOpenfga
+        | EditoastAuthzLegacyErrorStorage
+        | EditoastAuthzLegacyErrorUnknownResource
+        | EditoastAuthzLegacyErrorUnknownSubject
+        | EditoastAuthzLegacyErrorUnknownUser
         | EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject
         | EditoastAutoFixesEditoastErrorFixTrialFailure
         | EditoastAutoFixesEditoastErrorMaximumIterationReached
@@ -4718,12 +4755,15 @@ class EditoastError(
         | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorAuthorizer
         | EditoastAuthzErrorDatabase
-        | EditoastAuthzErrorOpenfga
-        | EditoastAuthzErrorStorage
         | EditoastAuthzErrorUnknownIdentities
         | EditoastAuthzErrorUnknownResource
         | EditoastAuthzErrorUnknownSubject
         | EditoastAuthzErrorUnknownUser
+        | EditoastAuthzLegacyErrorOpenfga
+        | EditoastAuthzLegacyErrorStorage
+        | EditoastAuthzLegacyErrorUnknownResource
+        | EditoastAuthzLegacyErrorUnknownSubject
+        | EditoastAuthzLegacyErrorUnknownUser
         | EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject
         | EditoastAutoFixesEditoastErrorFixTrialFailure
         | EditoastAutoFixesEditoastErrorMaximumIterationReached


### PR DESCRIPTION
Several authorization error enums were sharing the same variant names and base ids, which caused the openapi generation macros to produce a different openapi.yaml depending on which variants the macros parsed first, which itself depended on which version of the compiler cargo was running.