### PR TITLE
editoast: add project revoke grant function

### DIFF
--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -2,9 +2,11 @@ use fga::model::Relation as _;
 use futures::FutureExt;
 
 use crate::Group;
+use crate::Role;
 use crate::Subject;
 use crate::model::Project;
 use crate::model::ProjectGrant;
+use crate::v2::Actor;
 use crate::v2::Check;
 use crate::v2::Protected;
 
@@ -100,8 +102,39 @@ pub fn project_set_grant(subject: Subject, project: Project) -> Protected<()> {
         .with_check(Check::CanGiveSubjectProjectGrant(subject, project))
 }
 
+/// Revokes the (direct) grant a subject has on an [Project], if any
+///
+/// Returns `true` if a grant was revoked, `false` otherwise, making the operation idempotent.
+/// No transaction is setup as OpenFGA does not support them.
+pub fn project_revoke_grant(subject: Subject, project: Project) -> Protected<bool> {
+    // Revoking rules:
+    // Only admins can fully revoke grants
+    project_direct_grant(subject, project)
+        .map(move |openfga, grant| {
+            async move {
+                let Some(grant) = grant else {
+                    return Ok(false);
+                };
+
+                let mut delete = openfga.prepare_deletes();
+                match (subject, grant) {
+                    (Subject::User(user), ProjectGrant::Owner) => {
+                        delete.push(&Project::owner().tuple(&user, &project))
+                    }
+                    (Subject::Group(group), ProjectGrant::Owner) => delete
+                        .push(&Project::owner().tuple(Group::member().userset(&group), &project)),
+                };
+                delete.execute().await?;
+                Ok(true)
+            }
+            .boxed()
+        })
+        .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
+}
+
 #[cfg(test)]
 mod tests {
+    use fga::Client;
     use std::collections::HashSet;
 
     use crate::User;
@@ -277,7 +310,106 @@ mod tests {
             group_effective_grant(&openfga, 2).await,
             Some(ProjectGrant::Owner)
         );
+    }
 
