### PR TITLE
front: ui-charts: remove level property in curve style

### DIFF
--- a/front/src/modules/simulationResult/helpers/getCurveStyle.ts
+++ b/front/src/modules/simulationResult/helpers/getCurveStyle.ts
@@ -113,7 +113,6 @@ const getBaseStyle = (state: CurveVisualState, train: TrainForStyle): CurveStyle
   const dragStyle: CurveStyle = {
     color: DRAGGED_CURVE_COLOR,
     opacity: 1,
-    level: 1,
     outline: { offset: 0, width: 1.5, color: DRAGGED_CURVE_OUTLINE_COLOR },
     label: {
       color: colors.base,
@@ -150,7 +149,6 @@ const getHoveredStyle = (state: CurveVisualState, train: TrainForStyle): CurveSt
     return {
       color: colors.strong,
       opacity: 1,
-      level: 3,
       label: hoveredLabel(colors),
       ...(isSimulated === false && { outline: INVALID_OUTLINE }),
     };
@@ -241,7 +239,6 @@ const getTodStyle = (
       return {
         color: DRAGGED_CURVE_COLOR,
         opacity: 1,
-        level: 1,
         thickness: 1.5,
         outline: { offset: 0, color: DRAGGED_CURVE_OUTLINE_COLOR },
         label: {

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -1,6 +1,6 @@
 import { type HTMLProps } from 'react';
 
-import type { PathLevel, SpaceTimeChartTheme } from '../spaceTimeChart';
+import type { SpaceTimeChartTheme } from '../spaceTimeChart';
 import type { DataPoint, Handler, PointToData, DataToPoint } from '../spaceTimeChart/lib/types';
 import type { LAYERS, PICKING_LAYERS } from './consts';
 
@@ -46,7 +46,6 @@ export type CurveOutline = {
 export type CurveStyle = {
   color: string;
   opacity: number;
-  level?: PathLevel;
   outline?: CurveOutline;
   /** TOD occupancy bar height in px. */
   thickness?: number;


### PR DESCRIPTION
While refining the issue regarding the cleanup of ui-chart, we noticed that the `level` property of `CurveStyle` was not being used. We are therefore removing it in this PR.

close #17846