### PR TITLE
editoast: add `path_item_relative_location` field in `/track_occupancy` endoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4621,6 +4621,46 @@ paths:
                             time_begin:
                               type: integer
                               format: int64
+                        - type: object
+                          required:
+                          - path_item_relative_location
+                          properties:
+                            path_item_relative_location:
+                              oneOf:
+                              - type: object
+                                title: PathItemRelativeLocationExactPathItem
+                                required:
+                                - path_item_id
+                                - type
+                                properties:
+                                  path_item_id:
+                                    $ref: '#/components/schemas/NonBlankString'
+                                    description: Path item ID, when the operational point matches an item in the input path
+                                  type:
+                                    type: string
+                                    enum:
+                                    - exact_path_item
+                              - type: object
+                                title: PathItemRelativeLocationBetweenPathItems
+                                required:
+                                - previous_path_item_id
+                                - following_path_item_id
+                                - type
+                                properties:
+                                  following_path_item_id:
+                                    $ref: '#/components/schemas/NonBlankString'
+                                    description: Following path item ID, when the operational point is not one of the input path items
+                                  previous_path_item_id:
+                                    $ref: '#/components/schemas/NonBlankString'
+                                    description: Previous path item ID, when the operational point is not one of the input path items
+                                  type:
+                                    type: string
+                                    enum:
+                                    - between_path_items
+                              description: |-
+                                Position of an operational point on a path, relative to the input path items.
+                                If the OP matches an input path item, it is located using this path item's ID,
+                                else, if the path just passes by the OP, it is located using its previous and following path items IDs
   /train_schedules/{id}:
     get:
       tags:

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -7,6 +7,9 @@ use schemas::primitives::TimeWindow;
 use schemas::train_schedule::PathItem;
 use schemas::train_schedule::PathItemLocation;
 use schemas::train_schedule::ScheduleItem;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
 
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::path::pathfinding::PathfindingResult;
@@ -18,6 +21,7 @@ use crate::views::timetable::simulation;
 pub(super) struct TrackOccupancy {
     pub(super) local_track_name: Option<NonBlankString>,
     pub(super) time_window: TimeWindow,
+    pub(super) path_item_relative_location: PathItemRelativeLocation,
 }
 
 /// Structure holding extracted data needed for track occupancy computation
@@ -27,6 +31,25 @@ struct OccupancyContext<'a> {
     pathfinding_success: Option<&'a PathfindingResultSuccess>,
     matching_index: Option<usize>,
     schedule_item: Option<&'a ScheduleItem>,
+}
+
+/// Position of an operational point on a path, relative to the input path items.
+/// If the OP matches an input path item, it is located using this path item's ID,
+/// else, if the path just passes by the OP, it is located using its previous and following path items IDs
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[schema(title_variants)]
+pub(super) enum PathItemRelativeLocation {
+    ExactPathItem {
+        /// Path item ID, when the operational point matches an item in the input path
+        path_item_id: NonBlankString,
+    },
+    BetweenPathItems {
+        /// Previous path item ID, when the operational point is not one of the input path items
+        previous_path_item_id: NonBlankString,
+        /// Following path item ID, when the operational point is not one of the input path items
+        following_path_item_id: NonBlankString,
+    },
 }
 
 /// Search for the index of the first matching path item for an operational point in a given path
@@ -169,6 +192,49 @@ fn get_local_track_name(
         .cloned()
 }
 
