### PR TITLE
front: ui-charts: move mousecontext in common folder

### DIFF
--- a/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
+++ b/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import cx from 'classnames';
 
-import { TimeChartCanvasContext } from '../../common/context';
+import { MouseContext, TimeChartCanvasContext } from '../../common/context';
 import { getTimeToPixel, getPixelToTime } from '../../common/helpers/time';
 import { useCanvas } from '../../common/hooks/useCanvas';
 import { useMouseInteractions } from '../../common/hooks/useMouseInteractions';
@@ -10,11 +10,10 @@ import { useMouseTracking } from '../../common/hooks/useMouseTracking';
 import { useSize } from '../../common/hooks/useSize';
 import { TimeCaptions } from '../../common/layers/TimeCaptions';
 import TimeGraduations from '../../common/layers/TimeGraduations';
-import type { PickingElement, Point } from '../../common/types';
+import type { MouseContextType, PickingElement, Point } from '../../common/types';
 import { DEFAULT_THEME } from '../../spaceTimeChart/lib/consts';
-import { MouseContext } from '../../spaceTimeChart/lib/context';
 import { validateTheme } from '../../spaceTimeChart/lib/theme';
-import type { DataPoint, MouseContextType } from '../../spaceTimeChart/lib/types';
+import type { DataPoint } from '../../spaceTimeChart/lib/types';
 import { ChronogramContext } from '../lib/context';
 import type { ChronogramContextType, ChronogramCanvasProps } from '../lib/types';
 import { OccupancyBlocksLayer } from './OccupancyBlocksLayer';

--- a/front/ui/ui-charts/src/common/context.ts
+++ b/front/ui/ui-charts/src/common/context.ts
@@ -1,8 +1,17 @@
 import { createContext } from 'react';
 
-import type { CanvasContextType, TimeChartContextType } from './types';
+import type { CanvasContextType, TimeChartContextType, MouseContextType } from './types';
 
 export const TimeChartCanvasContext = createContext<CanvasContextType<TimeChartContextType>>(
   // That value should never be used, since the context should always be accessed within a provider
   undefined as unknown as CanvasContextType<TimeChartContextType>
+);
+
+/**
+ * This context exports everything necessary to draw the chart.
+ * It is updated anytime the scales are updated or the mouse moves.
+ */
+export const MouseContext = createContext<MouseContextType>(
+  // That value should never be used, since the context should always be accessed within a provider
+  undefined as unknown as MouseContextType
 );

--- a/front/ui/ui-charts/src/common/hooks/useMouseInteractions.ts
+++ b/front/ui/ui-charts/src/common/hooks/useMouseInteractions.ts
@@ -1,13 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import type { HoveredItem, Point } from '../../common/types';
-import {
-  type DataPoint,
-  type Handler,
-  type MouseContextType,
-  type PointToData,
-} from '../../spaceTimeChart/lib/types';
+import type { HoveredItem, Point } from '../../common';
+import { type DataPoint, type Handler, type PointToData } from '../../spaceTimeChart/lib/types';
 import { getEventPosition, getEventWheelDelta } from '../../spaceTimeChart/utils/events';
