### PR TITLE
e2e: replace non-retrying assertions with retrying ones

### DIFF
--- a/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
+++ b/front/tests/04-rolling-stock-editor/001-rolling-stock-editor.spec.ts
@@ -200,7 +200,7 @@ test.describe('Rolling stock editor management', { tag: '@rs-editor' }, () => {
     await test.step('Search deleted rolling stock → expect no results', async () => {
       await rollingStockEditorPage.searchRollingStock(uniqueDeletedRollingStockName, false);
       await expect(rollingStockEditorPage.noRollingStockResult).toBeVisible();
-      expect(await rollingStockEditorPage.getRollingStockSearchNumber()).toEqual(0);
+      await expect.poll(() => rollingStockEditorPage.getRollingStockSearchNumber()).toEqual(0);
     });
   });
 });

--- a/front/tests/04-rolling-stock-editor/002-rolling-stock-filter.spec.ts
+++ b/front/tests/04-rolling-stock-editor/002-rolling-stock-filter.spec.ts
@@ -15,37 +15,50 @@ test.describe('Rolling stock editor filter', { tag: ['@rs-editor', '@filter'] },
 
     await test.step('Toggle Electric filter and verify count', async () => {
       await rollingStockEditorPage.toggleElectricRollingStockFilter();
-      expect(await rollingStockEditorPage.electricRollingStockIcons.count()).toEqual(
-        await rollingStockEditorPage.getRollingStockSearchNumber()
-      );
+      await expect
+        .poll(async () => {
+          const iconCount = await rollingStockEditorPage.electricRollingStockIcons.count();
+          const searchNumber = await rollingStockEditorPage.getRollingStockSearchNumber();
+          return iconCount === searchNumber;
+        })
+        .toBe(true);
     });
 
     await test.step('Clear Electric filter and verify initial count', async () => {
       await rollingStockEditorPage.toggleElectricRollingStockFilter();
-      expect(await rollingStockEditorPage.rollingStockList.count()).toBeGreaterThanOrEqual(
-        initialRollingStockFoundNumber
-      );
+      await expect
+        .poll(() => rollingStockEditorPage.rollingStockList.count())
+        .toBeGreaterThanOrEqual(initialRollingStockFoundNumber);
     });
 
     await test.step('Toggle Thermal filter and verify count', async () => {
       await rollingStockEditorPage.toggleThermalRollingStockFilter();
-      expect(await rollingStockEditorPage.thermalRollingStockIcons.count()).toEqual(
-        await rollingStockEditorPage.getRollingStockSearchNumber()
-      );
+      await expect
+        .poll(async () => {
+          const iconCount = await rollingStockEditorPage.thermalRollingStockIcons.count();
+          const searchNumber = await rollingStockEditorPage.getRollingStockSearchNumber();
+          return iconCount === searchNumber;
+        })
+        .toBe(true);
     });
 
     await test.step('Toggle Electric with Thermal on (dual-mode) and verify count', async () => {
       await rollingStockEditorPage.toggleElectricRollingStockFilter();
-      expect(await rollingStockEditorPage.dualModeRollingStockIcons.count()).toEqual(
-        await rollingStockEditorPage.getRollingStockSearchNumber()
-      );
+      await expect
+        .poll(async () => {
+          const iconCount = await rollingStockEditorPage.dualModeRollingStockIcons.count();
+          const searchNumber = await rollingStockEditorPage.getRollingStockSearchNumber();
+          return iconCount === searchNumber;
+        })
+        .toBe(true);
     });
 
     await test.step('Clear both filters and verify count resets', async () => {
       await rollingStockEditorPage.toggleElectricRollingStockFilter();
       await rollingStockEditorPage.toggleThermalRollingStockFilter();
-      const currentCount = await rollingStockEditorPage.rollingStockList.count();
-      expect(currentCount).toEqual(initialRollingStockFoundNumber);
+      await expect(rollingStockEditorPage.rollingStockList).toHaveCount(
+        initialRollingStockFoundNumber
+      );
     });
   });
 
