### PR TITLE
core: reduce noisy http client loggings

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -6,10 +6,11 @@
         </encoder>
     </appender>
 
-    <root level="debug">
+    <root level="DEBUG">
         <appender-ref ref="COLOR"/>
     </root>
     <logger name="io.lettuce" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <logger name="software.amazon.awssdk" level="INFO"/>
+    <logger name="org.apache.hc.client5" level="INFO"/>
 </configuration>


### PR DESCRIPTION
This was due to apache logging. Passed it to info to remove almost all of the noise.