### PR TITLE
editoast: adapt /search_journeys response

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -16472,36 +16472,23 @@ components:
       additionalProperties: false
     TrainSchedulePart:
       type: object
-      description: A part of a train schedule, from one location to another.
+      description: A part of a train schedule, from one step of its path to another.
       required:
       - train_schedule_id
       - from
       - to
       properties:
         from:
-          $ref: '#/components/schemas/TrainSchedulePartBound'
+          type: integer
+          description: Index of the start path step in the train schedule's path
+          minimum: 0
         to:
-          $ref: '#/components/schemas/TrainSchedulePartBound'
+          type: integer
+          description: Index of the end path step in the train schedule's path
+          minimum: 0
         train_schedule_id:
           type: integer
           format: int64
-    TrainSchedulePartBound:
-      type: object
-      required:
-      - location
-      - time_ms
-      properties:
-        location:
-          $ref: '#/components/schemas/PathItemLocation'
-          description: This location is part of the train schedule's path.
-        time_ms:
-          type: integer
-          format: int32
-          description: |-
-            Scheduled time since the start of the train schedule in milliseconds.
-
-            Used to differentiate locations in case of backtracks.
-          minimum: 0
     TrainScheduleResponse:
       allOf:
       - $ref: '#/components/schemas/TrainSchedule'

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -107,7 +107,7 @@ pub struct JourneyListParams {
     pub transfer_ms: u32,
 }
 
-/// This returns a list of journeys, each journey being the list of connections to take given as their [ConnectionId].
+/// This returns up to 3 journeys, each journey being the list of connections to take given as their [ConnectionId].
 ///
 /// Some pre-conditions are required:
 ///
@@ -197,77 +197,80 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
         profiles.append(&mut earlier_profiles);
     }
 
-    to_journey_list(&profiles, &connections, transfer_ms, start, end)
-        .filter(|journey| {
-            // TODO can filter before creating the path
-            let departure_ms = connections[journey[0]].departure_ms;
+    let mut start_profiles: Vec<&Profile> = profiles[start]
+        .iter()
+        .filter(|profile| u32::abs_diff(profile.departure_ms, start_ms) <= start_tolerance)
+        .collect();
 
-            u32::abs_diff(departure_ms, start_ms) <= start_tolerance
+    // TODO: In this first version we try the departures closest to the requested time first.
+    // We should use more specific criteria to select the best 3 journeys.
+    start_profiles.sort_unstable_by_key(|profile| u32::abs_diff(profile.departure_ms, start_ms));
+
+    // Explore the profile graph to create up to 3 journeys that a traveler can take to go from start to end.
+    start_profiles
+        .into_iter()
+        .filter_map(|profile| {
+            let out_connection = profile.out_connection?;
+            to_journey_list_rec(
+                &profiles,
+                &connections,
+                transfer_ms,
+                end,
+                vec![out_connection],
+            )
         })
+        .take(3)
         .collect()
 }
 
-/// Explore the profile graph to create the list of journeys that a traveler can take to go from start to end.
-fn to_journey_list<'a>(
-    profiles: &'a [Vec<Profile>],
-    connections: &'a [Connection],
-    transfer_ms: u32,
-    start: StopId,
-    end: StopId,
-) -> impl Iterator<Item = Vec<ConnectionId>> + 'a {
-    profiles[start].iter().flat_map(move |profile| {
-        let Some(out_connection) = profile.out_connection else {
-            return Vec::new();
-        };
-        to_journey_list_rec(
-            profiles,
-            connections,
-            transfer_ms,
-            end,
-            vec![out_connection],
-        )
-    })
-}
-
+/// Recursively extends `path`, connection by connection, into a complete journey to `end`.
+///
+/// `path` is the non-empty list of connection taken so far.
+/// At each stop, the profiles are explored starting with the one reaching `end` earliest.
+/// A candidate connection is discarded when the transfer time cannot be met or when it would make the path loop.
+/// Returns `None` if no journey extends `path`.
 fn to_journey_list_rec(
     profiles: &[Vec<Profile>],
     connections: &[Connection],
     transfer_ms: u32,
     end: StopId,
     path: Vec<ConnectionId>,
-) -> Vec<Vec<ConnectionId>> {
+) -> Option<Vec<ConnectionId>> {
     let last_connection = connections[*path.last().unwrap()];
     let start: StopId = last_connection.arrival;
-    let time: TimeOfDayMs = last_connection.arrival_ms + transfer_ms;
 
     if start == end {
-        return vec![path];
+        return Some(path);
     }
 
-    profiles[start]
-        .iter()
-        .flat_map(|profile| {
-            let out_conn_id = profile
-                .out_connection
-                .expect("expected start != end to imply out_connection is Some");
+    // Try profiles from the one reaching the target earliest (see profiles construction) and stop at the first solution found
+    profiles[start].iter().rev().find_map(|profile| {
+        let out_conn_id = profile
+            .out_connection
+            .expect("expected start != end to imply out_connection is Some");
 
-            let out_conn = connections[out_conn_id];
+        let out_conn = connections[out_conn_id];
 
-            let next_stop = out_conn.arrival;
+        let next_stop = out_conn.arrival;
+        // The traveler only needs `transfer_ms` when changing trains
+        let earliest_next_departure_ms = if out_conn.trip == last_connection.trip {
+            last_connection.arrival_ms
+        } else {
+            last_connection.arrival_ms + transfer_ms
+        };
 
-            if path
-                .iter()
-                .any(|connection_id| connections[*connection_id].departure == next_stop)
-                || start == next_stop
-                || out_conn.departure_ms < time
-            {
-                return Vec::new();
-            }
+        if path
+            .iter()
+            .any(|connection_id| connections[*connection_id].departure == next_stop)
+            || start == next_stop
+            || out_conn.departure_ms < earliest_next_departure_ms
+        {
+            return None;
+        }
 
-            let mut new_path = path.clone();
-            new_path.push(out_conn_id);
+        let mut new_path = path.clone();
+        new_path.push(out_conn_id);
 
-            to_journey_list_rec(profiles, connections, transfer_ms, end, new_path)
-        })
-        .collect()
+        to_journey_list_rec(profiles, connections, transfer_ms, end, new_path)
+    })
 }

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -2,7 +2,7 @@
 //! Section 4 of the linked paper.
 //!
 //! Initially ported from this implementation:
