### PR TITLE
osrd_schemas: override OffsetInMs

### DIFF
--- a/osrd_schemas/generate-types.sh
+++ b/osrd_schemas/generate-types.sh
@@ -22,4 +22,5 @@ uv run datamodel-codegen \
     --use-annotated \
     --use-double-quotes \
     --allow-remote-refs \
-    --formatters black isort
+    --formatters black isort \
+    --type-overrides '{"TrainSchedule.start_time": ".overrides.OffsetInMs", "StartTimeChangeGroup.value": ".overrides.OffsetInMs"}'

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -9,6 +9,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel, constr
 
+from .overrides import OffsetInMs
+
 
 class PowerRestriction(BaseModel):
     model_config = ConfigDict(
@@ -3818,7 +3820,7 @@ class StandardPrivilege(Enum):
 
 
 class StartTimeChangeGroup(BaseModel):
-    value: int
+    value: OffsetInMs
     """
     For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.
     For hourly timetables: elapsed ms since the timetable start.
@@ -7146,7 +7148,7 @@ class TrainSchedule(BaseModel):
     rolling_stock_name: str
     schedule: list[ScheduleItem] | None = None
     speed_limit_tag: SpeedLimitTag | None = None
-    start_time: int
+    start_time: OffsetInMs
     """
     For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.
     For hourly timetables: elapsed ms since the timetable start.

--- a/osrd_schemas/osrd_schemas/overrides.py
+++ b/osrd_schemas/osrd_schemas/overrides.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+from typing import Annotated
+
+from pydantic import BeforeValidator, PlainSerializer
+
+
+def validate_one_of(instance, *fields: str):
+    """Raise if not exactly one of the given fields is set."""
+    set_count = sum(getattr(instance, f) is not None for f in fields)
+    if set_count != 1:
+        raise ValueError(f"Exactly one of {', '.join(fields)} must be set.")
+    return instance
+
+
+def timedelta_to_int_ms(delta: timedelta) -> int:
+    """Convert a timedelta to an int in ms."""
+    return int(delta.total_seconds() * 1000)
+
+
+def ensure_timedelta(value: int | timedelta) -> timedelta:
+    """Convert the given value to a timedelta."""
+    if isinstance(value, int):
+        return timedelta(milliseconds=value)
+    return value
+
+
+OffsetInMs = Annotated[
+    timedelta, BeforeValidator(ensure_timedelta), PlainSerializer(timedelta_to_int_ms)
+]

--- a/osrd_schemas/pyproject.toml
+++ b/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.1.0"
+version = "0.2.0"
 description = "Auto-generated OSRD pydantic schemas (editoast + railway manager interface openapi)"
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/osrd_schemas/uv.lock
+++ b/osrd_schemas/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },

--- a/python/railjson_generator/uv.lock
+++ b/python/railjson_generator/uv.lock
@@ -369,7 +369,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../../osrd_schemas" }
 dependencies = [
     { name = "datamodel-code-generator" },

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../osrd_schemas" }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
`TrainSchedule.start_time` and `StartTimeChangeGroup.value` are currently integers, and should be processed as `OffsetInMs`.