### PR TITLE
front: drop old modal: split button in new itinerary modal

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -422,7 +422,6 @@
       "alertMissingRequestedPoint": "At least two path steps are required to define an itinerary",
       "cancel": "Cancel",
       "cancelMapSelection": "Cancel",
-      "edit": "Edit itinerary",
       "focusLocationOnMap": "Focus the map on this operational point",
       "frameAll": "Center on all path steps on map",
       "intermediateWaypointsPanel": {
@@ -439,7 +438,6 @@
       "invalidOP": "Non recognized point: ",
       "moveLocationOnMap": "Move location on the map",
       "movePointOnMap": "Move this waypoint using the map",
-      "next": "Next",
       "noComputation": "There will be no computation for this train",
       "opId": "Operational point identifier",
       "opName": "Operational point name",
@@ -448,6 +446,13 @@
       "pass": "Pass",
       "requestedPoint": "Point on map",
       "stop": "Stop",
+      "submit": {
+        "addService": "Add service",
+        "addSingleTrain": "Add single train",
+        "editOccurrence": "Edit occurrence",
+        "editService": "Edit service",
+        "editSingleTrain": "Edit single train"
+      },
       "track": "Track",
       "trainName": "Train name",
       "trigram": "Trigram",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -422,7 +422,6 @@
       "alertMissingRequestedPoint": "Il faut au minimum deux points de passage pour définir un itinéraire",
       "cancel": "Annuler",
       "cancelMapSelection": "Annuler",
-      "edit": "Modifier l’itinéraire",
       "focusLocationOnMap": "Centrer la carte sur ce point remarquable",
       "frameAll": "Centrer sur tous les points de passage sur la carte",
       "intermediateWaypointsPanel": {
@@ -439,7 +438,6 @@
       "invalidOP": "Point non reconnu : ",
       "moveLocationOnMap": "Déplacer le point remarquable sur la carte",
       "movePointOnMap": "Déplacez ce point en utilisant la carte",
-      "next": "Suivant",
       "noComputation": "Il n'y aura pas de calcul pour ce train",
       "opId": "Identifiant de point",
       "opName": "Nom du point remarquable",
@@ -448,6 +446,13 @@
       "pass": "Passage",
       "requestedPoint": "Point sur la carte",
       "stop": "Arrêt",
+      "submit": {
+        "addService": "Ajouter la mission",
+        "addSingleTrain": "Ajouter le train unique",
+        "editOccurrence": "Modifier l'occurrence",
+        "editService": "Modifier la mission",
+        "editSingleTrain": "Modifier le train unique"
+      },
       "track": "Voie",
       "trainName": "Nom du train",
       "trigram": "Trigramme",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
 
-import { Button } from '@osrd-project/ui-core';
 import { ArrowSwitch, Fold, FrameAll, Plus, Unfold } from '@osrd-project/ui-icons';
 import along from '@turf/along';
 import bbox from '@turf/bbox';
@@ -56,6 +55,7 @@ import type { FeatureInfoClick } from '../types';
 import type { OperationalPointSuggestion } from './ComboBoxCustomList/ListElementComponent';
 import { usePathStepsMetadata } from './hooks/usePathStepsMetadata';
 import IntermediateWaypointsPanel from './IntermediateWaypointsPanel/IntermediateWaypointsPanel';
+import ItineraryModalFooter from './ItineraryModalFooter';
 import ItineraryModalFormHeader from './ItineraryModalFormHeader';
 import ItineraryModalMap from './ItineraryModalMap';
 import PathStepItem from './PathStepItem';
@@ -926,26 +926,11 @@ const ItineraryModal = ({
             </button>
           </div>
         </div>
-        <div className="itinerary-modal-form-footer" data-testid="itinerary-modal-form-footer">
-          <Button
-            label={t('cancel')}
-            variant="Cancel"
-            size="medium"
-            onClick={() => closeModal({ withChanges: false })}
-            dataTestID="close-itinerary-modal"
-          />
-          <Button
-            label={
-              displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.itinerary
-                ? t('edit')
-                : t('next')
-            }
-            variant="Primary"
-            size="medium"
-            onClick={submitItinerary}
-            dataTestID="itinerary-modal-next-button"
-          />
-        </div>
+        <ItineraryModalFooter
+          mode={displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.add ? 'new' : 'edit'}
+          onCancel={() => closeModal({ withChanges: false })}
+          onSubmit={submitItinerary}
+        />
       </div>
       {waypointsPanelOpen && (
         <div className="itinerary-modal-waypoints-panel-wrapper">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -31,6 +31,7 @@ import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import { updateItineraryForm } from 'reducers/osrdconf/operationalStudiesConf';
 import {
   getCategory,
+  getEditingTrainType,
   getName,
   getOperationalStudiesRollingStockID,
   getOperationalStudiesSpeedLimitByTag,
@@ -55,7 +56,7 @@ import type { FeatureInfoClick } from '../types';
 import type { OperationalPointSuggestion } from './ComboBoxCustomList/ListElementComponent';
 import { usePathStepsMetadata } from './hooks/usePathStepsMetadata';
 import IntermediateWaypointsPanel from './IntermediateWaypointsPanel/IntermediateWaypointsPanel';
-import ItineraryModalFooter from './ItineraryModalFooter';
+import ItineraryModalFooter, { type FooterTrainType } from './ItineraryModalFooter';
 import ItineraryModalFormHeader from './ItineraryModalFormHeader';
 import ItineraryModalMap from './ItineraryModalMap';
 import PathStepItem from './PathStepItem';
@@ -94,6 +95,7 @@ const ItineraryModal = ({
   const dispatch = useAppDispatch();
   const { updateViewport } = useMapSettingsActions();
   const infraId = useInfraID();
+  const editingTrainType = useSelector(getEditingTrainType);
 
   const [modalFormState, setModalFormState] = useState<ItineraryModalFormState>({
     name,
@@ -605,7 +607,7 @@ const ItineraryModal = ({
 
     launchPathfinding(reversePathSteps(updatedPathSteps), modalFormState.rollingStockId);
   };
-  const submitItinerary = () => {
+  const submitItinerary = (trainType?: FooterTrainType) => {
     setSubmitAttempted(true);
     setBannerWiggle((c) => c + 1);
     if (isNameEmpty) return;
@@ -633,6 +635,7 @@ const ItineraryModal = ({
         rollingStockName: modalFormState.rollingStockName,
         speedLimitTag: modalFormState.speedLimitTag,
         pathSteps: pathStepsFromV2,
+        trainType,
       })
     );
 
@@ -928,6 +931,7 @@ const ItineraryModal = ({
         </div>
         <ItineraryModalFooter
           mode={displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.add ? 'new' : 'edit'}
+          trainType={editingTrainType}
           onCancel={() => closeModal({ withChanges: false })}
           onSubmit={submitItinerary}
         />

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFooter.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFooter.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@osrd-project/ui-core';
+import { useTranslation } from 'react-i18next';
+
+export type ItineraryModalFooterProps = {
+  mode: 'new' | 'edit';
+  onCancel: () => void;
+  onSubmit: () => void;
+};
+
+export default function ItineraryModalFooter({
+  mode,
+  onCancel,
+  onSubmit,
+}: ItineraryModalFooterProps) {
+  const { t } = useTranslation('operational-studies', {
+    keyPrefix: 'manageTrainSchedule.itineraryModal',
+  });
+
+  return (
+    <div className="itinerary-modal-form-footer" data-testid="itinerary-modal-form-footer">
+      <Button
+        label={t('cancel')}
+        variant="Cancel"
+        size="medium"
+        onClick={onCancel}
+        dataTestID="close-itinerary-modal"
+      />
+      <Button
+        label={mode === 'edit' ? t('edit') : t('next')}
+        variant="Primary"
+        size="medium"
+        onClick={onSubmit}
+        dataTestID="itinerary-modal-next-button"
+      />
+    </div>
+  );
+}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFooter.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFooter.tsx
@@ -1,14 +1,21 @@
 import { Button } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
 
+import type { OperationalStudiesConfState } from 'reducers/osrdconf/types';
+
+// TODO: Define a proper type here as soon as we get rid of the old modal store
+export type FooterTrainType = OperationalStudiesConfState['editingTrainType'];
+
 export type ItineraryModalFooterProps = {
   mode: 'new' | 'edit';
+  trainType: FooterTrainType;
   onCancel: () => void;
-  onSubmit: () => void;
+  onSubmit: (trainType?: FooterTrainType) => void;
 };
 
 export default function ItineraryModalFooter({
   mode,
+  trainType,
   onCancel,
   onSubmit,
 }: ItineraryModalFooterProps) {
@@ -25,13 +32,38 @@ export default function ItineraryModalFooter({
         onClick={onCancel}
         dataTestID="close-itinerary-modal"
       />
-      <Button
-        label={mode === 'edit' ? t('edit') : t('next')}
-        variant="Primary"
-        size="medium"
-        onClick={onSubmit}
-        dataTestID="itinerary-modal-next-button"
-      />
+      {mode === 'new' ? (
+        <div className="itinerary-modal-submit-buttons">
+          <Button
+            label={t('submit.addSingleTrain')}
+            variant="Normal"
+            size="medium"
+            onClick={() => onSubmit('uniqueTrain')}
+            dataTestID="itinerary-modal-add-single-train-button"
+          />
+          <Button
+            label={t('submit.addService')}
+            variant="Primary"
+            size="medium"
+            onClick={() => onSubmit('pacedTrain')}
+            dataTestID="itinerary-modal-add-service-train-button"
+          />
+        </div>
+      ) : (
+        <Button
+          label={
+            trainType === 'uniqueTrain'
+              ? t('submit.editSingleTrain')
+              : trainType === 'pacedTrain'
+                ? t('submit.editService')
+                : t('submit.editOccurrence')
+          }
+          variant="Primary"
+          size="medium"
+          onClick={onSubmit}
+          dataTestID="itinerary-modal-edit-train-button"
+        />
+      )}
     </div>
   );
 }

--- a/front/src/reducers/osrdconf/operationalStudiesConf/trainSettingsReducer.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/trainSettingsReducer.ts
@@ -80,6 +80,10 @@ const trainSettingsReducer = {
     state.rollingStockName = action.payload.rollingStockName;
     state.speedLimitByTag = action.payload.speedLimitTag;
     state.pathSteps = action.payload.pathSteps;
+
+    if (action.payload.trainType) {
+      state.editingTrainType = action.payload.trainType;
+    }
   },
 };
 

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -48,6 +48,7 @@ export type ItineraryForm = {
   rollingStockName: string;
   speedLimitTag?: string;
   pathSteps: (PathStep | null)[];
+  trainType?: OperationalStudiesConfState['editingTrainType'];
 };
 
 export type OperationalStudiesConfState = OsrdConfState & {

--- a/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_itineraryModal.scss
@@ -554,6 +554,12 @@
       margin-top: var(--footer-box-shadow-height);
       box-shadow: 0 calc(-1 * var(--footer-box-shadow-height)) 0 0 var(--black10);
     }
+
+    .itinerary-modal-submit-buttons {
+      display: flex;
+      flex-direction: row;
+      gap: 32px;
+    }
   }
 
   .itinerary-modal-waypoints-panel-wrapper {

--- a/front/tests/pages/operational-studies/itinerary-modal-page.ts
+++ b/front/tests/pages/operational-studies/itinerary-modal-page.ts
@@ -7,7 +7,8 @@ class ItineraryModalPage {
   private readonly rocketSearch: Locator;
   private readonly itineraryModalMap: Locator;
   private readonly itineraryModalCancelButton: Locator;
-  private readonly itineraryModalNextButton: Locator;
+  private readonly itineraryModalAddSingleTrainButton: Locator;
+  private readonly itineraryModalAddServiceTrainButton: Locator;
   private readonly createTimetableItemButton: Locator;
   private readonly comboBox: Locator;
   private readonly opSuggestion: Locator;
@@ -37,7 +38,12 @@ class ItineraryModalPage {
     this.rocketSearch = page.getByTestId('type-and-path-input');
     this.itineraryModalMap = page.getByTestId('itinerary-modal-map');
     this.itineraryModalCancelButton = page.getByTestId('close-itinerary-modal');
-    this.itineraryModalNextButton = page.getByTestId('itinerary-modal-next-button');
+    this.itineraryModalAddSingleTrainButton = page.getByTestId(
+      'itinerary-modal-add-single-train-button'
+    );
+    this.itineraryModalAddServiceTrainButton = page.getByTestId(
+      'itinerary-modal-add-service-train-button'
+    );
     this.createTimetableItemButton = page.getByTestId('create-train-schedule-button');
     this.comboBox = page.getByTestId('path-step-combo-box');
     this.opSuggestion = page.getByTestId('op-suggestion');
@@ -67,7 +73,8 @@ class ItineraryModalPage {
     await expect(this.itineraryModalFormFooter).toBeVisible();
     await expect(this.itineraryModalMap).toBeVisible();
     await expect(this.itineraryModalCancelButton).toBeVisible();
-    await expect(this.itineraryModalNextButton).toBeVisible();
+    await expect(this.itineraryModalAddSingleTrainButton).toBeVisible();
+    await expect(this.itineraryModalAddServiceTrainButton).toBeVisible();
   }
 
   async checkItineraryModalHeader(expectedText: string) {
@@ -220,8 +227,8 @@ class ItineraryModalPage {
   }
 
   async createTrain() {
-    await expect(this.itineraryModalNextButton).toBeVisible();
-    await this.itineraryModalNextButton.click();
+    await expect(this.itineraryModalAddSingleTrainButton).toBeVisible();
+    await this.itineraryModalAddSingleTrainButton.click();
     await expect(this.createTimetableItemButton).toBeVisible();
     await this.createTimetableItemButton.click();
   }


### PR DESCRIPTION
Fixes #17554.

This is a two-step pull request:

- The first commit simply move the footer out of the itinerary modal big component;
- The second, "main" commit, properly splits the buttons, setting the `editingTrainType` on submit, and using the `editingTrainType` when we are editing a train to show the right button label.

<img width="2968" height="2206" alt="Capture d’écran 2026-07-20 à 11 51 27" src="https://github.com/user-attachments/assets/f76f3416-5ebd-4d01-a296-59583ad6ec74" />

I updated the end-to-end test to always click on the "add single train" button to not change anything else in the e2e test scenario.