### PR TITLE
Fix path item field disappearing on clear in itinerary modal

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -802,7 +802,6 @@ const ItineraryModal = ({
                     }}
                     onOpClear={() => {
                       clearStep(pathStep.id);
-                      handleDeletePathStep(pathStep.id);
                     }}
                     onOpFocus={() => {
                       markEditing(pathStep.id);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
@@ -403,6 +403,7 @@ const PathStepItem = ({
               className={cx('path-step-op-name', {
                 invalid: isInvalidAndIsEditing,
               })}
+              data-testid="path-step-op-name"
               onKeyDownCapture={handleKeyDown}
               onMouseDownCapture={(e) => {
                 const target = e.target as HTMLElement | null;

--- a/front/tests/02-operational-studies/itineraryModal/001-itinerary-modal.spec.ts
+++ b/front/tests/02-operational-studies/itineraryModal/001-itinerary-modal.spec.ts
@@ -81,6 +81,10 @@ test.describe('Itinerary Modal, Default ', { tag: ['@op', '@itinerary-modal'] },
       await itineraryModalPage.addEmptyIntermediateRow(2, 5);
       await itineraryModalPage.checkPathStepCounterText(2, '3');
     });
+    await test.step('Clear a path item field without removing the path item', async () => {
+      await itineraryModalPage.clearPathStepValue(1);
+      await itineraryModalPage.checkPathStepCounterText(2, '3');
+    });
     await test.step('Check trailing placeholder', async () => {
       await itineraryModalPage.checkTrailingPlaceholder();
     });

--- a/front/tests/pages/operational-studies/itinerary-modal-page.ts
+++ b/front/tests/pages/operational-studies/itinerary-modal-page.ts
@@ -10,6 +10,7 @@ class ItineraryModalPage {
   private readonly itineraryModalNextButton: Locator;
   private readonly createTimetableItemButton: Locator;
   private readonly comboBox: Locator;
+  private readonly pathStepWrapper: Locator;
   private readonly opSuggestion: Locator;
   private readonly pathStepGap: Locator;
   private readonly addPathStepButton: Locator;
@@ -40,6 +41,7 @@ class ItineraryModalPage {
     this.itineraryModalNextButton = page.getByTestId('itinerary-modal-next-button');
     this.createTimetableItemButton = page.getByTestId('create-train-schedule-button');
     this.comboBox = page.getByTestId('path-step-combo-box');
+    this.pathStepWrapper = page.getByTestId('path-step-wrapper');
     this.opSuggestion = page.getByTestId('op-suggestion');
     this.pathStepGap = page.getByTestId('path-step-gap');
     this.addPathStepButton = page.getByTestId('add-path-step-button');
@@ -59,6 +61,13 @@ class ItineraryModalPage {
     this.segmentedControlInputStop = page.getByTestId('segmented-control-stop');
     this.timetableItem = page.getByTestId('scenario-train-schedule');
     this.timetableItemName = this.timetableItem.getByTestId('train-name');
+  }
+
+  private getOpNameClearIcon(pathStepIndex: number): Locator {
+    return this.pathStepWrapper
+      .nth(pathStepIndex)
+      .getByTestId('path-step-op-name')
+      .getByTestId('clear-icon');
   }
 
   async checkItineraryModalDefaultState() {
@@ -127,6 +136,13 @@ class ItineraryModalPage {
   async deleteNumberedRow(counterIndex: number, expectedComboBoxCount: number) {
     await this.pathStepCounter.nth(counterIndex).click();
     await expect(this.comboBox).toHaveCount(expectedComboBoxCount);
+  }
+
+  async clearPathStepValue(pathStepIndex: number) {
+    const expectedComboBoxCount = await this.comboBox.count();
+    await this.getOpNameClearIcon(pathStepIndex).click();
+    await expect(this.comboBox).toHaveCount(expectedComboBoxCount);
+    await expect(this.comboBox.nth(pathStepIndex)).toHaveValue('');
   }
 
   async checkPathStepCounterText(index: number, expectedText: string) {

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -216,6 +216,7 @@ const ComboBox = <T,>({
               icon: <XCircle variant="fill" />,
               action: clearInput,
               className: 'clear-icon',
+              testId: 'clear-icon',
             },
           ]
         : []),

--- a/front/ui/ui-core/src/components/Input.tsx
+++ b/front/ui/ui-core/src/components/Input.tsx
@@ -43,6 +43,7 @@ type IconConfig = {
   icon: React.ReactNode;
   action: () => void;
   className?: string;
+  testId?: string;
 };
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
@@ -140,7 +141,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 key={index}
                 className={iconConfig?.className}
                 onClick={iconConfig.action}
-                data-testid={testIdPrefix ? `${testIdPrefix}-icon` : undefined}
+                data-testid={
+                  iconConfig.testId ?? (testIdPrefix ? `${testIdPrefix}-icon` : undefined)
+                }
               >
                 {iconConfig.icon}
               </span>


### PR DESCRIPTION
- Clearing the combobox now only removes the text in the input and keep the path item field
- Added an e2e test step to cover it

close #17520 
close #17523 