### PR TITLE
front: stdcm: fix and refactor format simulation sheet

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -12,7 +12,10 @@ import type {
   StdcmSimulationInputs,
   StdcmSuccessResponse,
 } from 'applications/stdcm/types';
-import { getStopDurationTime } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
+import {
+  durationToHHMM,
+  getStopDurationTime,
+} from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
 import { retainSimulation } from 'reducers/osrdconf/stdcmConf';
 import type { StdcmViaPathStep } from 'reducers/osrdconf/types';
 
@@ -94,16 +97,20 @@ const StdcmResultsTable = ({
                 : step.name || t('reportSheet.unknown')}
             </td>
             <td className={cx('ch', { 'muted-text': !isPathStep })}>{step.secondaryCode}</td>
-            <td className="stop">{isLastStep || step.stopDuration !== null ? step.time : ''}</td>
+            <td className="stop">
+              {isLastStep || step.stopDuration !== null ? durationToHHMM(step.time) : ''}
+            </td>
             <td className="stop">
               {isNotExtremity && (
                 <div className={step.stopDuration !== null ? 'stop-with-duration ml-n2' : 'stop'}>
-                  {step.stopDuration !== null ? getStopDurationTime(step.stopDuration) : step.time}
+                  {step.stopDuration !== null
+                    ? getStopDurationTime(step.stopDuration)
+                    : durationToHHMM(step.time)}
                 </div>
               )}
             </td>
             <td className="stop">
-              {isFirstStep || step.stopDuration !== null ? step.stopEndTime : ''}
+              {isFirstStep || step.stopDuration !== null ? durationToHHMM(step.stopEndTime) : ''}
             </td>
             <td className={cx('weight', { 'muted-text': !isFirstStep })}>
               {displayedMass ? `${displayedMass}t` : '='}

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -61,7 +61,7 @@ const StdcmResultsTable = ({
       ({ operationalPoint }) => operationalPoint && operationalPoint.id === step.opId
     );
     const shouldRenderRow =
-      isFirstStep || isRequestedPathStep || isLastStep || step.duration !== null;
+      isFirstStep || isRequestedPathStep || isLastStep || step.stopDuration !== null;
     const isPathStep = isFirstStep || isLastStep || isRequestedPathStep;
     const isNotExtremity = !isFirstStep && !isLastStep;
 
@@ -89,21 +89,21 @@ const StdcmResultsTable = ({
               {isNotExtremity &&
               !isRequestedPathStep &&
               step.name === prevStep.name &&
-              step.duration === null
+              step.stopDuration === null
                 ? '='
                 : step.name || t('reportSheet.unknown')}
             </td>
             <td className={cx('ch', { 'muted-text': !isPathStep })}>{step.secondaryCode}</td>
-            <td className="stop">{isLastStep || step.duration !== null ? step.time : ''}</td>
+            <td className="stop">{isLastStep || step.stopDuration !== null ? step.time : ''}</td>
             <td className="stop">
               {isNotExtremity && (
-                <div className={step.duration !== null ? 'stop-with-duration ml-n2' : 'stop'}>
-                  {step.duration !== null ? getStopDurationTime(step.duration) : step.time}
+                <div className={step.stopDuration !== null ? 'stop-with-duration ml-n2' : 'stop'}>
+                  {step.stopDuration !== null ? getStopDurationTime(step.stopDuration) : step.time}
                 </div>
               )}
             </td>
             <td className="stop">
-              {isFirstStep || step.duration !== null ? step.stopEndTime : ''}
+              {isFirstStep || step.stopDuration !== null ? step.stopEndTime : ''}
             </td>
             <td className={cx('weight', { 'muted-text': !isFirstStep })}>
               {displayedMass ? `${displayedMass}t` : '='}

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -13,7 +13,7 @@ import type {
   StdcmSuccessResponse,
 } from 'applications/stdcm/types';
 import {
-  durationToHHMM,
+  dateToHHMM,
   getStopDurationTime,
 } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
 import { retainSimulation } from 'reducers/osrdconf/stdcmConf';
@@ -98,19 +98,19 @@ const StdcmResultsTable = ({
             </td>
             <td className={cx('ch', { 'muted-text': !isPathStep })}>{step.secondaryCode}</td>
             <td className="stop">
-              {isLastStep || step.stopDuration !== null ? durationToHHMM(step.time) : ''}
+              {isLastStep || step.stopDuration !== null ? dateToHHMM(step.time) : ''}
             </td>
             <td className="stop">
               {isNotExtremity && (
                 <div className={step.stopDuration !== null ? 'stop-with-duration ml-n2' : 'stop'}>
                   {step.stopDuration !== null
                     ? getStopDurationTime(step.stopDuration)
-                    : durationToHHMM(step.time)}
+                    : dateToHHMM(step.time)}
                 </div>
               )}
             </td>
             <td className="stop">
-              {isFirstStep || step.stopDuration !== null ? durationToHHMM(step.stopEndTime) : ''}
+              {isFirstStep || step.stopDuration !== null ? dateToHHMM(step.stopEndTime) : ''}
             </td>
             <td className={cx('weight', { 'muted-text': !isFirstStep })}>
               {displayedMass ? `${displayedMass}t` : '='}

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -53,12 +53,12 @@ export type SimilarTrainWithSecondaryCode = {
 export type StdcmResultsOperationalPoint = {
   opId?: string;
   positionOnPath: number;
-  time: string | null;
+  time: Duration;
   name?: string;
   consistChange?: ConsistData;
   secondaryCode?: string | null;
   stopDuration: Duration | null;
-  stopEndTime: string;
+  stopEndTime: Duration;
   trackName?: string;
   stopType?: StdcmStopTypes;
   stopRequested: boolean;

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -57,7 +57,7 @@ export type StdcmResultsOperationalPoint = {
   name?: string;
   consistChange?: ConsistData;
   secondaryCode?: string | null;
-  duration: Duration | null;
+  stopDuration: Duration | null;
   stopEndTime: string;
   trackName?: string;
   stopType?: StdcmStopTypes;

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -53,12 +53,12 @@ export type SimilarTrainWithSecondaryCode = {
 export type StdcmResultsOperationalPoint = {
   opId?: string;
   positionOnPath: number;
-  time: Duration;
+  time: Date;
   name?: string;
   consistChange?: ConsistData;
   secondaryCode?: string | null;
   stopDuration: Duration | null;
-  stopEndTime: Duration;
+  stopEndTime: Date;
   trackName?: string;
   stopType?: StdcmStopTypes;
   stopRequested: boolean;

--- a/front/src/applications/stdcm/utils/simulationOutputUtils.ts
+++ b/front/src/applications/stdcm/utils/simulationOutputUtils.ts
@@ -7,7 +7,10 @@ import type {
   StdcmResultsOperationalPoint,
 } from 'applications/stdcm/types';
 import type { SimulationTableRow } from 'modules/SimulationReportSheet/types';
-import { getStopDurationTime } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
+import {
+  durationToHHMM,
+  getStopDurationTime,
+} from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
 import { getRowStyle } from 'modules/SimulationReportSheet/utils/formatSimulationTable';
 import type { SpeedDistanceDiagramData } from 'modules/simulationResult/types';
 import { capitalizeFirstLetter } from 'utils/strings';
@@ -48,8 +51,8 @@ export const formatStdcmDataForSimulationTable = (
     const isVia = stdcmPathSteps.slice(1, -1).some((step) => step.operationalPoint!.id === op.opId);
     const isPathStep = isFirst || isVia || isLast;
 
-    const startTime = isFirst || isStop ? op.stopEndTime : '';
-    const endTime = isLast || isStop ? op.time : '';
+    const startTime = isFirst || isStop ? durationToHHMM(op.stopEndTime) : '';
+    const endTime = isLast || isStop ? durationToHHMM(op.time) : '';
     const { stopType, trackName } = op;
 
     const stopTypeLabel = stopType
@@ -59,7 +62,7 @@ export const formatStdcmDataForSimulationTable = (
     let passageStop = '';
     if (!isFirst && !isLast) {
       passageStop =
-        op.stopDuration !== null ? getStopDurationTime(op.stopDuration) : String(op.time);
+        op.stopDuration !== null ? getStopDurationTime(op.stopDuration) : dateToHHMM(op.time);
     }
 
     let consistChanges;

--- a/front/src/applications/stdcm/utils/simulationOutputUtils.ts
+++ b/front/src/applications/stdcm/utils/simulationOutputUtils.ts
@@ -44,7 +44,7 @@ export const formatStdcmDataForSimulationTable = (
     const isLast = index === operationalPointsList.length - 1;
     const previousOp = operationalPointsList[index - 1];
 
-    const isStop = op.duration !== null && !isLast;
+    const isStop = op.stopDuration !== null && !isLast;
     const isVia = stdcmPathSteps.slice(1, -1).some((step) => step.operationalPoint!.id === op.opId);
     const isPathStep = isFirst || isVia || isLast;
 
@@ -58,7 +58,8 @@ export const formatStdcmDataForSimulationTable = (
 
     let passageStop = '';
     if (!isFirst && !isLast) {
-      passageStop = op.duration !== null ? getStopDurationTime(op.duration) : String(op.time);
+      passageStop =
+        op.stopDuration !== null ? getStopDurationTime(op.stopDuration) : String(op.time);
     }
 
     let consistChanges;
@@ -95,7 +96,7 @@ export const formatStdcmDataForSimulationTable = (
       stopTypeLabel,
       stopType,
       consistChanges,
-      ...getRowStyle(op.duration, isPathStep, isFirst, isLast),
+      ...getRowStyle(op.stopDuration, isPathStep, isFirst, isLast),
     };
   });
 };

--- a/front/src/applications/stdcm/utils/simulationOutputUtils.ts
+++ b/front/src/applications/stdcm/utils/simulationOutputUtils.ts
@@ -8,7 +8,7 @@ import type {
 } from 'applications/stdcm/types';
 import type { SimulationTableRow } from 'modules/SimulationReportSheet/types';
 import {
-  durationToHHMM,
+  dateToHHMM,
   getStopDurationTime,
 } from 'modules/SimulationReportSheet/utils/formatSimulationReportSheet';
 import { getRowStyle } from 'modules/SimulationReportSheet/utils/formatSimulationTable';
@@ -51,8 +51,8 @@ export const formatStdcmDataForSimulationTable = (
     const isVia = stdcmPathSteps.slice(1, -1).some((step) => step.operationalPoint!.id === op.opId);
     const isPathStep = isFirst || isVia || isLast;
 
-    const startTime = isFirst || isStop ? durationToHHMM(op.stopEndTime) : '';
-    const endTime = isLast || isStop ? durationToHHMM(op.time) : '';
+    const startTime = isFirst || isStop ? dateToHHMM(op.stopEndTime) : '';
+    const endTime = isLast || isStop ? dateToHHMM(op.time) : '';
     const { stopType, trackName } = op;
 
     const stopTypeLabel = stopType

--- a/front/src/modules/SimulationReportSheet/utils/__tests__/simulationReportSheet.spec.ts
+++ b/front/src/modules/SimulationReportSheet/utils/__tests__/simulationReportSheet.spec.ts
@@ -56,7 +56,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'A',
     positionOnPath: 0,
     time: '10:00',
-    duration: null,
+    stopDuration: null,
     stopEndTime: '10:00',
     stopRequested: false,
     weight: 10,
@@ -65,7 +65,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'B',
     positionOnPath: 50,
     time: '10:10',
-    duration: null,
+    stopDuration: null,
     stopEndTime: '10:10',
     stopRequested: false,
     weight: 10,
@@ -74,7 +74,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'C',
     positionOnPath: 100,
     time: '10:20',
-    duration: null,
+    stopDuration: null,
     stopEndTime: '10:20',
     stopRequested: false,
     weight: 10,
@@ -83,7 +83,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'D',
     positionOnPath: 150,
     time: '10:30',
-    duration: null,
+    stopDuration: null,
     stopEndTime: '10:30',
     stopRequested: false,
     weight: 10,
@@ -91,19 +91,19 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
   const opAwStop = {
     ...opA,
     stopRequested: true,
-    duration: new Duration({ seconds: 60 }),
+    stopDuration: new Duration({ seconds: 60 }),
     stopEndTime: '10:01',
   };
   const opCwStop = {
     ...opC,
     stopRequested: true,
-    duration: new Duration({ seconds: 180 }),
+    stopDuration: new Duration({ seconds: 180 }),
     stopEndTime: '10:23',
   };
   const opDwStop = {
     ...opD,
     stopRequested: true,
-    duration: new Duration({ seconds: 120 }),
+    stopDuration: new Duration({ seconds: 120 }),
     stopEndTime: '10:32',
   };
   const opAwStopNotDone = { ...opA, stopRequested: true };
@@ -145,7 +145,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       opAwStop,
       opB,
       opCwStop,
-      { ...opDwStop, duration: new Duration({ seconds: 300 }), stopEndTime: '10:36' },
+      { ...opDwStop, stopDuration: new Duration({ seconds: 300 }), stopEndTime: '10:36' },
     ]);
   });
 
@@ -169,7 +169,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       {
         opId: 'unplanned_stop_at_75',
         positionOnPath: 75,
-        duration: new Duration({ seconds: 60 }),
+        stopDuration: new Duration({ seconds: 60 }),
         time: '10:15',
         stopEndTime: '10:16',
         stopRequested: false,
@@ -179,7 +179,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       {
         opId: 'unplanned_stop_at_125',
         positionOnPath: 125,
-        duration: new Duration({ seconds: 60 }),
+        stopDuration: new Duration({ seconds: 60 }),
         time: '10:25',
         stopEndTime: '10:26',
         stopRequested: false,

--- a/front/src/modules/SimulationReportSheet/utils/__tests__/simulationReportSheet.spec.ts
+++ b/front/src/modules/SimulationReportSheet/utils/__tests__/simulationReportSheet.spec.ts
@@ -29,8 +29,7 @@ describe('getStopDurationBetweenTwoPositions', () => {
       positions: [1, 2, 2, 3, 4, 5],
       times: [0, 120000, 180000, 200000, 220000, 230000],
       speeds: [0, 0, 2, 0, 2, 0],
-      departureHour: 1,
-      departureMinute: 2,
+      departureTime: new Date(2026, 0, 1, 1, 2),
     };
     expect(getStopDurationAtPosition(1, train)).toBeNull(); // departure
     expect(getStopDurationAtPosition(2, train)).toEqual(new Duration({ milliseconds: 60000 })); // standard stop
@@ -55,36 +54,36 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
   const opA = {
     opId: 'A',
     positionOnPath: 0,
-    time: new Duration({ hours: 10 }),
+    time: new Date(2026, 0, 1, 10),
     stopDuration: null,
-    stopEndTime: new Duration({ hours: 10 }),
+    stopEndTime: new Date(2026, 0, 1, 10),
     stopRequested: false,
     weight: 10,
   };
   const opB = {
     opId: 'B',
     positionOnPath: 50,
-    time: new Duration({ hours: 10, minutes: 10 }),
+    time: new Date(2026, 0, 1, 10, 10),
     stopDuration: null,
-    stopEndTime: new Duration({ hours: 10, minutes: 10 }),
+    stopEndTime: new Date(2026, 0, 1, 10, 10),
     stopRequested: false,
     weight: 10,
   };
   const opC = {
     opId: 'C',
     positionOnPath: 100,
-    time: new Duration({ hours: 10, minutes: 20 }),
+    time: new Date(2026, 0, 1, 10, 20),
     stopDuration: null,
-    stopEndTime: new Duration({ hours: 10, minutes: 20 }),
+    stopEndTime: new Date(2026, 0, 1, 10, 20),
     stopRequested: false,
     weight: 10,
   };
   const opD = {
     opId: 'D',
     positionOnPath: 150,
-    time: new Duration({ hours: 10, minutes: 30 }),
+    time: new Date(2026, 0, 1, 10, 30),
     stopDuration: null,
-    stopEndTime: new Duration({ hours: 10, minutes: 30 }),
+    stopEndTime: new Date(2026, 0, 1, 10, 30),
     stopRequested: false,
     weight: 10,
   };
@@ -92,19 +91,19 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     ...opA,
     stopRequested: true,
     stopDuration: new Duration({ seconds: 60 }),
-    stopEndTime: new Duration({ hours: 10, minutes: 1, seconds: 2 }),
+    stopEndTime: new Date(2026, 0, 1, 10, 1, 2),
   };
   const opCwStop = {
     ...opC,
     stopRequested: true,
     stopDuration: new Duration({ seconds: 180 }),
-    stopEndTime: new Duration({ hours: 10, minutes: 23, seconds: 2 }),
+    stopEndTime: new Date(2026, 0, 1, 10, 23, 2),
   };
   const opDwStop = {
     ...opD,
     stopRequested: true,
     stopDuration: new Duration({ seconds: 120 }),
-    stopEndTime: new Duration({ hours: 10, minutes: 32 }),
+    stopEndTime: new Date(2026, 0, 1, 10, 32),
   };
   const opAwStopNotDone = { ...opA, stopRequested: true };
   const opCwStopNotDone = { ...opC, stopRequested: true };
@@ -116,8 +115,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       positions: [0, 0, 50, 100, 100, 150, 150],
       times: [0, 60000, 600000, 1200000, 1380000, 1800000, 1920000],
       speeds: [0, 2, 2, 0, 2, 2, 0],
-      departureHour: 10,
-      departureMinute: 0,
+      departureTime: new Date(2026, 0, 1, 10),
     };
     const result = insertMissingStopsInOperationalPointsWithTimes(
       [opAwStop, opB, opCwStop, opDwStop],
@@ -133,8 +131,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       positions: [0, 2, 2, 50, 100, 101, 101, 150, 154, 154],
       times: [0, 2000, 62000, 600000, 1200000, 1202000, 1382000, 1800000, 1840000, 2140000],
       speeds: [0, 0, 2, 2, 2, 0, 2, 2, 2, 0],
-      departureHour: 10,
-      departureMinute: 0,
+      departureTime: new Date(2026, 0, 1, 10),
     };
     const result = insertMissingStopsInOperationalPointsWithTimes(
       [opAwStopNotDone, opB, opCwStopNotDone, opDwStopNotDone],
@@ -148,7 +145,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       {
         ...opDwStop,
         stopDuration: new Duration({ seconds: 300 }),
-        stopEndTime: new Duration({ hours: 10, minutes: 35, seconds: 40 }),
+        stopEndTime: new Date(2026, 0, 1, 10, 35, 40),
       },
     ]);
   });
@@ -159,8 +156,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       positions: [0, 50, 75, 75, 100, 125, 125, 150],
       times: [0, 600000, 900000, 960000, 1200000, 1500000, 1560000, 1800000],
       speeds: [0, 2, 0, 2, 0, 0, 2, 0],
-      departureHour: 10,
-      departureMinute: 0,
+      departureTime: new Date(2026, 0, 1, 10),
     };
     const result = insertMissingStopsInOperationalPointsWithTimes(
       [opA, opB, opCwStop, opD],
@@ -174,8 +170,8 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
         opId: 'unplanned_stop_at_75',
         positionOnPath: 75,
         stopDuration: new Duration({ seconds: 60 }),
-        time: new Duration({ hours: 10, minutes: 15 }),
-        stopEndTime: new Duration({ hours: 10, minutes: 16 }),
+        time: new Date(2026, 0, 1, 10, 15),
+        stopEndTime: new Date(2026, 0, 1, 10, 16),
         stopRequested: false,
         weight: null,
       },
@@ -184,8 +180,8 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
         opId: 'unplanned_stop_at_125',
         positionOnPath: 125,
         stopDuration: new Duration({ seconds: 60 }),
-        time: new Duration({ hours: 10, minutes: 25 }),
-        stopEndTime: new Duration({ hours: 10, minutes: 26 }),
+        time: new Date(2026, 0, 1, 10, 25),
+        stopEndTime: new Date(2026, 0, 1, 10, 26),
         stopRequested: false,
         weight: null,
       },

--- a/front/src/modules/SimulationReportSheet/utils/__tests__/simulationReportSheet.spec.ts
+++ b/front/src/modules/SimulationReportSheet/utils/__tests__/simulationReportSheet.spec.ts
@@ -55,36 +55,36 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
   const opA = {
     opId: 'A',
     positionOnPath: 0,
-    time: '10:00',
+    time: new Duration({ hours: 10 }),
     stopDuration: null,
-    stopEndTime: '10:00',
+    stopEndTime: new Duration({ hours: 10 }),
     stopRequested: false,
     weight: 10,
   };
   const opB = {
     opId: 'B',
     positionOnPath: 50,
-    time: '10:10',
+    time: new Duration({ hours: 10, minutes: 10 }),
     stopDuration: null,
-    stopEndTime: '10:10',
+    stopEndTime: new Duration({ hours: 10, minutes: 10 }),
     stopRequested: false,
     weight: 10,
   };
   const opC = {
     opId: 'C',
     positionOnPath: 100,
-    time: '10:20',
+    time: new Duration({ hours: 10, minutes: 20 }),
     stopDuration: null,
-    stopEndTime: '10:20',
+    stopEndTime: new Duration({ hours: 10, minutes: 20 }),
     stopRequested: false,
     weight: 10,
   };
   const opD = {
     opId: 'D',
     positionOnPath: 150,
-    time: '10:30',
+    time: new Duration({ hours: 10, minutes: 30 }),
     stopDuration: null,
-    stopEndTime: '10:30',
+    stopEndTime: new Duration({ hours: 10, minutes: 30 }),
     stopRequested: false,
     weight: 10,
   };
@@ -92,19 +92,19 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     ...opA,
     stopRequested: true,
     stopDuration: new Duration({ seconds: 60 }),
-    stopEndTime: '10:01',
+    stopEndTime: new Duration({ hours: 10, minutes: 1, seconds: 2 }),
   };
   const opCwStop = {
     ...opC,
     stopRequested: true,
     stopDuration: new Duration({ seconds: 180 }),
-    stopEndTime: '10:23',
+    stopEndTime: new Duration({ hours: 10, minutes: 23, seconds: 2 }),
   };
   const opDwStop = {
     ...opD,
     stopRequested: true,
     stopDuration: new Duration({ seconds: 120 }),
-    stopEndTime: '10:32',
+    stopEndTime: new Duration({ hours: 10, minutes: 32 }),
   };
   const opAwStopNotDone = { ...opA, stopRequested: true };
   const opCwStopNotDone = { ...opC, stopRequested: true };
@@ -145,7 +145,11 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
       opAwStop,
       opB,
       opCwStop,
-      { ...opDwStop, stopDuration: new Duration({ seconds: 300 }), stopEndTime: '10:36' },
+      {
+        ...opDwStop,
+        stopDuration: new Duration({ seconds: 300 }),
+        stopEndTime: new Duration({ hours: 10, minutes: 35, seconds: 40 }),
+      },
     ]);
   });
 
