### PR TITLE
front: ui-charts: split type of the space time chart theme

### DIFF
--- a/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
+++ b/front/ui/ui-charts/src/chronogram/components/ChronogramCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import cx from 'classnames';
 
@@ -12,7 +12,6 @@ import { TimeCaptions } from '../../common/layers/TimeCaptions';
 import TimeGraduations from '../../common/layers/TimeGraduations';
 import type { MouseContextType, PickingElement, Point } from '../../common/types';
 import { DEFAULT_THEME } from '../../spaceTimeChart/lib/consts';
-import { validateTheme } from '../../spaceTimeChart/lib/theme';
 import type { DataPoint } from '../../spaceTimeChart/lib/types';
 import { ChronogramContext } from '../lib/context';
 import type { ChronogramContextType, ChronogramCanvasProps } from '../lib/types';
@@ -25,7 +24,6 @@ export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
     timeScale,
     xOffset = 0,
     yOffset = 0,
-    theme,
     onPan,
     onZoom,
     onClick, // TODO: the 3 last handlers are custom and need to be extracted but are not used for now
@@ -39,7 +37,6 @@ export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
 
   const [root, setRoot] = useState<HTMLDivElement | null>(null);
   const [canvasesRoot, setCanvasesRoot] = useState<HTMLDivElement | null>(null);
-  const fullTheme = useMemo(() => ({ ...DEFAULT_THEME, ...theme }), [theme]);
   const { width, height } = useSize(root);
 
   const fingerprint = useMemo(
@@ -98,11 +95,11 @@ export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
       timeScale,
       timePixelOffset: xOffset,
       yPixelOffset: yOffset,
-      theme: fullTheme,
-      captionSize: fullTheme.dateCaptionsSize + fullTheme.timeCaptionsSize,
+      theme: DEFAULT_THEME,
+      captionSize: DEFAULT_THEME.timeCaptionsSize,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fingerprint, pickingState, fullTheme]);
+  }, [fingerprint, pickingState]);
 
   const mouseState = useMouseTracking(root);
   const { position, down, isHover } = mouseState;
@@ -122,17 +119,12 @@ export const ChronogramCanvas = (props: ChronogramCanvasProps) => {
   // Handle interactions:
   useMouseInteractions(root, mouseContext, { onPan, onZoom }, contextState);
 
-  // Check theme validity:
-  useEffect(() => {
-    validateTheme(fullTheme);
-  }, [fullTheme]);
-
   return (
     <div
       {...attr}
       ref={setRoot}
       className={cx('relative h-full', attr.className)}
-      style={{ background: fullTheme.background }}
+      style={{ background: DEFAULT_THEME.background }}
     >
       <div ref={setCanvasesRoot} className="absolute inset-0">
         <ChronogramContext.Provider value={contextState}>

--- a/front/ui/ui-charts/src/chronogram/lib/types.ts
+++ b/front/ui/ui-charts/src/chronogram/lib/types.ts
@@ -1,5 +1,4 @@
 import type { ChartEventHandlers, TimeChartContextType } from '../../common/types';
-import type { SpaceTimeChartTheme } from '../../spaceTimeChart';
 
 export type OccupancyBlock = {
   startTime: number;
@@ -31,7 +30,6 @@ export type ChronogramCanvasProps = {
   yOffset?: number;
 
   // Custom styles:
-  theme?: Partial<SpaceTimeChartTheme>;
 } & ChartEventHandlers<ChronogramContextType>;
 
 export type ChronogramProps = {

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -166,3 +166,43 @@ export type MouseState = {
   position: Point;
   isHover: boolean;
 };
+
+type CaptionStyle = {
+  color: string;
+  font: string;
+  fontWeight?: string;
+  fontSize?: string;
+  topOffset?: number;
+  textAlign?: CanvasTextAlign;
+};
+
+type LineStyle = {
+  width: number;
+  color: string;
+  opacity?: number;
+  dashArray?: number[];
+};
+
+export type BaseChartStyles = {
+  background: string;
+  pathsStyles: {
+    fontSize: number;
+    fontFamily: string;
+  };
+};
+
+export type TimeChartStyles = {
+  breakpoints: number[]; // in pixels/minute
+  dateCaptionsStyle: CaptionStyle;
+  dateCaptionsSize: number;
+  timeCaptionsPriorities: number[][];
+  timeCaptionsStyles: Record<number, CaptionStyle>;
+  timeCaptionsSize: number;
+  timeGraduationsPriorities: number[][];
+  timeGraduationsStyles: Record<number, LineStyle>;
+  timeRanges: number[];
+};
+
+export type SpaceChartStyles = {
+  spaceGraduationsStyles: Record<number, LineStyle>;
+};

--- a/front/ui/ui-charts/src/spaceTimeChart/lib/types.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/lib/types.ts
@@ -1,6 +1,13 @@
 import type { ReactNode } from 'react';
 
-import type { TimeChartContextType, ChartEventHandlers, Point } from '../../common/types';
+import type {
+  TimeChartContextType,
+  ChartEventHandlers,
+  Point,
+  TimeChartStyles,
+  SpaceChartStyles,
+  BaseChartStyles,
+} from '../../common/types';
 
 // GLOBAL UTILITY TYPES:
 export type Handler<P extends object> = (payload: P) => void;
@@ -86,40 +93,8 @@ export type PixelToSpace = (y: number) => number;
 export type PointToData = (point: Point) => DataPoint;
 export type DataToPoint = (data: DataPoint) => Point;
 
-export type LineStyle = {
-  width: number;
-  color: string;
-  opacity?: number;
-  dashArray?: number[];
-};
-
-export type CaptionStyle = {
-  color: string;
-  font: string;
-  fontWeight?: string;
-  fontSize?: string;
-  topOffset?: number;
-  textAlign?: CanvasTextAlign;
-};
-
 // STYLES:
-export type SpaceTimeChartTheme = {
-  background: string;
-  breakpoints: number[]; // in pixels/minute
-  timeRanges: number[];
-  pathsStyles: {
-    fontSize: number;
-    fontFamily: string;
-  };
-  spaceGraduationsStyles: Record<number, LineStyle>;
-  timeCaptionsPriorities: number[][];
-  timeCaptionsStyles: Record<number, CaptionStyle>;
-  timeCaptionsSize: number;
-  timeGraduationsPriorities: number[][];
-  timeGraduationsStyles: Record<number, LineStyle>;
-  dateCaptionsStyle: CaptionStyle;
-  dateCaptionsSize: number;
-};
+export type SpaceTimeChartTheme = BaseChartStyles & TimeChartStyles & SpaceChartStyles;
 
 // CORE COMPONENT MAIN TYPES:
 export type SpaceTimeChartProps = {


### PR DESCRIPTION
The purpose of this issue is to refactor the type of the `SpaceTimeChartTheme`:
 - `SpaceTimeChartTheme` is divided into several parts (a base part, a temporal part, and a spatial part)
 - The reused types have been moved to the “common” file

close #17787 