### PR TITLE
editoast: add project privileges function

### DIFF
--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -21,6 +21,7 @@ use crate::Infra;
 use crate::InfraGrant;
 use crate::InfraPrivilege;
 use crate::Project;
+use crate::ProjectPrivilege;
 use crate::Role;
 use crate::RollingStock;
 use crate::RollingStockGrant;
@@ -69,6 +70,8 @@ pub enum Check {
     HasInfraPrivilege(Actor, InfraPrivilege, Infra),
     /// The actor needs a rolling stock privilege to perform the operation
     HasRollingStockPrivilege(Actor, RollingStockPrivilege, RollingStock),
+    /// The actor needs the project privilege to perform the operation
+    HasProjectPrivilege(Actor, ProjectPrivilege, Project),
     /// The issuer must be allowed to change the subject's infra grant
     ///
     /// Ensures that the issuer cannot demote a more or equally privileged user, except themself.

--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -1,9 +1,13 @@
+use std::collections::HashSet;
+
 use fga::model::Relation as _;
 use futures::FutureExt;
 
 use crate::Group;
+use crate::ProjectPrivilege;
 use crate::Role;
 use crate::Subject;
+use crate::User;
 use crate::model::Project;
 use crate::model::ProjectGrant;
 use crate::v2::Actor;
@@ -126,6 +130,32 @@ pub fn project_revoke_grant(subject: Subject, project: Project) -> Protected<boo
             .boxed()
         })
         .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
+}
+
+pub fn project_privileges(user: User, project: Project) -> Protected<HashSet<ProjectPrivilege>> {
+    Protected::new(move |openfga| {
+        async move {
+            let (admin, has_access) = openfga
+                .checks((
+                    User::role().check(&Role::Admin, &user),
+                    Project::has_access().check(&user, &project),
+                ))
+                .await?;
+
+            let privilege_set = if admin || has_access {
+                HashSet::from([ProjectPrivilege::HasAccess])
+            } else {
+                Default::default()
+            };
+            Ok(privilege_set)
+        }
+        .boxed()
+    })
+    .with_check(Check::HasProjectPrivilege(
+        Actor::Issuer,
+        ProjectPrivilege::HasAccess,
+        project,
+    ))
 }
 
 #[cfg(test)]
@@ -438,15 +468,66 @@ mod tests {
             openfga.project_direct_grant(subject, Project(1)).await,
             None
         );
+
         openfga.project_set_grant(subject, Project(1)).await;
+
         assert_eq!(
             openfga.project_direct_grant(subject, Project(1)).await,
             Some(ProjectGrant::Owner)
         );
-        openfga.project_set_grant(subject, Project(1)).await;
+    }
+
+    #[tokio::test]
+    async fn project_privileges_non_admin() {
+        let openfga = authz_client!();
+        let subject = Subject::user(1);
+
         assert_eq!(
             openfga.project_direct_grant(subject, Project(1)).await,
-            Some(ProjectGrant::Owner)
+            None
+        );
+        openfga.project_set_grant(subject, Project(1)).await;
+        assert_eq!(
+            openfga.project_privileges(User(1), Project(1)).await,
+            HashSet::from_iter([ProjectPrivilege::HasAccess])
+        )
+    }
+
+    #[tokio::test]
+    async fn project_privileges_admin() {
+        let openfga = authz_client!();
+
+        assert_eq!(
+            openfga
+                .project_direct_grant(Subject::user(1), Project(1))
+                .await,
+            None
+        );
+        openfga
+            .write_tuples(&[User::role().tuple(&Role::Admin, &User(1))])
+            .await
+            .unwrap();
+        assert_eq!(
+            openfga.project_privileges(User(1), Project(1)).await,
+            HashSet::from_iter([ProjectPrivilege::HasAccess])
+        )
+    }
+
+    #[tokio::test]
+    async fn no_project_privileges() {
+        let openfga = authz_client!();
+
+        openfga
+            .project_set_grant(Subject::user(2), Project(1))
+            .await;
+
+        assert_eq!(
+            openfga.project_privileges(User(1), Project(1)).await,
+            HashSet::from_iter([])
+        );
+        assert_eq!(
+            openfga.project_privileges(User(2), Project(1)).await,
+            HashSet::from_iter([ProjectPrivilege::HasAccess])
         );
     }
 
@@ -469,6 +550,12 @@ mod tests {
         project_revoke_grant(Subject::user(1), Project(1)).checks,
         &[
             Check::HasRole(Actor::Issuer, Role::Admin),
+        ]
+    )]
+    #[case::project_privileges(
+        project_privileges(User(1), Project(1)).checks,
+        &[
+            Check::HasProjectPrivilege(Actor::Issuer, ProjectPrivilege::HasAccess, Project(1))
         ]
     )]
     #[tokio::test]

--- a/editoast/authz/src/v2/test_client_ext.rs
+++ b/editoast/authz/src/v2/test_client_ext.rs
@@ -8,6 +8,7 @@ use crate::InfraGrant;
 use crate::InfraPrivilege;
 use crate::Project;
 use crate::ProjectGrant;
+use crate::ProjectPrivilege;
 use crate::Role;
 use crate::RollingStock;
 use crate::RollingStockGrant;
@@ -25,6 +26,7 @@ use crate::v2::infra_revoke_grant;
 use crate::v2::infra_set_grant;
 use crate::v2::project::project_direct_grant;
 use crate::v2::project_effective_grant;
+use crate::v2::project_privileges;
 use crate::v2::project_revoke_grant;
 use crate::v2::project_set_grant;
 use crate::v2::remove_members;
@@ -102,6 +104,7 @@ pub trait TestClientExt {
     ) -> Option<ProjectGrant>;
     async fn project_revoke_grant(&self, subject: Subject, project: Project) -> bool;
     async fn project_set_grant(&self, subject: Subject, project: Project) -> ();
+    async fn project_privileges(&self, user: User, project: Project) -> HashSet<ProjectPrivilege>;
 }
 
 impl TestClientExt for fga::Client {
@@ -330,6 +333,13 @@ impl TestClientExt for fga::Client {
         let authorize = special_authorizers::Authorize(self);
         authorize
             .access_value(project_set_grant(subject, project))
+            .await
+            .unwrap()
+    }
+
+    async fn project_privileges(&self, user: User, project: Project) -> HashSet<ProjectPrivilege> {
+        special_authorizers::Authorize(self)
+            .access_value(project_privileges(user, project))
             .await
             .unwrap()
     }

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -114,6 +114,14 @@ impl<'c> UserAuthorizer<'c> {
                         .await?;
                 (!privileges.contains(privilege)).then_some(check)
             }
+            Check::HasProjectPrivilege(actor, privilege, project) => {
+                let Ok(privileges) =
+                    authz::v2::project_privileges(*self.actor_user(actor), *project)
+                        .access_authorized::<Infallible>(self.openfga)
+                        .access()
+                        .await?;
+                (!privileges.contains(privilege)).then_some(check)
+            }
 
             Check::CanAlterSubjectInfraGrant(
                 subject @ authz::Subject::User(_),


### PR DESCRIPTION
>[!NOTE]
The first commits are cherry-pick.

Ref:  #17546

- Add `project_privileges` in `authz::v2::project`
- Add some unit tests