### PR TITLE
editoast: project effective grant function

### DIFF
--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -9,6 +9,9 @@ use crate::v2::Check;
 use crate::v2::Protected;
 
 /// Returns the *direct grant* a subject has on an [Project], if any
+///
+/// A user can have *indirect grants* on a resource through group membership.
+/// For those, use [`project_effective_grant`].
 pub fn project_direct_grant(subject: Subject, project: Project) -> Protected<Option<ProjectGrant>> {
     Protected::new(move |openfga| {
         async move {
@@ -35,9 +38,47 @@ pub fn project_direct_grant(subject: Subject, project: Project) -> Protected<Opt
     .with_check(Check::ProjectExists(project))
 }
 
+/// Returns the effective (maximum) grant a subject has on an [Project], if any
+///
+/// For direct grants, see [`project_direct_grant`].
+pub fn project_effective_grant(
+    subject: Subject,
+    project: Project,
+) -> Protected<Option<ProjectGrant>> {
+    Protected::new(move |openfga| {
+        async move {
+            let is_owner = match subject {
+                Subject::User(user) => {
+                    openfga
+                        .prepare_checks()
+                        .check(&Project::owner().check(&user, &project))
+                        .execute()
+                        .await?
+                }
+                Subject::Group(group) => {
+                    openfga
+                        .prepare_checks()
+                        .check(&Project::owner().check(Group::member().userset(&group), &project))
+                        .execute()
+                        .await?
+                }
+            };
+
+            Ok(is_owner
+                .first()
+                .expect("Non-empty list must be provided")
+                .then_some(ProjectGrant::Owner))
+        }
+        .boxed()
+    })
+    .with_check(Check::SubjectExists(subject))
+    .with_check(Check::ProjectExists(project))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::User;
+    use crate::authz_client;
     use crate::model::Project;
     use crate::v2::special_authorizers::Authorize;
 
@@ -46,7 +87,7 @@ mod tests {
     #[tokio::test]
     /// Verify that an user can or cannot have direct grant
     async fn user_project_direct_grant() {
-        let openfga = crate::authz_client!();
+        let openfga = authz_client!();
         let authorize = Authorize(&openfga);
 
         let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
@@ -73,7 +114,7 @@ mod tests {
     #[tokio::test]
     /// Verify that a group can or cannot have direct grant
     async fn group_project_direct_grant() {
-        let openfga = crate::authz_client!();
+        let openfga = authz_client!();
         let authorize = Authorize(&openfga);
 
         let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
@@ -100,7 +141,7 @@ mod tests {
     #[tokio::test]
     /// Verify that there is no inherance of direct grant between an user and a group
     async fn no_inference_project_direct_grant() {
-        let openfga = crate::authz_client!();
+        let openfga = authz_client!();
         let authorize = Authorize(&openfga);
 
         let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
@@ -134,6 +175,120 @@ mod tests {
         assert_eq!(group_grant(1).await, None);
 
         assert_eq!(user_grant(2).await, None);
+        assert_eq!(group_grant(2).await, Some(ProjectGrant::Owner));
+    }
+
+    #[tokio::test]
+    /// Verify for an user that direct grant implies effective grant
+    async fn user_project_effective_grant_direct() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
+            project_effective_grant(Subject::user(user_id), Project(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+
+        assert_eq!(user_grant(1).await, None);
+
+        openfga
+            .prepare_writes()
+            .write(&Project::owner().tuple(&User(1), &Project(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
+    }
+
+    #[tokio::test]
+    /// Verify that effective grants only inherant for user of group
+    async fn project_effective_grant_inherited() {
+        let openfga = crate::authz_client!();
+        let authorize = Authorize(&openfga);
+
+        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
+            project_effective_grant(Subject::user(user_id), Project(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
+            project_effective_grant(Subject::group(group_id), Project(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+
+        assert_eq!(user_grant(1).await, None);
+        assert_eq!(group_grant(1).await, None);
+
+        // Give `ProjectGrant::Owner` to `Group(1)`
+        // Only `User(1)` is in `Group(1)`, not `User(2)`
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(&Project::owner().tuple(Group::member().userset(&Group(1)), &Project(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(group_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
+    }
+
+    #[tokio::test]
+    /// Verify for a group that effective grant implies direct grant
+    /// and all users of group inherant
+    async fn no_inference_project_effective_grant() {
+        let openfga = authz_client!();
+        let authorize = Authorize(&openfga);
+
+        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
+            project_effective_grant(Subject::user(user_id), Project(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
+            project_effective_grant(Subject::group(group_id), Project(1))
+                .authorize(&authorize)
+                .await
+                .unwrap()
+                .unwrap_authorized()
+                .await
+        };
+
+        assert_eq!(user_grant(1).await, None);
+        assert_eq!(group_grant(1).await, None);
+
+        assert_eq!(user_grant(2).await, None);
+        assert_eq!(group_grant(2).await, None);
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(&Group::member().tuple(&User(2), &Group(2)))
+            .write(&Project::owner().tuple(&User(1), &Project(1)))
+            .write(&Project::owner().tuple(Group::member().userset(&Group(2)), &Project(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(group_grant(1).await, None);
+
+        assert_eq!(user_grant(2).await, Some(ProjectGrant::Owner));
         assert_eq!(group_grant(2).await, Some(ProjectGrant::Owner));
     }
 }

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -23,6 +23,7 @@ use crate::v2::infra_privileges;
 use crate::v2::infra_revoke_grant;
 use crate::v2::infra_set_grant;
 use crate::v2::project::project_direct_grant;
+use crate::v2::project_effective_grant;
 use crate::v2::rolling_stock_direct_grant;
 use crate::v2::rolling_stock_effective_grant;
 use crate::v2::rolling_stock_granted_subjects;
@@ -80,6 +81,11 @@ pub trait TestClientExt {
         grant: RollingStockGrant,
     );
     async fn project_direct_grant(
+        &self,
+        subject: Subject,
+        project: Project,
+    ) -> Option<ProjectGrant>;
+    async fn project_effective_grant(
         &self,
         subject: Subject,
         project: Project,
@@ -293,6 +299,18 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(project_direct_grant(subject, project))
+            .await
+            .unwrap()
+    }
+
+    async fn project_effective_grant(
+        &self,
+        subject: Subject,
+        project: Project,
+    ) -> Option<ProjectGrant> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(project_effective_grant(subject, project))
             .await
             .unwrap()
     }


### PR DESCRIPTION
## Context

See [#17546]

## Goal

- Add `project_effective_grant` in `authz::v2::project.rs`
- Add some unitary tests