### PR TITLE
front: group oxc bumps for dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,10 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+      oxc:
+        patterns:
+          - "oxlint"
+          - "oxlint-*"
       patch:
         update-types:
           - "patch"


### PR DESCRIPTION
This will avoid so warning/errors when installing dependencies with npm when their bumps are done separately

Regarding this [comment](https://github.com/OpenRailAssociation/osrd/pull/17693#issuecomment-4993052023).

> [!NOTE]
> Wonder if I should have done one pattern for oxfmt/oxlint-* and another one for oxlint/oxlint-* since their releases don't follow each other ? 