### PR TITLE
editoast: fix operational point cache loading speed

### DIFF
--- a/editoast/editoast_models/src/infra_objects.rs
+++ b/editoast/editoast_models/src/infra_objects.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
@@ -352,31 +353,30 @@ impl OperationalPointModel {
 }
 
 impl TrackSectionModel {
-    /// Retrieve the list of track sections that match the given (object) IDs
-    ///
-    /// Use this instead of [`TrackSectionModel::retrieve_batch_unchecked`]
-    /// when all the operational points are known to be in the same infra.
-    pub async fn retrieve_from_ids(
+    /// Checks the existence of a list of track section ids.
+    /// Returns only existing ids.
+    #[tracing::instrument(skip(conn), err)]
+    pub async fn exists_from_ids(
         conn: &mut DbConnection,
         infra_id: i64,
         ids: &[String],
-    ) -> Result<Vec<Self>, database::DatabaseError> {
+    ) -> Result<HashSet<String>, database::DatabaseError> {
         use database::tables::infra_object_track_section::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
 
         if ids.is_empty() {
             // We know the result of the SQL query is going to be empty, avoid sending it.
-            return Ok(Vec::new());
+            return Ok(Default::default());
         }
 
         Ok(dsl::infra_object_track_section
+            .select(dsl::obj_id)
             .filter(dsl::infra_id.eq(infra_id))
             .filter(dsl::obj_id.eq_any(ids))
-            .load(&mut conn.write().await)
+            .load::<String>(&mut conn.write().await)
             .await?
             .into_iter()
-            .map(Self::from_row)
             .collect())
     }
 }

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -10,7 +10,7 @@ use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
 use std::borrow::Borrow;
 use std::collections::HashMap;
-use std::collections::HashSet;
+use tracing::error;
 
 use crate::error::Result;
 use editoast_models::OperationalPointModel;
@@ -31,7 +31,8 @@ pub struct OperationalPointCache {
     trigram_to_indices: HashMap<NonBlankString, Vec<usize>>,
     /// Maps obj_id to index in the ops Vec
     obj_id_to_index: HashMap<String, usize>,
-    track_ids: HashSet<String>,
+    /// Information about track section existence for path item tracks
+    path_item_tracks_exists: HashMap<String, bool>,
     /// For each operational point, map track section to local track name
     track_ids_to_local_track_name: Vec<HashMap<String, NonBlankString>>,
 }
@@ -70,25 +71,21 @@ impl OperationalPointCache {
         .await?;
 
         // Retrieve track information
-        let op_tracks = op_cache
-            .ops
+        let path_item_tracks = path_items
             .iter()
-            .flat_map(|op| &op.parts)
-            .map(|part| part.track.0.clone());
+            .filter_map(|item| match item.borrow() {
+                PathItemLocation::TrackOffset(TrackOffset { track, .. }) => Some(track.0.clone()),
+                _ => None,
+            })
+            .collect_vec();
 
-        let path_item_tracks = path_items.iter().filter_map(|item| match item.borrow() {
-            PathItemLocation::TrackOffset(TrackOffset { track, .. }) => Some(track.0.clone()),
-            _ => None,
-        });
-
-        let req_track_ids = op_tracks.chain(path_item_tracks).collect::<Vec<String>>();
-        let track_sections =
-            TrackSectionModel::retrieve_from_ids(&mut conn, infra_id, &req_track_ids).await?;
+        let existing_track_sections =
+            TrackSectionModel::exists_from_ids(&mut conn, infra_id, &path_item_tracks).await?;
 
         // Not all track sections may have been found.
-        let resp_track_ids = track_sections
-            .iter()
-            .map(|track| track.obj_id.clone())
+        op_cache.path_item_tracks_exists = path_item_tracks
+            .into_iter()
+            .map(|track| (track.clone(), existing_track_sections.contains(&track)))
             .collect();
 
         let track_ids_to_local_track_name = op_cache
@@ -103,7 +100,6 @@ impl OperationalPointCache {
             .collect();
 
         op_cache.track_ids_to_local_track_name = track_ids_to_local_track_name;
-        op_cache.track_ids = resp_track_ids;
         Ok(op_cache)
     }
 
@@ -164,7 +160,7 @@ impl OperationalPointCache {
             uic_to_indices,
             trigram_to_indices,
             obj_id_to_index,
-            track_ids: Default::default(),
+            path_item_tracks_exists: Default::default(),
             track_ids_to_local_track_name: Default::default(),
         })
     }
