### PR TITLE
core: bump gradle to 9.6.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -230,3 +230,10 @@ tasks.register('copyOtelAgent', Copy) {
     into layout.buildDirectory.dir("libs/agent")
     rename { "opentelemetry-javaagent.jar" }
 }
+
+tasks.shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    filesNotMatching("META-INF/*.kotlin_module") {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+}

--- a/core/gradle/wrapper/gradle-wrapper.properties
+++ b/core/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Due to `gradleup.shadow` bump, gradle minimum requirement is `9.2.0` (see https://github.com/OpenRailAssociation/osrd/pull/17725). Bump gradle version.