### PR TITLE
editoast: add project effective grant function

### DIFF
--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -9,6 +9,9 @@ use crate::v2::Check;
 use crate::v2::Protected;
 
 /// Returns the *direct grant* a subject has for a [Project].
+///
+/// A user can have *indirect grants* on a resource through group membership.
+/// For those, use [`project_effective_grant`].
 pub fn project_direct_grant(subject: Subject, project: Project) -> Protected<Option<ProjectGrant>> {
     Protected::new(move |openfga| {
         async move {
@@ -26,6 +29,32 @@ pub fn project_direct_grant(subject: Subject, project: Project) -> Protected<Opt
                         .await?
                 }
             };
+
+            Ok(is_owner.then_some(ProjectGrant::Owner))
+        }
+        .boxed()
+    })
+    .with_check(Check::SubjectExists(subject))
+    .with_check(Check::ProjectExists(project))
+}
+
+/// Returns the effective grant a subject has on an [Project]
+///
+/// For direct grants, see [`project_direct_grant`].
+pub fn project_effective_grant(
+    subject: Subject,
+    project: Project,
+) -> Protected<Option<ProjectGrant>> {
+    Protected::new(move |openfga| {
+        async move {
+            let is_owner = match subject {
+                Subject::User(user) => openfga.check(Project::owner().check(&user, &project)).await,
+                Subject::Group(group) => {
+                    openfga
+                        .check(Project::owner().check(Group::member().userset(&group), &project))
+                        .await
+                }
+            }?;
 
             Ok(is_owner.then_some(ProjectGrant::Owner))
         }
@@ -89,7 +118,7 @@ mod tests {
     }
 
     #[tokio::test]
-    /// Verify that there is no inherance of direct grant between an user and a group
+    // Verify that there is no inheritance of direct grant between an user and a group
     async fn no_inference_project_direct_grant() {
         let openfga = authz_client!();
 
@@ -114,5 +143,105 @@ mod tests {
 
         assert_eq!(user_grant(1).await, None);
         assert_eq!(group_grant(1).await, Some(ProjectGrant::Owner));
+    }
+
+    #[tokio::test]
+    // Verify for an user that direct grant implies effective grant
+    async fn user_project_effective_grant_direct() {
+        let openfga = authz_client!();
+
+        assert_eq!(
+            openfga
+                .project_direct_grant(Subject::user(1), Project(1))
+                .await,
+            None
+        );
+
+        openfga
+            .prepare_writes()
+            .write(&Project::owner().tuple(&User(1), &Project(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            openfga
+                .project_direct_grant(Subject::user(1), Project(1))
+                .await,
+            Some(ProjectGrant::Owner)
+        );
+    }
+
+    #[tokio::test]
+    // Effective grants inherited from a group only apply to the members of that group
+    async fn project_effective_grant_inherited() {
+        let openfga = authz_client!();
+
+        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
+            openfga
+                .project_effective_grant(Subject::user(user_id), Project(1))
+                .await
+        };
+        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
+            openfga
+                .project_effective_grant(Subject::group(group_id), Project(1))
+                .await
+        };
+
+        assert_eq!(user_grant(1).await, None);
+        assert_eq!(user_grant(2).await, None);
+        assert_eq!(group_grant(1).await, None);
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(&Project::owner().tuple(Group::member().userset(&Group(1)), &Project(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(user_grant(2).await, None);
+        assert_eq!(group_grant(1).await, Some(ProjectGrant::Owner));
+    }
+
+    #[tokio::test]
+    // Verify for a group that effective grant implies direct grant
+    // and that all users of the group users inherit its grant
+    async fn no_inference_project_effective_grant() {
+        let openfga = authz_client!();
+
+        let user_grant = async |user_id: i64| -> Option<ProjectGrant> {
+            openfga
+                .project_effective_grant(Subject::user(user_id), Project(1))
+                .await
+        };
+        let group_grant = async |group_id: i64| -> Option<ProjectGrant> {
+            openfga
+                .project_effective_grant(Subject::group(group_id), Project(1))
+                .await
+        };
+
+        assert_eq!(user_grant(1).await, None);
+        assert_eq!(group_grant(1).await, None);
+
+        assert_eq!(user_grant(2).await, None);
+        assert_eq!(group_grant(2).await, None);
+
+        openfga
+            .prepare_writes()
+            .write(&Group::member().tuple(&User(1), &Group(1)))
+            .write(&Group::member().tuple(&User(2), &Group(2)))
+            .write(&Project::owner().tuple(&User(1), &Project(1)))
+            .write(&Project::owner().tuple(Group::member().userset(&Group(2)), &Project(1)))
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(user_grant(1).await, Some(ProjectGrant::Owner));
+        assert_eq!(group_grant(1).await, None);
+
+        assert_eq!(user_grant(2).await, Some(ProjectGrant::Owner));
+        assert_eq!(group_grant(2).await, Some(ProjectGrant::Owner));
     }
 }

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -25,6 +25,7 @@ use crate::v2::infra_privileges;
 use crate::v2::infra_revoke_grant;
 use crate::v2::infra_set_grant;
 use crate::v2::project::project_direct_grant;
+use crate::v2::project_effective_grant;
 use crate::v2::remove_members;
 use crate::v2::remove_roles;
 use crate::v2::rolling_stock_direct_grant;
@@ -88,6 +89,11 @@ pub trait TestClientExt {
         grant: RollingStockGrant,
     );
     async fn project_direct_grant(
+        &self,
+        subject: Subject,
+        project: Project,
+    ) -> Option<ProjectGrant>;
+    async fn project_effective_grant(
         &self,
         subject: Subject,
         project: Project,
@@ -332,6 +338,18 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(project_direct_grant(subject, project))
+            .await
+            .unwrap()
+    }
+
+    async fn project_effective_grant(
+        &self,
+        subject: Subject,
+        project: Project,
+    ) -> Option<ProjectGrant> {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(project_effective_grant(subject, project))
             .await
             .unwrap()
     }


### PR DESCRIPTION
## Context
See [#17546]

## Goal
- Add `project_effective_grant` in `authz::v2::project`.
- Add some unitary tests