### PR TITLE
editoast: add project set grant function

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -218,8 +218,7 @@ impl fga::model::Type for Role {
 #[derive(fga::Type, fga::Object, derive_more::FromStr, Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Project(pub i64);
 
-#[derive(EnumString, Serialize)]
-#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
+#[derive(Clone, Copy, Debug, EnumString, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ProjectPrivilege {

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -77,6 +77,12 @@ pub enum Check {
     /// IMPORTANT: it is *NOT* a replacement for [`Self::HasInfraPrivilege`] with sharing privileges (forbids illegal promotions)
     /// NOTE: groups grants are managed by admins exclusively so this check always rejects group subjects as admin checks are bypassed
     CanAlterSubjectInfraGrant(Subject, Infra, InfraGrant),
+    /// The issuer must be allowed to change the subject's infra grant
+    ///
+    /// No-op grant changes are allowed.
+    /// As [ProjectGrant] has only one grant level so anoyone with this grant has sharing privileges.
+    /// NOTE: groups grants are managed by admins exclusively so this check always rejects group subjects as admin checks are bypassed
+    CanGiveSubjectProjectGrant(Subject, Project),
     /// The subject must not have the specified effective infra grant
     SubjectEffectiveInfraGrantIsNot(InfraGrant, Subject, Infra),
     /// The subject must not be the last direct owner of the infra

--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -64,6 +64,42 @@ pub fn project_effective_grant(
     .with_check(Check::ProjectExists(project))
 }
 
+pub fn project_set_grant(subject: Subject, project: Project) -> Protected<()> {
+    project_direct_grant(subject, project)
+        .map(move |openfga, grant| {
+            async move {
+                // Projects only have one grant level, the subject either has it or doesn't
+                let update = match grant {
+                    Some(ProjectGrant::Owner) => false,
+                    None => true,
+                };
+
+                if !update {
+                    return Ok(());
+                }
+
+                match subject {
+                    Subject::User(user) => {
+                        openfga
+                            .write_tuples(&[Project::owner().tuple(&user, &project)])
+                            .await
+                    }
+                    Subject::Group(group) => {
+                        openfga
+                            .write_tuples(&[
+                                Project::owner().tuple(Group::member().userset(&group), &project)
+                            ])
+                            .await
+                    }
+                }?;
+
+                Ok(())
+            }
+            .boxed()
+        })
+        .with_check(Check::CanGiveSubjectProjectGrant(subject, project))
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -248,6 +284,47 @@ mod tests {
     }
 
     #[rstest::rstest]
+    #[case(Subject::user(1))]
+    #[case(Subject::group(1))]
+    #[tokio::test]
+    async fn project_set_grant_ok(#[case] subject: Subject) {
+        let openfga = authz_client!();
+
+        assert_eq!(
+            openfga.project_direct_grant(subject, Project(1)).await,
+            None
+        );
+        openfga.project_set_grant(subject, Project(1)).await;
+        assert_eq!(
+            openfga.project_direct_grant(subject, Project(1)).await,
+            Some(ProjectGrant::Owner)
+        );
+    }
+
+    #[rstest::rstest]
+    #[case(Subject::user(1))]
+    #[case(Subject::group(1))]
+    #[tokio::test]
+    async fn project_set_grant_idempotent(#[case] subject: Subject) {
+        let openfga = authz_client!();
+
+        assert_eq!(
+            openfga.project_direct_grant(subject, Project(1)).await,
+            None
+        );
+        openfga.project_set_grant(subject, Project(1)).await;
+        assert_eq!(
+            openfga.project_direct_grant(subject, Project(1)).await,
+            Some(ProjectGrant::Owner)
+        );
+        openfga.project_set_grant(subject, Project(1)).await;
+        assert_eq!(
+            openfga.project_direct_grant(subject, Project(1)).await,
+            Some(ProjectGrant::Owner)
+        );
+    }
+
+    #[rstest::rstest]
     #[case::project_direct_grant(
         project_direct_grant(Subject::user(1), Project(1)).checks,
         &[
@@ -260,6 +337,14 @@ mod tests {
         &[
             Check::SubjectExists(Subject::user(1)),
             Check::ProjectExists(Project(1)),
+        ]
+    )]
+    #[case::project_set_grant(
+        project_set_grant(Subject::user(1), Project(1)).checks,
+        &[
+            Check::SubjectExists(Subject::user(1)),
+            Check::ProjectExists(Project(1)),
+            Check::CanGiveSubjectProjectGrant(Subject::user(1), Project(1))
         ]
     )]
     #[tokio::test]

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -25,6 +25,7 @@ use crate::v2::infra_revoke_grant;
 use crate::v2::infra_set_grant;
 use crate::v2::project::project_direct_grant;
 use crate::v2::project_effective_grant;
+use crate::v2::project_set_grant;
 use crate::v2::remove_members;
 use crate::v2::remove_roles;
 use crate::v2::rolling_stock_direct_grant;
@@ -98,6 +99,7 @@ pub trait TestClientExt {
         subject: Subject,
         project: Project,
     ) -> Option<ProjectGrant>;
+    async fn project_set_grant(&self, subject: Subject, project: Project) -> ();
 }
 
 impl TestClientExt for fga::Client {
@@ -310,6 +312,14 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(project_effective_grant(subject, project))
+            .await
+            .unwrap()
+    }
+
+    async fn project_set_grant(&self, subject: Subject, project: Project) -> () {
+        let authorize = special_authorizers::Authorize(self);
+        authorize
+            .access_value(project_set_grant(subject, project))
             .await
             .unwrap()
     }

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,6 +1,7 @@
 use std::convert::Infallible;
 use std::ops::Not as _;
 
+use authz::ProjectGrant;
 use authz::v2::Access;
 use authz::v2::Actor;
 use authz::v2::Authorizer;
@@ -49,6 +50,7 @@ impl SystemAuthorizer<'_> {
             | Check::HasInfraPrivilege(..)
             | Check::HasRollingStockPrivilege(..)
             | Check::CanAlterSubjectInfraGrant(..)
+            | Check::CanGiveSubjectProjectGrant(..)
             | Check::SubjectEffectiveInfraGrantIsNot(..)
             | Check::CanAlterSubjectRollingStockGrant(..)
             | Check::SubjectEffectiveRollingStockGrantIsNot(..)
@@ -177,6 +179,26 @@ impl<'c> UserAuthorizer<'c> {
             Check::CanAlterSubjectInfraGrant(authz::Subject::Group(_), _, _) => {
                 // The only users allowed to alter groups grants are admins who bypass this entire
                 // verification function.
+                Some(check)
+            }
+
+            Check::CanGiveSubjectProjectGrant(authz::Subject::User(_), project) => {
+                // There is only one level of grant. The issuer must own a grant on the project to
+                // share it to other users.
+                let Ok(grant) = authz::v2::project_effective_grant(self.issuer(), *project)
+                    .access_authorized::<Infallible>(self.openfga)
+                    .access()
+                    .await?;
+
+                match grant {
+                    Some(ProjectGrant::Owner) => None,
+                    None => Some(check),
+                }
+            }
+            Check::CanGiveSubjectProjectGrant(authz::Subject::Group(_), _) => {
+                // The only users to allowed to alter group grants are admins who bypass this entire
+                // verification function: trying to give a grant to a group in the UserAuthorizer should
+                // always be rejected
                 Some(check)
             }
 


### PR DESCRIPTION
Ref:  #17546

- Add `project_set_grant` in `authz::v2::project`.
- Add some unit tests