-//! https://github.com/Tristramg/csa-rust/blob/72ee6d54de6652da81bc41d53b81ab721dcef479/src/algo.rs
+//! <https://github.com/Tristramg/csa-rust/blob/72ee6d54de6652da81bc41d53b81ab721dcef479/src/algo.rs>
 //!
 //! # Definitions
 //!
@@ -36,7 +36,9 @@
 /// Milliseconds since midnight.
 type TimeOfDayMs = u32;
 
-type ConnectionId = usize;
+/// Index of a [Connection] into [`JourneyListParams::connections`].
+pub type ConnectionId = usize;
+
 type StopId = usize;
 type TripId = usize;
 
@@ -105,16 +107,16 @@ pub struct JourneyListParams {
     pub transfer_ms: u32,
 }
 
-/// This returns a list of journeys, each journey in the form of a list of connections to take.
+/// This returns a list of journeys, each journey being the list of connections to take given as their [ConnectionId].
 ///
 /// Some pre-conditions are required:
 ///
-/// - [`connections`] must be sorted by descending `departure_ms`
-/// - All connections' `trip`s must be strictly lower than [`trip_count`]
-/// - All connections' `departure`s and `arrival`s must be strictly lower than [`stop_count`]
+/// - [`JourneyListParams::connections`] must be sorted by descending `departure_ms`
+/// - All connections' `trip`s must be strictly lower than [`JourneyListParams::trip_count`]
+/// - All connections' `departure`s and `arrival`s must be strictly lower than [`JourneyListParams::stop_count`]
 ///
 /// See asserts below for more pre-conditions.
-pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Connection>> {
+pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
     let JourneyListParams {
         stop_count,
         trip_count,
@@ -131,7 +133,7 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Connection>> {
 
     // stop index -> profiles
     // profiles are ordered by decreasing departure_ms
-    // they are also ordered by increasing arrival_ms
+    // they are also ordered by decreasing arrival_ms since they all lie on the Pareto front
     let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); stop_count];
     profiles[end].push(Profile {
         out_connection: None,
@@ -198,7 +200,7 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Connection>> {
     to_journey_list(&profiles, &connections, transfer_ms, start, end)
         .filter(|journey| {
             // TODO can filter before creating the path
-            let departure_ms = journey[0].departure_ms;
+            let departure_ms = connections[journey[0]].departure_ms;
 
             u32::abs_diff(departure_ms, start_ms) <= start_tolerance
         })
@@ -212,7 +214,7 @@ fn to_journey_list<'a>(
     transfer_ms: u32,
     start: StopId,
     end: StopId,
-) -> impl Iterator<Item = Vec<Connection>> + 'a {
+) -> impl Iterator<Item = Vec<ConnectionId>> + 'a {
     profiles[start].iter().flat_map(move |profile| {
         let Some(out_connection) = profile.out_connection else {
             return Vec::new();
@@ -222,7 +224,7 @@ fn to_journey_list<'a>(
             connections,
             transfer_ms,
             end,
-            vec![connections[out_connection]],
+            vec![out_connection],
         )
     })
 }
@@ -232,10 +234,11 @@ fn to_journey_list_rec(
     connections: &[Connection],
     transfer_ms: u32,
     end: StopId,
-    path: Vec<Connection>,
-) -> Vec<Vec<Connection>> {
-    let start: StopId = path.last().unwrap().arrival;
-    let time: TimeOfDayMs = path.last().unwrap().arrival_ms + transfer_ms;
+    path: Vec<ConnectionId>,
+) -> Vec<Vec<ConnectionId>> {
+    let last_connection = connections[*path.last().unwrap()];
+    let start: StopId = last_connection.arrival;
+    let time: TimeOfDayMs = last_connection.arrival_ms + transfer_ms;
 
     if start == end {
         return vec![path];
@@ -254,7 +257,7 @@ fn to_journey_list_rec(
 
             if path
                 .iter()
-                .any(|connection| connection.departure == next_stop)
+                .any(|connection_id| connections[*connection_id].departure == next_stop)
                 || start == next_stop
                 || out_conn.departure_ms < time
             {
@@ -262,7 +265,7 @@ fn to_journey_list_rec(
             }
 
             let mut new_path = path.clone();
-            new_path.push(out_conn);
+            new_path.push(out_conn_id);
 
             to_journey_list_rec(profiles, connections, transfer_ms, end, new_path)
         })

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -197,7 +197,9 @@ impl OperationalPointCache {
     pub fn get_op_ref_id(&self, op_ref: &OperationalPointReference) -> Option<String> {
         let (ops, secondary_code) = match op_ref {
             OperationalPointReference::Id { operational_point } => {
-                return Some(operational_point.0.clone());
+                return self
+                    .get_from_id(&operational_point.0)
+                    .map(|op| op.obj_id.clone());
             }
             OperationalPointReference::Trigram {
                 trigram,

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 use axum::Extension;
@@ -69,29 +70,50 @@ pub(in crate::views) struct JourneySearchQuery {
     transfer_ms: u32,
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
-struct TrainSchedulePartBound {
-    /// This location is part of the train schedule's path.
-    location: PathItemLocation,
-
-    /// Scheduled time since the start of the train schedule in milliseconds.
-    ///
-    /// Used to differentiate locations in case of backtracks.
-    time_ms: u32,
-}
-
-/// A part of a train schedule, from one location to another.
+/// A part of a train schedule, from one step of its path to another.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 struct TrainSchedulePart {
     train_schedule_id: i64,
-    from: TrainSchedulePartBound,
-    to: TrainSchedulePartBound,
+
+    /// Index of the start path step in the train schedule's path
+    from: usize,
+
+    /// Index of the end path step in the train schedule's path
+    to: usize,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub(in crate::views) struct JourneyProposals {
     /// Each journey is a list of train schedule parts.
     journeys: Vec<Vec<TrainSchedulePart>>,
+}
+
+/// A step of a train schedule's path that can be used in a connection
+#[derive(Clone, Copy)]
+struct ScheduleStep {
+    /// Index of the step in path.
+    path_index: usize,
+
+    /// Index of the operational point the step is located at.
+    op_index: usize,
+
+    /// Time of arrival at the path step
+    arrival_ms: u32,
+
+    /// Time of departure from the path step
+    departure_ms: u32,
+}
+
+/// A connection, along with the path steps it was built from.
+#[derive(Clone, Copy)]
+struct PathIndexedConnection {
+    connection: Connection,
+
+    /// Index in the train schedule's path of the connection departure.
+    departure_path_index: usize,
+
+    /// Index in the train schedule's path of the connection arrival.
+    arrival_path_index: usize,
 }
 
 /// Search possible journeys from A to B using train parts from the given timetables.
@@ -174,202 +196,199 @@ pub(in crate::views) async fn search_journeys(
 
     let op_cache = OperationalPointCache::load_path_items(conn, infra_id, &path_items).await?;
 
-    let operational_point_ids = op_references
+    let op_index_by_id: HashMap<String, usize> = op_references
         .iter()
         .filter_map(|op_ref| op_cache.get_op_ref_id(&op_ref.operational_point))
         .unique()
-        .collect_vec();
+        .enumerate()
+        .map(|(index, op_id)| (op_id, index))
+        .collect();
 
-    let Some(origin_index) =
-        find_op_index(&op_cache, &operational_point_ids, &origin.operational_point)
+    let Some(origin_index) = find_op_index(&op_cache, &op_index_by_id, &origin.operational_point)
     else {
         return Err(Error::InvalidInput {
             message: "origin not found in the infra",
         })?;
     };
 
-    let Some(destination_index) = find_op_index(
-        &op_cache,
-        &operational_point_ids,
-        &destination.operational_point,
-    ) else {
+    let Some(destination_index) =
+        find_op_index(&op_cache, &op_index_by_id, &destination.operational_point)
+    else {
         return Err(Error::InvalidInput {
             message: "destination not found in the infra",
         })?;
     };
 
-    let mut train_schedule_ids = Vec::new();
-    let mut train_schedule_parts = Vec::new();
-    let mut train_schedule_start_times = Vec::new();
-    for (timetable_type, train_schedules) in timetables {
-        let index_offset = train_schedule_ids.len();
+    let journeys = tokio::task::spawn_blocking(move || {
+        let mut train_schedule_ids = Vec::new();
+        let mut path_indexed_connections: Vec<PathIndexedConnection> = Vec::new();
+        for (timetable_type, train_schedules) in timetables {
+            let index_offset = train_schedule_ids.len();
 
-        train_schedule_ids.extend(
-            train_schedules
-                .iter()
-                .map(|train_schedule| train_schedule.id),
-        );
+            train_schedule_ids.extend(
+                train_schedules
+                    .iter()
+                    .map(|train_schedule| train_schedule.id),
+            );
 
-        train_schedule_start_times.extend(
-            train_schedules
-                .iter()
-                .map(|train_schedule| datetime_millis_from_midnight(train_schedule.start_time)),
-        );
-
-        train_schedule_parts.extend(train_schedules.into_iter().zip(index_offset..).flat_map(
-            |(train_schedule, train_schedule_index)| {
-                let offset_ms = match timetable_type {
-                    schemas::timetable_type::TimetableType::Calendar => {
-                        // TODO this handles badly train schedules that span longer than a day
-                        datetime_millis_from_midnight(train_schedule.start_time)
-                    }
-                    schemas::timetable_type::TimetableType::Hourly => u32::try_from(
-                        common::units::millisecond::i64::from(train_schedule.start_time),
-                    )
-                    .unwrap(),
-                };
-
-                // avoid moving them into the filter_map closure
-                let operational_point_ids = operational_point_ids.as_slice();
-                let op_cache = &op_cache;
-
-                train_schedule
-                    .path
-                    .into_iter()
-                    .enumerate()
-                    .filter_map(move |(i, path_item)| {
-                        let arrival_ms: u32;
-                        let stop_for_ms: u32;
-
-                        if i == 0 {
-                            arrival_ms = offset_ms;
-                            stop_for_ms = 0;
-                        } else {
-                            let schedule_item = train_schedule
-                                .schedule
-                                .iter()
-                                .find(|schedule_item| schedule_item.at == path_item.id)?;
-
-                            arrival_ms = offset_ms
-                                + u32::try_from(schedule_item.arrival?.num_milliseconds()).unwrap();
-                            stop_for_ms =
-                                u32::try_from(schedule_item.stop_for?.num_milliseconds()).unwrap();
-                        }
-
-                        let PathItemLocation::OperationalPointPartReference(op_ref) =
-                            path_item.location
-                        else {
-                            return None;
+            path_indexed_connections.extend(
+                train_schedules.into_iter().zip(index_offset..).flat_map(
+                    |(train_schedule, train_schedule_index)| {
+                        let offset_ms = match timetable_type {
+                            schemas::timetable_type::TimetableType::Calendar => {
+                                // TODO this handles badly train schedules that span longer than a day
+                                datetime_millis_from_midnight(train_schedule.start_time)
+                            }
+                            schemas::timetable_type::TimetableType::Hourly => u32::try_from(
+                                common::units::millisecond::i64::from(train_schedule.start_time),
+                            )
+                            .unwrap(),
                         };
 
-                        let op_index = find_op_index(
-                            op_cache,
-                            operational_point_ids,
-                            &op_ref.operational_point,
-                        )?;
+                        // avoid moving them into the filter_map closure
+                        let op_index_by_id = &op_index_by_id;
+                        let op_cache = &op_cache;
 
-                        Some((op_index, arrival_ms, stop_for_ms))
-                    })
-                    .tuple_windows()
-                    .map(
-                        move |(
-                            (start_op_index, start_op_arrival_ms, start_op_stop_for_ms),
-                            (end_op_index, end_op_arrival_ms, _end_op_stop_for_ms),
-                        )| {
-                            Connection {
-                                trip: train_schedule_index,
-                                departure: start_op_index,
-                                departure_ms: start_op_arrival_ms + start_op_stop_for_ms,
-                                arrival: end_op_index,
-                                arrival_ms: end_op_arrival_ms,
-                            }
-                        },
-                    )
-                    .filter(|connection| {
-                        // Simple filters to reduce the size of the problem.
+                        train_schedule
+                            .path
+                            .into_iter()
+                            .enumerate()
+                            .filter_map(move |(i, path_item)| {
+                                let arrival_ms: u32;
+                                let stop_for_ms: u32;
 
-                        // The connection isn't too early for the traveler to take it
-                        let departs_late_enough = (start_ms as i64 - start_tolerance as i64)
-                            <= connection.departure_ms as i64;
+                                if i == 0 {
+                                    arrival_ms = offset_ms;
+                                    stop_for_ms = 0;
+                                } else {
+                                    let schedule_item = train_schedule
+                                        .schedule
+                                        .iter()
+                                        .find(|schedule_item| schedule_item.at == path_item.id)?;
 
-                        // If the connection departs from the source OP, it
-                        // doesn't depart too late for the traveler to take it
-                        let departs_early_enough = connection.departure != origin_index
-                            || connection.departure_ms <= start_ms + start_tolerance;
+                                    arrival_ms = offset_ms
+                                        + u32::try_from(schedule_item.arrival?.num_milliseconds())
+                                            .unwrap();
+                                    stop_for_ms =
+                                        u32::try_from(schedule_item.stop_for?.num_milliseconds())
+                                            .unwrap();
+                                }
 
-                        departs_early_enough && departs_late_enough
-                    })
-            },
-        ));
-    }
+                                let PathItemLocation::OperationalPointPartReference(op_ref) =
+                                    path_item.location
+                                else {
+                                    return None;
+                                };
 
-    // Sort train schedule parts by *decreasing* departure time.
-    train_schedule_parts.sort_unstable_by(|a, b| u32::cmp(&b.departure_ms, &a.departure_ms));
+                                let op_index = find_op_index(
+                                    op_cache,
+                                    op_index_by_id,
+                                    &op_ref.operational_point,
+                                )?;
 
-    let journeys =
-        profile_connection_scan::journey_list(profile_connection_scan::JourneyListParams {
-            stop_count: operational_point_ids.len(),
-            trip_count: train_schedule_ids.len(),
-            connections: train_schedule_parts,
-            start_ms,
-            start_tolerance,
-            start: origin_index,
-            end: destination_index,
-            transfer_ms,
+                                Some(ScheduleStep {
+                                    path_index: i,
+                                    op_index,
+                                    arrival_ms,
+                                    departure_ms: arrival_ms + stop_for_ms,
+                                })
+                            })
+                            .tuple_windows()
+                            .map(move |(departure, arrival)| PathIndexedConnection {
+                                connection: Connection {
+                                    trip: train_schedule_index,
+                                    departure: departure.op_index,
+                                    departure_ms: departure.departure_ms,
+                                    arrival: arrival.op_index,
+                                    arrival_ms: arrival.arrival_ms,
+                                },
+                                departure_path_index: departure.path_index,
+                                arrival_path_index: arrival.path_index,
+                            })
+                            .filter(|path_indexed_connection| {
+                                // Simple filters to reduce the size of the problem.
+
+                                // The connection isn't too early for the traveler to take it
+                                let departs_late_enough = (start_ms as i64
+                                    - start_tolerance as i64)
+                                    <= path_indexed_connection.connection.departure_ms as i64;
+
+                                // If the connection departs from the source OP, it
+                                // doesn't depart too late for the traveler to take it
+                                let departs_early_enough =
+                                    path_indexed_connection.connection.departure != origin_index
+                                        || path_indexed_connection.connection.departure_ms
+                                            <= start_ms + start_tolerance;
+
+                                departs_early_enough && departs_late_enough
+                            })
+                    },
+                ),
+            );
+        }
+
+        // Sort train connections by *decreasing* departure time.
+        path_indexed_connections.sort_unstable_by(|a, b| {
+            u32::cmp(&b.connection.departure_ms, &a.connection.departure_ms)
         });
 
-    let journeys = journeys
-        .into_iter()
-        .map(|journey| {
-            dedup_connections(journey.into_iter())
-                .map(|connection| TrainSchedulePart {
-                    train_schedule_id: train_schedule_ids[connection.trip],
-                    from: TrainSchedulePartBound {
-                        location: path_item_id(&operational_point_ids[connection.departure]),
-                        time_ms: connection.departure_ms
-                            - train_schedule_start_times[connection.trip],
-                    },
-                    to: TrainSchedulePartBound {
-                        location: path_item_id(&operational_point_ids[connection.arrival]),
-                        time_ms: connection.arrival_ms
-                            - train_schedule_start_times[connection.trip],
-                    },
-                })
-                .collect()
-        })
-        .collect();
+        let connections = path_indexed_connections
+            .iter()
+            .map(|path_indexed_connection| path_indexed_connection.connection)
+            .collect_vec();
 
-    Ok(Json(JourneyProposals { journeys }))
-}
+        let journeys =
+            profile_connection_scan::journey_list(profile_connection_scan::JourneyListParams {
+                stop_count: op_index_by_id.len(),
+                trip_count: train_schedule_ids.len(),
+                connections,
+                start_ms,
+                start_tolerance,
+                start: origin_index,
+                end: destination_index,
+                transfer_ms,
+            });
 
-/// Make a [PathItemLocation] from an operational point identifier.
-fn path_item_id(id: &str) -> PathItemLocation {
-    PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
-        operational_point: OperationalPointReference::Id {
-            operational_point: id.into(),
-        },
-        local_track_name: None,
+        journeys
+            .into_iter()
+            .map(|journey| {
+                let path_indexed_connections = journey
+                    .into_iter()
+                    .map(|connection_id| path_indexed_connections[connection_id]);
+
+                merge_connections(path_indexed_connections)
+                    .map(|path_indexed_connection| TrainSchedulePart {
+                        train_schedule_id: train_schedule_ids
+                            [path_indexed_connection.connection.trip],
+                        from: path_indexed_connection.departure_path_index,
+                        to: path_indexed_connection.arrival_path_index,
+                    })
+                    .collect()
+            })
+            .collect()
     })
+    .instrument(tracing::info_span!("Building journeys"))
+    .await
+    .expect("Failed to build journeys");
+    Ok(Json(JourneyProposals { journeys }))
 }
 
 /// Find the index of an operational point reference
 fn find_op_index(
     op_cache: &OperationalPointCache,
-    operational_point_ids: &[String],
+    op_index_by_id: &HashMap<String, usize>,
     op_ref: &OperationalPointReference,
 ) -> Option<usize> {
     let op_ref_id = op_cache.get_op_ref_id(op_ref)?;
-    operational_point_ids
-        .iter()
-        .position(|op_id| *op_id == op_ref_id)
+    op_index_by_id.get(&op_ref_id).copied()
 }
 
-/// Deduplicate connections that have the same trip in the given iterator.
-fn dedup_connections<'a, I>(mut iter: I) -> impl Iterator<Item = Connection> + 'a
+/// Merge connections of a same trip taken in a row into a single one.
+fn merge_connections<'a, I>(mut iter: I) -> impl Iterator<Item = PathIndexedConnection> + 'a
 where
-    I: Iterator<Item = Connection> + 'a,
+    I: Iterator<Item = PathIndexedConnection> + 'a,
 {
-    let mut prev_connection: Option<Connection> = None;
+    let mut prev_connection: Option<PathIndexedConnection> = None;
 
     std::iter::from_fn(move || {
         loop {
@@ -380,9 +399,10 @@ where
 
             match &mut prev_connection {
                 Some(prev_conn) => {
-                    if prev_conn.trip == next_connection.trip {
-                        prev_conn.arrival = next_connection.arrival;
-                        prev_conn.arrival_ms = next_connection.arrival_ms;
+                    if prev_conn.connection.trip == next_connection.connection.trip {
+                        prev_conn.connection.arrival = next_connection.connection.arrival;
+                        prev_conn.connection.arrival_ms = next_connection.connection.arrival_ms;
+                        prev_conn.arrival_path_index = next_connection.arrival_path_index;
                     } else {
                         return prev_connection.replace(next_connection);
                     }

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -9,7 +9,6 @@ use editoast_models::Infra;
 use editoast_models::prelude::*;
 use itertools::Itertools;
 use profile_connection_scan::Connection;
-use schemas::primitives::ObjectType;
 use schemas::train_schedule::OperationalPointPartReference;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
@@ -141,9 +140,7 @@ pub(in crate::views) async fn search_journeys(
 
     let mut conn = db_pool.get().await?;
 
-    let infra =
-        Infra::retrieve_or_fail(conn.clone(), infra_id, || Error::InfraNotFound { infra_id })
-            .await?;
+    Infra::exists_or_fail(&mut conn, infra_id, || Error::InfraNotFound { infra_id }).await?;
 
     auth.check_authorization(async |authorizer| {
         authorizer
@@ -152,47 +149,50 @@ pub(in crate::views) async fn search_journeys(
     })
     .await?;
 
-    let span = tracing::info_span!("fetching operational points");
-    let operational_point_ids = infra
-        .list_objects(&mut conn, ObjectType::OperationalPoint)
-        .instrument(span)
-        .await?;
+    let mut timetables = Vec::new();
+    while let Some(ts_fut_result) = train_schedule_futs.join_next().await {
+        timetables.push(ts_fut_result??);
+    }
 
-    let path_items: Vec<PathItemLocation> = operational_point_ids
+    let op_references: Vec<&OperationalPointPartReference> = timetables
         .iter()
-        .map(|operational_point| path_item_id(operational_point))
+        .flat_map(|(_, train_schedules)| train_schedules)
+        .flat_map(|train_schedule| &train_schedule.path)
+        .filter_map(|path_item| match &path_item.location {
+            PathItemLocation::OperationalPointPartReference(op_ref) => Some(op_ref),
+            // We ignore track offsets as we can't do connections on them
+            PathItemLocation::TrackOffset(_) => None,
+        })
+        .chain([&origin, &destination])
+        .unique_by(|op_ref| &op_ref.operational_point)
+        .collect();
+
+    let path_items: Vec<PathItemLocation> = op_references
+        .iter()
+        .map(|op_ref| PathItemLocation::OperationalPointPartReference((*op_ref).clone()))
         .collect();
 
     let op_cache = OperationalPointCache::load_path_items(conn, infra_id, &path_items).await?;
 
-    let origin_op = &origin.operational_point;
-    let destination_op = &destination.operational_point;
-
-    let Some(origin_op) = op_cache.get_op_ref_id(origin_op) else {
-        return Err(Error::InvalidInput {
-            message: "origin not found in the infra",
-        })?;
-    };
-
-    let Some(destination_op) = op_cache.get_op_ref_id(destination_op) else {
-        return Err(Error::InvalidInput {
-            message: "destination not found in the infra",
-        })?;
-    };
-
-    let Some(origin_index) = operational_point_ids
+    let operational_point_ids = op_references
         .iter()
-        .position(|operational_point_id| *operational_point_id == origin_op)
+        .filter_map(|op_ref| op_cache.get_op_ref_id(&op_ref.operational_point))
+        .unique()
+        .collect_vec();
+
+    let Some(origin_index) =
+        find_op_index(&op_cache, &operational_point_ids, &origin.operational_point)
     else {
         return Err(Error::InvalidInput {
             message: "origin not found in the infra",
         })?;
     };
 
-    let Some(destination_index) = operational_point_ids
-        .iter()
-        .position(|operational_point_id| *operational_point_id == destination_op)
-    else {
+    let Some(destination_index) = find_op_index(
+        &op_cache,
+        &operational_point_ids,
+        &destination.operational_point,
+    ) else {
         return Err(Error::InvalidInput {
             message: "destination not found in the infra",
         })?;
@@ -201,9 +201,7 @@ pub(in crate::views) async fn search_journeys(
     let mut train_schedule_ids = Vec::new();
     let mut train_schedule_parts = Vec::new();
     let mut train_schedule_start_times = Vec::new();
-    while let Some(ts_fut_result) = train_schedule_futs.join_next().await {
-        let (timetable_type, train_schedules) = ts_fut_result??;
-
+    for (timetable_type, train_schedules) in timetables {
         let index_offset = train_schedule_ids.len();
 
         train_schedule_ids.extend(
@@ -232,7 +230,7 @@ pub(in crate::views) async fn search_journeys(
                 };
 
                 // avoid moving them into the filter_map closure
-                let operational_points = operational_point_ids.as_slice();
+                let operational_point_ids = operational_point_ids.as_slice();
                 let op_cache = &op_cache;
 
                 train_schedule
@@ -264,11 +262,11 @@ pub(in crate::views) async fn search_journeys(
                             return None;
                         };
 
-                        let op_id = op_cache.get_op_ref_id(&op_ref.operational_point)?;
-
-                        let op_index = operational_points
-                            .iter()
-                            .position(|operational_point| &op_id == operational_point)?;
+                        let op_index = find_op_index(
+                            op_cache,
+                            operational_point_ids,
+                            &op_ref.operational_point,
+                        )?;
 
                         Some((op_index, arrival_ms, stop_for_ms))
                     })
@@ -352,6 +350,18 @@ fn path_item_id(id: &str) -> PathItemLocation {
         },
         local_track_name: None,
     })
+}
+
+/// Find the index of an operational point reference
+fn find_op_index(
+    op_cache: &OperationalPointCache,
+    operational_point_ids: &[String],
+    op_ref: &OperationalPointReference,
+) -> Option<usize> {
+    let op_ref_id = op_cache.get_op_ref_id(op_ref)?;
+    operational_point_ids
+        .iter()
+        .position(|op_id| *op_id == op_ref_id)
 }
 
 /// Deduplicate connections that have the same trip in the given iterator.

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -326,6 +326,7 @@ pub mod tests {
     use core_client::pathfinding::TrackRange;
     use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ReportTrain;
+    use editoast_models::OperationalPointModel;
     use pretty_assertions::assert_eq;
     use reqwest::StatusCode;
     use rstest::rstest;
@@ -406,20 +407,33 @@ pub mod tests {
             _ => (Identifier::from("T1"), 50, vec![50, 100, 150]),
         };
         let op_cache = OperationalPointCache::new(
-            Vec::new(),
+            vec![
+                OperationalPointModel {
+                    obj_id: "op_1".into(),
+                    ..Default::default()
+                },
+                OperationalPointModel {
+                    obj_id: "op_2".into(),
+                    ..Default::default()
+                },
+                OperationalPointModel {
+                    obj_id: "op_3".into(),
+                    ..Default::default()
+                },
+            ],
             HashMap::new(),
             HashMap::new(),
             HashMap::from([
                 ("op_1".to_string(), 0),
-                ("op_2".to_string(), 0),
-                ("op_3".to_string(), 0),
+                ("op_2".to_string(), 1),
+                ("op_3".to_string(), 2),
             ]),
             HashMap::new(),
-            vec![HashMap::from([
-                ("T1".into(), "V1".into()),
-                ("T2".into(), "V2".into()),
-                ("T3".into(), "V3".into()),
-            ])],
+            vec![
+                HashMap::from([("T1".into(), "V1".into())]),
+                HashMap::from([("T2".into(), "V2".into())]),
+                HashMap::from([("T3".into(), "V3".into())]),
+            ],
         );
 
         let operational_point_track_offsets = vec![TrackOffset {
@@ -596,7 +610,23 @@ pub mod tests {
                 ),
             },
         ];
-        let cache = OperationalPointCache::default();
+        let cache = OperationalPointCache::new(
+            vec![
+                OperationalPointModel {
+                    obj_id: "op_1".into(),
+                    ..Default::default()
+                },
+                OperationalPointModel {
+                    obj_id: "op_2".into(),
+                    ..Default::default()
+                },
+            ],
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::from([("op_1".to_string(), 0), ("op_2".to_string(), 1)]),
+            HashMap::new(),
+            Vec::new(),
+        );
 
         assert_eq!(
             find_matching_path_item_index(&path, op_id, &cache),
@@ -632,7 +662,10 @@ pub mod tests {
         let pathfinding = make_pathfinding_success(Identifier::from("T2"), vec![0, 100]);
 
         let op_cache = OperationalPointCache::new(
-            Vec::new(),
+            vec![OperationalPointModel {
+                obj_id: "op_2".into(),
+                ..Default::default()
+            }],
             HashMap::new(),
             HashMap::new(),
             HashMap::from([("op_2".to_string(), 0)]),

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4446,17 +4446,11 @@ export type SearchPayload = {
   /** The query to run */
   query: SearchQuery;
 };
-export type TrainSchedulePartBound = {
-  /** This location is part of the train schedule's path. */
-  location: PathItemLocation;
-  /** Scheduled time since the start of the train schedule in milliseconds.
-    
-    Used to differentiate locations in case of backtracks. */
-  time_ms: number;
-};
 export type TrainSchedulePart = {
-  from: TrainSchedulePartBound;
-  to: TrainSchedulePartBound;
+  /** Index of the start path step in the train schedule's path */
+  from: number;
+  /** Index of the end path step in the train schedule's path */
+  to: number;
   train_schedule_id: number;
 };
 export type JourneyProposals = {

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -4153,6 +4153,22 @@ class TrainScheduleOptions(BaseModel):
     use_speed_limits_for_simulation: bool | None = None
 
 
+class TrainSchedulePart(BaseModel):
+    """
+    A part of a train schedule, from one step of its path to another.
+    """
+
+    from_: Annotated[int, Field(alias="from", ge=0)]
+    """
+    Index of the start path step in the train schedule's path
+    """
+    to: Annotated[int, Field(ge=0)]
+    """
+    Index of the end path step in the train schedule's path
+    """
+    train_schedule_id: int
+
+
 class TrainScheduleSet(BaseModel):
     catalog_entry_id: int | None = None
     description: str
@@ -5081,6 +5097,13 @@ class InfraPathfindingInput(BaseModel):
     starting: PathfindingTrackLocationInput
 
 
+class JourneyProposals(BaseModel):
+    journeys: list[list[TrainSchedulePart]]
+    """
+    Each journey is a list of train schedule parts.
+    """
+
+
 class LevelCrossing(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5882,21 +5905,6 @@ class TrainCategoryMain(BaseModel):
     main_category: TrainMainCategory
 
 
-class TrainSchedulePartBound(BaseModel):
-    location: (
-        PathItemLocationTrackOffset | PathItemLocationOperationalPointPartReference
-    )
-    """
-    This location is part of the train schedule's path.
-    """
-    time_ms: Annotated[int, Field(ge=0)]
-    """
-    Scheduled time since the start of the train schedule in milliseconds.
-
-    Used to differentiate locations in case of backtracks.
-    """
-
-
 class WorkSchedule(BaseModel):
     end_date_time: AwareDatetime
     id: int
@@ -6662,16 +6670,6 @@ class TrackSectionModel(BaseModel):
     slopes: list[Slope]
 
 
-class TrainSchedulePart(BaseModel):
-    """
-    A part of a train schedule, from one location to another.
-    """
-
-    from_: Annotated[TrainSchedulePartBound, Field(alias="from")]
-    to: TrainSchedulePartBound
-    train_schedule_id: int
-
-
 class TrainScheduleSimulationSummaryResult(BaseModel):
     exceptions: dict[
         str,
@@ -6806,13 +6804,6 @@ class InfraObjectSpeedSection(BaseModel):
 class InfraObjectSwitch(BaseModel):
     obj_type: Literal["Switch"]
     railjson: Switch
-
-
-class JourneyProposals(BaseModel):
-    journeys: list[list[TrainSchedulePart]]
-    """
-    Each journey is a list of train schedule parts.
-    """
 
 
 class NeutralSection(BaseModel):


### PR DESCRIPTION
This PR aims to improve the `/search_journeys`endpoint : 

- Only load the operational points actually served by the trains instead of the whole infra - _second commit_
    - To make it more robust, update `get_op_ref_id` to validate `Id` references against the cache instead of trusting them blindly - _first commit_

- Change the `/search_journeys` response to return path step index instead of oppartref values (easier to handle on the front end and more robust for backtracking) - _third commit_

- Reduce the number of results returned by the algorithm to 3 results. Keep relevant results but this point will be improve in another issue - _last commit_
    - Pick profile by proximity to the requested departure time
    - Keep at most one journey per profile (the single best continuation at each stop)
    - `transfer_ms` is no longer required between connections of the same trips (no transfer in this case)