### PR TITLE
front: repeat train curves in space time chart for hourly timetables

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -88,6 +88,7 @@ import {
 import ProjectionLoadingMessage from './ProjectionLoadingMessage';
 import SettingsPanel from './SettingsPanel';
 import SpaceTimeChartToolbar from './SpaceTimeChartToolbar';
+import TimeRangeObserver from './TimeRangeObserver';
 import useWaypointMenu from './useWaypointMenu';
 import WaypointsPanel from './WaypointsPanel';
 
@@ -208,6 +209,7 @@ const SpaceTimeChartWrapper = ({
   const [dragOverTrackId, setDragOverTrackId] = useState<string | undefined>();
   const [dragOffsetMs, setDragOffsetMs] = useState<number | null>(null);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  const [_chartTimeRange, setChartTimeRange] = useState<{ start: number; end: number }>();
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) =>
@@ -780,6 +782,7 @@ const SpaceTimeChartWrapper = ({
                 )}
               </>
             )}
+            <TimeRangeObserver onChange={setChartTimeRange} />
           </SpaceTimeChart>
           {showCurvePanel && (
             <CurveSelectionSidePanel

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -26,6 +26,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import useScenario from 'applications/operationalStudies/hooks/useScenario';
 import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import { type PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
@@ -53,6 +54,7 @@ import {
   getSelectedTrain,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
+import { Duration } from 'utils/duration';
 import {
   extractEditoastIdFromTrainScheduleId,
   extractExceptionIdFromOccurrenceId,
@@ -195,6 +197,7 @@ const SpaceTimeChartWrapper = ({
   const dispatch = useAppDispatch();
   const hoveredTrainId = useSelector(getHoveredTrainId);
   const isSimulationEnabled = useSelector(getIsSimulationEnabled);
+  const { scenario: { timetable_type: timetableType } = {} } = useScenario();
   const selection = useSelector(getSelectedTrain);
   const { id: selectedTrainId, by: selectedTrainBy } = selection ?? {};
 
@@ -209,7 +212,7 @@ const SpaceTimeChartWrapper = ({
   const [dragOverTrackId, setDragOverTrackId] = useState<string | undefined>();
   const [dragOffsetMs, setDragOffsetMs] = useState<number | null>(null);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-  const [_chartTimeRange, setChartTimeRange] = useState<{ start: number; end: number }>();
+  const [chartTimeRange, setChartTimeRange] = useState<{ start: number; end: number }>();
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) =>
@@ -264,9 +267,20 @@ const SpaceTimeChartWrapper = ({
     showSignalsStates: false,
   });
 
+  const repeatTimeRange = useMemo(
+    () =>
+      chartTimeRange && timetableType === 'HOURLY'
+        ? {
+            start: new Duration({ milliseconds: chartTimeRange.start }),
+            end: new Duration({ milliseconds: chartTimeRange.end }),
+          }
+        : undefined,
+    [chartTimeRange, timetableType]
+  );
+
   const projectedTrains = useMemo(
-    () => makeProjectedTrains(trainScheduleProjections),
-    [trainScheduleProjections]
+    () => makeProjectedTrains(trainScheduleProjections, repeatTimeRange),
+    [trainScheduleProjections, repeatTimeRange]
   );
 
   // Cut the spacetime chart curves if the first or last waypoints are hidden

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -752,7 +752,7 @@ const SpaceTimeChartWrapper = ({
               );
               return (
                 <PathLayer
-                  key={`${path.id}-${path.points[0]?.position}`}
+                  key={path.key}
                   path={path}
                   color={style.color}
                   level={style.level}

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/TimeRangeObserver.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/TimeRangeObserver.tsx
@@ -1,0 +1,23 @@
+import { useContext, useMemo, useEffect } from 'react';
+
+import { SpaceTimeChartContext } from '@osrd-project/ui-charts';
+
+const TimeRangeObserver = ({
+  onChange,
+}: {
+  onChange: (range: { start: number; end: number }) => void;
+}) => {
+  const { width, height, getData } = useContext(SpaceTimeChartContext);
+
+  const timeRange = useMemo(() => {
+    const minPoint = getData({ x: 0, y: 0 });
+    const maxPoint = getData({ x: width, y: height });
+    return { start: minPoint.time, end: maxPoint.time };
+  }, [width, height, getData]);
+
+  useEffect(() => onChange(timeRange), [timeRange]);
+
+  return null;
+};
+
+export default TimeRangeObserver;

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
@@ -125,7 +125,7 @@ describe('makeProjectedTrains', () => {
 
       expect(result[0]).toEqual({
         id: 'indexedoccurrence_2562_0',
-        key: 'indexedoccurrence_2562_0',
+        key: 'indexedoccurrence_2562_0-2025-07-09T05:30:00.000Z',
         name: `${pacedTrain.name} 1`,
         departureTime: pacedTrain.departureTime,
         type: 'occurrence',
@@ -134,7 +134,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[1]).toEqual({
         id: 'indexedoccurrence_2562_1',
-        key: 'indexedoccurrence_2562_1',
+        key: 'indexedoccurrence_2562_1-2025-07-09T06:30:00.000Z',
         name: `${exception.train_name!.value}≠`,
         departureTime: new Date('2025-07-09T06:30:00.000Z'),
         type: 'exception',
@@ -258,7 +258,7 @@ describe('makeProjectedTrains', () => {
       expect(result.length).toBe(4);
       expect(result[0]).toEqual({
         id: 'indexedoccurrence_2564_0',
-        key: 'indexedoccurrence_2564_0',
+        key: 'indexedoccurrence_2564_0-2025-07-09T05:30:00.000Z',
         name: 'auie 1',
         departureTime: pacedTrain.departureTime,
         type: 'occurrence',
@@ -267,7 +267,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[1]).toEqual({
         id: 'indexedoccurrence_2564_1',
-        key: 'indexedoccurrence_2564_1',
+        key: 'indexedoccurrence_2564_1-2025-07-09T06:30:00.000Z',
         name: `${pacedTrain.name} 3`,
         departureTime: dayjs(pacedTrain.departureTime).add(1, 'hour').toDate(),
         type: 'occurrence',
@@ -276,7 +276,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[2]).toEqual({
         id: 'indexedoccurrence_2564_2',
-        key: 'indexedoccurrence_2564_2',
+        key: 'indexedoccurrence_2564_2-2025-07-09T07:30:00.000Z',
         name: `${pacedTrain.name} 5`,
         departureTime: dayjs(pacedTrain.departureTime).add(2, 'hour').toDate(),
         type: 'occurrence',
@@ -285,7 +285,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[3]).toEqual({
         id: 'exception_2564_2',
-        key: 'exception_2564_2',
+        key: 'exception_2564_2-2025-07-30T14:00:00.000Z',
         name: `${exception.train_name!.value}≠`,
         departureTime: new Date(exception.start_time!.value),
         type: 'exception',
@@ -317,7 +317,7 @@ describe('makeProjectedTrains', () => {
       expect(result.length).toBe(4);
       expect(result[3]).toEqual({
         id: 'exception_2564_2',
-        key: 'exception_2564_2',
+        key: 'exception_2564_2-2025-07-30T14:00:00.000Z',
         name: 'auie/+≠',
         departureTime: exceptionStartTime,
         type: 'exception',
@@ -325,6 +325,40 @@ describe('makeProjectedTrains', () => {
         spaceTimeCurves: basePacedTrainProjection.spaceTimeCurves,
         signalUpdates: basePacedTrainProjection.signalUpdates,
       });
+    });
+
+    test('time range should repeat occurrences', () => {
+      const timeRange = {
+        start: new Duration({ minutes: -5 }),
+        end: new Duration({ minutes: 10 }),
+      };
+      const result = makeProjectedTrains([basePacedTrainProjection], timeRange);
+      expect(result.map(({ id, departureTime }) => ({ id, departureTime }))).toEqual([
+        {
+          id: 'indexedoccurrence_2564_0',
+          departureTime: new Date('2025-07-09T02:30:00.000Z'),
+        },
+        {
+          id: 'indexedoccurrence_2564_1',
+          departureTime: new Date('2025-07-09T03:30:00.000Z'),
+        },
+        {
+          id: 'indexedoccurrence_2564_2',
+          departureTime: new Date('2025-07-09T04:30:00.000Z'),
+        },
+        {
+          id: 'indexedoccurrence_2564_0',
+          departureTime: new Date('2025-07-09T05:30:00.000Z'),
+        },
+        {
+          id: 'indexedoccurrence_2564_1',
+          departureTime: new Date('2025-07-09T06:30:00.000Z'),
+        },
+        {
+          id: 'indexedoccurrence_2564_2',
+          departureTime: new Date('2025-07-09T07:30:00.000Z'),
+        },
+      ]);
     });
   });
 });

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/makeProjectedTrains.spec.ts
@@ -125,6 +125,7 @@ describe('makeProjectedTrains', () => {
 
       expect(result[0]).toEqual({
         id: 'indexedoccurrence_2562_0',
+        key: 'indexedoccurrence_2562_0',
         name: `${pacedTrain.name} 1`,
         departureTime: pacedTrain.departureTime,
         type: 'occurrence',
@@ -133,6 +134,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[1]).toEqual({
         id: 'indexedoccurrence_2562_1',
+        key: 'indexedoccurrence_2562_1',
         name: `${exception.train_name!.value}≠`,
         departureTime: new Date('2025-07-09T06:30:00.000Z'),
         type: 'exception',
@@ -256,6 +258,7 @@ describe('makeProjectedTrains', () => {
       expect(result.length).toBe(4);
       expect(result[0]).toEqual({
         id: 'indexedoccurrence_2564_0',
+        key: 'indexedoccurrence_2564_0',
         name: 'auie 1',
         departureTime: pacedTrain.departureTime,
         type: 'occurrence',
@@ -264,6 +267,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[1]).toEqual({
         id: 'indexedoccurrence_2564_1',
+        key: 'indexedoccurrence_2564_1',
         name: `${pacedTrain.name} 3`,
         departureTime: dayjs(pacedTrain.departureTime).add(1, 'hour').toDate(),
         type: 'occurrence',
@@ -272,6 +276,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[2]).toEqual({
         id: 'indexedoccurrence_2564_2',
+        key: 'indexedoccurrence_2564_2',
         name: `${pacedTrain.name} 5`,
         departureTime: dayjs(pacedTrain.departureTime).add(2, 'hour').toDate(),
         type: 'occurrence',
@@ -280,6 +285,7 @@ describe('makeProjectedTrains', () => {
       });
       expect(result[3]).toEqual({
         id: 'exception_2564_2',
+        key: 'exception_2564_2',
         name: `${exception.train_name!.value}≠`,
         departureTime: new Date(exception.start_time!.value),
         type: 'exception',
@@ -311,6 +317,7 @@ describe('makeProjectedTrains', () => {
       expect(result.length).toBe(4);
       expect(result[3]).toEqual({
         id: 'exception_2564_2',
+        key: 'exception_2564_2',
         name: 'auie/+≠',
         departureTime: exceptionStartTime,
         type: 'exception',

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
@@ -22,6 +22,7 @@ import {
 } from 'utils/trainId';
 
 export type PathDataWithSimulated = PathData & {
+  key: string;
   colors: CategoryColors;
   isSimulated?: boolean;
 };
@@ -66,6 +67,7 @@ const formatSpaceTimeCurves = (
     const departureTime = train.departureTime.getTime();
 
     return train.spaceTimeCurves.map((curve) => ({
+      key: `${train.key}-${curve.positions[0]}`,
       id: train.id,
       isSimulated: train.isSimulated,
       label: train.name,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
@@ -19,9 +19,11 @@ const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
   trainScheduleProjections.flatMap<IndividualTrainProjection>((projectedTrain) => {
     const { paced } = projectedTrain;
     if (!paced) {
+      const id = formatEditoastIdToTrainScheduleId(projectedTrain.id);
       return {
         ...projectedTrain,
-        id: formatEditoastIdToTrainScheduleId(projectedTrain.id),
+        id,
+        key: id,
         type: 'trainSchedule',
       };
     }
@@ -52,6 +54,8 @@ const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
           name += EXCEPTION_SUFFIX;
         }
 
+        const key = id;
+
         if (exception) {
           // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
           const exceptionProjection = paced.exceptionProjections.get(exception.id!);
@@ -59,6 +63,7 @@ const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
           return {
             ...(exceptionProjection ?? pacedTrainCurves),
             id,
+            key,
             type: 'exception',
             name,
             departureTime,
@@ -71,6 +76,7 @@ const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
           return {
             ...pacedTrainCurves,
             id,
+            key,
             type: 'occurrence',
             name,
             departureTime,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/makeProjectedTrains.ts
@@ -1,8 +1,15 @@
 import { pick } from 'lodash';
 
-import { generateBareOccurrences } from 'applications/operationalStudies/helpers/generateBareOccurrences';
+import {
+  generateBareOccurrences,
+  type BareOccurrence,
+} from 'applications/operationalStudies/helpers/generateBareOccurrences';
+import getTrainScheduleRepeatOffsets, {
+  type TimeRange,
+} from 'modules/simulationResult/helpers/getTrainScheduleRepeatOffsets';
 import type { IndividualTrainProjection, TrainSpaceTimeData } from 'modules/simulationResult/types';
 import computeOccurrenceName from 'modules/trainSchedule/helpers/computeOccurrenceName';
+import { addDurationToDate } from 'utils/duration';
 import {
   formatEditoastIdToTrainScheduleId,
   isIndexedOccurrenceId,
@@ -11,11 +18,34 @@ import {
 
 export const EXCEPTION_SUFFIX = '≠';
 
+function repeatOccurrencesInRange(
+  projectedTrain: TrainSpaceTimeData,
+  occurrences: BareOccurrence<Date>[],
+  timeRange: TimeRange
+): BareOccurrence<Date>[] {
+  const repeatOffsets = getTrainScheduleRepeatOffsets(projectedTrain, timeRange);
+
+  const repeatedOccurrences: BareOccurrence<Date>[] = [];
+  for (const offset of repeatOffsets) {
+    for (const occurrence of occurrences) {
+      repeatedOccurrences.push({
+        ...occurrence,
+        startTime: addDurationToDate(occurrence.startTime, offset),
+      });
+    }
+  }
+
+  return repeatedOccurrences;
+}
+
 /**
  * Turns trainSpaceTimeData (unique trains + pacedTrains) into individual train projection.
  * Extracts everything into one flat array.
  */
-const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
+const makeProjectedTrains = (
+  trainScheduleProjections: TrainSpaceTimeData[],
+  repeatTimeRange?: TimeRange
+) =>
   trainScheduleProjections.flatMap<IndividualTrainProjection>((projectedTrain) => {
     const { paced } = projectedTrain;
     if (!paced) {
@@ -34,13 +64,18 @@ const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
       'isSimulated',
     ]);
 
-    return generateBareOccurrences({
+    let bareOccurrences = generateBareOccurrences({
       id: projectedTrain.id,
       startTime: projectedTrain.departureTime,
       paced,
-    })
-      .filter(({ exception }) => !exception?.disabled)
-      .map(({ id, startTime: departureTime, exception }): IndividualTrainProjection => {
+    }).filter(({ exception }) => !exception?.disabled);
+
+    if (repeatTimeRange) {
+      bareOccurrences = repeatOccurrencesInRange(projectedTrain, bareOccurrences, repeatTimeRange);
+    }
+
+    return bareOccurrences.map(
+      ({ id, startTime: departureTime, exception }): IndividualTrainProjection => {
         let name = exception?.train_name?.value;
         if (isIndexedOccurrenceId(id)) {
           name ??= computeOccurrenceName(
@@ -54,7 +89,7 @@ const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
           name += EXCEPTION_SUFFIX;
         }
 
-        const key = id;
+        const key = `${id}-${departureTime.toISOString()}`;
 
         if (exception) {
           // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
@@ -82,7 +117,8 @@ const makeProjectedTrains = (trainScheduleProjections: TrainSpaceTimeData[]) =>
             departureTime,
           };
         }
-      });
+      }
+    );
   });
 
 export default makeProjectedTrains;

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -72,6 +72,7 @@ export type TrainSpaceTimeData = {
 
 /** Contains an individual projection, either of a unique train or an occurrence */
 export type IndividualTrainProjection = {
+  key: string;
   name: string;
   departureTime: Date;
 } & BaseTrainProjection &


### PR DESCRIPTION
_See individual commits._

Closes https://github.com/OpenRailAssociation/osrd/issues/17629  
~~Depends on https://github.com/OpenRailAssociation/osrd/pull/17682~~

To test, create a hourly timetable, import this file and play with the space time chart pan/zoom:
[timetable(4).json](https://github.com/user-attachments/files/30657272/timetable.4.json)
