### PR TITLE
editoast: enable backtracking using debug flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,7 @@ services:
       S3_SECRET_ACCESS_KEY: secret_key
       S3_ENDPOINT_URL: http://s3:9900
       S3_BUCKET_NAME: osrd
+      ENABLE_BACKTRACK: ${ENABLE_BACKTRACK-false}
     command: >
       /bin/sh -c "
         fga_migrations apply &&

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -50,7 +50,7 @@ pub struct PathItem {
     /// The track offsets of the path item.
     pub locations: Vec<TrackOffset>,
     /// If true, the train can backtrack at these track offsets.
-    pub can_backtrack: Option<bool>,
+    pub can_backtrack: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -177,25 +177,30 @@ pub struct PathfindingConstraints {
     pub allowed_track_sections: BTreeSet<String>,
 }
 
-/// A set of [TrackOffset]
+/// A waypoint the resulting path must pass through
 ///
-/// The resulting path can cross any of these.
+/// The waypoint is given as a set of [TrackOffset] alternatives: the resulting
+/// path can cross any of these.
 #[derive(Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(test, derive(Clone))]
-pub struct PathItemConstraint(Vec<TrackOffset>);
-
-impl FromIterator<TrackOffset> for PathItemConstraint {
-    fn from_iter<T: IntoIterator<Item = TrackOffset>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
-    }
+pub struct PathItemConstraint {
+    pub path_item_alternatives: Vec<TrackOffset>,
+    /// Whether the train is allowed to backtrack at this waypoint
+    pub can_backtrack: bool,
 }
 
-impl IntoIterator for PathItemConstraint {
-    type Item = TrackOffset;
-    type IntoIter = <Vec<TrackOffset> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+#[cfg(test)]
+impl PathItemConstraint {
+    /// Reserved to tests: everywhere else, build the struct with named fields so that the origin
+    /// of `can_backtrack` stays explicit at the call site
+    pub(crate) fn new(
+        path_item_alternatives: impl IntoIterator<Item = TrackOffset>,
+        can_backtrack: bool,
+    ) -> Self {
+        Self {
+            path_item_alternatives: path_item_alternatives.into_iter().collect(),
+            can_backtrack,
+        }
     }
 }
 
@@ -383,9 +388,12 @@ pub fn pathfinding_request_from_consist_constraints(
             .path_items
             .iter()
             .map(
-                |PathItemConstraint(track_alternatives)| core_client::pathfinding::PathItem {
-                    locations: track_alternatives.clone(),
-                    can_backtrack: Some(false),
+                |PathItemConstraint {
+                     path_item_alternatives: tracks,
+                     can_backtrack,
+                 }| core_client::pathfinding::PathItem {
+                    locations: tracks.clone(),
+                    can_backtrack: *can_backtrack,
                 },
             )
             .collect(),
@@ -458,12 +466,15 @@ pub(crate) mod test_data {
     pub(crate) fn constraints(id: usize) -> PathfindingConstraints {
         PathfindingConstraints {
             path_items: vec![
-                PathItemConstraint::from_iter([TrackOffset::new("id", id as u64)]),
-                PathItemConstraint::from_iter([
-                    TrackOffset::new("tr1", 100),
-                    TrackOffset::new("tr1bis", 100),
-                ]),
-                PathItemConstraint::from_iter([TrackOffset::new("tr2", 200)]),
+                PathItemConstraint::new([TrackOffset::new("id", id as u64)], false),
+                PathItemConstraint::new(
+                    [
+                        TrackOffset::new("tr1", 100),
+                        TrackOffset::new("tr1bis", 100),
+                    ],
+                    false,
+                ),
+                PathItemConstraint::new([TrackOffset::new("tr2", 200)], false),
             ],
             allowed_track_sections: BTreeSet::new(),
         }

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -172,7 +172,7 @@ pub struct PathfindingConsist {
 #[cfg_attr(test, derive(Clone))]
 pub struct PathfindingConstraints {
     /// An ordered list of waypoints the resulting path must pass through
-    pub path_items: Vec<PathItemAlternatives>,
+    pub path_items: Vec<PathItemConstraint>,
     /// Set of authorized track section ids, empty means no restriction
     pub allowed_track_sections: BTreeSet<String>,
 }
@@ -182,15 +182,15 @@ pub struct PathfindingConstraints {
 /// The resulting path can cross any of these.
 #[derive(Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(test, derive(Clone))]
-pub struct PathItemAlternatives(Vec<TrackOffset>);
+pub struct PathItemConstraint(Vec<TrackOffset>);
 
-impl FromIterator<TrackOffset> for PathItemAlternatives {
+impl FromIterator<TrackOffset> for PathItemConstraint {
     fn from_iter<T: IntoIterator<Item = TrackOffset>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
-impl IntoIterator for PathItemAlternatives {
+impl IntoIterator for PathItemConstraint {
     type Item = TrackOffset;
     type IntoIter = <Vec<TrackOffset> as IntoIterator>::IntoIter;
 
@@ -383,7 +383,7 @@ pub fn pathfinding_request_from_consist_constraints(
             .path_items
             .iter()
             .map(
-                |PathItemAlternatives(track_alternatives)| core_client::pathfinding::PathItem {
+                |PathItemConstraint(track_alternatives)| core_client::pathfinding::PathItem {
                     locations: track_alternatives.clone(),
                     can_backtrack: Some(false),
                 },
@@ -458,12 +458,12 @@ pub(crate) mod test_data {
     pub(crate) fn constraints(id: usize) -> PathfindingConstraints {
         PathfindingConstraints {
             path_items: vec![
-                PathItemAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
-                PathItemAlternatives::from_iter([
+                PathItemConstraint::from_iter([TrackOffset::new("id", id as u64)]),
+                PathItemConstraint::from_iter([
                     TrackOffset::new("tr1", 100),
                     TrackOffset::new("tr1bis", 100),
                 ]),
-                PathItemAlternatives::from_iter([TrackOffset::new("tr2", 200)]),
+                PathItemConstraint::from_iter([TrackOffset::new("tr2", 200)]),
             ],
             allowed_track_sections: BTreeSet::new(),
         }

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -329,6 +329,7 @@ pub(crate) mod test_data {
     use schemas::train_schedule::MarginValue;
 
     use super::*;
+    use crate::PathItemConstraint;
 
     /// We use the length field to identify it since the content doesn't matter
     pub(crate) fn path(id: usize, positions_count: u64) -> serde_json::Value {
@@ -429,12 +430,12 @@ pub(crate) mod test_data {
             ),
         );
         builder.push_schedule_item(
-            pathfinding::PathItemConstraint::from_iter([TrackOffset::new("id", id as u64)]),
+            PathItemConstraint::new([TrackOffset::new("id", id as u64)], false),
             NonBlankString::from("start"),
             ScheduleItem::pass_by(),
         );
         builder.push_schedule_item(
-            pathfinding::PathItemConstraint::from_iter([TrackOffset::new("a", 42)]),
+            PathItemConstraint::new([TrackOffset::new("a", 42)], false),
             NonBlankString::from("a"),
             ScheduleItem {
                 arrival_at: Some(1200),
@@ -443,10 +444,10 @@ pub(crate) mod test_data {
             },
         );
         builder.push_schedule_item(
-            pathfinding::PathItemConstraint::from_iter([
-                TrackOffset::new("b", 43),
-                TrackOffset::new("bis", 34),
-            ]),
+            PathItemConstraint::new(
+                [TrackOffset::new("b", 43), TrackOffset::new("bis", 34)],
+                false,
+            ),
             NonBlankString::from("b"),
             ScheduleItem {
                 arrival_at: None,
@@ -455,7 +456,7 @@ pub(crate) mod test_data {
             },
         );
         builder.push_schedule_item(
-            pathfinding::PathItemConstraint::from_iter([TrackOffset::new("finish", 44)]),
+            PathItemConstraint::new([TrackOffset::new("finish", 44)], false),
             NonBlankString::from("finish"),
             ScheduleItem {
                 arrival_at: Some(2400),

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -429,12 +429,12 @@ pub(crate) mod test_data {
             ),
         );
         builder.push_schedule_item(
-            pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("id", id as u64)]),
+            pathfinding::PathItemConstraint::from_iter([TrackOffset::new("id", id as u64)]),
             NonBlankString::from("start"),
             ScheduleItem::pass_by(),
         );
         builder.push_schedule_item(
-            pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("a", 42)]),
+            pathfinding::PathItemConstraint::from_iter([TrackOffset::new("a", 42)]),
             NonBlankString::from("a"),
             ScheduleItem {
                 arrival_at: Some(1200),
@@ -443,7 +443,7 @@ pub(crate) mod test_data {
             },
         );
         builder.push_schedule_item(
-            pathfinding::PathItemAlternatives::from_iter([
+            pathfinding::PathItemConstraint::from_iter([
                 TrackOffset::new("b", 43),
                 TrackOffset::new("bis", 34),
             ]),
@@ -455,7 +455,7 @@ pub(crate) mod test_data {
             },
         );
         builder.push_schedule_item(
-            pathfinding::PathItemAlternatives::from_iter([TrackOffset::new("finish", 44)]),
+            pathfinding::PathItemConstraint::from_iter([TrackOffset::new("finish", 44)]),
             NonBlankString::from("finish"),
             ScheduleItem {
                 arrival_at: Some(2400),

--- a/editoast/core_task/src/envs/simulation/inputs.rs
+++ b/editoast/core_task/src/envs/simulation/inputs.rs
@@ -19,7 +19,7 @@ use crate::PathfindingConsist;
 use crate::PathfindingConstraints;
 use crate::PathfindingTrain;
 use crate::TrainKey;
-use crate::envs::pathfinding::PathItemAlternatives;
+use crate::envs::pathfinding::PathItemConstraint;
 
 #[derive(Debug)]
 pub(crate) struct SimulationInputs<Train>
@@ -221,7 +221,7 @@ impl SimulationTrain {
     /// The label can be reused for [Self::set_power_restriction] and [Self::set_margin].
     pub fn push_schedule_item(
         &mut self,
-        path_constraint: PathItemAlternatives,
+        path_constraint: PathItemConstraint,
         label: NonBlankString,
         schedule_item: ScheduleItem,
     ) {

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -163,7 +163,7 @@ mod tests {
 
     use super::*;
     use crate::envs::pathfinding;
-    use crate::envs::pathfinding::PathItemAlternatives;
+    use crate::envs::pathfinding::PathItemConstraint;
     use crate::envs::simulation;
     use crate::envs::simulation::ScheduleItem;
     use crate::envs::simulation::SimulationTrain;
@@ -187,8 +187,8 @@ mod tests {
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
         let path_items = vec![
-            PathItemAlternatives::from_iter([]),
-            PathItemAlternatives::from_iter([]),
+            PathItemConstraint::from_iter([]),
+            PathItemConstraint::from_iter([]),
         ];
         let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
@@ -288,11 +288,11 @@ mod tests {
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
         let path_items = vec![
-            PathItemAlternatives::from_iter([]),
-            PathItemAlternatives::from_iter([]),
-            PathItemAlternatives::from_iter([]),
-            PathItemAlternatives::from_iter([]),
-            PathItemAlternatives::from_iter([]),
+            PathItemConstraint::from_iter([]),
+            PathItemConstraint::from_iter([]),
+            PathItemConstraint::from_iter([]),
+            PathItemConstraint::from_iter([]),
+            PathItemConstraint::from_iter([]),
         ];
         let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
@@ -468,12 +468,12 @@ mod tests {
             ),
         );
         builder.push_schedule_item(
-            PathItemAlternatives::from_iter([]),
+            PathItemConstraint::from_iter([]),
             NonBlankString::from("a"),
             ScheduleItem::pass_by(),
         );
         builder.push_schedule_item(
-            PathItemAlternatives::from_iter([]),
+            PathItemConstraint::from_iter([]),
             NonBlankString::from("b"),
             ScheduleItem {
                 arrival_at: Some(300),

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -187,8 +187,8 @@ mod tests {
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
         let path_items = vec![
-            PathItemConstraint::from_iter([]),
-            PathItemConstraint::from_iter([]),
+            PathItemConstraint::new([], false),
+            PathItemConstraint::new([], false),
         ];
         let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
@@ -288,11 +288,11 @@ mod tests {
 
         let core_env = CoreEnv::new_mock(MockingClient::new());
         let path_items = vec![
-            PathItemConstraint::from_iter([]),
-            PathItemConstraint::from_iter([]),
-            PathItemConstraint::from_iter([]),
-            PathItemConstraint::from_iter([]),
-            PathItemConstraint::from_iter([]),
+            PathItemConstraint::new([], false),
+            PathItemConstraint::new([], false),
+            PathItemConstraint::new([], false),
+            PathItemConstraint::new([], false),
+            PathItemConstraint::new([], false),
         ];
         let pf_input = pathfinding::PathfindingKey(
             Arc::new(pathfinding::test_data::consist(1)),
@@ -468,12 +468,12 @@ mod tests {
             ),
         );
         builder.push_schedule_item(
-            PathItemConstraint::from_iter([]),
+            PathItemConstraint::new([], false),
             NonBlankString::from("a"),
             ScheduleItem::pass_by(),
         );
         builder.push_schedule_item(
-            PathItemConstraint::from_iter([]),
+            PathItemConstraint::new([], false),
             NonBlankString::from("b"),
             ScheduleItem {
                 arrival_at: Some(300),

--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 // Crate-level exports
 pub use envs::TrainSet;
 pub use envs::core::CoreEnv;
-pub use envs::pathfinding::PathItemAlternatives;
+pub use envs::pathfinding::PathItemConstraint;
 pub use envs::pathfinding::PathfindingConsist;
 pub use envs::pathfinding::PathfindingConstraints;
 pub use envs::pathfinding::PathfindingEnv;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12912,6 +12912,12 @@ components:
             type: string
           description: Set of authorized track section ids, empty means no restriction
           uniqueItems: true
+        can_backtrack_path_items:
+          type: array
+          items:
+            type: integer
+            minimum: 0
+          description: Indexes, in `path_items`, of the waypoints where the train is allowed to backtrack
         path_items:
           type: array
           items:
@@ -14156,6 +14162,8 @@ components:
           - type: string
             minLength: 1
           description: Position on the path of the schedule item.
+        can_backtrack:
+          type: boolean
         reception_signal:
           $ref: '#/components/schemas/ReceptionSignal'
         reference_base_arrival:

--- a/editoast/schemas/src/primitives/duration.rs
+++ b/editoast/schemas/src/primitives/duration.rs
@@ -61,7 +61,7 @@ pub enum PositiveDurationError {
 /// let err_s = r#"{"duration":"P1M"}"#; // 1 month
 /// assert!(serde_json::from_str::<MyStruct>(err_s).is_err());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PositiveDuration(ChronoDuration);
 
 #[cfg(feature = "testing")]

--- a/editoast/schemas/src/train_schedule/schedule_item.rs
+++ b/editoast/schemas/src/train_schedule/schedule_item.rs
@@ -19,7 +19,7 @@ pub enum ReceptionSignal {
 }
 
 #[serde_as]
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
 #[serde(remote = "Self")]
 pub struct ScheduleItem {
@@ -39,6 +39,8 @@ pub struct ScheduleItem {
     pub reception_signal: ReceptionSignal,
     pub reference_base_arrival: Option<PositiveDuration>,
     pub reference_position: Option<u64>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub can_backtrack: bool,
 }
 
 #[cfg(feature = "testing")]
@@ -51,6 +53,7 @@ impl ScheduleItem {
             reception_signal: ReceptionSignal::Open,
             reference_base_arrival: None,
             reference_position: None,
+            can_backtrack: false,
         }
     }
 }
@@ -99,6 +102,7 @@ mod tests {
             reception_signal: ReceptionSignal::Stop,
             reference_base_arrival: None,
             reference_position: None,
+            can_backtrack: false,
         };
         let invalid_str = to_string(&schedule_item).unwrap();
         assert!(from_str::<ScheduleItem>(&invalid_str).is_err());

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -20,6 +20,7 @@ use core_client::pathfinding::PathfindingRequest;
 use core_client::pathfinding::PathfindingResultSuccess;
 use database::DbConnection;
 use educe::Educe;
+use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use schemas::rolling_stock::LoadingGaugeType;
 use schemas::train_schedule::PathItemLocation;
@@ -38,9 +39,12 @@ use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::timetable::PhysicsConsistParameters;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
+use serde_with::DefaultOnNull;
+use serde_with::serde_as;
 
 /// Path input is described by some rolling stock information
 /// and a list of path waypoints
+#[serde_as]
 #[derive(Deserialize, Clone, Debug, Hash, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]
 pub(in crate::views) struct PathfindingInput {
@@ -68,6 +72,10 @@ pub(in crate::views) struct PathfindingInput {
     /// Set of authorized track section ids, empty means no restriction
     #[serde(default)]
     allowed_track_sections: BTreeSet<String>,
+    /// Indexes, in `path_items`, of the waypoints where the train is allowed to backtrack
+    #[serde(default)]
+    #[serde_as(as = "DefaultOnNull")]
+    pub can_backtrack_path_items: Vec<usize>,
 }
 
 impl PathfindingInput {
@@ -93,6 +101,12 @@ impl PathfindingInput {
             speed_limit_tag: train_schedule.speed_limit_tag().cloned(),
             stops_at_end_of_block: Some(train_schedule.options().stops_at_end_of_block()),
             allowed_track_sections: BTreeSet::new(),
+            can_backtrack_path_items: train_schedule
+                .schedule()
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, item)| if item.can_backtrack { Some(idx) } else { None })
+                .collect(),
         }
     }
 
@@ -314,11 +328,11 @@ async fn pathfinding_blocks_batch(
 
     // Handle miss cache:
     debug!("Extracting locations from path items");
-    let path_items: Vec<_> = pathfinding_cached_results
+    let path_items = pathfinding_cached_results
         .iter()
         .filter(|(_, res)| res.is_none())
         .flat_map(|(hash, _)| &path_request_map[*hash].path_items)
-        .collect();
+        .collect_vec();
     let op_cache = OperationalPointCache::load_path_items(conn, infra.id, &path_items).await?;
 
     debug!(
@@ -399,9 +413,10 @@ fn build_pathfinding_request(
         expected_version: infra.version,
         path_items: track_offsets
             .into_iter()
-            .map(|offsets| core_client::pathfinding::PathItem {
+            .enumerate()
+            .map(|(index, offsets)| core_client::pathfinding::PathItem {
                 locations: offsets,
-                can_backtrack: Some(false),
+                can_backtrack: pathfinding_input.can_backtrack_path_items.contains(&index),
             })
             .collect(),
         rolling_stock_loading_gauge: pathfinding_input.rolling_stock_loading_gauge,
@@ -504,6 +519,7 @@ pub mod tests {
             stops_at_end_of_block: None,
             allowed_track_sections: BTreeSet::new(),
             path_items,
+            can_backtrack_path_items: Default::default(),
         }
     }
 

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -14,6 +14,7 @@ use core_client::simulation::SimulationScheduleItem;
 use core_client::simulation::SimulationSuccess;
 use core_client::simulation::SpeedLimitProperties;
 use core_client::simulation::StopDetails;
+use core_task::PathItemConstraint;
 use core_task::PathfindingConsist;
 use core_task::SimulationConsist;
 use core_task::SimulationTrain;
@@ -31,6 +32,7 @@ use schemas::train_schedule::TrainScheduleLike;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -709,13 +711,14 @@ pub fn build_simulation_train(
         .map(|schedule_item @ ScheduleItem { at, .. }| (at, schedule_item))
         .collect::<HashMap<_, _>>();
     for (track_offsets, PathItem { id, .. }) in track_offsets.iter().zip(path) {
-        let (at, simulation_schedule_item) = match schedule_map.get(id) {
-            None => (id, core_task::ScheduleItem::pass_by()),
+        let (at, simulation_schedule_item, can_backtrack) = match schedule_map.get(id) {
+            None => (id, core_task::ScheduleItem::pass_by(), false),
             Some(ScheduleItem {
                 at,
                 arrival,
                 stop_for,
                 reception_signal,
+                can_backtrack,
                 ..
             }) => (
                 at,
@@ -724,10 +727,14 @@ pub fn build_simulation_train(
                     stop_for: stop_for.as_ref().map(|s| s.num_milliseconds() as u64),
                     reception_signal: *reception_signal,
                 },
+                *can_backtrack,
             ),
         };
         simulation_train.push_schedule_item(
-            track_offsets.iter().cloned().collect(),
+            PathItemConstraint {
+                path_item_alternatives: track_offsets.to_vec(),
+                can_backtrack,
+            },
             at.clone(),
             simulation_schedule_item,
         )
@@ -816,14 +823,35 @@ pub fn build_sim_schedule_items(
     schedule_items: &[ScheduleItem],
     path_items_to_position: &HashMap<&schemas::primitives::NonBlankString, u64>,
     path_items: &[PathItem],
-    backtrack_path_items: Option<&Vec<usize>>,
+    backtrack_path_item_indexes: Option<&Vec<usize>>,
 ) -> Vec<SimulationScheduleItem> {
+    assert_eq!(path_items_to_position.len(), path_items.len());
+
+    // assert that schedule_items are included in path_items
+    let path_item_ids: HashSet<_> = path_items.iter().map(|item| &item.id).collect();
+    assert!(
+        schedule_items
+            .iter()
+            .all(|item| path_item_ids.contains(&item.at))
+    );
+
+    // assert that backtrack_path_item_indexes are included in schedule_items
+    if let Some(backtrack_path_item_indexes) = backtrack_path_item_indexes {
+        let schedule_items_ids: HashSet<_> = schedule_items.iter().map(|item| &item.at).collect();
+        assert!(
+            backtrack_path_item_indexes
+                .iter()
+                .all(|&index| index < path_items.len()
+                    && schedule_items_ids.contains(&path_items[index].id)),
+        )
+    }
+
     let schedule_items: HashMap<_, _> = schedule_items
         .iter()
         .map(|schedule_item| (&schedule_item.at, schedule_item))
         .collect();
     let mut is_backtracking = vec![false; path_items.len()];
-    backtrack_path_items
+    backtrack_path_item_indexes
         .unwrap_or(&vec![])
         .iter()
         .for_each(|index| is_backtracking[*index] = true);
@@ -832,13 +860,14 @@ pub fn build_sim_schedule_items(
         .zip(is_backtracking)
         .map(
             |(path_item, is_backtracking)| match schedule_items.get(&path_item.id) {
-                None => match is_backtracking {
-                    true => unreachable!(),
-                    _ => SimulationScheduleItem {
-                        path_offset: path_items_to_position[&path_item.id],
-                        arrival: None,
-                        stop_details: None,
-                    },
+                None => SimulationScheduleItem {
+                    path_offset: path_items_to_position[&path_item.id],
+                    arrival: None,
+                    stop_details: is_backtracking.then(|| StopDetails {
+                        duration: 0,
+                        reception_signal: Default::default(),
+                        is_backtracking,
+                    }),
                 },
                 Some(schedule_item) => SimulationScheduleItem {
                     path_offset: path_items_to_position[&schedule_item.at],

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -455,6 +455,10 @@ impl VirtualTrainRun {
         infra: &Infra,
         consists_parameters: &[PhysicsConsistParameters],
     ) -> Result<Vec<Self>> {
+        // TODO : Remove this env var when the backtracking feature is done
+        let enable_backtrack =
+            std::env::var("ENABLE_BACKTRACK").unwrap_or_else(|_| "false".to_string()) == "true";
+
         // Doesn't matter for now, but eventually it will affect tmp speed limits
         let approx_start_time = stdcm_request.get_earliest_step_time();
         let train_schedules_with_consists = itertools::chain!(
@@ -466,21 +470,37 @@ impl VirtualTrainRun {
         .zip(consists_parameters)
         .map(|((start, end), consist)| {
             let path = convert_steps(&stdcm_request.steps[start..=end]);
-            let last_step = path.last().expect("empty step list");
-
             let train_occurrence = TrainOccurrence {
                 train_name: "".to_string(),
                 labels: vec![],
                 rolling_stock_name: consist.traction_engine.name.clone(),
                 start_time: millisecond::i64::new(approx_start_time.timestamp_millis()),
-                schedule: vec![ScheduleItem {
-                    // Make the train stop at the end
-                    at: last_step.id.clone(),
-                    arrival: None,
-                    stop_for: Some(PositiveDuration::try_from(Duration::zero()).unwrap()),
-                    reception_signal: ReceptionSignal::Open,
-                    ..Default::default()
-                }],
+                schedule: stdcm_request.steps[start..=end]
+                    .iter()
+                    .zip(&path)
+                    .map(|(stdcm_step, path_item)| ScheduleItem {
+                        at: path_item.id.clone(),
+                        arrival: stdcm_step.timing_data.as_ref().map(|timing_data| {
+                            PositiveDuration::try_from(
+                                timing_data
+                                    .arrival_time
+                                    .signed_duration_since(approx_start_time),
+                            )
+                            .unwrap()
+                        }),
+                        stop_for: stdcm_step.duration.map(|duration| {
+                            PositiveDuration::try_from(Duration::milliseconds(duration as i64))
+                                .unwrap()
+                        }),
+                        reception_signal: ReceptionSignal::Stop,
+                        can_backtrack: if enable_backtrack {
+                            stdcm_step.duration.is_some()
+                        } else {
+                            false
+                        },
+                        ..Default::default()
+                    })
+                    .collect::<Vec<ScheduleItem>>(),
                 margins: build_single_margin(stdcm_request.margin),
                 initial_speed: 0.0,
                 comfort: stdcm_request.comfort,

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -264,6 +264,10 @@ impl Request {
                 _ => panic!("Unexpected pathfinding result"),
             })?;
 
+        // TODO : Remove this env var when the backtracking feature is done
+        let enable_backtrack =
+            std::env::var("ENABLE_BACKTRACK").unwrap_or_else(|_| "false".to_string()) == "true";
+
         Ok(track_offsets
             .iter()
             .zip(&self.steps)
@@ -272,7 +276,11 @@ impl Request {
                     stop_duration: path_item.duration,
                     path_item: core_client::pathfinding::PathItem {
                         locations: track_offset.clone(),
-                        can_backtrack: Some(false),
+                        can_backtrack: if enable_backtrack {
+                            path_item.duration.is_some()
+                        } else {
+                            false
+                        },
                     },
                     step_timing_data: path_item.timing_data.as_ref().map(|timing_data| {
                         core_client::stdcm::StepTimingData {

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -58,6 +58,7 @@ fn find_matching_path_item_index(
     operational_point_id: &str,
     op_cache: &OperationalPointCache,
 ) -> Option<usize> {
+    // TODO : use more information to match: backtrack + number of times we crossed that item
     path_items.iter().position(|path_item| {
         let PathItemLocation::OperationalPointPartReference(op_ref) = &path_item.location else {
             return false;
@@ -171,6 +172,7 @@ fn get_local_track_name(
     op_cache: &OperationalPointCache,
     train_schedule: &schemas::TrainOccurrence,
 ) -> Option<NonBlankString> {
+    // TODO : use more information to match: backtrack + number of times we crossed that item
     if let Some(idx) = context.matching_index {
         let PathItemLocation::OperationalPointPartReference(op_ref) =
             &train_schedule.path[idx].location

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -659,12 +659,14 @@ pub(in crate::views) async fn get_path(
         return Ok(Json(PathfindingResult::Failure(failure)));
     };
 
-    let path_items = train_occurrence.locations();
+    // The path items are kept whole, and not only their location, to relate each of them to its
+    // schedule item below
+    let path = train_occurrence.path();
 
-    let path_items = match (begin_index, end_index) {
-        (None, None) => &path_items,
+    let path = match (begin_index, end_index) {
+        (None, None) => path,
         (begin_index, end_index) => {
-            let path_items_count = path_items.len();
+            let path_items_count = path.len();
             let begin = begin_index.unwrap_or(0);
             let end = end_index.unwrap_or(path_items_count.saturating_sub(1));
             if begin > end || end >= path_items_count {
@@ -675,22 +677,41 @@ pub(in crate::views) async fn get_path(
                 }
                 .into());
             }
-            &path_items[begin..=end]
+            &path[begin..=end]
         }
     };
 
-    let track_offsets = match OperationalPointCache::load_path_items(conn, infra.id, path_items)
+    let path_items = path
+        .iter()
+        .map(|path_item| &path_item.location)
+        .collect_vec();
+
+    let track_offsets = match OperationalPointCache::load_path_items(conn, infra.id, &path_items)
         .await?
-        .extract_location_from_path_items(path_items)
+        .extract_location_from_path_items(&path_items)
     {
         Ok(track_offsets) => track_offsets,
         Err(err) => return Ok(Json(PathfindingResult::Failure(err))),
     };
 
+    // A train can backtrack on a waypoint when its corresponding schedule item says so
+    let backtrack_path_item_ids = train_occurrence
+        .schedule()
+        .iter()
+        .filter(|schedule_item| schedule_item.can_backtrack)
+        .map(|schedule_item| &schedule_item.at)
+        .collect::<HashSet<_>>();
+
     let constraints = core_task::PathfindingConstraints {
-        path_items: track_offsets
-            .into_iter()
-            .map(core_task::PathItemConstraint::from_iter)
+        path_items: path
+            .iter()
+            .zip(track_offsets)
+            .map(
+                |(path_item, path_item_alternatives)| core_task::PathItemConstraint {
+                    path_item_alternatives,
+                    can_backtrack: backtrack_path_item_ids.contains(&path_item.id),
+                },
+            )
             .collect(),
         allowed_track_sections: BTreeSet::new(),
     };

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -690,7 +690,7 @@ pub(in crate::views) async fn get_path(
     let constraints = core_task::PathfindingConstraints {
         path_items: track_offsets
             .into_iter()
-            .map(core_task::PathItemAlternatives::from_iter)
+            .map(core_task::PathItemConstraint::from_iter)
             .collect(),
         allowed_track_sections: BTreeSet::new(),
     };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3845,6 +3845,8 @@ export type PathfindingResult =
 export type PathfindingInput = {
   /** Set of authorized track section ids, empty means no restriction */
   allowed_track_sections?: string[];
+  /** Indexes, in `path_items`, of the waypoints where the train is allowed to backtrack */
+  can_backtrack_path_items?: number[];
   /** List of waypoints given to the pathfinding */
   path_items: PathItemLocation[];
   /** Can the rolling stock run on non-electrified tracks */
@@ -4416,6 +4418,7 @@ export type ScheduleItem = {
   arrival?: null | PositiveDuration;
   /** Position on the path of the schedule item. */
   at: string;
+  can_backtrack?: boolean;
   reception_signal?: ReceptionSignal;
   reference_base_arrival?: null | PositiveDuration;
   reference_position?: number | null;

--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -136,6 +136,7 @@ export type Items2 = {
   arrival?: null | ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesScheduleItemsPropertiesReferenceBaseArrivalOneOf1;
   /** Position on the path of the schedule item. */
   at: string;
+  can_backtrack?: boolean;
   /** State of the signal where the train is received for its stop.
     For (important) details, see <https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields>. */
   reception_signal?: 'OPEN' | 'STOP' | 'SHORT_SLIP_STOP';
@@ -250,6 +251,7 @@ export type TransformTimetableResponse = {
       arrival?: null | ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesScheduleItemsPropertiesReferenceBaseArrivalOneOf1;
       /** Position on the path of the schedule item. */
       at: string;
+      can_backtrack?: boolean;
       /** State of the signal where the train is received for its stop.
             For (important) details, see <https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields>. */
       reception_signal?: 'OPEN' | 'STOP' | 'SHORT_SLIP_STOP';

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -3121,6 +3121,10 @@ class PathfindingFailurePathfindingNotFound4(
     pass
 
 
+class CanBacktrackPathItem(RootModel[int]):
+    root: Annotated[int, Field(ge=0)]
+
+
 SwitchesDirectionsAdditionalProperty = TypeAliasType(
     "SwitchesDirectionsAdditionalProperty",
     Annotated[str, Field(max_length=255, min_length=1)],
@@ -3438,6 +3442,7 @@ class ScheduleItem(BaseModel):
     """
     Position on the path of the schedule item.
     """
+    can_backtrack: bool | None = None
     reception_signal: ReceptionSignal | None = None
     reference_base_arrival: timedelta | None = None
     reference_position: Annotated[int | None, Field(ge=0)] = None
@@ -5410,6 +5415,10 @@ class PathfindingInput(BaseModel):
     allowed_track_sections: list[str] | None = None
     """
     Set of authorized track section ids, empty means no restriction
+    """
+    can_backtrack_path_items: list[CanBacktrackPathItem] | None = None
+    """
+    Indexes, in `path_items`, of the waypoints where the train is allowed to backtrack
     """
     path_items: list[
         PathItemLocationTrackOffset | PathItemLocationOperationalPointPartReference


### PR DESCRIPTION
closes #17550
To enable the backtracking feature in LMR, it is needed to set `$ export ENABLE_BACKTRACK=true`
in your shell before launching the stack.

You can test the backtracking in LMR with this example :
 St-Louis-les-Aygalades -> Miramas -> Fos