### PR TITLE
editoast: stdcm: adapt struct for failures explainer

### DIFF
--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -91,7 +91,7 @@ pub struct InvalidPathItem {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum PathfindingCoreResult {
-    Success(PathfindingResultSuccess),
+    Success(PathfindingResult),
     NotFoundInBlocks {
         track_section_ranges: Vec<TrackRange>,
         length: u64,
@@ -102,7 +102,7 @@ pub enum PathfindingCoreResult {
     },
     NotFoundInTracks,
     IncompatibleConstraints {
-        relaxed_constraints_path: Box<PathfindingResultSuccess>,
+        relaxed_constraints_path: Box<PathfindingResult>,
         incompatible_constraints: Box<IncompatibleConstraints>,
     },
     InvalidPathItems {
@@ -116,9 +116,9 @@ pub enum PathfindingCoreResult {
 
 /// A successful pathfinding result. This is also used for STDCM response.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
-#[schema(as = CorePathfindingResultSuccess)]
+#[schema(as = CorePathfindingResult)]
 #[derive(Default)]
-pub struct PathfindingResultSuccess {
+pub struct PathfindingResult {
     /// Full description of the path data
     pub path: TrainPath,
     /// Length of the path in mm
@@ -163,7 +163,7 @@ pub enum PathfindingNotFound {
     #[default]
     NotFoundInTracks,
     IncompatibleConstraints {
-        relaxed_constraints_path: Box<PathfindingResultSuccess>,
+        relaxed_constraints_path: Box<PathfindingResult>,
         incompatible_constraints: Box<IncompatibleConstraints>,
     },
 }

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -187,7 +187,12 @@ pub enum Response {
         path: PathfindingResult,
         departure_time: DateTime<Utc>,
     },
-    PathNotFound,
+    PathNotFound {
+        most_blocking_work_schedule_ids: Vec<i64>,
+        nearest_to_destination_work_schedule_ids: Vec<i64>,
+        partial_path: Option<PathfindingResult>,
+        last_reached_operational_point: Option<LastReachedOperationalPoint>,
+    },
 }
 
 impl AsCoreRequest<Json<Response>> for Request {

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use super::pathfinding::PathItem;
-use super::pathfinding::PathfindingResultSuccess;
+use super::pathfinding::PathfindingResult;
 use super::pathfinding::TrackRange;
 use super::simulation::PhysicsConsist;
 use super::simulation::SimulationSuccess;
@@ -173,7 +173,7 @@ pub struct ProgressCoordinates {
 pub enum Response {
     Success {
         simulation: SimulationSuccess,
-        path: PathfindingResultSuccess,
+        path: PathfindingResult,
         departure_time: DateTime<Utc>,
     },
     PathNotFound,

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 
 use chrono::DateTime;
 use chrono::Utc;
+use common::geometry::GeoJsonPoint;
+use geos::geojson::Geometry;
 use schemas::rolling_stock::LoadingGaugeType;
 use schemas::train_schedule::Comfort;
 use schemas::train_schedule::MarginValue;
@@ -144,6 +146,15 @@ pub struct ConsistSchedule {
     pub boundaries: Vec<usize>,
     // Consist configuration for each segment
     pub values: Vec<ConsistConfiguration>,
+}
+
+// Represents the last reached operational point in a failed pathfinding result
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+pub struct LastReachedOperationalPoint {
+    pub name: String,
+    #[schema(value_type = GeoJsonPoint)]
+    pub geographic: Geometry,
+    pub arrival_time: DateTime<Utc>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -333,7 +333,7 @@ pub(crate) mod test_data {
     /// We use the length field to identify it since the content doesn't matter
     pub(crate) fn path(id: usize, positions_count: u64) -> serde_json::Value {
         let response = core_client::pathfinding::PathfindingCoreResult::Success(
-            core_client::pathfinding::PathfindingResultSuccess {
+            core_client::pathfinding::PathfindingResult {
                 path: core_client::pathfinding::TrainPath {
                     blocks: Vec::new(),
                     routes: Vec::new(),

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -16,12 +16,12 @@ pub(super) fn build_request(
     core_env: &CoreEnv,
     electrical_profile_set_id: Option<u64>,
     SimulationKey(sim_consist, params, pathfinding::PathfindingKey(pf_consist, constraints)): &SimulationKey,
-    core_client::pathfinding::PathfindingResultSuccess {
+    core_client::pathfinding::PathfindingResult {
         path,
         path_item_positions,
         backtrack_path_items,
         ..
-    }: core_client::pathfinding::PathfindingResultSuccess,
+    }: core_client::pathfinding::PathfindingResult,
 ) -> Result<core_client::simulation::Request, ()> {
     if constraints.path_items.len() != path_item_positions.len() {
         tracing::error!(
@@ -174,7 +174,7 @@ mod tests {
             routes: Vec::new(),
             track_section_ranges: Vec::new(),
         };
-        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+        let path_success = core_client::pathfinding::PathfindingResult {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
@@ -275,7 +275,7 @@ mod tests {
             routes: Vec::new(),
             track_section_ranges: Vec::new(),
         };
-        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+        let path_success = core_client::pathfinding::PathfindingResult {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
@@ -436,7 +436,7 @@ mod tests {
             routes: Vec::new(),
             track_section_ranges: Vec::new(),
         };
-        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+        let path_success = core_client::pathfinding::PathfindingResult {
             path,
             length: 100,
             path_item_positions: path_positions,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -15287,8 +15287,28 @@ components:
       - type: object
         title: StdcmResponsePathNotFound
         required:
+        - most_blocking_work_schedule_ids
+        - nearest_to_destination_work_schedule_ids
         - status
         properties:
+          last_reached_operational_point:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/LastReachedOperationalPoint'
+          most_blocking_work_schedule_ids:
+            type: array
+            items:
+              type: integer
+              format: int64
+          nearest_to_destination_work_schedule_ids:
+            type: array
+            items:
+              type: integer
+              format: int64
+          partial_pathfinding_result:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/CorePathfindingResult'
           status:
             type: string
             enum:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5743,8 +5743,8 @@ components:
           incompatible_constraints:
             $ref: '#/components/schemas/CoreIncompatibleConstraints'
           relaxed_constraints_path:
-            $ref: '#/components/schemas/CorePathfindingResultSuccess'
-    CorePathfindingResultSuccess:
+            $ref: '#/components/schemas/CorePathfindingResult'
+    CorePathfindingResult:
       type: object
       description: A successful pathfinding result. This is also used for STDCM response.
       required:
@@ -12799,7 +12799,7 @@ components:
     PathfindingResult:
       oneOf:
       - allOf:
-        - $ref: '#/components/schemas/CorePathfindingResultSuccess'
+        - $ref: '#/components/schemas/CorePathfindingResult'
         - type: object
           required:
           - status
@@ -15263,7 +15263,7 @@ components:
             type: string
             format: date-time
           pathfinding_result:
-            $ref: '#/components/schemas/CorePathfindingResultSuccess'
+            $ref: '#/components/schemas/CorePathfindingResult'
           simulation:
             $ref: '#/components/schemas/SimulationResponseSuccess'
           status:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11425,6 +11425,20 @@ components:
           type: array
           items:
             type: string
+    LastReachedOperationalPoint:
+      type: object
+      required:
+      - name
+      - geographic
+      - arrival_time
+      properties:
+        arrival_time:
+          type: string
+          format: date-time
+        geographic:
+          $ref: '#/components/schemas/GeoJsonPoint'
+        name:
+          type: string
     LevelCrossing:
       type: object
       required:

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -383,7 +383,6 @@ mod tests {
 
     use chrono::TimeDelta;
     use core_client::mocking::MockingClient;
-    use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::pathfinding::TrainPath;
     use reqwest::StatusCode;
     use schemas::infra::LevelCrossingPart;
@@ -446,8 +445,8 @@ mod tests {
         assert!(result.is_none());
     }
 
-    fn pathfinding_result_success() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
+    fn pathfinding_result_success() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -17,7 +17,6 @@ use core_client::pathfinding::PathfindingCoreResult;
 use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingNotFound;
 use core_client::pathfinding::PathfindingRequest;
-use core_client::pathfinding::PathfindingResultSuccess;
 use database::DbConnection;
 use educe::Educe;
 use futures::StreamExt;
@@ -145,7 +144,7 @@ impl From<PathfindingInput> for core_task::PathfindingConsist {
 #[serde(tag = "status", rename_all = "snake_case")]
 #[schema(title_variants)]
 pub enum PathfindingResult {
-    Success(PathfindingResultSuccess),
+    Success(core_client::pathfinding::PathfindingResult),
     Failure(PathfindingFailure),
 }
 
@@ -529,7 +528,6 @@ pub mod tests {
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::InvalidPathItem;
     use core_client::pathfinding::PathfindingInputError;
-    use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::pathfinding::TrainPath;
     use pretty_assertions::assert_eq;
     use schemas::rolling_stock::LoadingGaugeType;
@@ -562,7 +560,7 @@ pub mod tests {
     }
 
     fn pathfinding_result(length: u64) -> PathfindingResult {
-        PathfindingResult::Success(PathfindingResultSuccess {
+        PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -1,6 +1,5 @@
 use crate::error::Result;
 use core_client::CoreClient;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::pathfinding::TrackRange;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::ReportTrain;
@@ -528,7 +527,7 @@ impl TrainToProjectOnOperationalPoint {
     fn new_from_invalid<T: TrainScheduleLike>(
         ts: &T,
         sim: SimulationResponseSuccess,
-        path: PathfindingResultSuccess,
+        path: core_client::pathfinding::PathfindingResult,
     ) -> Self {
         // Reuse the space-time curve from the track projection, so that scheduled
         // `PathItemLocation::TrackOffset`s are visible on the STD even for invalid trains.
@@ -859,7 +858,7 @@ pub fn compute_projected_train_path_op_without_simulation<T: TrainScheduleLike>(
 fn extract_curve_for_invalid_train_with_sim<T: TrainScheduleLike>(
     train_schedule: &T,
     sim: &SimulationResponseSuccess,
-    path: &PathfindingResultSuccess,
+    path: &core_client::pathfinding::PathfindingResult,
 ) -> SpaceTimeCurve {
     let mut positions = vec![0];
     let mut times = vec![0];

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -2,7 +2,6 @@ use chrono::Duration;
 use core_client::AsCoreRequest;
 use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingNotFound;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::pathfinding::TrainPath;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::ElectricalProfiles;
@@ -518,7 +517,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
             consist,
         } = train_schedule_with_consist;
         let (path, path_item_positions, backtrack_path_items) = match pathfinding.as_ref() {
-            PathfindingResult::Success(PathfindingResultSuccess {
+            PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
                 path,
                 path_item_positions,
                 backtrack_path_items,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -19,6 +19,7 @@ use core_client::CoreClient;
 use core_client::pathfinding::InvalidPathItem;
 use core_client::stdcm::ConsistConfiguration;
 use core_client::stdcm::ConsistSchedule;
+use core_client::stdcm::LastReachedOperationalPoint;
 use core_client::stdcm::Request as StdcmRequest;
 use core_client::stdcm::UndirectedTrackRange;
 use database::DbConnectionPoolV2;
@@ -78,7 +79,14 @@ pub(in crate::views) enum StdcmResponse {
         pathfinding_result: core_client::pathfinding::PathfindingResult,
         departure_time: DateTime<Utc>,
     },
-    PathNotFound,
+    PathNotFound {
+        most_blocking_work_schedule_ids: Vec<i64>,
+        nearest_to_destination_work_schedule_ids: Vec<i64>,
+        partial_pathfinding_result: Option<core_client::pathfinding::PathfindingResult>,
+        last_reached_operational_point: Option<LastReachedOperationalPoint>,
+        //#[serde(skip_serializing_if = "Option::is_none")]
+        //core_payload: Option<StdcmRequest>,
+    },
     PreprocessingSimulationError {
         error: simulation::Response,
     },
@@ -406,9 +414,20 @@ pub(in crate::views) async fn stdcm(
                                 departure_time,
                             })
                         }
-                        core_client::stdcm::Response::PathNotFound => {
+                        core_client::stdcm::Response::PathNotFound {
+                            most_blocking_work_schedule_ids,
+                            nearest_to_destination_work_schedule_ids,
+                            partial_path,
+                            last_reached_operational_point,
+                        } => {
                             span.record("path_found", false);
-                            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
+                            StdcmProgression::Completed(StdcmResponse::PathNotFound {
+                                most_blocking_work_schedule_ids,
+                                nearest_to_destination_work_schedule_ids,
+                                partial_pathfinding_result: partial_path,
+                                last_reached_operational_point,
+                                //core_payload: Some(stdcm_request)
+                            })
                         }
                     },
                 },
@@ -719,6 +738,28 @@ mod tests {
             length: 1,
             path_item_positions: vec![0, 10],
             backtrack_path_items: Some(vec![]),
+        }
+    }
+
+    fn partial_pathfinding_result() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
+            path: TrainPath {
+                blocks: vec![],
+                routes: vec![],
+                track_section_ranges: vec![],
+            },
+            length: 10,
+            path_item_positions: vec![0, 5],
+            backtrack_path_items: Some(vec![]),
+        }
+    }
+
+    fn last_reached_operational_point() -> LastReachedOperationalPoint {
+        LastReachedOperationalPoint {
+            name: "Foo".to_string(),
+            geographic: Geometry::new(Value::Point(vec![2.0, 2.0])),
+            arrival_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                .expect("Failed to parse datetime"),
         }
     }
 
@@ -1091,7 +1132,12 @@ mod tests {
         core.stub("/stdcm")
             .response(StatusCode::OK)
             .json(core_client::stdcm::ProgressStatus::Done {
-                result: core_client::stdcm::Response::PathNotFound,
+                result: core_client::stdcm::Response::PathNotFound {
+                    most_blocking_work_schedule_ids: vec![0, 1],
+                    nearest_to_destination_work_schedule_ids: vec![2],
+                    partial_path: Some(partial_pathfinding_result()),
+                    last_reached_operational_point: Some(last_reached_operational_point()),
+                },
             })
             .finish();
 
@@ -1119,7 +1165,12 @@ mod tests {
 
         assert_eq!(
             stdcm_response,
-            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
+            StdcmProgression::Completed(StdcmResponse::PathNotFound {
+                most_blocking_work_schedule_ids: vec![0, 1],
+                nearest_to_destination_work_schedule_ids: vec![2],
+                partial_pathfinding_result: Some(partial_pathfinding_result()),
+                last_reached_operational_point: Some(last_reached_operational_point()),
+            })
         );
     }
 
@@ -1212,7 +1263,12 @@ mod tests {
                 best_travel_time: 5,
             })
             .json(core_client::stdcm::ProgressStatus::Done {
-                result: core_client::stdcm::Response::PathNotFound,
+                result: core_client::stdcm::Response::PathNotFound {
+                    most_blocking_work_schedule_ids: vec![0, 1],
+                    nearest_to_destination_work_schedule_ids: vec![2],
+                    partial_path: Some(partial_pathfinding_result()),
+                    last_reached_operational_point: Some(last_reached_operational_point()),
+                },
             })
             .finish();
 
@@ -1255,7 +1311,12 @@ mod tests {
         );
         assert_eq!(
             stdcm_response[2].clone(),
-            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
+            StdcmProgression::Completed(StdcmResponse::PathNotFound {
+                most_blocking_work_schedule_ids: vec![0, 1],
+                nearest_to_destination_work_schedule_ids: vec![2],
+                partial_pathfinding_result: Some(partial_pathfinding_result()),
+                last_reached_operational_point: Some(last_reached_operational_point()),
+            })
         );
     }
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -17,7 +17,6 @@ use common::units::millisecond;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::InvalidPathItem;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::stdcm::ConsistConfiguration;
 use core_client::stdcm::ConsistSchedule;
 use core_client::stdcm::Request as StdcmRequest;
@@ -76,7 +75,7 @@ use editoast_models::timetable::Timetable;
 pub(in crate::views) enum StdcmResponse {
     Success {
         simulation: SimulationResponseSuccess,
-        pathfinding_result: PathfindingResultSuccess,
+        pathfinding_result: core_client::pathfinding::PathfindingResult,
         departure_time: DateTime<Utc>,
     },
     PathNotFound,
@@ -710,8 +709,8 @@ mod tests {
         }
     }
 
-    fn pathfinding_result_success() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
+    fn pathfinding_result_success() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -1,5 +1,4 @@
 use common::units::millisecond;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::simulation::ReportTrain;
 use schemas::infra::TrackOffset;
 use schemas::primitives::NonBlankString;
@@ -24,7 +23,7 @@ pub(super) struct TrackOccupancy {
 struct OccupancyContext<'a> {
     op_id: &'a str,
     report_train: Option<&'a ReportTrain>,
-    pathfinding_success: Option<&'a PathfindingResultSuccess>,
+    pathfinding_success: Option<&'a core_client::pathfinding::PathfindingResult>,
     matching_index: Option<usize>,
     schedule_item: Option<&'a ScheduleItem>,
 }
@@ -293,7 +292,7 @@ pub mod tests {
         track_section: Identifier,
         path_item_positions: Vec<u64>,
     ) -> PathfindingResult {
-        PathfindingResult::Success(PathfindingResultSuccess {
+        PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
             path: core_client::pathfinding::TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -15,7 +15,6 @@ use common::units::millisecond;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::PathfindingInputError;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::signal_projection::SignalUpdate;
 use core_client::simulation::PhysicsConsist;
 use core_task::Correlated;
@@ -868,12 +867,13 @@ pub(in crate::views) async fn etcs_braking_curves(
     .unwrap();
 
     // Extract simulation path
-    let pathfinding_response: PathfindingResultSuccess = match pathfinding_result.as_ref() {
-        PathfindingResult::Success(path) => path.clone(),
-        _ => {
-            return Err(TrainScheduleError::PathfindingFailed { train_schedule_id }.into());
-        }
-    };
+    let pathfinding_response: core_client::pathfinding::PathfindingResult =
+        match pathfinding_result.as_ref() {
+            PathfindingResult::Success(path) => path.clone(),
+            _ => {
+                return Err(TrainScheduleError::PathfindingFailed { train_schedule_id }.into());
+            }
+        };
 
     // Extract mrsp
     let mrsp = match simulation_result.as_ref() {
@@ -1823,7 +1823,6 @@ mod tests {
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::InvalidPathItem;
     use core_client::pathfinding::PathfindingInputError;
-    use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::pathfinding::TrackRange;
     use core_client::pathfinding::TrainPath;
     use core_client::simulation::CompleteReportTrain;
@@ -2757,7 +2756,7 @@ mod tests {
 
         assert_eq!(
             response,
-            PathfindingResult::Success(PathfindingResultSuccess {
+            PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
                 path: TrainPath {
                     blocks: vec![],
                     routes: vec![],
@@ -2974,7 +2973,7 @@ mod tests {
 
         assert_eq!(
             response,
-            PathfindingResult::Success(PathfindingResultSuccess {
+            PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
                 path: TrainPath {
                     blocks: vec![],
                     routes: vec![],
@@ -3114,8 +3113,8 @@ mod tests {
         );
     }
 
-    fn pathfinding_result_success() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
+    fn pathfinding_result_success() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next';
 
-import type { CorePathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResult, TrainSchedule } from 'common/api/osrdEditoastApi';
 import type {
   PathOperationalPoint,
   EditoastPathOperationalPoint,
@@ -14,21 +14,21 @@ const HIGHEST_PRIORITY_WEIGHT = 100;
 export function upsertMapWaypointsInOperationalPoints(
   type: 'PathOperationalPoint',
   path: TrainSchedule['path'],
-  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResult['path_item_positions'],
   operationalPoints: PathOperationalPoint[],
   t: TFunction<'operational-studies'>
 ): PathOperationalPoint[];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
-  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResult['path_item_positions'],
   operationalPoints: EditoastPathOperationalPoint[],
   t: TFunction<'operational-studies'>
 ): EditoastPathOperationalPoint[];
 export function upsertMapWaypointsInOperationalPoints(
   type: 'PathOperationalPoint' | 'EditoastPathOperationalPoint',
   path: TrainSchedule['path'],
-  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResult['path_item_positions'],
   operationalPoints: (PathOperationalPoint | EditoastPathOperationalPoint)[],
   t: TFunction<'operational-studies'>
 ): (PathOperationalPoint | EditoastPathOperationalPoint)[] {

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -4,7 +4,7 @@ import type {
   CoreIncompatibleConstraints,
   TrainSchedule,
   PathProperties,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   SimulationResponse,
   SimulationResponseSuccess,
   MacroNodeForm,
@@ -71,7 +71,7 @@ export type ManageTrainSchedulePathProperties = {
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];
   length: number;
-  trackSectionRanges: NonNullable<CorePathfindingResultSuccess['path']['track_section_ranges']>;
+  trackSectionRanges: NonNullable<CorePathfindingResult['path']['track_section_ranges']>;
   incompatibleConstraints?: CoreIncompatibleConstraints;
 };
 
@@ -144,7 +144,7 @@ export type SimulationResults =
       train: Train;
       rollingStock: RollingStockWithLiveries;
       simulation: SimulationResponseSuccess;
-      path: CorePathfindingResultSuccess;
+      path: CorePathfindingResult;
       pathProperties: PathPropertiesFormatted;
       powerRestrictions: LayerData<PowerRestrictionValues>[];
     };
@@ -204,7 +204,7 @@ export type PathProjectionResult = {
 } & (
   | {
       pathfindingStatus: 'succeeded';
-      pathfinding: CorePathfindingResultSuccess;
+      pathfinding: CorePathfindingResult;
       geometry: PathProperties['geometry'];
       projectingOnSimulatedPathException: boolean | undefined;
     }

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -4,7 +4,7 @@ import { type Dictionary, isEqual } from 'lodash';
 import type {
   OperationalPoint,
   OperationalPointReference,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   PathItemLocation,
   PathProperties,
   RelatedOperationalPoint,
@@ -173,7 +173,7 @@ export const transformElectricalBoundariesToRanges = (
 export const preparePathPropertiesData = (
   electricalProfiles: SimulationResponseSuccess['electrical_profiles'] | undefined,
   { slopes, curves, electrifications, operational_points, geometry }: PathProperties,
-  { path_item_positions, length }: CorePathfindingResultSuccess,
+  { path_item_positions, length }: CorePathfindingResult,
   trainSchedulePath: TrainSchedule['path'],
   t: TFunction<'operational-studies'>
 ): PathPropertiesFormatted => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
@@ -9,7 +9,7 @@ import type {
   PathPropertiesFormatted,
 } from 'applications/operationalStudies/types';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   RollingStockWithLiveries,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
@@ -20,7 +20,7 @@ import exportTrainCSV from './exportTrainCSV';
 import useFormattedOperationalPoints from './useFormattedOperationalPoints';
 
 const exportTrainPDF = async (
-  path: CorePathfindingResultSuccess,
+  path: CorePathfindingResult,
   scenarioData: { name: string; infraName: string },
   train: Train,
   simulation: SimulationResponseSuccess,
@@ -63,7 +63,7 @@ const exportTrainPDF = async (
 };
 
 type SimulationResultsExportProps = {
-  path: CorePathfindingResultSuccess;
+  path: CorePathfindingResult;
   scenarioData: { name: string; infraName: string };
   train: Train;
   simulation: SimulationResponseSuccess;

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -12,7 +12,7 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import { matchOpRefAndOp } from 'applications/operationalStudies/utils';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   RelatedOperationalPoint,
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
@@ -36,7 +36,7 @@ const MAP_ID = 'simulation-result-map';
 type SimulationResultMapProps = {
   pathSteps?: TrainSchedule['path'];
   pathProperties?: PathPropertiesFormatted;
-  pathfindingResults?: CorePathfindingResultSuccess;
+  pathfindingResults?: CorePathfindingResult;
   setMapCanvas?: (mapCanvas: string) => void;
 };
 
@@ -87,7 +87,7 @@ const SimulationResultMap = ({
       steps: TrainSchedule['path'],
       matchedOps: Map<string, RelatedOperationalPoint | null>,
       pathPropertiesOps?: PathPropertiesFormatted['operationalPoints'],
-      simulatedPath?: CorePathfindingResultSuccess
+      simulatedPath?: CorePathfindingResult
     ) => {
       // 1. Get path steps track ids to fetch their track metadata
       const allTrackIds = steps.reduce<string[]>((acc, step) => {

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -5,7 +5,7 @@ import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/
 import type { StdcmPathProperties } from 'applications/stdcm/types';
 import type {
   PostInfraByInfraIdPathPropertiesApiArg,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
@@ -17,7 +17,7 @@ import type { AppDispatch } from 'store';
  *  Function to fetch and format path properties
  */
 const fetchPathProperties = async (
-  pathfinding_result: CorePathfindingResultSuccess,
+  pathfinding_result: CorePathfindingResult,
   infraId: number,
   dispatch: AppDispatch
 ): Promise<StdcmPathProperties> => {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3704,7 +3704,7 @@ export type CoreTrainPath = {
   /** Track section ranges, in order. */
   track_section_ranges: CoreTrackRange[];
 };
-export type CorePathfindingResultSuccess = {
+export type CorePathfindingResult = {
   /** The indexes of the path items where the train backtracks */
   backtrack_path_items?: number[] | null;
   /** Length of the path in mm */
@@ -3783,7 +3783,7 @@ export type CorePathfindingNotFound =
   | {
       error_type: 'incompatible_constraints';
       incompatible_constraints: CoreIncompatibleConstraints;
-      relaxed_constraints_path: CorePathfindingResultSuccess;
+      relaxed_constraints_path: CorePathfindingResult;
     };
 export type PathfindingFailure =
   | (CorePathfindingInputError & {
@@ -3793,7 +3793,7 @@ export type PathfindingFailure =
       failed_status: 'pathfinding_not_found';
     });
 export type PathfindingResult =
-  | (CorePathfindingResultSuccess & {
+  | (CorePathfindingResult & {
       status: 'success';
     })
   | (PathfindingFailure & {
@@ -4871,7 +4871,7 @@ export type SimulationResponse =
 export type StdcmResponse =
   | {
       departure_time: string;
-      pathfinding_result: CorePathfindingResultSuccess;
+      pathfinding_result: CorePathfindingResult;
       simulation: SimulationResponseSuccess;
       status: 'success';
     }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4881,6 +4881,10 @@ export type StdcmResponse =
       status: 'success';
     }
   | {
+      last_reached_operational_point?: null | LastReachedOperationalPoint;
+      most_blocking_work_schedule_ids: number[];
+      nearest_to_destination_work_schedule_ids: number[];
+      partial_pathfinding_result?: null | CorePathfindingResult;
       status: 'path_not_found';
     }
   | {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4848,6 +4848,11 @@ export type StdcmProgressionEvent = {
   best_travel_time: number;
   point: GeoJsonPoint;
 };
+export type LastReachedOperationalPoint = {
+  arrival_time: string;
+  geographic: GeoJsonPoint;
+  name: string;
+};
 export type InternalError = {
   context: {
     [key: string]: unknown;

--- a/front/src/modules/SimulationReportSheet/SimulationReportSheet.tsx
+++ b/front/src/modules/SimulationReportSheet/SimulationReportSheet.tsx
@@ -4,7 +4,7 @@ import { Page, Text, Image, Document, View } from '@react-pdf/renderer';
 import type { TFunction } from 'i18next';
 
 import type { OperationalPointWithTimeAndSpeed } from 'applications/operationalStudies/types';
-import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResult } from 'common/api/osrdEditoastApi';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
 import { msToKmh, kgToT } from 'utils/physics';
 
@@ -16,7 +16,7 @@ import type { RouteTableRow, SimulationSheetData } from './types';
 import { formatOperationalStudiesDataForSimulationTable } from './utils/formatSimulationTable';
 
 type SimulationReportSheetProps = {
-  path: CorePathfindingResultSuccess;
+  path: CorePathfindingResult;
   scenarioData: { name: string; infraName: string };
   trainData: SimulationSheetData;
   mapCanvas?: string;

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
@@ -1,7 +1,7 @@
 import type { Style } from '@react-pdf/types';
 
 import type { OperationalPointWithTimeAndSpeed } from 'applications/operationalStudies/types';
-import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResult } from 'common/api/osrdEditoastApi';
 import { timeToLocaleStringRounded } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { kgToT } from 'utils/physics';
@@ -58,7 +58,7 @@ export const getRowStyle = (
 
 export const formatOperationalStudiesDataForSimulationTable = (
   operationalPointsList: OperationalPointWithTimeAndSpeed[],
-  pathItemPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemPositions: CorePathfindingResult['path_item_positions'],
   rollingStock: { mass: number; name: string },
   dateTimeLocale: Intl.Locale
 ) =>

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -9,7 +9,7 @@ import type { ManageTrainSchedulePathProperties } from 'applications/operational
 import type {
   CoreIncompatibleConstraints,
   CorePathfindingInputError,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   PostInfraByInfraIdPathPropertiesApiArg,
   RelatedOperationalPoint,
 } from 'common/api/osrdEditoastApi';
@@ -158,7 +158,7 @@ const usePathfinding = ({
 
   const populateStoreWithPathfinding = async (
     pathStepsInput: PathStep[],
-    pathResult: CorePathfindingResultSuccess,
+    pathResult: CorePathfindingResult,
     incompatibleConstraints?: CoreIncompatibleConstraints
   ) => {
     const pathPropertiesParams: PostInfraByInfraIdPathPropertiesApiArg = {

--- a/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
+++ b/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
@@ -3,7 +3,7 @@ import { compact } from 'lodash';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   RollingStock,
   TrainSchedule,
   TrainScheduleResponse,
@@ -18,7 +18,7 @@ import { mmToKm, mToMm } from 'utils/physics';
 export const formatPowerRestrictionRanges = (
   powerRestrictions: NonNullable<TrainSchedule['power_restrictions']>,
   path: TrainSchedule['path'],
-  stepsPathPositions: CorePathfindingResultSuccess['path_item_positions']
+  stepsPathPositions: CorePathfindingResult['path_item_positions']
 ): LayerData<Omit<PowerRestrictionValues, 'handled'>>[] =>
   compact(
     powerRestrictions.map((powerRestriction) => {
@@ -81,7 +81,7 @@ const formatPowerRestrictionRangesWithHandled = ({
 }: {
   selectedTrainSchedule: Pick<TrainScheduleResponse, 'path' | 'power_restrictions'>;
   selectedTrainRollingStock?: RollingStock;
-  pathfindingResult: CorePathfindingResultSuccess;
+  pathfindingResult: CorePathfindingResult;
   pathProperties: PathPropertiesFormatted;
 }) => {
   if (powerRestrictions && selectedTrainRollingStock) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 
 import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import type { PathOperationalPoint, ProjectionData } from 'modules/simulationResult/types';
@@ -23,7 +23,7 @@ const useGetProjectedTrainOperationalPoints = ({
   infraId: number;
   timetableId: number | undefined;
   path?: TrainScheduleResponse['path'];
-  pathfinding?: CorePathfindingResultSuccess;
+  pathfinding?: CorePathfindingResult;
   projectedOperationalPoints?: ProjectionData['operationalPoints'];
 }) => {
   const { t } = useTranslation('operational-studies');

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
@@ -4,14 +4,14 @@ import type {
   Conflict,
   CoreConflictRequirement,
   PathProperties,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 
 const useProjectedConflicts = (
   infraId: number,
   conflicts: Conflict[],
-  path: CorePathfindingResultSuccess | undefined
+  path: CorePathfindingResult | undefined
 ) => {
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useLazyQuery();
@@ -20,7 +20,7 @@ const useProjectedConflicts = (
   useEffect(() => {
     const fetchProjectedZones = async ({
       path: { track_section_ranges },
-    }: CorePathfindingResultSuccess) => {
+    }: CorePathfindingResult) => {
       const { zones } = await postPathProperties({
         infraId,
         pathPropertiesInput: {

--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   ReceptionSignal,
   RollingStock,
   SimulationResponseSuccess,
@@ -34,7 +34,7 @@ type TimeStopsTableWrapperProps = {
   trainSchedulesWithDetails: TrainScheduleWithDetails[];
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
   simulatedTrain?: SimulationResponseSuccess['final_output'];
-  simulatedPath?: CorePathfindingResultSuccess;
+  simulatedPath?: CorePathfindingResult;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
   simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'];
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -3827,10 +3827,6 @@ class StartTimeChangeGroup(BaseModel):
     """
 
 
-class StdcmResponsePathNotFound(BaseModel):
-    status: Literal["path_not_found"]
-
-
 class StdcmResponseInternalError(BaseModel):
     error: InternalError
     status: Literal["internal_error"]
@@ -6618,6 +6614,14 @@ class StdcmResponseSuccess(BaseModel):
     pathfinding_result: CorePathfindingResult
     simulation: SimulationResponseSuccess
     status: Literal["success"]
+
+
+class StdcmResponsePathNotFound(BaseModel):
+    last_reached_operational_point: LastReachedOperationalPoint | None = None
+    most_blocking_work_schedule_ids: list[int]
+    nearest_to_destination_work_schedule_ids: list[int]
+    partial_pathfinding_result: CorePathfindingResult | None = None
+    status: Literal["path_not_found"]
 
 
 class StdcmResponsePreprocessingSimulationError(BaseModel):

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -5959,7 +5959,7 @@ class CorePathfindingInputError(
     )
 
 
-class CorePathfindingResultSuccess(BaseModel):
+class CorePathfindingResult(BaseModel):
     """
     A successful pathfinding result. This is also used for STDCM response.
     """
@@ -6297,7 +6297,7 @@ class PathItem(BaseModel):
 class PathfindingNotFoundIncompatibleConstraints(BaseModel):
     error_type: Literal["incompatible_constraints"]
     incompatible_constraints: CoreIncompatibleConstraints
-    relaxed_constraints_path: CorePathfindingResultSuccess
+    relaxed_constraints_path: CorePathfindingResult
 
 
 class PathfindingFailurePathfindingNotFound5(
@@ -6306,7 +6306,7 @@ class PathfindingFailurePathfindingNotFound5(
     pass
 
 
-class PathfindingResultSuccess(CorePathfindingResultSuccess):
+class PathfindingResultSuccess(CorePathfindingResult):
     status: Literal["success"]
 
 
@@ -6609,7 +6609,7 @@ class SpeedSection(BaseModel):
 
 class StdcmResponseSuccess(BaseModel):
     departure_time: AwareDatetime
-    pathfinding_result: CorePathfindingResultSuccess
+    pathfinding_result: CorePathfindingResult
     simulation: SimulationResponseSuccess
     status: Literal["success"]
 

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -5078,6 +5078,12 @@ class InfraPathfindingInput(BaseModel):
     starting: PathfindingTrackLocationInput
 
 
+class LastReachedOperationalPoint(BaseModel):
+    arrival_time: AwareDatetime
+    geographic: GeoJsonPoint
+    name: str
+
+
 class LevelCrossing(BaseModel):
     model_config = ConfigDict(
         extra="forbid",


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/17547

Question: the last commit is a WIP because I'm not sure why we need the `core_payload` field in `StdcmResponse::PathNotFound`

TODO:
- [ ] Fix tests
- [ ] Check if we need to change anything in osrd-data