@@ -56,9 +69,9 @@ test.describe('Rolling stock editor filter', { tag: ['@rs-editor', '@filter'] },
 
     await test.step('Search a specific rolling stock and verify icons', async () => {
       await rollingStockEditorPage.searchRollingStock(dualModeRollingStockName);
-      expect(
+      await expect(
         rollingStockEditorPage.page.getByTestId(`rollingstock-${dualModeRollingStockName}`)
-      ).toBeDefined();
+      ).toBeVisible();
 
       await expect(rollingStockEditorPage.thermalRollingStockFirstIcon).toBeVisible();
       await expect(rollingStockEditorPage.electricRollingStockFirstIcon).toBeVisible();
@@ -66,7 +79,7 @@ test.describe('Rolling stock editor filter', { tag: ['@rs-editor', '@filter'] },
 
     await test.step('Clear search and verify count resets', async () => {
       await rollingStockEditorPage.clearSearchRollingStock();
-      expect(await rollingStockEditorPage.rollingStockList.count()).toEqual(
+      await expect(rollingStockEditorPage.rollingStockList).toHaveCount(
         initialRollingStockFoundNumber
       );
     });
@@ -77,7 +90,7 @@ test.describe('Rolling stock editor filter', { tag: ['@rs-editor', '@filter'] },
         false
       );
       await expect(rollingStockEditorPage.noRollingStockResult).toBeVisible();
-      expect(await rollingStockEditorPage.getRollingStockSearchNumber()).toEqual(0);
+      await expect.poll(() => rollingStockEditorPage.getRollingStockSearchNumber()).toEqual(0);
     });
   });
 });

--- a/front/tests/pages/common-page.ts
+++ b/front/tests/pages/common-page.ts
@@ -91,8 +91,9 @@ class CommonPage {
   }
 
   async validateNumericBudget(locator: Locator, expectedBudget: string): Promise<void> {
-    const budgetText = await locator.textContent();
-    expect(budgetText?.replace(/[^0-9]/g, '')).toEqual(expectedBudget);
+    await expect
+      .poll(async () => (await locator.textContent())?.replace(/[^0-9]/g, ''))
+      .toEqual(expectedBudget);
   }
 }
 

--- a/front/tests/pages/operational-studies/get-manchette-component.ts
+++ b/front/tests/pages/operational-studies/get-manchette-component.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import { getCleanText, isGreyed, isOverflowing } from '../../utils';
+import { getCleanText, isOverflowing } from '../../utils';
 import type { Waypoint } from '../../utils/manchette';
 import type { SimulationResultsTranslations } from '../../utils/types';
 import OpSimulationResultPage from './simulation-results-page';
