### PR TITLE
tests: add duplicate OP in small infra and etcs infra

### DIFF
--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -968,7 +968,7 @@ pub mod tests {
             .assert_status_ok()
             .json();
 
-        assert_eq!(response.len(), 8);
+        assert_eq!(response.len(), 9);
         assert!(
             response
                 .iter()
@@ -1003,7 +1003,7 @@ pub mod tests {
             .assert_status_ok()
             .json();
 
-        assert_eq!(response.len(), 3);
+        assert_eq!(response.len(), 4);
         assert!(
             response
                 .iter()

--- a/python/railjson_generator/railjson_generator/schema/infra/infra.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/infra.py
@@ -100,7 +100,9 @@ class Infra:
                 if op.secondary_code is not None
                 else None,
                 is_passenger_station=op.is_passenger_station,
-                secondary_name=models.SecondaryName("0"),
+                secondary_name=models.SecondaryName(op.secondary_name)
+                if op.secondary_name is not None
+                else None,
             )
             ops.append(new_op)
         return ops

--- a/python/railjson_generator/railjson_generator/schema/infra/operational_point.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/operational_point.py
@@ -18,6 +18,7 @@ class OperationalPoint:
     country_code: NonBlankStr
     main_code: NonBlankStr
     secondary_code: NonBlankStr | None
+    secondary_name: NonBlankStr | None
     is_passenger_station: bool
 
     def __init__(
@@ -29,6 +30,7 @@ class OperationalPoint:
         plc: NonBlankStr | None = None,
         weight: int | None = None,
         secondary_code: NonBlankStr | None = "BV",
+        secondary_name: NonBlankStr | None = "0",
         country_code: NonBlankStr = "FR",
         is_passenger_station: bool = True,
     ):
@@ -39,6 +41,7 @@ class OperationalPoint:
         self.weight = weight
         self.id = id or label
         self.secondary_code = secondary_code
+        self.secondary_name = secondary_name
         self.plc = plc
         self.country_code = country_code
         self.is_passenger_station = is_passenger_station

--- a/tests/data/infras/etcs_infra/infra.json
+++ b/tests/data/infras/etcs_infra/infra.json
@@ -904,6 +904,38 @@
         },
         {
             "country_code": "FR",
+            "id": "Mid_West_station_duplicate",
+            "is_passenger_station": true,
+            "main_code": "MWS",
+            "name": "Mid_West_station_duplicate",
+            "parts": [
+                {
+                    "local_track_name": "V1'",
+                    "position": 550.0,
+                    "track": "TC0"
+                },
+                {
+                    "local_track_name": "V2'",
+                    "position": 550.0,
+                    "track": "TC1"
+                },
+                {
+                    "local_track_name": "V3'",
+                    "position": 450.0,
+                    "track": "TC2"
+                },
+                {
+                    "local_track_name": "V4'",
+                    "position": 450.0,
+                    "track": "TC3"
+                }
+            ],
+            "secondary_code": "BV2",
+            "secondary_name": "Duplicate station",
+            "uic": 87332
+        },
+        {
+            "country_code": "FR",
             "id": "Mid_East_station",
             "is_passenger_station": true,
             "main_code": "MES",

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -904,6 +904,38 @@
         },
         {
             "country_code": "FR",
+            "id": "Mid_West_station_duplicate",
+            "is_passenger_station": true,
+            "main_code": "MWS",
+            "name": "Mid_West_station_duplicate",
+            "parts": [
+                {
+                    "local_track_name": "V1'",
+                    "position": 550.0,
+                    "track": "TC0"
+                },
+                {
+                    "local_track_name": "V2'",
+                    "position": 550.0,
+                    "track": "TC1"
+                },
+                {
+                    "local_track_name": "V3'",
+                    "position": 450.0,
+                    "track": "TC2"
+                },
+                {
+                    "local_track_name": "V4'",
+                    "position": 450.0,
+                    "track": "TC3"
+                }
+            ],
+            "secondary_code": "BV2",
+            "secondary_name": "Duplicate station",
+            "uic": 87332
+        },
+        {
+            "country_code": "FR",
             "id": "Mid_East_station",
             "is_passenger_station": true,
             "main_code": "MES",

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -327,13 +327,29 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         [(-0.309, LAT_1 - LAT_LINE_SPACE), (-0.297, LAT_1 - LAT_LINE_SPACE)]
     )
     # Station
+    mid_west_tc0 = 550
+    mid_west_tc1 = 550
+    mid_west_tc2 = 450
+    mid_west_tc3 = 450
     mid_west = builder.add_operational_point(
         label="Mid_West_station", main_code="MWS", uic=8733
     )
-    mid_west.add_part(tc0, 550, "V1")
-    mid_west.add_part(tc1, 550, "V2")
-    mid_west.add_part(tc2, 450, "V3")
-    mid_west.add_part(tc3, 450, "V4")
+    mid_west.add_part(tc0, mid_west_tc0, "V1")
+    mid_west.add_part(tc1, mid_west_tc1, "V2")
+    mid_west.add_part(tc2, mid_west_tc2, "V3")
+    mid_west.add_part(tc3, mid_west_tc3, "V4")
+    # Duplicate station (to test for duplicate OPs)
+    mid_west_duplicate = builder.add_operational_point(
+        label="Mid_West_station_duplicate",
+        main_code="MWS",
+        uic=87332,
+        secondary_code="BV2",
+        secondary_name="Duplicate station",
+    )
+    mid_west_duplicate.add_part(tc0, mid_west_tc0, "V1'")
+    mid_west_duplicate.add_part(tc1, mid_west_tc1, "V2'")
+    mid_west_duplicate.add_part(tc2, mid_west_tc2, "V3'")
+    mid_west_duplicate.add_part(tc3, mid_west_tc3, "V4'")
     # ================================
     #  Around station D: Mid-East
     # ================================


### PR DESCRIPTION
Some STDCM imports had train schedules going through duplicate OPs and triggered bugs between front, core and editoast like #9727, #13785, #17603 and #17125. This patch adds a duplicate OP in small infra to encounter and test this case more often.