### PR TITLE
front: fix path properties operational points order when they share the same position

### DIFF
--- a/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
@@ -1,9 +1,12 @@
 import { cleanup, waitFor } from '@testing-library/react';
 import { renderHookWithStore } from 'store/__tests__';
+import { v4 as uuidV4 } from 'uuid';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { mockOsrdEditoastEndpoints } from 'common/api/__mocks__/osrdEditoastApi';
 import type {
+  CoreOperationalPointOnPath,
+  PathItem,
   PacedTrainException,
   PathfindingResult,
   PathProperties,
@@ -11,7 +14,7 @@ import type {
   SimulationResponse,
 } from 'common/api/osrdEditoastApi';
 
-import useSimulationResults from '../useSimulationResults';
+import useSimulationResults, { sortPathOperationalPoints } from '../useSimulationResults';
 
 const INFRA_ID = 12;
 const ELECTRICAL_PROFILE_SET_ID = 34;
@@ -492,5 +495,52 @@ describe.skip('useSimulationResults', () => {
         exceptionId: undefined,
       });
     });
+  });
+});
+
+describe('sortPathOperationalPoints', () => {
+  const makeOp = (id: string, position: number) => ({ id, position }) as CoreOperationalPointOnPath;
+
+  const makePathItem = (opId: string): PathItem => ({
+    id: uuidV4(),
+    location: {
+      type: 'operational_point_part_reference',
+      operational_point: { type: 'id', operational_point: opId },
+    },
+  });
+
+  it('should not modify a list already sorted by position', () => {
+    const ops = [makeOp('A', 0), makeOp('B', 100), makeOp('C', 200)];
+    const path = [makePathItem('A'), makePathItem('B'), makePathItem('C')];
+    const result = sortPathOperationalPoints(ops, path);
+    expect(result.map((op) => op.id)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('should put the path origin first in the list when its position matches the one of other waypoints', () => {
+    const ops = [makeOp('A', 0), makeOp('C', 0), makeOp('B', 0), makeOp('D', 200)];
+    const path = [makePathItem('C'), makePathItem('A'), makePathItem('D')];
+    const result = sortPathOperationalPoints(ops, path);
+    expect(result.map((op) => op.id)).toEqual(['C', 'A', 'B', 'D']);
+  });
+
+  it('should sort two path items based on their index in the path if they are next to each other in ops when they are neither the origin or destination)', () => {
+    const ops = [
+      makeOp('A', 0),
+      makeOp('C', 200),
+      makeOp('D', 200),
+      makeOp('B', 200),
+      makeOp('E', 200),
+      makeOp('F', 300),
+    ];
+    const path = [makePathItem('A'), makePathItem('B'), makePathItem('D'), makePathItem('F')];
+    const result = sortPathOperationalPoints(ops, path);
+    expect(result.map((op) => op.id)).toEqual(['A', 'C', 'B', 'D', 'E', 'F']);
+  });
+
+  it('should put the path destination at the end of the list when its position matches the one of other waypoints', () => {
+    const ops = [makeOp('A', 0), makeOp('D', 100), makeOp('B', 100), makeOp('C', 100)];
+    const path = [makePathItem('A'), makePathItem('C'), makePathItem('D')];
+    const result = sortPathOperationalPoints(ops, path);
+    expect(result.map((op) => op.id)).toEqual(['A', 'B', 'C', 'D']);
   });
 });

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -4,7 +4,12 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import { osrdEditoastApi, type TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import {
+  osrdEditoastApi,
+  type CoreOperationalPointOnPath,
+  type PathItem,
+  type TrainScheduleResponse,
+} from 'common/api/osrdEditoastApi';
 import formatPowerRestrictionRangesWithHandled from 'modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled';
 import {
   extractOccurrenceDetailsFromPacedTrain,
@@ -23,8 +28,37 @@ import {
 } from 'utils/trainId';
 
 import type { SimulationResults } from '../types';
-import { preparePathPropertiesData } from '../utils';
+import { matchOpRefAndOp, preparePathPropertiesData } from '../utils';
 import { useScenarioContext } from './useScenarioContext';
+
+/**
+ * Sort operational points by position on the path (mm from origin).
+ * We want to ensure the following properties:
+ * - All path items specified by the user appear in-order in the OP list.
+ * - The first OP in the list is the first path item specified by the user.
+ * - The last OP in the list is the last path item specified by the user.
+ * - TODO: it doesn't order ops not at origin/destination, find a clean way to handle this case
+ */
+export const sortPathOperationalPoints = (
+  ops: CoreOperationalPointOnPath[],
+  path: PathItem[]
+): CoreOperationalPointOnPath[] =>
+  ops.toSorted((a, b) => {
+    if (a.position !== b.position) return a.position - b.position;
+    const aPathIndex = path.findIndex((pathItem) => matchOpRefAndOp(pathItem.location, a));
+    const bPathIndex = path.findIndex((pathItem) => matchOpRefAndOp(pathItem.location, b));
+    const lastIndex = path.length - 1;
+    const aIsOrigin = aPathIndex === 0;
+    const bIsOrigin = bPathIndex === 0;
+    const aIsDestination = aPathIndex === lastIndex;
+    const bIsDestination = bPathIndex === lastIndex;
+    if (aIsOrigin && !bIsOrigin) return -1;
+    if (bIsOrigin && !aIsOrigin) return 1;
+    if (aIsDestination && !bIsDestination) return 1;
+    if (bIsDestination && !aIsDestination) return -1;
+    if (aPathIndex !== -1 && bPathIndex !== -1) return aPathIndex - bPathIndex;
+    return 0;
+  });
 
 /**
  * Prepare data to be used in simulation results
@@ -132,6 +166,18 @@ const useSimulationResults = (
         : skipToken
     );
 
+  const orderedRawPathProperties = useMemo(() => {
+    if (!rawPathProperties || !train) return rawPathProperties;
+
+    return {
+      ...rawPathProperties,
+      operational_points: sortPathOperationalPoints(
+        rawPathProperties.operational_points,
+        train.path
+      ),
+    };
+  }, [rawPathProperties, train]);
+
   const isSimulationDataLoading =
     isPathfindingFetching || isSimulationFetching || isPathPropertiesFetching;
 
@@ -139,7 +185,7 @@ const useSimulationResults = (
     return { results: undefined, isSimulationDataLoading };
   }
 
-  if (pathfinding?.status !== 'success' || !rawPathProperties || !rollingStock) {
+  if (pathfinding?.status !== 'success' || !orderedRawPathProperties || !rollingStock) {
     return {
       results: { isValid: false, train, path: pathfinding, rollingStock },
       isSimulationDataLoading,
@@ -148,7 +194,7 @@ const useSimulationResults = (
 
   const pathProperties = preparePathPropertiesData(
     simulation?.status === 'success' ? simulation.electrical_profiles : undefined,
-    rawPathProperties,
+    orderedRawPathProperties,
     pathfinding,
     train.path,
     t


### PR DESCRIPTION
Due to some data issues, different operational points can share the same position in the path properties response. If that's the case, we expect to prioritize ops that belongs to the corresponding train schedule path first and by preserving their index in the path.

This allows to have a proper sorted op list in the time stops table but also in the speed distance diagram, the simulation report sheet and the csv export.

close #17125 

@Yohh Wasn't sure what was the guidelines for the test location of a helper used only in a hook

> [!NOTE]
> The related issue is indirectly fixed since the origin is now always positioned first in the time stops table but to test the table and propagation behavior more when two path steps share the same position, we should first do the core adaptation mentioned in the issue