### PR TITLE
actions: add zizmor for github actions analysis

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -35,7 +35,9 @@ jobs:
       output_method: ${{ steps.bake-metadata.outputs.output_method }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Make bake metadata
         id: bake-metadata
@@ -52,7 +54,7 @@ jobs:
           echo ::endgroup::
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4.2.0
         with:
           buildkitd-flags: --debug
 
@@ -107,7 +109,7 @@ jobs:
           echo "All retries failed, exiting."
           exit 1
       - name: Upload image tarballs as artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         if: steps.bake-metadata.outputs.output_method == 'artifact'
         with:
           name: ${{ inputs.artifact_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1076,3 +1076,5 @@ jobs:
 
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@v0.6.0
+        with:
+          config: .github/zizmor.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1015,3 +1015,16 @@ jobs:
       - name: Ruff format
         run: |
           uv --directory osrd_schemas/ run ruff format --check
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
     name: Check dockerfiles
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Build dummy test_data and static_assets images
         run: |
@@ -94,7 +94,7 @@ jobs:
     name: Check models.py sync
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -115,10 +115,10 @@ jobs:
     name: Check scripts
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Find and check all scripts using ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           ignore_names: gradlew
 
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check generated railjson sync
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check railjson generator
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -178,10 +178,9 @@ jobs:
     name: Check commits
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
-
       - name: Check commit names
         run: |
           # We don't have a base ref to check against if we aren't in a
@@ -219,7 +218,7 @@ jobs:
       - name: Install ripgrep
         run: sudo apt-get install -y ripgrep
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Check final newline is present
         run: |
           # search missing final newline
@@ -239,7 +238,7 @@ jobs:
     name: Check integration tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -262,9 +261,9 @@ jobs:
     name: Check toml
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Install taplo
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@v3.4.0
         with:
           crate: taplo-cli
           locked: true
@@ -276,7 +275,7 @@ jobs:
     name: Check infra schema sync
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -300,11 +299,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built images
         if: needs.build-front.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-front
           path: .
@@ -336,11 +335,11 @@ jobs:
       - build-core
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built images
         if: needs.build-core.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-core
           path: .
@@ -377,11 +376,11 @@ jobs:
       - build-editoast
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built editoast-test image
         if: needs.build-editoast.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-editoast
           path: .
@@ -426,11 +425,11 @@ jobs:
       - build-editoast
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built images
         if: needs.build-editoast.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-editoast
           path: .
@@ -474,17 +473,17 @@ jobs:
       - build-front
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built editoast image
         if: needs.build-editoast.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-editoast
           path: .
       - name: Download built front-tests image
         if: needs.build-front.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-front
           path: .
@@ -521,11 +520,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built images
         if: needs.build-gateway.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-gateway
           path: .
@@ -574,11 +573,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built images
         if: needs.build-osrdyne.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-osrdyne
           path: .
@@ -624,7 +623,7 @@ jobs:
     name: Check Rust lockfiles
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Set up Rust toolchain
         run: rustup update stable && rustup default stable
       - name: Check editoast lockfile
@@ -642,11 +641,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Download built images
         if: needs.build-front.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-front
           path: .
@@ -701,22 +700,22 @@ jobs:
       # TODO: check if we can deduplicate the base steps from integration_tests_quality
       # https://www.jameskerr.blog/posts/sharing-steps-in-github-action-workflows/
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Download built editoast image
         if: needs.build-editoast.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-editoast
           path: .
       - name: Download built core image
         if: needs.build-core.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-core
           path: .
       - name: Download built osrdyne image
         if: needs.build-osrdyne.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-osrdyne
           path: .
@@ -763,7 +762,7 @@ jobs:
         run: docker compose logs > container-logs
         if: always()
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: integration-container-logs
@@ -779,22 +778,22 @@ jobs:
       - build-osrdyne
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Download built editoast image
         if: needs.build-editoast.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-editoast
           path: .
       - name: Download built core image
         if: needs.build-core.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-core
           path: .
       - name: Download built osrdyne image
         if: needs.build-osrdyne.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-osrdyne
           path: .
@@ -821,9 +820,9 @@ jobs:
     name: Check Playwright version for nix
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           summarize: false # Suppress the Nix build job summary
       - name: Check versions of playwright
@@ -842,34 +841,34 @@ jobs:
       # TODO: check if we can deduplicate the base steps from integration_tests_quality
       # https://www.jameskerr.blog/posts/sharing-steps-in-github-action-workflows/
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Download built front-tests image
         if: needs.build-front.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-front
           path: .
       - name: Download built editoast image
         if: needs.build-editoast.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-editoast
           path: .
       - name: Download built core image
         if: needs.build-core.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-core
           path: .
       - name: Download built gateway-front image
         if: needs.build-gateway.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-gateway
           path: .
       - name: Download built osrdyne image
         if: needs.build-osrdyne.outputs.output_method == 'artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: images-osrdyne
           path: .
@@ -940,7 +939,7 @@ jobs:
 
       - name: Upload media artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: playwright-media
           path: |
@@ -950,7 +949,7 @@ jobs:
 
       - name: Upload trace artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: playwright-traces
           path: front/test-results/**/trace.zip
@@ -977,7 +976,7 @@ jobs:
         run: docker compose logs > container-logs
         if: always()
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: e2e-container-logs
@@ -988,15 +987,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Check reuse compliance
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v6
+        uses: fsfe/reuse-action@v6.0.0
 
   check_osrd_schemas:
     runs-on: ubuntu-latest
     name: Check osrd_schemas
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -1022,9 +1021,7 @@ jobs:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v7.0.1
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        uses: zizmorcore/zizmor-action@v0.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build dummy test_data and static_assets images
         run: |
@@ -95,6 +97,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -116,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Find and check all scripts using ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
@@ -127,6 +133,8 @@ jobs:
     name: Check generated railjson sync
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -150,6 +158,8 @@ jobs:
     name: Check railjson generator
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -181,6 +191,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
+          persist-credentials: false
       - name: Check commit names
         run: |
           # We don't have a base ref to check against if we aren't in a
@@ -219,6 +230,8 @@ jobs:
         run: sudo apt-get install -y ripgrep
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Check final newline is present
         run: |
           # search missing final newline
@@ -239,6 +252,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -262,6 +277,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install taplo
         uses: baptiste0928/cargo-install@v3.4.0
         with:
@@ -276,6 +293,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -300,6 +319,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built images
         if: needs.build-front.outputs.output_method == 'artifact'
@@ -336,6 +357,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built images
         if: needs.build-core.outputs.output_method == 'artifact'
@@ -377,6 +400,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built editoast-test image
         if: needs.build-editoast.outputs.output_method == 'artifact'
@@ -426,6 +451,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built images
         if: needs.build-editoast.outputs.output_method == 'artifact'
@@ -474,6 +501,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built editoast image
         if: needs.build-editoast.outputs.output_method == 'artifact'
@@ -521,6 +550,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built images
         if: needs.build-gateway.outputs.output_method == 'artifact'
@@ -574,6 +605,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built images
         if: needs.build-osrdyne.outputs.output_method == 'artifact'
@@ -624,6 +657,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Rust toolchain
         run: rustup update stable && rustup default stable
       - name: Check editoast lockfile
@@ -642,6 +677,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download built images
         if: needs.build-front.outputs.output_method == 'artifact'
@@ -701,6 +738,8 @@ jobs:
       # https://www.jameskerr.blog/posts/sharing-steps-in-github-action-workflows/
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Download built editoast image
         if: needs.build-editoast.outputs.output_method == 'artifact'
         uses: actions/download-artifact@v8.0.1
@@ -779,6 +818,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Download built editoast image
         if: needs.build-editoast.outputs.output_method == 'artifact'
         uses: actions/download-artifact@v8.0.1
@@ -821,6 +862,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:
@@ -842,6 +885,8 @@ jobs:
       # https://www.jameskerr.blog/posts/sharing-steps-in-github-action-workflows/
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Download built front-tests image
         if: needs.build-front.outputs.output_method == 'artifact'
         uses: actions/download-artifact@v8.0.1
@@ -988,6 +1033,8 @@ jobs:
     name: Check reuse compliance
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v6.0.0
 
@@ -996,6 +1043,8 @@ jobs:
     name: Check osrd_schemas
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up 'uv'
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -1022,6 +1071,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@v0.6.0

--- a/.github/workflows/chart-build.yml
+++ b/.github/workflows/chart-build.yml
@@ -17,10 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@v5.0.1
 
       - name: Setup go
         uses: actions/setup-go@v7.0.0

--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@v5.0.1
 
       - name: Set Name and Version
         run: |

--- a/.github/workflows/interface-change.yml
+++ b/.github/workflows/interface-change.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - name: Get reference OpenAPI
@@ -18,14 +18,14 @@ jobs:
       - name: Get new OpenAPI
         run: git show ${{ github.event.pull_request.head.sha }}:editoast/openapi.yaml > new-openapi.yaml
       - name: Find comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@v4.0.0
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: API changes
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v5.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/interface-change.yml
+++ b/.github/workflows/interface-change.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Get reference OpenAPI
         run: git show ${{ github.event.pull_request.base.sha }}:editoast/openapi.yaml > base-openapi.yaml
       - name: Get new OpenAPI

--- a/.github/workflows/osrd-ui-publish.yml
+++ b/.github/workflows/osrd-ui-publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/osrd-ui-publish.yml
+++ b/.github/workflows/osrd-ui-publish.yml
@@ -18,17 +18,13 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: "24"
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Cache node_modules
-        uses: actions/cache@v6.1.0
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+          package-manager-cache: false
 
       - name: Publish
         run: |

--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -33,17 +33,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: "24"
-
-      - name: Cache node_modules
-        uses: actions/cache@v6.1.0
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+          package-manager-cache: false
 
       - name: Build
         run: |
@@ -52,7 +49,7 @@ jobs:
           npm run build --workspaces --if-present
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ env.artifact_name }}
           path: "./front/ui/storybook/storybook-static"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,10 @@ jobs:
     name: "Label PR"
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Label PR
-        uses: actions/labeler@v6
+        uses: actions/labeler@v7.0.0
         with:
           sync-labels: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Make bake metadata
         id: bake-metadata
@@ -39,7 +39,7 @@ jobs:
           echo ::endgroup::
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4.2.0
         with:
           buildkitd-flags: --debug
 

--- a/.github/workflows/ui-icons-optimize.yml
+++ b/.github/workflows/ui-icons-optimize.yml
@@ -8,9 +8,11 @@ jobs:
   optimize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.10"
           cache: "pip"
@@ -30,7 +32,7 @@ jobs:
           npm install
           npm run svgo
 
-      - uses: EndBug/add-and-commit@v10
+      - uses: EndBug/add-and-commit@v10.0.0
         with:
           add: "front/ui/ui-icons/icons"
           message: "Optimize SVGs"

--- a/.github/workflows/update_nix_flake.yml
+++ b/.github/workflows/update_nix_flake.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@main
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           commit-msg: "ci: update flake.lock"
           pr-title: "ci: update flake.lock"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,3 @@
+rules:
+  unpinned-uses:
+    disable: true


### PR DESCRIPTION
https://docs.zizmor.sh/

Recommended by @mxmehl, the idea is to have a fast, simple tool to find and fix many common security issues in typical GitHub Actions CI/CD setups.