@@ -170,8 +174,8 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
         opId: 'unplanned_stop_at_75',
         positionOnPath: 75,
         stopDuration: new Duration({ seconds: 60 }),
-        time: '10:15',
-        stopEndTime: '10:16',
+        time: new Duration({ hours: 10, minutes: 15 }),
+        stopEndTime: new Duration({ hours: 10, minutes: 16 }),
         stopRequested: false,
         weight: null,
       },
@@ -180,8 +184,8 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
         opId: 'unplanned_stop_at_125',
         positionOnPath: 125,
         stopDuration: new Duration({ seconds: 60 }),
-        time: '10:25',
-        stopEndTime: '10:26',
+        time: new Duration({ hours: 10, minutes: 25 }),
+        stopEndTime: new Duration({ hours: 10, minutes: 26 }),
         stopRequested: false,
         weight: null,
       },

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -55,7 +55,7 @@ export function getStopDurationTime(duration?: Duration): string {
  * @param duration Duration object
  * @returns The duration formatted as a string in "HH:MM" format
  */
-function durationToHHMM(duration: Duration): string {
+export function durationToHHMM(duration: Duration): string {
   const totalMinutes = Math.round(duration.total('minute'));
   const hours = Math.floor(totalMinutes / 60) % 24;
   const minutes = totalMinutes % 60;
@@ -139,9 +139,9 @@ function formatMinimalOperationalPointWithTimes(
   return {
     opId: op.opId,
     positionOnPath: op.positionOnPath,
-    time: durationToHHMM(stopBegin),
+    time: stopBegin,
     stopDuration: duration,
-    stopEndTime: durationToHHMM(stopEnd),
+    stopEndTime: stopEnd,
     stopRequested: false,
     weight: null,
   };
@@ -265,22 +265,16 @@ export function insertMissingStopsInOperationalPointsWithTimes(
 function consolidateOvertakesToSingleSteps(
   steps: StdcmResultsOperationalPoint[]
 ): StdcmResultsOperationalPoint[] {
-  function convertHHMMTimeToSeconds(time: string): number {
-    const [hours, minutes] = time.split(':').map(Number);
-    return hours * 3600 + minutes * 60;
-  }
   const consolidatedSteps: StdcmResultsOperationalPoint[] = [];
   for (let i = 0; i < steps.length - 1; i += 1) {
     const [step, nextStep] = [steps[i], steps[i + 1]];
     const overtakenStepMatch = step.name?.match(/OVERTAKE[^;]*;(.*)$/);
     if (overtakenStepMatch) {
-      const stopDuration =
-        convertHHMMTimeToSeconds(nextStep.time!) - convertHHMMTimeToSeconds(step.time!);
       const consolidatedStep: StdcmResultsOperationalPoint = {
         ...step,
         name: overtakenStepMatch[1],
-        stopDuration: new Duration({ seconds: stopDuration }),
-        stopEndTime: nextStep.time!,
+        stopDuration: nextStep.time.sub(step.time),
+        stopEndTime: nextStep.time,
         stopType: StdcmStopTypes.OVERTAKE,
       };
       consolidatedSteps.push(consolidatedStep);

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -276,13 +276,12 @@ function consolidateOvertakesToSingleSteps(
     if (overtakenStepMatch) {
       const stopDuration =
         convertHHMMTimeToSeconds(nextStep.time!) - convertHHMMTimeToSeconds(step.time!);
-      const consolidatedStep = {
+      const consolidatedStep: StdcmResultsOperationalPoint = {
         ...step,
         name: overtakenStepMatch[1],
         stopDuration: new Duration({ seconds: stopDuration }),
         stopEndTime: nextStep.time!,
         stopType: StdcmStopTypes.OVERTAKE,
-        stopFor: stopDuration / 60,
       };
       consolidatedSteps.push(consolidatedStep);
       i += 1; // to skip the next step, as we consolidated two overtake steps in one

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -12,7 +12,7 @@ import type { ConsistChange, RequestedStep, StepType } from 'common/api/osrdRail
 import { interpolateValue } from 'modules/simulationResult/helpers/utils';
 import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
-import { Duration } from 'utils/duration';
+import { addDurationToDate, Duration } from 'utils/duration';
 import { tToKg } from 'utils/physics';
 import { capitalizeFirstLetter } from 'utils/strings';
 
@@ -52,13 +52,13 @@ export function getStopDurationTime(duration?: Duration): string {
 }
 
 /**
- * @param duration Duration object
- * @returns The duration formatted as a string in "HH:MM" format
+ * @param duration Date object
+ * @returns The date formatted as a string in "HH:MM" format
  */
-export function durationToHHMM(duration: Duration): string {
-  const totalMinutes = Math.round(duration.total('minute'));
-  const hours = Math.floor(totalMinutes / 60) % 24;
-  const minutes = totalMinutes % 60;
+export function dateToHHMM(date: Date): string {
+  const roundedDate = new Date(date.getTime() + 30000); // 30s shift so truncating returns rounded minute/hour
+  const hours = roundedDate.getHours();
+  const minutes = roundedDate.getMinutes();
   return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 }
 
@@ -66,23 +66,21 @@ export function durationToHHMM(duration: Duration): string {
  * @property positions List of positions of a train in mm
  * @property times List of times in milliseconds corresponding to the train positions
  * @property speeds List of speeds in m/s corresponding to the train positions
- * @property departureHour Hour of the train departure (24h format)
- * @property departureMinute Minute of the train departure
+ * @property departureTime Timestamp of the train departure
  */
 type TrainSimulation = {
   positions: number[];
   times: number[];
   speeds: number[];
-  departureHour: number;
-  departureMinute: number;
+  departureTime: Date;
 };
 
 /**
  * @param position Distance from the beginning of the path in mm
  * @param train Object containing simulated train positions, times, and departure time
- * @returns The estimated time of passage at the given position in format hh:mm
+ * @returns The estimated date and time of passage at the given position
  */
-function getTimeAtPosition(position: number, train: TrainSimulation): Duration {
+function getTimeAtPosition(position: number, train: TrainSimulation): Date {
   const milliseconds = interpolateValue(
     {
       positions: train.positions,
@@ -93,11 +91,7 @@ function getTimeAtPosition(position: number, train: TrainSimulation): Duration {
     'times'
   );
   const duration = new Duration({ milliseconds });
-  const trainDeparture = new Duration({
-    hours: train.departureHour,
-    minutes: train.departureMinute,
-  });
-  return trainDeparture.add(duration);
+  return addDurationToDate(train.departureTime, duration);
 }
 
 /**
@@ -134,7 +128,7 @@ function formatMinimalOperationalPointWithTimes(
   const stopBegin = getTimeAtPosition(op.positionOnPath, train);
 
   const duration = getStopDurationAtPosition(op.positionOnPath, train);
-  const stopEnd = stopBegin.add(duration || Duration.zero);
+  const stopEnd = addDurationToDate(stopBegin, duration || Duration.zero);
 
   return {
     opId: op.opId,
@@ -273,7 +267,7 @@ function consolidateOvertakesToSingleSteps(
       const consolidatedStep: StdcmResultsOperationalPoint = {
         ...step,
         name: overtakenStepMatch[1],
-        stopDuration: nextStep.time.sub(step.time),
+        stopDuration: Duration.subtractDate(nextStep.time, step.time),
         stopEndTime: nextStep.time,
         stopType: StdcmStopTypes.OVERTAKE,
       };
@@ -313,9 +307,6 @@ export function getOperationalPointsWithTimes({
 }): StdcmResultsOperationalPoint[] {
   const { positions, times, speeds } = simulation.final_output;
 
-  const departureHour = departureTime.getHours();
-  const departureMinute = departureTime.getMinutes();
-
   const formattedOps = suggestedOperationalPoints
     .filter((suggestedOp) => {
       // Keep if the OP is not in the exclusion list
@@ -332,7 +323,7 @@ export function getOperationalPointsWithTimes({
       formatOperationalPointWithTimesAndWeight(
         suggestedOp,
         operationalPoints,
-        { positions, times, speeds, departureHour, departureMinute },
+        { positions, times, speeds, departureTime },
         simulationPathSteps
       )
     );
@@ -341,7 +332,7 @@ export function getOperationalPointsWithTimes({
   const formattedOpsWithAllStops = insertMissingStopsInOperationalPointsWithTimes(
     formattedOps,
     stopPositions,
-    { positions, times, speeds, departureHour, departureMinute }
+    { positions, times, speeds, departureTime }
   );
   const formattedConsolidatedOps = consolidateOvertakesToSingleSteps(formattedOpsWithAllStops);
 

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -140,7 +140,7 @@ function formatMinimalOperationalPointWithTimes(
     opId: op.opId,
     positionOnPath: op.positionOnPath,
     time: durationToHHMM(stopBegin),
-    duration,
+    stopDuration: duration,
     stopEndTime: durationToHHMM(stopEnd),
     stopRequested: false,
     weight: null,
@@ -243,10 +243,10 @@ export function insertMissingStopsInOperationalPointsWithTimes(
       },
       train
     );
-    if (lastAddedOp.stopRequested && lastAddedOp.duration === null) {
+    if (lastAddedOp.stopRequested && lastAddedOp.stopDuration === null) {
       // If a stop was requested at the last op and no stop was performed,
       // we assume the current stop actually corresponds to the last op
-      lastAddedOp.duration = formattedStop.duration;
+      lastAddedOp.stopDuration = formattedStop.stopDuration;
       lastAddedOp.stopEndTime = formattedStop.stopEndTime;
     } else {
       // Otherwise we create a new op at the current stop, with unknown name and minimal informations
@@ -279,7 +279,7 @@ function consolidateOvertakesToSingleSteps(
       const consolidatedStep = {
         ...step,
         name: overtakenStepMatch[1],
-        duration: new Duration({ seconds: stopDuration }),
+        stopDuration: new Duration({ seconds: stopDuration }),
         stopEndTime: nextStep.time!,
         stopType: StdcmStopTypes.OVERTAKE,
         stopFor: stopDuration / 60,
@@ -354,8 +354,8 @@ export function getOperationalPointsWithTimes({
 
   return formattedConsolidatedOps.map((op) => ({
     ...op,
-    stopType: op.duration || !op.stopType ? op.stopType : StdcmStopTypes.PASSAGE_TIME, // no stop duration -> stoptype = undefined or PASSAGE_TIME
-    consistChange: op.duration ? op.consistChange : undefined,
+    stopType: op.stopDuration || !op.stopType ? op.stopType : StdcmStopTypes.PASSAGE_TIME, // no stop duration -> stoptype = undefined or PASSAGE_TIME
+    consistChange: op.stopDuration ? op.consistChange : undefined,
   }));
 }
 

--- a/front/tests/assets/stdcm/linked-train/anterior-linked-train-table.json
+++ b/front/tests/assets/stdcm/linked-train/anterior-linked-train-table.json
@@ -6,7 +6,7 @@
     "track": "V1",
     "endStop": "",
     "passageStop": "",
-    "startStop": "12:37",
+    "startStop": "12:38",
     "weight": "236t",
     "refEngine": "FAST_RS_E2E"
   },
@@ -15,9 +15,9 @@
     "operationalPoint": "North_station",
     "code": "BV",
     "track": "V1bis",
-    "endStop": "13:25",
+    "endStop": "13:26",
     "passageStop": "4 min",
-    "startStop": "13:30",
+    "startStop": "13:31",
     "weight": "=",
     "refEngine": "="
   },

--- a/front/tests/assets/stdcm/linked-train/posterior-linked-train-table.json
+++ b/front/tests/assets/stdcm/linked-train/posterior-linked-train-table.json
@@ -15,7 +15,7 @@
     "operationalPoint": "Mid_East_station",
     "code": "BV",
     "track": "V1",
-    "endStop": "12:37",
+    "endStop": "12:38",
     "passageStop": "3 min",
     "startStop": "12:41",
     "weight": "=",

--- a/front/tests/assets/stdcm/stdcm-all-stops.json
+++ b/front/tests/assets/stdcm/stdcm-all-stops.json
@@ -14,7 +14,7 @@
     "operationalPoint": "Mid_West_station",
     "code": "BV",
     "endStop": "",
-    "passageStop": "00:28",
+    "passageStop": "00:29",
     "startStop": "",
     "weight": "=",
     "refEngine": "="


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/15696

In getTimeAtPosition (not touched by this pr), the times are converted from durations from the train start to durations from midnight on the day of the train start. Then in durationToHHMM, they were converted to string. What my pr does is delay this second conversion until the actual display step, as the HHMM format doesn't contain enough informations to perform operations on times when steps have different dates.

I do believe the decision to compute times as durations from the start of the day of the train start in the first place rather than either from the start of the train, from the standard epoch or as actual datetimes is a bit weird though. While it seems to be internally consistent, I think it fails the principle of least surprise and it seems bug prone. What do you think of using datetimes (Date, Temporal) instead?

Edit: I decided to go ahead and make them Date. Not sure whether to merge with the previous commit.

Ai usage disclaimer: I used an llm to update the test data faster (but I reviewed it manually).