### PR TITLE
editoast: views: `POST:/rolling_stock/{id}/livery`: fix incorrect content-type in documentation

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2505,7 +2505,7 @@ paths:
           format: int64
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
               $ref: '#/components/schemas/RollingStockLiveryCreateForm'
         required: true

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -477,7 +477,7 @@ async fn parse_multipart_content(
     post, path = "",
     tags = ["rolling_stock", "rolling_stock_livery"],
     params(RollingStockIdParam),
-    request_body = RollingStockLiveryCreateForm,
+    request_body(content = RollingStockLiveryCreateForm, content_type = "multipart/form-data"),
     responses(
         (status = 200, description = "The created rolling stock", body = RollingStockLivery),
         (status = 404, description = "The requested rolling stock was not found"),


### PR DESCRIPTION
Change the content-type from application/json (which was selected by default by utoipa) to multipart/form-data (what the endpoint actually expects).