+    async fn user_revoke_grant(openfga: &Client, user_id: i64) -> bool {
+        openfga
+            .project_revoke_grant(Subject::user(user_id), Project(1))
+            .await
+    }
+
+    async fn group_revoke_grant(openfga: &Client, group_id: i64) -> bool {
+        openfga
+            .project_revoke_grant(Subject::group(group_id), Project(1))
+            .await
+    }
+
+    #[tokio::test]
+    // Revoking a non-existent project grant should fail
+    async fn project_revoke_no_op() {
+        let openfga = authz_client!();
+        assert!(!user_revoke_grant(&openfga, 1).await);
+        assert!(!group_revoke_grant(&openfga, 1).await);
+    }
+
+    // TODO
+    // Refactorize the two following tests using `rstest` when `project_set_grant` is done
+    #[tokio::test]
+    async fn project_revoke_grant_user_ok() {
+        let openfga = authz_client!();
+
+        assert_eq!(user_direct_grant(&openfga, 1).await, None);
+
+        openfga
+            .write_tuples(&[Project::owner().tuple(&User(1), &Project(1))])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            user_direct_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert!(user_revoke_grant(&openfga, 1).await);
+        assert_eq!(user_direct_grant(&openfga, 1).await, None);
+    }
+
+    #[tokio::test]
+    async fn project_revoke_grant_group_ok() {
+        let openfga = authz_client!();
+
+        assert_eq!(group_direct_grant(&openfga, 1).await, None);
+
+        openfga
+            .write_tuples(
+                &[Project::owner().tuple(Group::member().userset(&Group(1)), &Project(1))],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            group_direct_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert!(group_revoke_grant(&openfga, 1).await);
+        assert_eq!(group_direct_grant(&openfga, 1).await, None);
+    }
+
+    #[tokio::test]
+    // The inherited grants of a user on a project are not affected by revoking that user direct grants on the project
+    async fn project_revoke_grant_keep_effective() {
+        let openfga = authz_client!();
+
+        assert_eq!(user_direct_grant(&openfga, 1).await, None);
+        assert_eq!(group_direct_grant(&openfga, 1).await, None);
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(&Project::owner().tuple(&User(1), &Project(1)))
+            .write(&Project::owner().tuple(Group::member().userset(&Group(1)), &Project(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            user_effective_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert_eq!(
+            group_effective_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
+
+        assert!(user_revoke_grant(&openfga, 1).await);
+
+        assert_eq!(
+            user_effective_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert_eq!(
+            group_effective_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
     }
 
     #[rstest::rstest]
@@ -342,6 +474,14 @@ mod tests {
             Check::SubjectExists(Subject::user(1)),
             Check::ProjectExists(Project(1)),
             Check::CanGiveSubjectProjectGrant(Subject::user(1), Project(1))
+        ]
+    )]
+    #[case::project_revoke_grant(
+        project_revoke_grant(Subject::user(1), Project(1)).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::ProjectExists(Project(1)),
+            Check::HasRole(Actor::Issuer, Role::Admin),
         ]
     )]
     #[tokio::test]

--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -111,17 +111,23 @@ mod tests {
 
     use super::*;
 
+    async fn user_direct_grant(openfga: &Client, user_id: i64) -> Option<ProjectGrant> {
+        openfga
+            .project_direct_grant(Subject::user(user_id), Project(1))
+            .await
+    }
+
+    async fn group_direct_grant(openfga: &Client, group_id: i64) -> Option<ProjectGrant> {
+        openfga
+            .project_direct_grant(Subject::group(group_id), Project(1))
+            .await
+    }
+
     #[tokio::test]
     async fn user_project_direct_grant() {
         let openfga = authz_client!();
 
-        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_direct_grant(Subject::user(user_id), Project(1))
-                .await
-        };
-
-        assert_eq!(user_grant(1).await, None);
+        assert_eq!(user_direct_grant(&openfga, 1).await, None);
 
         openfga
             .prepare_writes()
@@ -130,20 +136,17 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(
+            user_direct_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
     }
 
     #[tokio::test]
     async fn group_project_direct_grant() {
         let openfga = authz_client!();
 
-        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_direct_grant(Subject::group(group_id), Project(1))
-                .await
-        };
-
-        assert_eq!(group_grant(1).await, None);
+        assert_eq!(group_direct_grant(&openfga, 1).await, None);
 
         openfga
             .prepare_writes()
@@ -152,7 +155,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(group_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(
+            group_direct_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
     }
 
     #[tokio::test]
@@ -160,17 +166,6 @@ mod tests {
     async fn no_inference_project_direct_grant() {
         let openfga = authz_client!();
 
-        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_direct_grant(Subject::user(user_id), Project(1))
-                .await
-        };
-        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_direct_grant(Subject::group(group_id), Project(1))
-                .await
-        };
-
         openfga
             .prepare_writes()
             .write(&Group::member().tuple(&User(1), &Group(1)))
@@ -179,8 +174,11 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(user_grant(1).await, None);
-        assert_eq!(group_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(user_direct_grant(&openfga, 1).await, None);
+        assert_eq!(
+            group_direct_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
     }
 
     #[tokio::test]
@@ -188,12 +186,7 @@ mod tests {
     async fn user_project_effective_grant_direct() {
         let openfga = authz_client!();
 
-        assert_eq!(
-            openfga
-                .project_direct_grant(Subject::user(1), Project(1))
-                .await,
-            None
-        );
+        assert_eq!(user_direct_grant(&openfga, 1).await, None);
 
         openfga
             .prepare_writes()
@@ -203,11 +196,21 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            openfga
-                .project_direct_grant(Subject::user(1), Project(1))
-                .await,
+            user_direct_grant(&openfga, 1).await,
             Some(ProjectGrant::Owner)
         );
+    }
+
+    async fn user_effective_grant(openfga: &Client, user_id: i64) -> Option<ProjectGrant> {
+        openfga
+            .project_effective_grant(Subject::user(user_id), Project(1))
+            .await
+    }
+
+    async fn group_effective_grant(openfga: &Client, group_id: i64) -> Option<ProjectGrant> {
+        openfga
+            .project_effective_grant(Subject::group(group_id), Project(1))
+            .await
     }
 
     #[tokio::test]
@@ -215,20 +218,9 @@ mod tests {
     async fn project_effective_grant_inherited() {
         let openfga = authz_client!();
 
-        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_effective_grant(Subject::user(user_id), Project(1))
-                .await
-        };
-        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_effective_grant(Subject::group(group_id), Project(1))
-                .await
-        };
-
-        assert_eq!(user_grant(1).await, None);
-        assert_eq!(user_grant(2).await, None);
-        assert_eq!(group_grant(1).await, None);
+        assert_eq!(user_effective_grant(&openfga, 1).await, None);
+        assert_eq!(user_effective_grant(&openfga, 2).await, None);
+        assert_eq!(group_effective_grant(&openfga, 1).await, None);
 
         openfga
             .prepare_writes()
@@ -238,9 +230,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
-        assert_eq!(user_grant(2).await, None);
-        assert_eq!(group_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(
+            user_effective_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert_eq!(user_effective_grant(&openfga, 2).await, None);
+        assert_eq!(
+            group_effective_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
     }
 
     #[tokio::test]
@@ -249,22 +247,11 @@ mod tests {
     async fn no_inference_project_effective_grant() {
         let openfga = authz_client!();
 
-        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_effective_grant(Subject::user(user_id), Project(1))
-                .await
-        };
-        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
-            openfga
-                .project_effective_grant(Subject::group(group_id), Project(1))
-                .await
-        };
+        assert_eq!(user_effective_grant(&openfga, 1).await, None);
+        assert_eq!(group_effective_grant(&openfga, 1).await, None);
 
-        assert_eq!(user_grant(1).await, None);
-        assert_eq!(group_grant(1).await, None);
-
-        assert_eq!(user_grant(2).await, None);
-        assert_eq!(group_grant(2).await, None);
+        assert_eq!(user_effective_grant(&openfga, 2).await, None);
+        assert_eq!(group_effective_grant(&openfga, 2).await, None);
 
         openfga
             .prepare_writes()
@@ -276,11 +263,21 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
-        assert_eq!(group_grant(1).await, None);
+        assert_eq!(
+            user_effective_grant(&openfga, 1).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert_eq!(group_effective_grant(&openfga, 1).await, None);
 
-        assert_eq!(user_grant(2).await, Some(ProjectGrant::Owner));
-        assert_eq!(group_grant(2).await, Some(ProjectGrant::Owner));
+        assert_eq!(
+            user_effective_grant(&openfga, 2).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert_eq!(
+            group_effective_grant(&openfga, 2).await,
+            Some(ProjectGrant::Owner)
+        );
+
     }
 
     #[rstest::rstest]

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -25,6 +25,7 @@ use crate::v2::infra_revoke_grant;
 use crate::v2::infra_set_grant;
 use crate::v2::project::project_direct_grant;
 use crate::v2::project_effective_grant;
+use crate::v2::project_revoke_grant;
 use crate::v2::project_set_grant;
 use crate::v2::remove_members;
 use crate::v2::remove_roles;
@@ -99,6 +100,7 @@ pub trait TestClientExt {
         subject: Subject,
         project: Project,
     ) -> Option<ProjectGrant>;
+    async fn project_revoke_grant(&self, subject: Subject, project: Project) -> bool;
     async fn project_set_grant(&self, subject: Subject, project: Project) -> ();
 }
 
@@ -312,6 +314,14 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(project_effective_grant(subject, project))
+            .await
+            .unwrap()
+    }
+
+    async fn project_revoke_grant(&self, subject: Subject, project: Project) -> bool {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(project_revoke_grant(subject, project))
             .await
             .unwrap()
     }


### PR DESCRIPTION
Ref:  #17546

- Add `project_revoke_grant` in `authz::v2::project`.
- Add some unit tests