@@ -195,11 +191,6 @@ impl OperationalPointCache {
     pub fn get_name_by_track(&self, op_id: String, track_id: &str) -> Option<&NonBlankString> {
         let op_index = self.obj_id_to_index.get(&op_id)?;
         self.track_ids_to_local_track_name[*op_index].get(track_id)
-    }
-
-    /// Check if a track exists
-    pub fn track_exists(&self, track: &str) -> bool {
-        self.track_ids.contains(track)
     }
 
     /// Retrieve the operational point ID given a reference
@@ -237,7 +228,28 @@ impl OperationalPointCache {
             let path_item = path_item.borrow();
             let track_offsets = match path_item {
                 PathItemLocation::TrackOffset(track_offset) => {
-                    vec![track_offset.clone()]
+                    match self.path_item_tracks_exists.get(&track_offset.track.0) {
+                        Some(true) => {
+                            vec![track_offset.clone()]
+                        }
+                        Some(false) => {
+                            invalid_path_items.push(InvalidPathItem {
+                                index,
+                                path_item: path_item.clone(),
+                            });
+                            continue;
+                        }
+                        None => {
+                            error!(
+                                "The path item track was not part of the operational point cache."
+                            );
+                            invalid_path_items.push(InvalidPathItem {
+                                index,
+                                path_item: path_item.clone(),
+                            });
+                            continue;
+                        }
+                    }
                 }
                 PathItemLocation::OperationalPointPartReference(
                     OperationalPointPartReference {
@@ -315,17 +327,6 @@ impl OperationalPointCache {
                 }
             };
 
-            // Check if tracks exist
-            for track_offset in &track_offsets {
-                if !self.track_exists(&track_offset.track.0) {
-                    invalid_path_items.push(InvalidPathItem {
-                        index,
-                        path_item: path_item.clone(),
-                    });
-                    continue;
-                }
-            }
-
             result.push(track_offsets);
         }
 
@@ -346,7 +347,7 @@ impl OperationalPointCache {
         uic_to_indices: HashMap<u32, Vec<usize>>,
         trigram_to_indices: HashMap<NonBlankString, Vec<usize>>,
         obj_id_to_index: HashMap<String, usize>,
-        track_ids: HashSet<String>,
+        path_item_tracks_exists: HashMap<String, bool>,
         track_ids_to_local_track_name: Vec<HashMap<String, NonBlankString>>,
     ) -> Self {
         Self {
@@ -354,7 +355,7 @@ impl OperationalPointCache {
             uic_to_indices,
             trigram_to_indices,
             obj_id_to_index,
-            track_ids,
+            path_item_tracks_exists,
             track_ids_to_local_track_name,
         }
     }

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -338,7 +338,6 @@ pub mod tests {
     use schemas::train_schedule::OperationalPointReference;
     use schemas::train_schedule::ReceptionSignal;
     use std::collections::HashMap;
-    use std::collections::HashSet;
 
     use super::*;
 
@@ -415,7 +414,7 @@ pub mod tests {
                 ("op_2".to_string(), 0),
                 ("op_3".to_string(), 0),
             ]),
-            HashSet::new(),
+            HashMap::new(),
             vec![HashMap::from([
                 ("T1".into(), "V1".into()),
                 ("T2".into(), "V2".into()),
@@ -637,7 +636,7 @@ pub mod tests {
             HashMap::new(),
             HashMap::new(),
             HashMap::from([("op_2".to_string(), 0)]),
-            HashSet::new(),
+            HashMap::new(),
             vec![HashMap::from([("T2".into(), "V2".into())])],
         );
 
@@ -684,7 +683,7 @@ pub mod tests {
             HashMap::new(),
             HashMap::new(),
             HashMap::from([("op_1".to_string(), 0)]),
-            HashSet::new(),
+            HashMap::new(),
             vec![HashMap::from([("T0".into(), "V0".into())])],
         );
 


### PR DESCRIPTION
Stop loading track sections since we only need them to check obj_id existance.
Loading is 2x faster.