### PR TITLE
ops: double the default openfga timeouts in local and in pr-tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,9 @@ services:
       OPENFGA_HTTP_ADDR: "0.0.0.0:8091"
       OPENFGA_GRPC_ADDR: "0.0.0.0:8093"
       OPENFGA_PLAYGROUND_PORT: 8092
+      OPENFGA_LIST_OBJECTS_DEADLINE: "6s"
+      OPENFGA_LIST_USERS_DEADLINE: "6s"
+      OPENFGA_REQUEST_TIMEOUT: "6s"
     command: run
     ports:
       - "8091:8091" # http

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -79,6 +79,9 @@ services:
       OPENFGA_HTTP_ADDR: "0.0.0.0:8191"
       OPENFGA_GRPC_ADDR: "0.0.0.0:8193"
       OPENFGA_PLAYGROUND_PORT: 8192
+      OPENFGA_LIST_OBJECTS_DEADLINE: "6s"
+      OPENFGA_LIST_USERS_DEADLINE: "6s"
+      OPENFGA_REQUEST_TIMEOUT: "6s"
     command: run
     ports:
       - "8191:8191" # http


### PR DESCRIPTION
Context: Editoast testsuite regularly has failures when Openfga cancels ongoing requests. It seems to be coming from timeouts while handling the requests.

Double the default timeouts so that they don't cause the tests to crash runs as often.

>[!NOTE]
That's the easy, lazy fix. In local it seemed to make a difference: I tested with the timeout values reduced to 75ms and then doubled and got more cancellation errors on shorter timeouts. If cancellations happen because some queries take an exceptionnally long time for some reason (10s, 20s...) we should add a retry policy in the `fga::Client` instead (or in addition), but that fix would be more involved.

>[!NOTE]
There is also a configurable timeout for gRPC queries in Openfga. I didn't change it as we only do HTTP queries AFAIK.

I might have missed some deployment files. Currently the PR only updates the timeouts for local development and for the PR test runs. Do we want it on the deployed envs too ?