### PR TITLE
front: stdcm: fix consist changes row background color

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -52,6 +52,7 @@ const StdcmResultsTable = ({
     totalMass: consist.totalMass!,
   };
 
+  let renderedRowIndex = 0;
   for (const [index, step] of operationalPointsList.entries()) {
     const isFirstStep = index === 0;
     const isLastStep = index === operationalPointsList.length - 1;
@@ -78,9 +79,11 @@ const StdcmResultsTable = ({
     currentConsist = step.consistChange ? step.consistChange : currentConsist;
 
     if (showAllOP || shouldRenderRow) {
+      renderedRowIndex += 1;
+      const isEvenRow = renderedRowIndex % 2 === 0;
       operationalPointRows.push(
         <Fragment key={`op-list-row-${index}`}>
-          <tr className={cx({ isPathStep })}>
+          <tr className={cx({ isPathStep, 'even-row': isEvenRow, 'odd-row': !isEvenRow })}>
             <td className={cx('index', { 'muted-text': !isPathStep })}>{index + 1}</td>
             <td className="name">
               {isNotExtremity &&
@@ -110,7 +113,7 @@ const StdcmResultsTable = ({
             </td>
           </tr>
           {step.consistChange && (
-            <tr>
+            <tr className={cx({ 'even-row': isEvenRow, 'odd-row': !isEvenRow })}>
               <td className="index">
                 <Container />
               </td>

--- a/front/src/applications/stdcm/styles/_results.scss
+++ b/front/src/applications/stdcm/styles/_results.scss
@@ -211,10 +211,10 @@
             th:last-child {
               text-transform: none;
             }
-            tbody tr:nth-child(odd) {
+            .odd-row {
               background-color: var(--ambientA10);
             }
-            tbody tr:nth-child(even) {
+            .even-row {
               background-color: var(--color-ambientA-5);
             }
             tbody tr.isPathStep {


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/16300

Putting both the consist change and the path step in the same row would create complex layout issues. Instead, tying the background color to a class makes the issue trivial.

Before:
<img width="821" height="221" alt="image" src="https://github.com/user-attachments/assets/1945b6b8-8777-4646-80f2-8dfb989711e9" />

After:
<img width="821" height="221" alt="image" src="https://github.com/user-attachments/assets/e75cf8c1-899e-444e-8d92-c5b670b3258b" />
