### PR TITLE
front: stdcm: disable requests button while not ready

### DIFF
--- a/front/src/applications/stdcm/components/StdcmHeader.tsx
+++ b/front/src/applications/stdcm/components/StdcmHeader.tsx
@@ -84,7 +84,8 @@ const StdcmHeader = ({
             <Bug />
           </button>
         )}
-        {railwayManagerUrl &&
+        {isDebugMode &&
+          railwayManagerUrl &&
           sendLMRAuthorizedResponse?.authorized &&
           requestsFolderUrl.isSuccess && (
             <button


### PR DESCRIPTION
The feature is not ready so it's better to hide the button behind a "feature flag" (debug mode).