@@ -226,18 +226,18 @@ class GetManchetteComponent extends OpSimulationResultPage {
     await expect(this.manchetteLinearModeButton).toBeVisible();
 
     // initial state assertions
-    expect(await isGreyed(this.manchetteKmModeButton)).toBe(false);
-    expect(await isGreyed(this.manchetteLinearModeButton)).toBe(true);
+    await expect(this.manchetteKmModeButton).not.toHaveClass(/text-grey-30/);
+    await expect(this.manchetteLinearModeButton).toHaveClass(/text-grey-30/);
 
     // linear on
     await this.manchetteLinearModeButton.click();
-    expect(await isGreyed(this.manchetteLinearModeButton)).toBe(false);
-    expect(await isGreyed(this.manchetteKmModeButton)).toBe(true);
+    await expect(this.manchetteLinearModeButton).not.toHaveClass(/text-grey-30/);
+    await expect(this.manchetteKmModeButton).toHaveClass(/text-grey-30/);
 
     // back to km
     await this.manchetteKmModeButton.click();
-    expect(await isGreyed(this.manchetteKmModeButton)).toBe(false);
-    expect(await isGreyed(this.manchetteLinearModeButton)).toBe(true);
+    await expect(this.manchetteKmModeButton).not.toHaveClass(/text-grey-30/);
+    await expect(this.manchetteLinearModeButton).toHaveClass(/text-grey-30/);
   }
 
   async openWayPointMenu(index = 0, isRequestedPoint = false) {

--- a/front/tests/pages/operational-studies/project-page.ts
+++ b/front/tests/pages/operational-studies/project-page.ts
@@ -68,8 +68,9 @@ class ProjectPage extends HomePage {
   }
 
   private async validateObjectives(expectedObjectives: string) {
-    const objectives = await this.projectObjectivesLabel.textContent();
-    expect(cleanText(objectives)).toContain(cleanText(expectedObjectives));
+    await expect
+      .poll(async () => cleanText(await this.projectObjectivesLabel.textContent()))
+      .toContain(cleanText(expectedObjectives));
   }
 
   async createProject(details: ProjectDetails) {

--- a/front/tests/pages/operational-studies/route-tab.ts
+++ b/front/tests/pages/operational-studies/route-tab.ts
@@ -210,8 +210,7 @@ class RouteTab {
       ''
     );
     await expect(this.missingParamMessage).toBeVisible();
-    const actualMessage = await this.missingParamMessage.innerText();
-    expect(actualMessage).toContain(expectedMessage);
+    await expect(this.missingParamMessage).toContainText(expectedMessage);
   }
 
   // Click the add buttons for the specified via names.

--- a/front/tests/pages/operational-studies/times-and-stops-tab.ts
+++ b/front/tests/pages/operational-studies/times-and-stops-tab.ts
@@ -76,10 +76,7 @@ class TimesAndStopsTab {
           await expect(signalReceptionCheckbox).toBeChecked();
 
           const shortSlipCheckbox = rowLocator.locator('input[type="checkbox"]').nth(1);
-          const isShortSlipEnabled = await shortSlipCheckbox.isEnabled();
-          if (!isShortSlipEnabled) {
-            throw new Error('The shortSlipDistance checkbox is not enabled');
-          }
+          await expect(shortSlipCheckbox).toBeEnabled();
 
           await shortSlipCheckbox.click();
           await expect(shortSlipCheckbox).toBeChecked();

--- a/front/tests/pages/operational-studies/times-stops-table-page.ts
+++ b/front/tests/pages/operational-studies/times-stops-table-page.ts
@@ -233,11 +233,11 @@ class TimesStopsTablePage extends OpSimulationResultPage {
   }
 
   async verifyComputedArrivalChanged(row: Locator, previousText: string): Promise<void> {
-    expect(await this.getComputedArrivalText(row)).not.toBe(previousText);
+    await expect(this.computedArrival(row)).not.toHaveText(previousText);
   }
 
   async verifyComputedDepartureChanged(row: Locator, previousText: string): Promise<void> {
-    expect(await this.getComputedDepartureText(row)).not.toBe(previousText);
+    await expect(this.computedDeparture(row)).not.toHaveText(previousText);
   }
 
   async verifyComputedArrivalNotEmpty(row: Locator): Promise<void> {

--- a/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-editor-page.ts
@@ -164,7 +164,7 @@ class RollingstockEditorPage extends RollingStockSelector {
 
   async selectLoadingGauge(value: string) {
     await this.loadingGauge.selectOption(value);
-    expect(await this.loadingGauge.inputValue()).toBe(value);
+    await expect(this.loadingGauge).toHaveValue(value);
   }
 
   async selectPrimaryCategory(value: string) {
@@ -324,8 +324,7 @@ class RollingstockEditorPage extends RollingStockSelector {
       const valueCell = row.getByRole('cell').nth(1);
       await expect(valueCell).toBeVisible();
 
-      const actualValue = await valueCell.textContent();
-      expect(actualValue?.trim()).toBe(
+      await expect(valueCell).toHaveText(
         Array.isArray(expectedValue) ? expectedValue.join(', ') : expectedValue.toString()
       );
     }

--- a/front/tests/pages/rolling-stock/rolling-stock-selector.ts
+++ b/front/tests/pages/rolling-stock/rolling-stock-selector.ts
@@ -100,8 +100,7 @@ class RollingStockSelector extends CommonPage {
   }
 
   async verifySelectedComfortMatches(expectedComfort: string): Promise<void> {
-    const selectedComfort = await this.selectedComfortType.innerText();
-    expect(selectedComfort).toMatch(new RegExp(expectedComfort, 'i'));
+    await expect(this.selectedComfortType).toHaveText(new RegExp(expectedComfort, 'i'));
   }
 
   async toggleThermalRollingStockFilter() {

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -195,17 +195,15 @@ class SimulationResultPage {
       ? `Simulation n°${validSimulationNumber}`
       : noOutputSimulationName;
 
-    const actualSimulationName = await this.getSimulationNameLocator(simulationIndex).textContent();
-    expect(actualSimulationName).toEqual(expectedSimulationName);
+    await expect(this.getSimulationNameLocator(simulationIndex)).toHaveText(expectedSimulationName);
 
     const expectedLengthAndDuration = isResultTableVisible
       ? simulationLengthAndDuration
       : noCapacityLengthAndDuration;
 
-    const actualLengthAndDuration =
-      await this.getSimulationLengthAndDurationLocator(simulationIndex).textContent();
-
-    expect(actualLengthAndDuration).toEqual(expectedLengthAndDuration);
+    await expect(this.getSimulationLengthAndDurationLocator(simulationIndex)).toHaveText(
+      expectedLengthAndDuration ?? ''
+    );
   }
 
   async verifyFeedbackCardVisibility(): Promise<void> {
@@ -225,15 +223,17 @@ class SimulationResultPage {
     expectedBody: string,
     expectedEmail: string
   ): Promise<void> {
-    const mailtoUrl = await this.feedbackButton.getAttribute('href');
-
-    expect(mailtoUrl).toBeTruthy();
-
-    const decodedMailtoUrl = decodeURIComponent(mailtoUrl ?? '');
-
-    expect(decodedMailtoUrl).toContain(expectedEmail);
-    expect(decodedMailtoUrl).toContain(expectedSubject);
-    expect(decodedMailtoUrl).toContain(expectedBody);
+    await expect
+      .poll(async () => {
+        const mailtoUrl = await this.feedbackButton.getAttribute('href');
+        const decodedMailtoUrl = decodeURIComponent(mailtoUrl ?? '');
+        return (
+          decodedMailtoUrl.includes(expectedEmail) &&
+          decodedMailtoUrl.includes(expectedSubject) &&
+          decodedMailtoUrl.includes(expectedBody)
+        );
+      })
+      .toBe(true);
   }
 }
 

--- a/front/tests/pages/stdcm/stdcm-page.ts
+++ b/front/tests/pages/stdcm/stdcm-page.ts
@@ -63,7 +63,7 @@ class STDCMPage {
 
   async verifySuggestions(expectedSuggestions: string[]) {
     await expect(this.suggestionList).toBeVisible();
-    expect(await this.suggestionItems.count()).toBe(expectedSuggestions.length);
+    await expect(this.suggestionItems).toHaveCount(expectedSuggestions.length);
     const actualSuggestions = await this.suggestionItems.allTextContents();
     expect(actualSuggestions).toEqual(expectedSuggestions);
   }

--- a/front/tests/utils/index.ts
+++ b/front/tests/utils/index.ts
@@ -22,7 +22,7 @@ export async function fillAndCheckInputById(
 
   await input.click();
   await input.fill(`${value}`);
-  expect(await input.inputValue()).toBe(`${value}`);
+  await expect(input).toHaveValue(`${value}`);
 }
 
 /**
@@ -41,7 +41,7 @@ export async function verifyAndCheckInputById(
 ) {
   const input = isTestId ? page.getByTestId(inputId) : page.locator(`#${inputId}`);
 
-  expect(await input.inputValue()).toContain(`${expectedValue}`);
+  await expect.poll(() => input.inputValue()).toContain(`${expectedValue}`);
 }
 
 /**
@@ -165,13 +165,6 @@ export const waitForInfraStateToBeCached = async (infraId: number): Promise<void
  */
 export async function getCleanText(locator: Locator): Promise<string> {
   return ((await locator.textContent()) ?? '').trim();
-}
-
-/**
- * Check whether the element has the grey text class
- */
-export async function isGreyed(locator: Locator): Promise<boolean> {
-  return locator.evaluate((el) => el.classList.contains('text-grey-30'));
 }
 
 /**


### PR DESCRIPTION
Several Playwright page objects/specs assert a locator's state using [non-retrying assertions](https://playwright.dev/docs/test-assertions#non-retrying-assertions). These should be replaced with [auto-retrying assertions](https://playwright.dev/docs/test-assertions#auto-retrying-assertions) or `expect.poll`, where appropriate