### PR TITLE
front: fix subcategories not displayed in timesstops table header

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useCategoryColors.ts
+++ b/front/src/applications/operationalStudies/hooks/useCategoryColors.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import type { TrainCategory } from 'common/api/osrdEditoastApi';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
-import isMainCategory from 'modules/rollingStock/helpers/category';
+import isMainCategory, { findSubCategory } from 'modules/rollingStock/helpers/category';
 
 import { DEFAULT_TRAIN_PATH_COLORS, TRAIN_MAIN_CATEGORY_PATH_COLORS } from '../consts';
 import getSubCategoryColors from '../helpers/getSubCategoryColors';
@@ -11,10 +11,7 @@ import type { CategoryColors } from '../types';
 const useCategoryColors = (category: TrainCategory | null | undefined) => {
   const subCategories = useSubCategoryContext();
 
-  const currentSubCategory =
-    category && !isMainCategory(category)
-      ? subCategories.find((option) => option.code === category.sub_category_code)
-      : undefined;
+  const currentSubCategory = findSubCategory(subCategories, category);
 
   const categoryColors: CategoryColors = useMemo(() => {
     if (category && isMainCategory(category)) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainSchedule.tsx
@@ -21,7 +21,7 @@ import Itinerary from 'modules/pathfinding/components/Itinerary';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import { RollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
-import isMainCategory, { checkCategoryWarning } from 'modules/rollingStock/helpers/category';
+import { checkCategoryWarning, findSubCategory } from 'modules/rollingStock/helpers/category';
 import { isElectric } from 'modules/rollingStock/helpers/electric';
 import TimesStopsInput from 'modules/timesStops/TimesStopsInput';
 import {
@@ -256,10 +256,10 @@ const ManageTrainSchedule = () => {
 
   const subCategories = useSubCategoryContext();
 
-  const currentSubCategory = useMemo(() => {
-    if (isMainCategory(currentCategory)) return undefined;
-    return subCategories.find((option) => option.code === currentCategory.sub_category_code);
-  }, [currentCategory, subCategories]);
+  const currentSubCategory = useMemo(
+    () => findSubCategory(subCategories, currentCategory),
+    [currentCategory, subCategories]
+  );
 
   const isCategoryWarning = checkCategoryWarning(rollingStock, currentCategory, currentSubCategory);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/RoundTrips/RoundTripsModalCard.tsx
@@ -10,7 +10,7 @@ import type { SubCategory } from 'common/api/osrdEditoastApi';
 import type { OSRDMenuItem } from 'common/OSRDMenu';
 import OSRDMenu from 'common/OSRDMenu';
 import OSRDTooltip from 'common/OSRDTooltip';
-import isMainCategory from 'modules/rollingStock/helpers/category';
+import { findSubCategory } from 'modules/rollingStock/helpers/category';
 
 import { getTrainCategoryClassName } from '../Timetable/utils';
 import type { PairDataToolTip, PairingItem } from './types';
@@ -133,10 +133,7 @@ const RoundTripsModalCard = ({
     container: document.querySelector('.round-trips-modal'),
   });
 
-  const currentSubCategory =
-    category && !isMainCategory(category)
-      ? subCategories.find((option) => option.code === category.sub_category_code)
-      : undefined;
+  const currentSubCategory = findSubCategory(subCategories, category);
 
   return (
     <div

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -20,7 +20,7 @@ import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { useRollingStockContext } from 'common/RollingStockContext';
-import isMainCategory from 'modules/rollingStock/helpers/category';
+import { findSubCategory } from 'modules/rollingStock/helpers/category';
 import { getOccurrencesWorstStatus } from 'modules/trainSchedule/helpers/pacedTrain';
 import {
   createExceptions,
@@ -322,10 +322,7 @@ const PacedTrainItem = ({
 
   const { category } = pacedTrain;
 
-  const currentSubCategory =
-    category && !isMainCategory(category)
-      ? subCategories.find((option) => option.code === category.sub_category_code)
-      : undefined;
+  const currentSubCategory = findSubCategory(subCategories, category);
 
   const worstCase = useMemo(
     () => getOccurrencesWorstStatus(pacedTrain.summary, pacedTrain.paced.exceptions),

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -15,7 +15,7 @@ import {
 } from 'common/api/osrdEditoastApi';
 import { SkeletonLoader } from 'common/Loaders';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
-import isMainCategory from 'modules/rollingStock/helpers/category';
+import { findSubCategory } from 'modules/rollingStock/helpers/category';
 import {
   createTrainSchedules,
   deleteTrainSchedules,
@@ -168,10 +168,7 @@ const UniqueTrainItem = ({
 
   const { category } = train;
 
-  const currentSubCategory =
-    category && !isMainCategory(category)
-      ? subCategories.find((option) => option.code === category.sub_category_code)
-      : undefined;
+  const currentSubCategory = findSubCategory(subCategories, category);
 
   return (
     <div

--- a/front/src/modules/rollingStock/helpers/category.ts
+++ b/front/src/modules/rollingStock/helpers/category.ts
@@ -4,6 +4,14 @@ export default function isMainCategory(category: TrainCategory | null) {
   return category === null || 'main_category' in category;
 }
 
+export const findSubCategory = (
+  subCategories: SubCategory[],
+  category: TrainCategory | null | undefined
+) =>
+  !category || isMainCategory(category)
+    ? undefined
+    : subCategories.find((option) => option.code === category.sub_category_code);
+
 export function checkCategoryWarning(
   rollingStock: LightRollingStock | undefined,
   currentCategory: TrainCategory | null,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/formatSpaceTimeCurves.ts
@@ -7,7 +7,7 @@ import {
 import getSubCategoryColors from 'applications/operationalStudies/helpers/getSubCategoryColors';
 import type { CategoryColors } from 'applications/operationalStudies/types';
 import type { SubCategory } from 'common/api/osrdEditoastApi';
-import isMainCategory from 'modules/rollingStock/helpers/category';
+import isMainCategory, { findSubCategory } from 'modules/rollingStock/helpers/category';
 import type { IndividualTrainProjection } from 'modules/simulationResult/types';
 import {
   findExceptionWithOccurrenceId,
@@ -56,9 +56,7 @@ const formatSpaceTimeCurves = (
       if (isMainCategory(category)) {
         colors = TRAIN_MAIN_CATEGORY_PATH_COLORS[category.main_category];
       } else {
-        const currentSubCategory = subCategories.find(
-          (option) => option.code === category.sub_category_code
-        );
+        const currentSubCategory = findSubCategory(subCategories, category);
         if (currentSubCategory) {
           colors = getSubCategoryColors(currentSubCategory);
         }

--- a/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
+++ b/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { PacedTrain } from 'applications/operationalStudies/types';
+import { useSubCategoryContext } from 'common/SubCategoryContext';
 import type { Train } from 'reducers/osrdconf/types';
 import { useDateTimeLocale } from 'utils/date';
 import { findExceptionInPacedTrainByOccurrenceId } from 'utils/trainExceptions';
@@ -38,6 +39,7 @@ const CollapsedTrainOverview = ({
     occurrenceId && pacedTrain
       ? findExceptionInPacedTrainByOccurrenceId(occurrenceId, pacedTrain)
       : null;
+  const subCategories = useSubCategoryContext();
 
   return (
     <div className="train-header collapsed-train-summary">
@@ -56,7 +58,7 @@ const CollapsedTrainOverview = ({
           </div>
         )}
         <div className="train-departure-date">{getShortDepartureDate(train, dateTimeLocale)}</div>
-        <div className="train-category">{getShortCategoryName(train, t)}</div>
+        <div className="train-category">{getShortCategoryName(train, t, subCategories)}</div>
         {train.rolling_stock_name && (
           <div className="train-rolling-stock">{train.rolling_stock_name}</div>
         )}

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -24,7 +24,7 @@ import Banner from 'common/Banner';
 import { useInfraID } from 'common/osrdContext';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
-import isMainCategory, { checkCategoryWarning } from 'modules/rollingStock/helpers/category';
+import { checkCategoryWarning, findSubCategory } from 'modules/rollingStock/helpers/category';
 import useCategoryOptions, {
   categoryOptionId,
 } from 'modules/rollingStock/hooks/useCategoryOptions';
@@ -353,11 +353,10 @@ const ExpandedTrainForm = ({
   );
 
   const subCategories = useSubCategoryContext();
-  const currentSubCategory = useMemo(() => {
-    const category = fields.category;
-    if (!category || isMainCategory(category)) return undefined;
-    return subCategories.find((option) => option.code === category.sub_category_code);
-  }, [fields.category, subCategories]);
+  const currentSubCategory = useMemo(
+    () => findSubCategory(subCategories, fields.category),
+    [fields.category, subCategories]
+  );
   const isCategoryWarning = checkCategoryWarning(
     selectedRollingStock,
     fields.category,

--- a/front/src/modules/trainHeader/utils/trainProperties.ts
+++ b/front/src/modules/trainHeader/utils/trainProperties.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from 'i18next';
 
 import type { PacedTrain } from 'applications/operationalStudies/types';
+import type { SubCategory } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 
@@ -13,15 +14,18 @@ export const getShortDepartureDate = (train: Train, locale?: Intl.Locale) =>
       })
     : null;
 
-export const getShortCategoryName = (train: Train, t: TFunction<'translation'>): string | null =>
-  train.category && 'main_category' in train.category
-    ? t(`translation:rollingStock.shortCategoriesOptions.${train.category.main_category}`)
-    : null;
+export const getShortCategoryName = (
+  train: Train,
+  t: TFunction<'translation'>,
+  subCategories: SubCategory[]
+): string | undefined => {
+  const category = train.category;
+  if (!category) return undefined;
+  if ('main_category' in category)
+    return t(`translation:rollingStock.shortCategoriesOptions.${category.main_category}`);
+  return subCategories.find((option) => option.code === category.sub_category_code)?.name;
+};
 
-export const getCategoryName = (train: Train, t: TFunction<'translation'>): string | null =>
-  train.category && 'main_category' in train.category
-    ? t(`translation:rollingStock.categoriesOptions.${train.category.main_category}`)
-    : null;
 
 export const getComfortType = (train: Train, t: TFunction<'translation'>): string | null =>
   train.comfort ? t(`translation:rollingStock.comfortTypes.${train.comfort}`) : '';

--- a/front/src/modules/trainHeader/utils/trainProperties.ts
+++ b/front/src/modules/trainHeader/utils/trainProperties.ts
@@ -2,6 +2,7 @@ import type { TFunction } from 'i18next';
 
 import type { PacedTrain } from 'applications/operationalStudies/types';
 import type { SubCategory } from 'common/api/osrdEditoastApi';
+import { findSubCategory } from 'modules/rollingStock/helpers/category';
 import type { Train } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
 
@@ -23,9 +24,8 @@ export const getShortCategoryName = (
   if (!category) return undefined;
   if ('main_category' in category)
     return t(`translation:rollingStock.shortCategoriesOptions.${category.main_category}`);
-  return subCategories.find((option) => option.code === category.sub_category_code)?.name;
+  return findSubCategory(subCategories, category)?.name;
 };
-
 
 export const getComfortType = (train: Train, t: TFunction<'translation'>): string | null =>
   train.comfort ? t(`translation:rollingStock.comfortTypes.${train.comfort}`) : '';


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/17753

Before:
<img width="1002" height="235" alt="image" src="https://github.com/user-attachments/assets/174d41d5-18e9-407a-a109-dd16b909d847" />

After:
<img width="1002" height="235" alt="image" src="https://github.com/user-attachments/assets/34961c35-0956-4599-8d1a-8c4f468ad6d6" />

Subcategories created with
```bash
curl -sS -X POST http://localhost:8090/sub_category -H 'Content-Type: application/json' -d '[{"code":"tgv_spe","name":"TGV_special","main_category":"HIGH_SPEED_TRAIN","color":"#E05252","background_color":"#FBEAEA","hovered_color":"#F5CACA"},{"code":"tche","name":"TER_chelou","main_category":"COMMUTER_TRAIN","color":"#3274D9","background_color":"#E8F0FC","hovered_color":"#C8DAF7"},{"code":"fast","name":"GottaGoFast","main_category":"HIGH_SPEED_TRAIN","color":"#7A52B3","background_color":"#F0EAF8","hovered_color":"#DDCFF0"}]' -H "x-osrd-skip-authz: true"
```
with osrd running in mode host sw dev-front