### PR TITLE
front: add a switch from unique to service model in train header

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -538,7 +538,7 @@
         "invalidInitialSpeedRounding": "Initial velocity must be rounded to the first decimal",
         "recoveryMargin": "Recovery margin",
         "rollingStock": "Rolling stock",
-        "serviceCadence": "Cadence",
+        "serviceInterval": "Cadence",
         "serviceWindow": "Repeat window",
         "tags": "Tags",
         "trainCategory": "Train category",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -538,7 +538,7 @@
         "invalidInitialSpeedRounding": "La vitesse initiale doit être arrondie à une décimale",
         "recoveryMargin": "Marge de régularité",
         "rollingStock": "Matériel roulant",
-        "serviceCadence": "Cadence",
+        "serviceInterval": "Cadence",
         "serviceWindow": "Plage de répétition",
         "tags": "Étiquettes",
         "trainCategory": "Catégorie de train",

--- a/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
+++ b/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
@@ -51,7 +51,7 @@ const CollapsedTrainOverview = ({
       )}
       <div className="train-metadata">
         {pacedTrain && !occurrenceId && (
-          <div className="train-service-cadence">
+          <div className="train-service-interval">
             {getServiceInterval(pacedTrain)}’ — {getServiceWindow(pacedTrain)}’
           </div>
         )}

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -62,7 +62,7 @@ export type TrainFieldsState = {
   comfort: Comfort | null;
   is_unique: boolean;
   category: TrainCategory | null;
-  service_cadence?: number;
+  service_interval?: number;
   service_window?: number;
   use_electrical_profiles: boolean | null;
   labels: string[];
@@ -95,7 +95,7 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     comfort: train.comfort ?? null,
     category: train.category ?? null,
     is_unique: !train.paced,
-    service_cadence: train.paced ? Duration.parse(train.paced.interval).valueOf() : undefined,
+    service_interval: train.paced ? Duration.parse(train.paced.interval).valueOf() : undefined,
     service_window: train.paced ? Duration.parse(train.paced.time_window).valueOf() : undefined,
     use_electrical_profiles: train?.options?.use_electrical_profiles ?? null,
     labels: train.labels ?? [],
@@ -125,8 +125,8 @@ function applyFieldsToPaced(fields: TrainFieldsState, train: Train): Train['pace
     ? {
         exceptions: train.paced.exceptions,
         interval:
-          fields.service_changed_confirmed && !computeServiceTimingError(fields.service_cadence)
-            ? new Duration({ milliseconds: fields.service_cadence }).toISOString()
+          fields.service_changed_confirmed && !computeServiceTimingError(fields.service_interval)
+            ? new Duration({ milliseconds: fields.service_interval }).toISOString()
             : train.paced.interval,
         time_window:
           fields.service_changed_confirmed && !computeServiceTimingError(fields.service_window)
@@ -372,7 +372,7 @@ const ExpandedTrainForm = ({
   const revertServiceChange = useCallback(() => {
     setFields({
       ...fields,
-      service_cadence: fieldsFromTrain.service_cadence,
+      service_interval: fieldsFromTrain.service_interval,
       service_window: fieldsFromTrain.service_window,
       is_unique: fieldsFromTrain.is_unique,
     });

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -359,19 +359,17 @@ const ExpandedTrainForm = ({
 
   return (
     <div className="train-header expanded-train-form">
-      {train.paced && (
-        <TrainServiceForm
-          train={train}
-          fields={fields}
-          fieldsFromTrain={fieldsFromTrain}
-          initialSpeedError={initialSpeedError}
-          onCollapse={onCollapse}
-          onFieldChange={onFieldChange}
-          onFieldImmediateChange={onFieldImmediateChange}
-          onPersistTrain={onPersistTrain}
-          revertServiceChange={revertServiceChange}
-        />
-      )}
+      <TrainServiceForm
+        train={train}
+        fields={fields}
+        fieldsFromTrain={fieldsFromTrain}
+        initialSpeedError={initialSpeedError}
+        onCollapse={onCollapse}
+        onFieldChange={onFieldChange}
+        onFieldImmediateChange={onFieldImmediateChange}
+        onPersistTrain={onPersistTrain}
+        revertServiceChange={revertServiceChange}
+      />
       <div className="train-form">
         <div className="train-name">
           <Input

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -168,7 +168,7 @@ function trainPayloadChanged(updatedTrain: Train, train: Train): boolean {
     updatedTrain.paced?.interval !== train.paced?.interval ||
     updatedTrain.paced?.time_window !== train.paced?.time_window ||
     updatedTrain.train_name !== train.train_name ||
-    updatedTrain.speed_limit_tag !== train.speed_limit_tag ||
+    (updatedTrain.speed_limit_tag ?? null) !== (train.speed_limit_tag ?? null) ||
     updatedTrain.constraint_distribution !== train.constraint_distribution ||
     updatedTrain.comfort !== train.comfort ||
     updatedTrain.rolling_stock_name !== train.rolling_stock_name ||

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   ComboBox,
   DatePicker,
-  DurationInput,
   Input,
   Select,
   Switch,
@@ -12,11 +11,9 @@ import {
   useDefaultComboBox,
   type CalendarSlot,
 } from '@osrd-project/ui-core';
-import { ChevronUp } from '@osrd-project/ui-icons';
 import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import type { PacedTrain } from 'applications/operationalStudies/types';
 import type {
   LightRollingStockWithLiveries,
   PathfindingResult,
@@ -32,17 +29,13 @@ import useCategoryOptions, {
 } from 'modules/rollingStock/hooks/useCategoryOptions';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 import type { Train } from 'reducers/osrdconf/types';
-import { Duration, MAX_DURATION_MS } from 'utils/duration';
+import { Duration } from 'utils/duration';
 import { usePrevious } from 'utils/hooks/state';
 import { kmhToMs } from 'utils/physics';
-import { findExceptionInPacedTrainByOccurrenceId } from 'utils/trainExceptions';
-import { isOccurrenceId } from 'utils/trainId';
 import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
-import ExtraOccurrenceForm from './ExtraOccurrenceForm';
-import ExtraOccurrenceRow from './ExtraOccurrenceRow';
-import { ServiceChangeWarningDialog } from './ServiceChangeWarningDialog';
 import type { ExtraOccurrencesChanges } from './TrainHeader';
+import TrainServiceForm, { computeServiceTimingError } from './TrainServiceForm';
 
 // TODO: Passing `undefined` to DatePicker's selectableSlot prop should mean this
 export const ANY_DATE_SLOT: CalendarSlot = { start: new Date(0), end: null };
@@ -58,7 +51,7 @@ export type ExpandedTrainFormProps = {
   onItineraryOpened: () => void;
 };
 
-type TrainFieldsState = {
+export type TrainFieldsState = {
   train_name: string;
   speed_limit_tag: string | null;
   constraint_distribution: ConstraintDistribution;
@@ -75,25 +68,17 @@ type TrainFieldsState = {
   service_changed_confirmed: boolean;
 };
 
-type initialSpeedProblem = 'INVALID_NUMBER' | 'ROUNDING' | 'TOO_HIGH' | null;
+export type InitialSpeedError = 'INVALID_NUMBER' | 'ROUNDING' | 'TOO_HIGH' | null;
 
 function computeInitialSpeedError(
   initialSpeed: string | null,
   rollingStock?: LightRollingStockWithLiveries
-): initialSpeedProblem {
+): InitialSpeedError {
   if (!initialSpeed) return 'INVALID_NUMBER';
   const floatInitialSpeed = Number.parseFloat(initialSpeed);
   if (!isFinite(floatInitialSpeed) || floatInitialSpeed < 0) return 'INVALID_NUMBER';
   if (Math.round(floatInitialSpeed * 10) / 10 !== floatInitialSpeed) return 'ROUNDING';
   if (rollingStock && kmhToMs(floatInitialSpeed) > rollingStock.max_speed) return 'TOO_HIGH';
-  return null;
-}
-
-type ServiceTimingError = 'TOO_LOW' | 'TOO_HIGH' | null;
-
-function computeServiceTimingError(serviceTiming?: number): ServiceTimingError {
-  if (!serviceTiming) return 'TOO_LOW';
-  if (serviceTiming > MAX_DURATION_MS) return 'TOO_HIGH';
   return null;
 }
 
@@ -227,18 +212,8 @@ const ExpandedTrainForm = ({
     resetSuggestions: resetRollingStockSuggestions,
   } = useDefaultComboBox(rollingStocks, getRollingStockLabel);
 
-  const pacedTrain = train.paced ? (train as PacedTrain) : null;
-  const occurrenceId = isOccurrenceId(train.id) ? train.id : null;
-  const exception =
-    occurrenceId && pacedTrain
-      ? findExceptionInPacedTrainByOccurrenceId(occurrenceId, pacedTrain)
-      : null;
-
   const fieldsFromTrain = useMemo(() => getFieldsFromTrain(train), [train]);
   const [fields, setFields] = useState<TrainFieldsState>(fieldsFromTrain);
-  const [extraOccurrencesVisible, setExtraOccurrencesVisible] = useState(false);
-  const extraOccurrences =
-    train.paced?.exceptions?.filter((exp) => exp.occurrence_index === undefined) ?? [];
 
   const selectedRollingStock = useMemo(
     () => rollingStocks.find((rs) => rs.name === fields.rolling_stock_name),
@@ -374,50 +349,6 @@ const ExpandedTrainForm = ({
     [fields.initial_speed, selectedRollingStock, computeInitialSpeedError]
   );
 
-  const isPacedTrain = !!pacedTrain;
-
-  const serviceCadenceError = useMemo(
-    () => (isPacedTrain ? computeServiceTimingError(fields.service_cadence) : null),
-    [isPacedTrain, fields.service_cadence]
-  );
-
-  const serviceWindowError = useMemo(
-    () => (isPacedTrain ? computeServiceTimingError(fields.service_window) : null),
-    [isPacedTrain, fields.service_window]
-  );
-
-  const erroneousFields = useMemo(
-    () =>
-      !fields.train_name ||
-      !fields.initial_speed ||
-      !!initialSpeedError ||
-      !!serviceCadenceError ||
-      !!serviceWindowError,
-    [
-      fields.train_name,
-      fields.initial_speed,
-      initialSpeedError,
-      serviceCadenceError,
-      serviceWindowError,
-    ]
-  );
-
-  const toggleBand = (
-    <div className="toggle-band">
-      <button className="header-toggle" onClick={() => onCollapse()} disabled={erroneousFields}>
-        <ChevronUp />
-      </button>
-    </div>
-  );
-
-  const isServiceChangeWarningDialogVisible = useMemo(
-    () =>
-      !fields.service_changed_confirmed &&
-      (fields.service_cadence?.valueOf() !== fieldsFromTrain.service_cadence?.valueOf() ||
-        fields.service_window?.valueOf() !== fieldsFromTrain.service_window?.valueOf()),
-    [train.paced, fields, fieldsFromTrain]
-  );
-
   const revertServiceChange = useCallback(() => {
     setFields({
       ...fields,
@@ -426,122 +357,21 @@ const ExpandedTrainForm = ({
     });
   }, [fields, fieldsFromTrain]);
 
-  const confirmServiceChange = useCallback(() => {
-    onFieldImmediateChange('service_changed_confirmed', true);
-  }, [onFieldImmediateChange]);
-
   return (
     <div className="train-header expanded-train-form">
-      {pacedTrain && (
-        <div className="train-service">
-          {toggleBand}
-          {occurrenceId ? (
-            <div className="train-occurrence">
-              <div className="train-paced-kind">
-                {t('manageTrainSchedule.trainHeader.serviceOccurrence')}
-                {exception && ' ≠'}
-              </div>
-            </div>
-          ) : (
-            <>
-              <div className="train-service-form">
-                <div className="train-paced-kind">
-                  {t('manageTrainSchedule.trainHeader.serviceModelTrain')}
-                </div>
-                <div className="train-service-cadence">
-                  <DurationInput
-                    id="train-header-service-cadence-input"
-                    small
-                    units={['m']}
-                    padChar="0"
-                    label={t('manageTrainSchedule.trainHeader.form.serviceCadence')}
-                    value={fields.service_cadence ?? 1_800_000} // 30m
-                    onChange={(ms) => onFieldImmediateChange('service_cadence', ms)}
-                    statusWithMessage={
-                      serviceCadenceError
-                        ? {
-                            status: 'error',
-                            message:
-                              serviceCadenceError === 'TOO_HIGH'
-                                ? t('manageTrainSchedule.errorMessages.intervalTooHigh')
-                                : t('manageTrainSchedule.errorMessages.intervalTooLow'),
-                          }
-                        : undefined
-                    }
-                  />
-                </div>
-                <div className="train-service-window">
-                  <DurationInput
-                    id="train-header-service-window-input"
-                    small
-                    units={['h', 'm']}
-                    padChar="0"
-                    label={t('manageTrainSchedule.trainHeader.form.serviceWindow')}
-                    value={fields.service_window ?? 2 * 3_600_000} // 2h00m
-                    onChange={(ms) => onFieldImmediateChange('service_window', ms)}
-                    statusWithMessage={
-                      serviceWindowError
-                        ? {
-                            status: 'error',
-                            message:
-                              serviceWindowError === 'TOO_HIGH'
-                                ? t('manageTrainSchedule.errorMessages.timeWindowTooHigh')
-                                : t('manageTrainSchedule.errorMessages.timeWindowTooLow'),
-                          }
-                        : undefined
-                    }
-                  />
-                </div>
-                <div className="actions">
-                  <Button
-                    label={t('manageTrainSchedule.trainHeader.form.extraOccurrences', {
-                      count: extraOccurrences.length,
-                    })}
-                    variant="Quiet"
-                    onClick={() => {
-                      setExtraOccurrencesVisible(!extraOccurrencesVisible);
-                    }}
-                    size="small"
-                  />
-                </div>
-              </div>
-
-              {extraOccurrencesVisible && (
-                <div className="train-extra-occurrences">
-                  <ExtraOccurrenceForm
-                    addedExceptionDate={fields.added_exception_date}
-                    setAddedExceptionDate={(newAddedExceptionDate) =>
-                      onFieldChange('added_exception_date', newAddedExceptionDate)
-                    }
-                    onCreateAddedException={() => {
-                      onPersistTrain(train, {
-                        addedExceptions: [{ startTime: fields.added_exception_date }],
-                      });
-                    }}
-                  />
-                  <div className="train-extra-occurrences-list">
-                    {extraOccurrences
-                      .filter((occurrence) => occurrence.start_time?.value)
-                      .map((occurrence) => (
-                        <ExtraOccurrenceRow
-                          key={`${occurrence.id}-${occurrence.key}`}
-                          startTime={new Date(occurrence.start_time!.value)}
-                          onDelete={() => {
-                            // TODO_EXCEPTION: remove this when the exception migration will be done
-                            if (occurrence.id !== null && occurrence.id !== undefined) {
-                              onPersistTrain(train, { deletedAddedExceptionId: occurrence.id });
-                            }
-                          }}
-                        />
-                      ))}
-                  </div>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+      {train.paced && (
+        <TrainServiceForm
+          train={train}
+          fields={fields}
+          fieldsFromTrain={fieldsFromTrain}
+          initialSpeedError={initialSpeedError}
+          onCollapse={onCollapse}
+          onFieldChange={onFieldChange}
+          onFieldImmediateChange={onFieldImmediateChange}
+          onPersistTrain={onPersistTrain}
+          revertServiceChange={revertServiceChange}
+        />
       )}
-      {!pacedTrain && toggleBand}
       <div className="train-form">
         <div className="train-name">
           <Input
@@ -732,13 +562,6 @@ const ExpandedTrainForm = ({
         />
       )}
       {categoryWarning && <Banner message={categoryWarning} />}
-      {isServiceChangeWarningDialogVisible && (
-        <ServiceChangeWarningDialog
-          exceptionsCount={train.paced!.exceptions.length}
-          onCancel={revertServiceChange}
-          onConfirm={confirmServiceChange}
-        />
-      )}
     </div>
   );
 };

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -32,6 +32,7 @@ import type { Train } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 import { usePrevious } from 'utils/hooks/state';
 import { kmhToMs } from 'utils/physics';
+import { isOccurrenceId } from 'utils/trainId';
 import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 import type { ExtraOccurrencesChanges } from './TrainHeader';
@@ -39,6 +40,9 @@ import TrainServiceForm, { computeServiceTimingError } from './TrainServiceForm'
 
 // TODO: Passing `undefined` to DatePicker's selectableSlot prop should mean this
 export const ANY_DATE_SLOT: CalendarSlot = { start: new Date(0), end: null };
+
+export const DEFAULT_SERVICE_INTERVAL = new Duration({ minutes: 60 });
+export const DEFAULT_SERVICE_TIME_WINDOW = new Duration({ minutes: 120 });
 
 export type ExpandedTrainFormProps = {
   train: Train;
@@ -56,6 +60,7 @@ export type TrainFieldsState = {
   speed_limit_tag: string | null;
   constraint_distribution: ConstraintDistribution;
   comfort: Comfort | null;
+  is_unique: boolean;
   category: TrainCategory | null;
   service_cadence?: number;
   service_window?: number;
@@ -89,6 +94,7 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
     constraint_distribution: train.constraint_distribution,
     comfort: train.comfort ?? null,
     category: train.category ?? null,
+    is_unique: !train.paced,
     service_cadence: train.paced ? Duration.parse(train.paced.interval).valueOf() : undefined,
     service_window: train.paced ? Duration.parse(train.paced.time_window).valueOf() : undefined,
     use_electrical_profiles: train?.options?.use_electrical_profiles ?? null,
@@ -102,12 +108,20 @@ function getFieldsFromTrain(train: Train): TrainFieldsState {
   };
 }
 
-function applyFieldsToTrain(
-  fields: TrainFieldsState,
-  train: Train,
-  rollingStock?: LightRollingStockWithLiveries
-): Train {
-  const paced = train.paced
+function applyFieldsToPaced(fields: TrainFieldsState, train: Train): Train['paced'] {
+  if (fields.is_unique && !isOccurrenceId(train.id) && fields.service_changed_confirmed) {
+    return undefined;
+  }
+
+  if (!fields.is_unique && !train.paced) {
+    return {
+      exceptions: [],
+      interval: DEFAULT_SERVICE_INTERVAL.toISOString(),
+      time_window: DEFAULT_SERVICE_TIME_WINDOW.toISOString(),
+    };
+  }
+
+  return train.paced
     ? {
         exceptions: train.paced.exceptions,
         interval:
@@ -120,7 +134,13 @@ function applyFieldsToTrain(
             : train.paced.time_window,
       }
     : undefined;
+}
 
+function applyFieldsToTrain(
+  fields: TrainFieldsState,
+  train: Train,
+  rollingStock?: LightRollingStockWithLiveries
+): Train {
   return {
     ...train,
     train_name: fields.train_name || train.train_name,
@@ -130,7 +150,7 @@ function applyFieldsToTrain(
     category: fields.category === null ? undefined : fields.category,
     labels: fields.labels,
     rolling_stock_name: fields.rolling_stock_name,
-    paced,
+    paced: applyFieldsToPaced(fields, train),
     options: {
       use_electrical_profiles:
         fields?.use_electrical_profiles === null ? undefined : fields.use_electrical_profiles,
@@ -354,6 +374,7 @@ const ExpandedTrainForm = ({
       ...fields,
       service_cadence: fieldsFromTrain.service_cadence,
       service_window: fieldsFromTrain.service_window,
+      is_unique: fieldsFromTrain.is_unique,
     });
   }, [fields, fieldsFromTrain]);
 

--- a/front/src/modules/trainHeader/TrainServiceForm.tsx
+++ b/front/src/modules/trainHeader/TrainServiceForm.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { Button, DurationInput } from '@osrd-project/ui-core';
+import { ChevronUp } from '@osrd-project/ui-icons';
+import { useTranslation } from 'react-i18next';
+
+import type { PacedTrain } from 'applications/operationalStudies/types';
+import type { Train } from 'reducers/osrdconf/types';
+import { MAX_DURATION_MS } from 'utils/duration';
+import { findExceptionInPacedTrainByOccurrenceId } from 'utils/trainExceptions';
+import { isOccurrenceId } from 'utils/trainId';
+
+import type {
+  ExpandedTrainFormProps,
+  InitialSpeedError,
+  TrainFieldsState,
+} from './ExpandedTrainForm';
+import ExtraOccurrenceForm from './ExtraOccurrenceForm';
+import ExtraOccurrenceRow from './ExtraOccurrenceRow';
+import { ServiceChangeWarningDialog } from './ServiceChangeWarningDialog';
+
+export type ServiceTimingError = 'TOO_LOW' | 'TOO_HIGH' | null;
+
+export function computeServiceTimingError(serviceTiming?: number): ServiceTimingError {
+  if (!serviceTiming) return 'TOO_LOW';
+  if (serviceTiming > MAX_DURATION_MS) return 'TOO_HIGH';
+  return null;
+}
+
+type TrainServiceFormProps = {
+  train: Train;
+  fields: TrainFieldsState;
+  fieldsFromTrain: TrainFieldsState;
+  initialSpeedError: InitialSpeedError;
+  onCollapse: ExpandedTrainFormProps['onCollapse'];
+  onFieldChange: (
+    fieldName: keyof TrainFieldsState,
+    value: TrainFieldsState[typeof fieldName]
+  ) => void;
+  onFieldImmediateChange: (
+    fieldName: keyof TrainFieldsState,
+    value: TrainFieldsState[typeof fieldName]
+  ) => void;
+  onPersistTrain: ExpandedTrainFormProps['onPersistTrain'];
+  revertServiceChange: () => void;
+};
+
+export default function TrainServiceForm({
+  train,
+  fields,
+  fieldsFromTrain,
+  initialSpeedError,
+  onCollapse,
+  onFieldChange,
+  onFieldImmediateChange,
+  onPersistTrain,
+  revertServiceChange,
+}: TrainServiceFormProps) {
+  const { t } = useTranslation(['operational-studies', 'translation']);
+  const [extraOccurrencesVisible, setExtraOccurrencesVisible] = useState(false);
+
+  const pacedTrain = train.paced ? (train as PacedTrain) : null;
+  const occurrenceId = isOccurrenceId(train.id) ? train.id : null;
+  const exception =
+    occurrenceId && pacedTrain
+      ? findExceptionInPacedTrainByOccurrenceId(occurrenceId, pacedTrain)
+      : null;
+  const isPacedTrain = !!train.paced;
+  const extraOccurrences =
+    train.paced?.exceptions?.filter((exp) => exp.occurrence_index === undefined) ?? [];
+
+  const serviceCadenceError = useMemo(
+    () => (isPacedTrain ? computeServiceTimingError(fields.service_cadence) : null),
+    [isPacedTrain, fields.service_cadence]
+  );
+
+  const serviceWindowError = useMemo(
+    () => (isPacedTrain ? computeServiceTimingError(fields.service_window) : null),
+    [isPacedTrain, fields.service_window]
+  );
+
+  const erroneousFields = useMemo(
+    () =>
+      !fields.train_name ||
+      !fields.initial_speed ||
+      !!initialSpeedError ||
+      !!serviceCadenceError ||
+      !!serviceWindowError,
+    [
+      fields.train_name,
+      fields.initial_speed,
+      initialSpeedError,
+      serviceCadenceError,
+      serviceWindowError,
+    ]
+  );
+
+  const isServiceChangeWarningDialogVisible = useMemo(
+    () =>
+      !fields.service_changed_confirmed &&
+      (fields.service_cadence?.valueOf() !== fieldsFromTrain.service_cadence?.valueOf() ||
+        fields.service_window?.valueOf() !== fieldsFromTrain.service_window?.valueOf()),
+    [train.paced, fields, fieldsFromTrain]
+  );
+
+  const confirmServiceChange = useCallback(() => {
+    onFieldImmediateChange('service_changed_confirmed', true);
+  }, [onFieldImmediateChange]);
+
+  return (
+    <div className="train-service">
+      <div className="toggle-band">
+        <button className="header-toggle" onClick={() => onCollapse()} disabled={erroneousFields}>
+          <ChevronUp />
+        </button>
+      </div>
+      {occurrenceId ? (
+        <div className="train-occurrence">
+          <div className="train-paced-kind">
+            {t('manageTrainSchedule.trainHeader.serviceOccurrence')}
+            {exception && ' ≠'}
+          </div>
+        </div>
+      ) : (
+        <div className="train-service-form">
+          <div className="train-paced-kind">
+            {t('manageTrainSchedule.trainHeader.serviceModelTrain')}
+          </div>
+          {isPacedTrain && (
+            <>
+              <div className="train-service-cadence">
+                <DurationInput
+                  id="train-header-service-cadence-input"
+                  small
+                  units={['m']}
+                  padChar="0"
+                  label={t('manageTrainSchedule.trainHeader.form.serviceCadence')}
+                  value={fields.service_cadence ?? 1_800_000} // 30m
+                  onChange={(ms) => onFieldImmediateChange('service_cadence', ms)}
+                  statusWithMessage={
+                    serviceCadenceError
+                      ? {
+                          status: 'error',
+                          message:
+                            serviceCadenceError === 'TOO_HIGH'
+                              ? t('manageTrainSchedule.errorMessages.intervalTooHigh')
+                              : t('manageTrainSchedule.errorMessages.intervalTooLow'),
+                        }
+                      : undefined
+                  }
+                />
+              </div>
+              <div className="train-service-window">
+                <DurationInput
+                  id="train-header-service-window-input"
+                  small
+                  units={['h', 'm']}
+                  padChar="0"
+                  label={t('manageTrainSchedule.trainHeader.form.serviceWindow')}
+                  value={fields.service_window ?? 2 * 3_600_000} // 2h00m
+                  onChange={(ms) => onFieldImmediateChange('service_window', ms)}
+                  statusWithMessage={
+                    serviceWindowError
+                      ? {
+                          status: 'error',
+                          message:
+                            serviceWindowError === 'TOO_HIGH'
+                              ? t('manageTrainSchedule.errorMessages.timeWindowTooHigh')
+                              : t('manageTrainSchedule.errorMessages.timeWindowTooLow'),
+                        }
+                      : undefined
+                  }
+                />
+              </div>
+              <div className="actions">
+                <Button
+                  label={t('manageTrainSchedule.trainHeader.form.extraOccurrences', {
+                    count: extraOccurrences.length,
+                  })}
+                  variant="Quiet"
+                  onClick={() => {
+                    setExtraOccurrencesVisible(!extraOccurrencesVisible);
+                  }}
+                  size="small"
+                />
+              </div>
+            </>
+          )}
+        </div>
+      )}
+      {extraOccurrencesVisible && (
+        <div className="train-extra-occurrences">
+          <ExtraOccurrenceForm
+            addedExceptionDate={fields.added_exception_date}
+            setAddedExceptionDate={(newAddedExceptionDate) =>
+              onFieldChange('added_exception_date', newAddedExceptionDate)
+            }
+            onCreateAddedException={() => {
+              onPersistTrain(train, {
+                addedExceptions: [{ startTime: fields.added_exception_date }],
+              });
+            }}
+          />
+          <div className="train-extra-occurrences-list">
+            {extraOccurrences
+              .filter((occurrence) => occurrence.start_time?.value)
+              .map((occurrence) => (
+                <ExtraOccurrenceRow
+                  key={`${occurrence.id}-${occurrence.key}`}
+                  startTime={new Date(occurrence.start_time!.value)}
+                  onDelete={() => {
+                    // TODO_EXCEPTION: remove this when the exception migration will be done
+                    if (occurrence.id !== null && occurrence.id !== undefined) {
+                      onPersistTrain(train, { deletedAddedExceptionId: occurrence.id });
+                    }
+                  }}
+                />
+              ))}
+          </div>
+        </div>
+      )}
+      {isServiceChangeWarningDialogVisible && (
+        <ServiceChangeWarningDialog
+          exceptionsCount={train.paced!.exceptions.length}
+          onCancel={revertServiceChange}
+          onConfirm={confirmServiceChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/front/src/modules/trainHeader/TrainServiceForm.tsx
+++ b/front/src/modules/trainHeader/TrainServiceForm.tsx
@@ -69,9 +69,9 @@ export default function TrainServiceForm({
   const extraOccurrences =
     train.paced?.exceptions?.filter((exp) => exp.occurrence_index === undefined) ?? [];
 
-  const serviceCadenceError = useMemo(
-    () => (isPacedTrain ? computeServiceTimingError(fields.service_cadence) : null),
-    [isPacedTrain, fields.service_cadence]
+  const serviceIntervalError = useMemo(
+    () => (isPacedTrain ? computeServiceTimingError(fields.service_interval) : null),
+    [isPacedTrain, fields.service_interval]
   );
 
   const serviceWindowError = useMemo(
@@ -84,13 +84,13 @@ export default function TrainServiceForm({
       !fields.train_name ||
       !fields.initial_speed ||
       !!initialSpeedError ||
-      !!serviceCadenceError ||
+      !!serviceIntervalError ||
       !!serviceWindowError,
     [
       fields.train_name,
       fields.initial_speed,
       initialSpeedError,
-      serviceCadenceError,
+      serviceIntervalError,
       serviceWindowError,
     ]
   );
@@ -98,7 +98,7 @@ export default function TrainServiceForm({
   const isServiceChangeWarningDialogVisible = useMemo(
     () =>
       !fields.service_changed_confirmed &&
-      (fields.service_cadence?.valueOf() !== fieldsFromTrain.service_cadence?.valueOf() ||
+      (fields.service_interval?.valueOf() !== fieldsFromTrain.service_interval?.valueOf() ||
         fields.service_window?.valueOf() !== fieldsFromTrain.service_window?.valueOf() ||
         fields.is_unique !== fieldsFromTrain.is_unique),
     [train.paced, fields, fieldsFromTrain]
@@ -135,21 +135,21 @@ export default function TrainServiceForm({
           </div>
           {isPacedTrain && (
             <>
-              <div className="train-service-cadence">
+              <div className="train-service-interval">
                 <DurationInput
-                  id="train-header-service-cadence-input"
+                  id="train-header-service-interval-input"
                   small
                   units={['m']}
                   padChar="0"
-                  label={t('manageTrainSchedule.trainHeader.form.serviceCadence')}
-                  value={fields.service_cadence ?? 1_800_000} // 30m
-                  onChange={(ms) => onFieldImmediateChange('service_cadence', ms)}
+                  label={t('manageTrainSchedule.trainHeader.form.serviceInterval')}
+                  value={fields.service_interval ?? 1_800_000} // 30m
+                  onChange={(ms) => onFieldImmediateChange('service_interval', ms)}
                   statusWithMessage={
-                    serviceCadenceError
+                    serviceIntervalError
                       ? {
                           status: 'error',
                           message:
-                            serviceCadenceError === 'TOO_HIGH'
+                            serviceIntervalError === 'TOO_HIGH'
                               ? t('manageTrainSchedule.errorMessages.intervalTooHigh')
                               : t('manageTrainSchedule.errorMessages.intervalTooLow'),
                         }

--- a/front/src/modules/trainHeader/TrainServiceForm.tsx
+++ b/front/src/modules/trainHeader/TrainServiceForm.tsx
@@ -99,7 +99,8 @@ export default function TrainServiceForm({
     () =>
       !fields.service_changed_confirmed &&
       (fields.service_cadence?.valueOf() !== fieldsFromTrain.service_cadence?.valueOf() ||
-        fields.service_window?.valueOf() !== fieldsFromTrain.service_window?.valueOf()),
+        fields.service_window?.valueOf() !== fieldsFromTrain.service_window?.valueOf() ||
+        fields.is_unique !== fieldsFromTrain.is_unique),
     [train.paced, fields, fieldsFromTrain]
   );
 
@@ -124,10 +125,12 @@ export default function TrainServiceForm({
           <div className="train-schedule-kind">
             <Switch
               id="train-header-schedule-kind-toggle"
-              checked={isPacedTrain}
+              checked={!fields.is_unique}
               label={t('manageTrainSchedule.trainHeader.serviceModelTrain')}
               size="sm"
-              disabled
+              onChange={() => {
+                onFieldImmediateChange('is_unique', !fields.is_unique);
+              }}
             />
           </div>
           {isPacedTrain && (

--- a/front/src/modules/trainHeader/TrainServiceForm.tsx
+++ b/front/src/modules/trainHeader/TrainServiceForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { Button, DurationInput } from '@osrd-project/ui-core';
+import { Button, DurationInput, Switch } from '@osrd-project/ui-core';
 import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
@@ -115,16 +115,20 @@ export default function TrainServiceForm({
         </button>
       </div>
       {occurrenceId ? (
-        <div className="train-occurrence">
-          <div className="train-paced-kind">
-            {t('manageTrainSchedule.trainHeader.serviceOccurrence')}
-            {exception && ' ≠'}
-          </div>
+        <div className="train-occurrence-tag">
+          {t('manageTrainSchedule.trainHeader.serviceOccurrence')}
+          {exception && ' ≠'}
         </div>
       ) : (
         <div className="train-service-form">
-          <div className="train-paced-kind">
-            {t('manageTrainSchedule.trainHeader.serviceModelTrain')}
+          <div className="train-schedule-kind">
+            <Switch
+              id="train-header-schedule-kind-toggle"
+              checked={isPacedTrain}
+              label={t('manageTrainSchedule.trainHeader.serviceModelTrain')}
+              size="sm"
+              disabled
+            />
           </div>
           {isPacedTrain && (
             <>
@@ -188,7 +192,7 @@ export default function TrainServiceForm({
           )}
         </div>
       )}
-      {extraOccurrencesVisible && (
+      {isPacedTrain && extraOccurrencesVisible && (
         <div className="train-extra-occurrences">
           <ExtraOccurrenceForm
             addedExceptionDate={fields.added_exception_date}

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -83,7 +83,7 @@
 
     .train-schedule-kind {
       padding: var(--non-field-spacing);
-      padding-block: 16px;
+      padding-block: 8px;
       align-self: center;
 
       label {

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -91,7 +91,7 @@
       }
     }
 
-    .train-service-cadence,
+    .train-service-interval,
     .train-service-window {
       .ui-duration-input {
         width: 100%;

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -3,7 +3,7 @@
   border-bottom: 1px solid var(--black25);
   font-size: 14px;
   display: grid;
-  grid-template-columns: repeat(3, minmax(200px, 1fr)) 1fr [end-column];
+  grid-template-columns: repeat(3, minmax(210px, 1fr)) 1fr [end-column];
 
   /* Useful to align some non-field element with other fields  */
   --non-field-spacing: 32px 13px 16px 16px;
@@ -81,6 +81,16 @@
       padding-inline: 16px;
     }
 
+    .train-schedule-kind {
+      padding: var(--non-field-spacing);
+      padding-block: 16px;
+      align-self: center;
+
+      label {
+        font-weight: 400;
+      }
+    }
+
     .train-service-cadence,
     .train-service-window {
       .ui-duration-input {
@@ -89,11 +99,11 @@
     }
   }
 
-  .train-paced-kind {
-    background-color: var(--black5);
+  .train-occurrence-tag {
+    background-color: var(--white50);
     color: var(--info60);
     font-weight: 600;
-    margin: 16px 14px 0 16px;
+    margin: 16px 14px 16px 16px;
     height: 28px;
     display: flex;
     align-items: center;
@@ -103,16 +113,7 @@
     border-radius: 3px;
     white-space: nowrap;
     padding-inline: 16px;
-  }
-
-  .train-occurrence {
-    display: grid;
-    grid-template-columns: subgrid;
-    padding-bottom: 16px;
-
-    .train-paced-kind {
-      background-color: var(--white50);
-    }
+    grid-column: 1;
   }
 
   .train-service-form {
@@ -121,10 +122,6 @@
 
     label {
       margin-bottom: unset;
-    }
-
-    .train-paced-kind {
-      margin-top: 32px;
     }
 
     .actions {

--- a/front/ui/ui-core/src/styles/switch.css
+++ b/front/ui/ui-core/src/styles/switch.css
@@ -27,6 +27,9 @@
 
   --ui-switch-transition: 200ms ease;
 
+  --ui-switch-inner-shadow-color: rgba(24, 68, 239, 0.16);
+  --ui-switch-inner-shadow: 0 2px 2px -1px var(--ui-switch-inner-shadow-color);
+
   &.size-sm {
     --ui-switch-width: 28px;
     --ui-switch-height: 18px;
@@ -61,6 +64,8 @@
 
     --ui-switch-thumb-border-checked: var(--color-primary-60);
     --ui-switch-thumb-border-hover-checked: var(--color-primary-80);
+
+    --ui-switch-inner-shadow: 0 0 0 0 transparent;
   }
 
   display: flex;
@@ -86,6 +91,7 @@
     display: flex;
     align-items: center;
     cursor: inherit;
+    flex-shrink: 0;
 
     width: var(--ui-switch-width);
     height: var(--ui-switch-height);
@@ -99,7 +105,7 @@
 
     box-shadow:
       0 1px 0 0 var(--color-white-100),
-      0 2px 2px -1px inset rgb(var(--color-primary-60) / 16%),
+      var(--ui-switch-inner-shadow) inset,
       0 1px 2px 0 inset var(--color-black-15);
 
     outline: 0 none;
@@ -121,7 +127,9 @@
       border-radius: 4px;
       box-shadow:
         0 0 0 var(--ui-switch-thumb-border-length) inset var(--color-black-50),
-        0 0 0 var(--ui-switch-thumb-inner-length) inset var(--color-grey-10);
+        0 0 0 var(--ui-switch-thumb-inner-length) inset var(--color-grey-10),
+        0 1px 2px 0 var(--color-black-10),
+        var(--ui-switch-inner-shadow);
       transition:
         margin-left 300ms ease,
         box-shadow var(--ui-switch-transition),


### PR DESCRIPTION
Closes #17558.

This pull request is a little bit more than I expected at first, because I had to fix some shadows in the `Switch` component (first commit); I then proceeded to refactor the train header part that is related to the service/model part of the form, and then I added the switch in a disabled state, and at last I wired it to a proper field that allowed users to properly do the action of transforming a service model train into a unique train and vice-versa.

> [!TIP]
> Even if its 305+/221- line changes can be intimidating, most of it is a move from a file to another; I suggest a review in a commit-by-commit basis and you will see that it is quite trivial! 

https://github.com/user-attachments/assets/fec8ea83-a513-47d6-a41f-02b8dbf604f8