+import type { MouseContextType } from '../types';
 
 type Handlers<T> = {
   onPan?: Handler<{

--- a/front/ui/ui-charts/src/common/hooks/useMouseTracking.ts
+++ b/front/ui/ui-charts/src/common/hooks/useMouseTracking.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { type MouseState } from '../../spaceTimeChart/lib/types';
 import { getEventPosition } from '../../spaceTimeChart/utils/events';
+import { type MouseState } from '../types';
 
 /**
  * This hook handles SpaceTimeChart mouse tracking.

--- a/front/ui/ui-charts/src/common/index.ts
+++ b/front/ui/ui-charts/src/common/index.ts
@@ -13,3 +13,5 @@ export type {
   PickingElement,
   Point,
 } from './types';
+
+export { MouseContext } from './context';

--- a/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
+++ b/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useContext } from 'react';
 
 import { MINUTE } from '../../common/consts';
-import { TimeChartCanvasContext } from '../../common/context';
+import { MouseContext, TimeChartCanvasContext } from '../../common/context';
 import { computeVisibleTimeMarkers, getCrispLineCoordinate } from '../../common/helpers/time';
 import type { TimeChartContextType, DrawingFunction } from '../../common/types';
-import { MouseContext } from '../../spaceTimeChart/lib/context';
 import { BLACK_ALPHA_25, GREY_50 } from '../helpers/colors';
 import { useDraw } from '../hooks/useCanvas';
 

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -154,3 +154,15 @@ export type ChartEventHandlers<T> = {
   }>;
   onHoveredChildUpdate?: Handler<{ item: HoveredItem | null; context: T }>;
 } & Omit<HTMLProps<HTMLDivElement>, 'onClick' | 'onMouseMove'>;
+
+export type MouseContextType = MouseState & {
+  data: DataPoint;
+  hoveredItem: HoveredItem | null;
+};
+
+// MOUSE CONTEXT:
+export type MouseState = {
+  down?: { ctrl?: boolean; shift?: boolean };
+  position: Point;
+  isHover: boolean;
+};

--- a/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import cx from 'classnames';
 
-import { TimeChartCanvasContext } from '../../common/context';
+import type { PickingElement } from '../../common';
+import { MouseContext, TimeChartCanvasContext } from '../../common/context';
 import { getTimeToPixel, getPixelToTime } from '../../common/helpers/time';
 import { useCanvas } from '../../common/hooks/useCanvas';
 import { useMouseInteractions } from '../../common/hooks/useMouseInteractions';
@@ -10,15 +11,11 @@ import { useMouseTracking } from '../../common/hooks/useMouseTracking';
 import { useSize } from '../../common/hooks/useSize';
 import { TimeCaptions } from '../../common/layers/TimeCaptions';
 import TimeGraduations from '../../common/layers/TimeGraduations';
-import type { PickingElement } from '../../common/types';
+import type { MouseContextType } from '../../common/types';
 import { DEFAULT_THEME } from '../lib/consts';
-import { MouseContext, SpaceTimeChartCanvasContext, SpaceTimeChartContext } from '../lib/context';
+import { SpaceTimeChartCanvasContext, SpaceTimeChartContext } from '../lib/context';
 import { validateTheme } from '../lib/theme';
-import {
-  type MouseContextType,
-  type SpaceTimeChartContextType,
-  type SpaceTimeChartProps,
-} from '../lib/types';
+import type { SpaceTimeChartContextType, SpaceTimeChartProps } from '../lib/types';
 import {
   getDataToPoint,
   getFlatSteps,

--- a/front/ui/ui-charts/src/spaceTimeChart/index.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/index.ts
@@ -12,7 +12,7 @@ export * from './components/Quadrilateral';
 export * from './components/ZoomRect';
 
 export { DEFAULT_THEME } from './lib/consts';
-export { MouseContext, SpaceTimeChartContext, SpaceTimeChartCanvasContext } from './lib/context';
+export { SpaceTimeChartContext, SpaceTimeChartCanvasContext } from './lib/context';
 export type {
   SpaceTimeChartProps,
   SpaceScale,

--- a/front/ui/ui-charts/src/spaceTimeChart/lib/context.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/lib/context.ts
@@ -1,10 +1,9 @@
 import { createContext } from 'react';
 
 import type { CanvasContextType } from '../../common/types';
-import type { MouseContextType, SpaceTimeChartContextType } from './types';
+import type { SpaceTimeChartContextType } from './types';
 
-// There are three different contexts because they have very different lifecycles:
-// - MouseContext
+// There are two different contexts because they have very different lifecycles:
 // - SpaceTimeChartContext
 // - SpaceTimeChartCanvasContext
 
@@ -22,13 +21,4 @@ export const SpaceTimeChartCanvasContext = createContext<
 >(
   // That value should never be used, since the context should always be accessed within a provider
   undefined as unknown as CanvasContextType<SpaceTimeChartContextType>
-);
-
-/**
- * This context exports everything necessary to draw the chart.
- * It is updated anytime the scales are updated or the mouse moves.
- */
-export const MouseContext = createContext<MouseContextType>(
-  // That value should never be used, since the context should always be accessed within a provider
-  undefined as unknown as MouseContextType
 );

--- a/front/ui/ui-charts/src/spaceTimeChart/lib/types.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/lib/types.ts
@@ -1,11 +1,6 @@
 import type { ReactNode } from 'react';
 
-import type {
-  TimeChartContextType,
-  ChartEventHandlers,
-  HoveredItem,
-  Point,
-} from '../../common/types';
+import type { TimeChartContextType, ChartEventHandlers, Point } from '../../common/types';
 
 // GLOBAL UTILITY TYPES:
 export type Handler<P extends object> = (payload: P) => void;
@@ -90,18 +85,6 @@ export type SpaceToPixel = (position: number, fromEnd?: boolean) => number;
 export type PixelToSpace = (y: number) => number;
 export type PointToData = (point: Point) => DataPoint;
 export type DataToPoint = (data: DataPoint) => Point;
-
-// MOUSE CONTEXT:
-export type MouseState = {
-  down?: { ctrl?: boolean; shift?: boolean };
-  position: Point;
-  isHover: boolean;
-};
-
-export type MouseContextType = MouseState & {
-  data: DataPoint;
-  hoveredItem: HoveredItem | null;
-};
 
 export type LineStyle = {
   width: number;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useMemo, useEffect } from 'react';
 
 import { X } from '@osrd-project/ui-icons';
 
+import { MouseContext } from '../../common';
 import { SpaceTimeChartContext } from '../../spaceTimeChart';
-import { MouseContext } from '../../spaceTimeChart/lib/context';
 import { CANVAS_PADDING, TRACK_HEIGHT_CONTAINER } from '../lib/consts';
 import type { OccupancyZone, Track } from '../lib/types';
 import DraggingOccupancyZonesLayer from './layers/DraggingOccupancyZonesLayer';

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/DraggingOccupancyZonesLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/DraggingOccupancyZonesLayer.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useContext } from 'react';
 
+import { MouseContext } from '../../../common';
 import { useDraw } from '../../../common/hooks/useCanvas';
 import type { DrawingFunction } from '../../../common/types';
 import {
   SpaceTimeChartCanvasContext,
   type SpaceTimeChartContextType,
 } from '../../../spaceTimeChart';
-import { MouseContext } from '../../../spaceTimeChart/lib/context';
 import { COLORS } from '../../lib/consts';
 import type { OccupancyZone } from '../../lib/types';
 import { drawThroughTrain } from '../helpers/drawElements/drawOccupancyZones';


### PR DESCRIPTION
As part of the ui-charts refactoring, we want to move MouseContext to the common folder because it is used in several charts, not just in `SpaceTimeChart`.
close #17769 