### PR TITLE
raimi, front: add and propagate backtrack stop-type to RaiMI api

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -188,6 +188,7 @@
         "selectPathType": "Select",
         "stop": "Stop at {{stopAt}} for {{stopType}} — {{minutes}}",
         "stopType": {
+          "backtrack": "a backtrack",
           "consistChange": "a consist change",
           "driverSwitch": "a driver switch",
           "overtake": "an overtake",
@@ -301,6 +302,7 @@
     "respectDestinationSchedule": "respect the destination schedule",
     "stopFor": "Minimum stop time",
     "stopType": {
+      "backtrack": "backtrack",
       "consistChange": "consist change",
       "driverSwitch": "driver switch",
       "overtake": "overtake",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -188,6 +188,7 @@
         "selectPathType": "Choisir",
         "stop": "Arrêt {{stopAt}} pour {{stopType}} — {{minutes}}",
         "stopType": {
+          "backtrack": "rebroussement",
           "consistChange": "changement de convoi",
           "driverSwitch": "relève conducteur",
           "overtake": "dépassement",
@@ -301,6 +302,7 @@
     "respectDestinationSchedule": "respecter l'horaire de la destination",
     "stopFor": "Temps d'arrêt minimum",
     "stopType": {
+      "backtrack": "rebroussement",
       "consistChange": "ch. de convoi",
       "driverSwitch": "relève conducteur",
       "overtake": "dépassement",

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -224,6 +224,7 @@ export enum StdcmStopTypes {
   SERVICE_STOP = 'serviceStop',
   OVERTAKE = 'overtake',
   CONSIST_CHANGE = 'consistChange',
+  BACKTRACK = 'backtrack',
 }
 
 export type StdcmLinkedTrainExtremity = {

--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -352,7 +352,7 @@ export type TimingData = {
   /** Tolerance in ms */
   arrival_time_tolerance_after: number;
 };
-export type StepType = 'VIA' | 'DRIVER_SWITCH' | 'STOP';
+export type StepType = 'VIA' | 'DRIVER_SWITCH' | 'STOP' | 'BACKTRACK';
 export type RequestedStep = {
   /** New consist to use from this step onward. Not included for the first step. */
   consist_change?: ConsistChange;

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -23,6 +23,7 @@ const STOP_TYPE_MAPPING: Record<StdcmStopTypes, StepType> = {
   [StdcmStopTypes.SERVICE_STOP]: 'STOP',
   [StdcmStopTypes.OVERTAKE]: 'VIA',
   [StdcmStopTypes.CONSIST_CHANGE]: 'STOP',
+  [StdcmStopTypes.BACKTRACK]: 'BACKTRACK',
 };
 
 function generateRandomString(length: number): string {

--- a/front/tests/03-stdcm/001-stdcm.spec.ts
+++ b/front/tests/03-stdcm/001-stdcm.spec.ts
@@ -1,3 +1,4 @@
+import { StdcmStopTypes } from 'applications/stdcm/types';
 import type { Infra, TowedRollingStock } from 'common/api/osrdEditoastApi';
 
 import {
@@ -20,7 +21,6 @@ import {
   TRACTION_ENGINE_PREFILLED_VALUES,
   VIA_DETAILS,
   VIA_STOP_TIMES,
-  VIA_STOP_TYPES,
   VIA_SUGGESTIONS,
 } from '../assets/constants/stdcm/stdcm-const';
 import type { ConsistFields } from '../utils/stdcm-types';
@@ -76,7 +76,7 @@ test.describe('STDCM simulation with all stops and towed rolling stock', { tag: 
       });
 
       await test.step('Add/delete default via and linked path', async () => {
-        await viaSection.addAndDeletedDefaultVia(VIA_STOP_TYPES.PASSAGE_TIME);
+        await viaSection.addAndDeletedDefaultVia(StdcmStopTypes.PASSAGE_TIME);
         await linkedTrainSection.addAndDeleteDefaultLinkedPath({
           defaultDate: DEFAULT_DETAILS.arrivalDate,
         });
@@ -135,7 +135,7 @@ test.describe('STDCM simulation with all stops and towed rolling stock', { tag: 
           await viaSection.fillAndVerifyViaDetails({
             ...viaDetail,
             expectedChValue: DEFAULT_DETAILS.chValue,
-            stopTypes: VIA_STOP_TYPES,
+            stopTypes: StdcmStopTypes,
             stopTimes: VIA_STOP_TIMES,
             suggestionTextBySearch: {
               mid_west: VIA_SUGGESTIONS[0],
@@ -246,7 +246,7 @@ test.describe('STDCM simulation with all stops and towed rolling stock', { tag: 
         viaNumber: 1,
         ciSearchText: 'mid_west',
         expectedChValue: DEFAULT_DETAILS.chValue,
-        stopTypes: VIA_STOP_TYPES,
+        stopTypes: StdcmStopTypes,
         stopTimes: VIA_STOP_TIMES,
         suggestionTextBySearch: {
           mid_west: VIA_SUGGESTIONS[0],

--- a/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/03-stdcm/002-stdcm-simulation-sheet.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 
+import { StdcmStopTypes } from 'applications/stdcm/types';
 import type { Infra } from 'common/api/osrdEditoastApi';
 
 import simulationSheetDetails from '../assets/constants/stdcm/simulation-sheet-const';
@@ -17,7 +18,6 @@ import {
   STDCM_WITHOUT_ALL_VIA_DATA_PATH,
   TRACTION_ENGINE_PREFILLED_VALUES,
   VIA_STOP_TIMES,
-  VIA_STOP_TYPES,
   VIA_SUGGESTIONS,
 } from '../assets/constants/stdcm/stdcm-const';
 import test from './../page-object-fixture';
@@ -93,7 +93,7 @@ test.describe('STDCM simulation sheet', { tag: ['@stdcm, @stdcm-sheet'] }, () =>
           viaNumber: 1,
           ciSearchText: 'mid_west',
           expectedChValue: DEFAULT_DETAILS.chValue,
-          stopTypes: VIA_STOP_TYPES,
+          stopTypes: StdcmStopTypes,
           stopTimes: VIA_STOP_TIMES,
           suggestionTextBySearch: {
             mid_west: VIA_SUGGESTIONS[0],

--- a/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
+++ b/front/tests/03-stdcm/003-stdcm-linked-train.spec.ts
@@ -1,3 +1,4 @@
+import { StdcmStopTypes } from 'applications/stdcm/types';
 import type { Infra, TowedRollingStock } from 'common/api/osrdEditoastApi';
 
 import LINKED_TRAIN_DETAILS from '../assets/constants/stdcm/linked-train-const';
@@ -15,7 +16,6 @@ import {
   STDCM_URL,
   TOWED_ROLLING_STOCK_PREFILLED_VALUES,
   VIA_STOP_TIMES,
-  VIA_STOP_TYPES,
   VIA_SUGGESTIONS,
 } from '../assets/constants/stdcm/stdcm-const';
 import type { ConsistFields } from '../utils/stdcm-types';
@@ -84,7 +84,7 @@ test.describe('STDCM linked train simulation', { tag: ['@stdcm', '@stdcm-linked-
         viaNumber: 1,
         ciSearchText: 'nS',
         expectedChValue: DEFAULT_DETAILS.chValue,
-        stopTypes: VIA_STOP_TYPES,
+        stopTypes: StdcmStopTypes,
         stopTimes: VIA_STOP_TIMES,
         suggestionTextBySearch: {
           mid_west: VIA_SUGGESTIONS[0],
@@ -150,7 +150,7 @@ test.describe('STDCM linked train simulation', { tag: ['@stdcm', '@stdcm-linked-
 
       await newViaSection.verifyViaDetails({
         expectedCiValue: CI_SUGGESTIONS.north[1],
-        expectedViaType: VIA_STOP_TYPES.DRIVER_SWITCH,
+        expectedViaType: StdcmStopTypes.DRIVER_SWITCH,
         expectedStopTime: VIA_STOP_TIMES.driverSwitch.validInput,
       });
     });
@@ -182,7 +182,7 @@ test.describe('STDCM linked train simulation', { tag: ['@stdcm', '@stdcm-linked-
         viaNumber: 1,
         ciSearchText: 'mid_east',
         expectedChValue: DEFAULT_DETAILS.chValue,
-        stopTypes: VIA_STOP_TYPES,
+        stopTypes: StdcmStopTypes,
         stopTimes: VIA_STOP_TIMES,
         suggestionTextBySearch: {
           mid_west: VIA_SUGGESTIONS[0],

--- a/front/tests/03-stdcm/006-stdcm-consist-change.spec.ts
+++ b/front/tests/03-stdcm/006-stdcm-consist-change.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 
+import { StdcmStopTypes } from 'applications/stdcm/types';
 import type { Infra } from 'common/api/osrdEditoastApi';
 
 import {
@@ -19,7 +20,6 @@ import {
   STDCM_TRANSLATIONS,
   STDCM_URL,
   TRACTION_ENGINE_PREFILLED_VALUES,
-  VIA_STOP_TYPES,
   VIA_SUGGESTIONS,
 } from '../assets/constants/stdcm/stdcm-const';
 import test from '../page-object-fixture';
@@ -87,8 +87,8 @@ test.describe('STDCM Consist Change', { tag: ['@stdcm', '@stdcm-consist-change']
         ciSearchText: 'mid_west',
         expectedChValue: DEFAULT_DETAILS.chValue,
         selectedSuggestionText: VIA_SUGGESTIONS[0],
-        defaultViaType: VIA_STOP_TYPES.PASSAGE_TIME,
-        stopType: VIA_STOP_TYPES.SERVICE_STOP,
+        defaultViaType: StdcmStopTypes.PASSAGE_TIME,
+        stopType: StdcmStopTypes.SERVICE_STOP,
         stopTime: CONSIST_CHANGE_VIA_STOP_TIME,
       });
 
@@ -108,8 +108,8 @@ test.describe('STDCM Consist Change', { tag: ['@stdcm', '@stdcm-consist-change']
         ciSearchText: 'mid_east',
         expectedChValue: DEFAULT_DETAILS.chValue,
         selectedSuggestionText: VIA_SUGGESTIONS[1],
-        defaultViaType: VIA_STOP_TYPES.PASSAGE_TIME,
-        stopType: VIA_STOP_TYPES.SERVICE_STOP,
+        defaultViaType: StdcmStopTypes.PASSAGE_TIME,
+        stopType: StdcmStopTypes.SERVICE_STOP,
         stopTime: CONSIST_CHANGE_VIA_STOP_TIME,
       });
 
@@ -128,11 +128,11 @@ test.describe('STDCM Consist Change', { tag: ['@stdcm', '@stdcm-consist-change']
         CONSIST_CHANGE_UPDATED_PREFILL
       );
 
-      await viaSection.setViaStopType(2, VIA_STOP_TYPES.PASSAGE_TIME);
+      await viaSection.setViaStopType(2, StdcmStopTypes.PASSAGE_TIME);
       await consistChangeSection.verifyConsistChangeCardHidden(2);
       await consistChangeSection.verifyEditConsistButtonHidden(2);
 
-      await viaSection.setViaStopType(2, VIA_STOP_TYPES.SERVICE_STOP);
+      await viaSection.setViaStopType(2, StdcmStopTypes.SERVICE_STOP);
       await consistChangeSection.verifyConsistChangeCardHidden(2);
       await consistChangeSection.verifyEditConsistButtonVisible(2);
     });

--- a/front/tests/assets/constants/stdcm/stdcm-const.ts
+++ b/front/tests/assets/constants/stdcm/stdcm-const.ts
@@ -101,13 +101,6 @@ export const VIA_STOP_TIMES = {
   },
 };
 
-export const VIA_STOP_TYPES = {
-  PASSAGE_TIME: 'passageTime',
-  SERVICE_STOP: 'serviceStop',
-  DRIVER_SWITCH: 'driverSwitch',
-  BACKTRACK: 'backtrack',
-};
-
 export const CONFLICT_ARRIVAL_TIME = '16:29';
 
 export const CONSIST_DETAILS: ConsistFields = {

--- a/front/tests/assets/constants/stdcm/stdcm-const.ts
+++ b/front/tests/assets/constants/stdcm/stdcm-const.ts
@@ -105,6 +105,7 @@ export const VIA_STOP_TYPES = {
   PASSAGE_TIME: 'passageTime',
   SERVICE_STOP: 'serviceStop',
   DRIVER_SWITCH: 'driverSwitch',
+  BACKTRACK: 'backtrack',
 };
 
 export const CONFLICT_ARRIVAL_TIME = '16:29';

--- a/front/tests/utils/stdcm-types.ts
+++ b/front/tests/utils/stdcm-types.ts
@@ -90,6 +90,7 @@ export type ViaStopTypes = {
   PASSAGE_TIME: string;
   SERVICE_STOP: string;
   DRIVER_SWITCH: string;
+  BACKTRACK: string;
 };
 
 export type ViaStopTimes = {

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -4273,6 +4273,7 @@ class StepType(Enum):
     VIA = "VIA"
     DRIVER_SWITCH = "DRIVER_SWITCH"
     STOP = "STOP"
+    BACKTRACK = "BACKTRACK"
 
 
 class RequestedStep(BaseModel):

--- a/railway_manager_interface/openapi.yaml
+++ b/railway_manager_interface/openapi.yaml
@@ -204,6 +204,7 @@ components:
       - VIA
       - DRIVER_SWITCH
       - STOP
+      - BACKTRACK
       title: StepType
       description: Describes the type of step.
     RequestedStep:


### PR DESCRIPTION
Only minimal add, no use