+/// Returns the path_item_relative_location for an operational point
+fn get_path_item_relative_location<'a>(
+    context: &OccupancyContext<'a>,
+    operational_point_track_offsets: &[TrackOffset],
+    train_schedule: &schemas::TrainOccurrence,
+) -> Option<PathItemRelativeLocation> {
+    if let Some(idx) = context.matching_index {
+        return Some(PathItemRelativeLocation::ExactPathItem {
+            path_item_id: train_schedule.path[idx].id.clone(),
+        });
+    }
+    if let (Some(report_train), Some(pathfinding_success)) =
+        (context.report_train, context.pathfinding_success)
+    {
+        let path_projection = PathProjection::new(&pathfinding_success.path.track_section_ranges);
+        let path_offset = operational_point_track_offsets
+            .iter()
+            .find_map(|track_offset| path_projection.get_position(track_offset));
+        if let Some(path_offset) = path_offset {
+            match pathfinding_success
+                .path_item_positions
+                .binary_search(&path_offset)
+            {
+                Ok(idx) => {
+                    return Some(PathItemRelativeLocation::ExactPathItem {
+                        path_item_id: train_schedule.path[idx].id.clone(),
+                    });
+                }
+                Err(idx) => {
+                    if idx == 0 || idx == report_train.positions.len() {
+                        panic!("The path offset is out of bound.")
+                    }
+                    return Some(PathItemRelativeLocation::BetweenPathItems {
+                        previous_path_item_id: train_schedule.path[idx - 1].id.clone(),
+                        following_path_item_id: train_schedule.path[idx].id.clone(),
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Find track occupancies for a train at an operational point
 /// This is a generic function used by both train_schedule and paced_train modules
 pub fn find_track_occupancy_for_operational_point(
@@ -223,6 +289,12 @@ fn find_track_occupancy_for_operational_point_with_context<'a>(
         return vec![];
     };
 
+    let Some(path_item_relative_location) =
+        get_path_item_relative_location(&context, operational_point_track_offsets, train_schedule)
+    else {
+        return vec![];
+    };
+
     let stop_duration = context
         .schedule_item
         .and_then(|item| item.stop_for)
@@ -239,6 +311,7 @@ fn find_track_occupancy_for_operational_point_with_context<'a>(
             time_begin: train_schedule.start_time + millisecond::i64::new(arrival_time),
             duration: stop_duration,
         },
+        path_item_relative_location,
     }]
 }
 

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -344,9 +344,9 @@ pub mod tests {
 
     fn make_simulation_success(path_item_times: Vec<u64>) -> simulation::Response {
         let report_train = ReportTrain {
-            positions: vec![],
-            times: vec![],
-            speeds: vec![],
+            positions: vec![0, 25, 50, 75, 100],
+            times: vec![0, 1000, 2000, 3000, 5000],
+            speeds: vec![0., 25., 20., 35., 0.],
             energy_consumption: 0.0,
             path_item_times,
         };
@@ -535,6 +535,7 @@ pub mod tests {
                         time_begin,
                         duration,
                     },
+                path_item_relative_location,
                 ..
             } = &results[0];
 
@@ -547,6 +548,16 @@ pub mod tests {
                 PositiveDuration::try_from(Duration::milliseconds(expected_stop_duration_ms))
                     .unwrap()
             );
+            let expected_location_path_item = match op_id {
+                "op_1" => "path_item_1",
+                "op_2" => "path_item_2",
+                "op_3" => "path_item_3",
+                _ => "path_item_1",
+            };
+            let expected_location = PathItemRelativeLocation::ExactPathItem {
+                path_item_id: expected_location_path_item.into(),
+            };
+            assert_eq!(*path_item_relative_location, expected_location)
         } else {
             // We expect no results in failure cases
             assert_eq!(results.len(), 0);
@@ -653,5 +664,101 @@ pub mod tests {
             results[0].time_window.time_begin,
             start_time + millisecond::i64::new(300_000)
         );
+        assert_eq!(
+            results[0].path_item_relative_location,
+            PathItemRelativeLocation::ExactPathItem {
+                path_item_id: "op_2".into()
+            }
+        )
+    }
+
+    #[test]
+    fn test_get_occupancy_location_between_path_items() {
+        // Create test data
+        let op_id = "op_1";
+        let track_section: Identifier = Identifier::from("T0");
+        let track_offset = 75;
+        let path_item_positions = vec![0, 50, 100];
+        let op_cache = OperationalPointCache::new(
+            Vec::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([("op_1".to_string(), 0)]),
+            HashSet::new(),
+            vec![HashMap::from([("T0".into(), "V0".into())])],
+        );
+
+        let operational_point_track_offsets = vec![TrackOffset {
+            track: track_section.clone(),
+            offset: track_offset,
+        }];
+
+        // Create a train schedule with path items
+        let train_schedule = schemas::TrainOccurrence {
+            path: vec![
+                PathItem {
+                    id: "path_item_1".into(),
+                    location: PathItemLocation::TrackOffset(TrackOffset {
+                        track: "T0".into(),
+                        offset: 0,
+                    }),
+                },
+                PathItem {
+                    id: "path_item_2".into(),
+                    location: PathItemLocation::TrackOffset(TrackOffset {
+                        track: "V0".into(),
+                        offset: 50,
+                    }),
+                },
+                PathItem {
+                    id: "path_item_3".into(),
+                    location: PathItemLocation::TrackOffset(TrackOffset {
+                        track: "V0".into(),
+                        offset: 100,
+                    }),
+                },
+            ],
+            schedule: vec![
+                ScheduleItem {
+                    at: "path_item_2".into(),
+                    arrival: None,
+                    stop_for: Some(
+                        PositiveDuration::try_from(Duration::milliseconds(1000)).unwrap(),
+                    ),
+                    reception_signal: ReceptionSignal::Open,
+                    ..Default::default()
+                },
+                ScheduleItem {
+                    at: "path_item_3".into(),
+                    arrival: Some(
+                        PositiveDuration::try_from(Duration::milliseconds(5000)).unwrap(),
+                    ),
+                    stop_for: None,
+                    reception_signal: ReceptionSignal::Open,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let simulation = make_simulation_success(vec![0, 2000, 5000]);
+        let pathfinding = make_pathfinding_success(track_section.clone(), path_item_positions);
+        let results = find_track_occupancy_for_operational_point(
+            op_id,
+            &operational_point_track_offsets,
+            &op_cache,
+            &simulation,
+            &pathfinding,
+            &train_schedule,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].path_item_relative_location,
+            PathItemRelativeLocation::BetweenPathItems {
+                previous_path_item_id: "path_item_2".into(),
+                following_path_item_id: "path_item_3".into()
+            }
+        )
     }
 }

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -76,6 +76,7 @@ use crate::views::timetable::simulation::build_sim_power_restriction_items;
 use crate::views::timetable::simulation::build_sim_schedule_items;
 use crate::views::timetable::simulation::train_simulation_ordered_batch;
 use crate::views::timetable::track_occupancy;
+use crate::views::timetable::track_occupancy::PathItemRelativeLocation;
 use editoast_models::Infra;
 use editoast_models::TrainScheduleSet;
 use editoast_models::rolling_stock::RollingStock;
@@ -1413,6 +1414,8 @@ pub(in crate::views) struct TrackOccupancy {
     #[serde(flatten)]
     #[schema(inline)]
     time_window: TimeWindow,
+    #[schema(inline)]
+    path_item_relative_location: PathItemRelativeLocation,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -1616,12 +1619,14 @@ async fn find_track_occupancy_for_known_operational_point_with_simulation(
                 move |track_occupancy::TrackOccupancy {
                           local_track_name,
                           time_window,
+                          path_item_relative_location,
                       }| {
                     (
                         local_track_name,
                         TrackOccupancy {
                             train_id: train_id.clone(),
                             time_window,
+                            path_item_relative_location,
                         },
                     )
                 },
@@ -1651,12 +1656,14 @@ fn find_track_occupancy_for_known_operational_point_without_simulation(
                 move |track_occupancy::TrackOccupancy {
                           local_track_name,
                           time_window,
+                          path_item_relative_location,
                       }| {
                     (
                         local_track_name,
                         TrackOccupancy {
                             train_id: train_id.clone(),
                             time_window,
+                            path_item_relative_location,
                         },
                     )
                 },
@@ -1721,6 +1728,9 @@ fn find_track_occupancy_unknown_operational_point(
                         TrackOccupancy {
                             train_id: train_id.clone(),
                             time_window,
+                            path_item_relative_location: PathItemRelativeLocation::ExactPathItem {
+                                path_item_id: path_item.id.clone(),
+                            },
                         },
                     ))
                 })

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2786,6 +2786,23 @@ export type PostTrainSchedulesTrackOccupancyApiResponse =
     ) & {
       duration: string;
       time_begin: number;
+    } & {
+      /** Position of an operational point on a path, relative to the input path items.
+        If the OP matches an input path item, it is located using this path item's ID,
+        else, if the path just passes by the OP, it is located using its previous and following path items IDs */
+      path_item_relative_location:
+        | {
+            /** Path item ID, when the operational point matches an item in the input path */
+            path_item_id: NonBlankString;
+            type: 'exact_path_item';
+          }
+        | {
+            /** Following path item ID, when the operational point is not one of the input path items */
+            following_path_item_id: NonBlankString;
+            /** Previous path item ID, when the operational point is not one of the input path items */
+            previous_path_item_id: NonBlankString;
+            type: 'between_path_items';
+          };
     })[];
   }[];
 export type PostTrainSchedulesTrackOccupancyApiArg = {


### PR DESCRIPTION
Add `location` field in `TrackOccupancy` to make it easier for the frontend to know the path item corresponding to a track occupancy (if it matches a path item), or the previous and following path items (if it doesn’t match a path item)