### PR TITLE
front: ui-charts: create type for useedgepan

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -656,7 +656,8 @@ const SpaceTimeChartWrapper = ({
 
   const { onMouseMove } = useEdgePan({
     enableY: isDraggingOccupancyZone,
-    spaceTimeChartProps,
+    hideTimeCaptions: spaceTimeChartProps.hideTimeCaptions,
+    themeTimeCaptionsSize: spaceTimeChartProps.theme?.timeCaptionsSize,
     pan,
   });
 

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyStandalone.tsx
@@ -113,7 +113,12 @@ const TrackOccupancyStandalone = ({
 
   const isDragging = Boolean(draggingOccupancyZones?.length);
 
-  const { onMouseMove } = useEdgePan({ enableY: isDragging, spaceTimeChartProps, pan });
+  const { onMouseMove } = useEdgePan({
+    enableY: isDragging,
+    hideTimeCaptions: spaceTimeChartProps.hideTimeCaptions,
+    themeTimeCaptionsSize: spaceTimeChartProps.theme?.timeCaptionsSize,
+    pan,
+  });
 
   return (
     <div className="track-occupancy-standalone flex flex-col">

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/__tests__/useEdgePan.spec.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/__tests__/useEdgePan.spec.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import type { SpaceTimeChartProps, SpaceTimeChartContextType } from '../../../spaceTimeChart';
+import type { SpaceTimeChartContextType } from '../../../spaceTimeChart';
 import useEdgePan, { PAN_INTERVAL_MS } from '../useEdgePan';
 
 describe('useEdgePan', () => {
@@ -10,17 +10,10 @@ describe('useEdgePan', () => {
     y += dy;
   };
 
-  const spaceTimeChartProps: SpaceTimeChartProps = {
-    operationalPoints: [],
-    spaceOrigin: 0,
-    spaceScales: [],
-    timeOrigin: 0,
-    timeScale: 1,
-  };
-
   const initialProps = {
     enableY: true,
-    spaceTimeChartProps,
+    hideTimeCaptions: false,
+    themeTimeCaptionsSize: 20,
     pan,
   };
 

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/useEdgePan.ts
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/hooks/useEdgePan.ts
@@ -14,22 +14,26 @@ type State = {
   dy: number;
 };
 
+type UseEdgePanParams = {
+  enableY?: boolean;
+  hideTimeCaptions?: boolean;
+  themeTimeCaptionsSize: number | undefined;
+  pan: (pos: { dy: number }) => void;
+};
+
 /**
  * Pan when the mouse approaches the edge of the chart. Useful for navigating
  * the chart during drag-and-drop operations.
  */
 const useEdgePan = ({
   enableY,
-  spaceTimeChartProps,
+  hideTimeCaptions,
+  themeTimeCaptionsSize,
   pan,
-}: {
-  enableY?: boolean;
-  spaceTimeChartProps: SpaceTimeChartProps;
-  pan: (pos: { dy: number }) => void;
-}) => {
-  const timeCaptionsSize = spaceTimeChartProps.hideTimeCaptions
+}: UseEdgePanParams) => {
+  const timeCaptionsSize = hideTimeCaptions
     ? 0
-    : (spaceTimeChartProps.theme?.timeCaptionsSize ?? DEFAULT_THEME.timeCaptionsSize);
+    : (themeTimeCaptionsSize ?? DEFAULT_THEME.timeCaptionsSize);
 
   const stateRef = useRef<State>({
     intervalID: null,


### PR DESCRIPTION
  `useEdgePan` uses only two properties of the `SpaceTimeChartProps` object.
  We've created a type `useEdgePanParams` and pass those two properties to it instead of the object.

close #17850 