### PR TITLE
front: test useMouseInteractions

### DIFF
--- a/front/ui/ui-charts/src/common/hooks/__tests__/useMouseInteractions.spec.ts
+++ b/front/ui/ui-charts/src/common/hooks/__tests__/useMouseInteractions.spec.ts
@@ -1,0 +1,176 @@
+import { fireEvent, renderHook, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { MouseContextType } from '../../types.ts';
+import { useMouseInteractions } from '../useMouseInteractions';
+
+const contextMock = {
+  fingerprint: 'test',
+  getData: () => ({ time: 0, position: 0 }),
+};
+
+const mockOnClick = vi.fn();
+const mockOnZoom = vi.fn();
+const mockOnMouseMove = vi.fn();
+const mockOnPan = vi.fn();
+
+const mockMouseContext: MouseContextType = {
+  data: { time: 0, position: 0 },
+  hoveredItem: null,
+  position: { x: 0, y: 0 },
+  down: undefined,
+  isHover: true,
+};
+
+const dom: HTMLElement = document.body;
+
+describe('useMouseInteractions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should call the onClick handler when the mouse is clicked', () => {
+    renderHook(() =>
+      useMouseInteractions(dom, mockMouseContext, { onClick: mockOnClick }, contextMock)
+    );
+
+    fireEvent.click(dom);
+
+    expect(mockOnClick).toHaveBeenCalledOnce();
+  });
+
+  it('should call the onZoom handler when the mouse wheel is used', () => {
+    renderHook(() =>
+      useMouseInteractions(dom, mockMouseContext, { onZoom: mockOnZoom }, contextMock)
+    );
+
+    fireEvent.wheel(dom, { deltaY: 10 });
+
+    expect(mockOnZoom).toHaveBeenCalledWith(expect.objectContaining({ delta: (10 * -3) / 360 }));
+  });
+
+  it('should call the onMouseMove handler when the mouse is moved', () => {
+    const { rerender } = renderHook(
+      ({ mouseContext }) =>
+        useMouseInteractions(dom, mouseContext, { onMouseMove: mockOnMouseMove }, contextMock),
+      { initialProps: { mouseContext: mockMouseContext } }
+    );
+
+    rerender({
+      mouseContext: {
+        ...mockMouseContext,
+        position: { x: 10, y: 20 },
+      },
+    });
+
+    expect(mockOnMouseMove).toHaveBeenCalledWith(
+      expect.objectContaining({
+        position: { x: 10, y: 20 },
+      })
+    );
+  });
+
+  it('should call the onPan handler when down and position change', () => {
+    const { rerender } = renderHook(
+      ({ mouseContext }) =>
+        useMouseInteractions(dom, mouseContext, { onPan: mockOnPan }, contextMock),
+      {
+        initialProps: { mouseContext: mockMouseContext },
+      }
+    );
+
+    rerender({
+      mouseContext: {
+        ...mockMouseContext,
+        down: {},
+        position: { x: 10, y: 20 },
+      },
+    });
+
+    rerender({
+      mouseContext: {
+        ...mockMouseContext,
+        position: { x: 15, y: 25 },
+      },
+    });
+
+    expect(mockOnPan).toHaveBeenCalledWith({
+      initialPosition: { x: 10, y: 20 },
+      position: { x: 15, y: 25 },
+      isPanning: true,
+      initialData: { time: 0, position: 0 },
+      data: { time: 0, position: 0 },
+      context: contextMock,
+    });
+  });
+
+  it('should trigger onClick if the position has changed less than 3 px', () => {
+    const { rerender } = renderHook(
+      ({ mouseContext }) =>
+        useMouseInteractions(
+          dom,
+          mouseContext,
+          { onClick: mockOnClick, onPan: mockOnPan },
+          contextMock
+        ),
+      { initialProps: { mouseContext: mockMouseContext } }
+    );
+
+    rerender({
+      mouseContext: {
+        ...mockMouseContext,
+        down: {},
+        position: { x: 10, y: 20 },
+      },
+    });
+
+    rerender({
+      mouseContext: {
+        ...mockMouseContext,
+        down: {},
+        position: { x: 12, y: 22 },
+      },
+    });
+
+    fireEvent.click(dom);
+
+    expect(mockOnClick).toHaveBeenCalledOnce();
+  });
+
+  it('should not trigger onClick if the position has changed more than 3 px', () => {
+    const { rerender } = renderHook(
+      ({ mouseContext }) =>
+        useMouseInteractions(
+          dom,
+          mouseContext,
+          { onClick: mockOnClick, onPan: mockOnPan },
+          contextMock
+        ),
+      { initialProps: { mouseContext: mockMouseContext } }
+    );
+
+    rerender({
+      mouseContext: {
+        ...mockMouseContext,
+        down: {},
+        position: { x: 10, y: 20 },
+      },
+    });
+
+    rerender({
+      mouseContext: {
+        ...mockMouseContext,
+        down: {},
+        position: { x: 20, y: 30 },
+      },
+    });
+
+    fireEvent.click(dom);
+
+    expect(mockOnClick).not.toHaveBeenCalled();
+  });
+});

--- a/front/ui/ui-charts/src/common/hooks/useMouseInteractions.ts
+++ b/front/ui/ui-charts/src/common/hooks/useMouseInteractions.ts
@@ -39,6 +39,15 @@ type Handlers<T> = {
 /**
  * This hook handles SpaceTimeChart mouse interactions.
  * It is an internal hook, and should only be used inside SpaceTimeChart.
+ *
+ * onClick is related to mouse events, hoveredItem and position updates
+ * onZoom is related to wheel events and dom updates
+ * onMouseMove and onPan are related to dom, down and position updates
+ *
+ * @param dom The DOM element to bind the events to
+ * @param mouseContext The mouse context, containing the current position, hovered item, down ctrl and/or shift state and hover state
+ * @param handlers The event handlers to call on mouse interactions
+ * @param context The context to pass to the event handlers
  */
 export function useMouseInteractions<T extends { fingerprint: string; getData: PointToData }>(
   dom: HTMLElement | null,


### PR DESCRIPTION
`onClick` and `onZoom` are triggered by the dom update and their related `event`, so we can test the use of them with `fireEvent`

`onMouseMove` and `onPan` are triggered by `useEffect()` dependencies `down` and `position` mainly, so `fireEvent` can't help for testing them.

close #17227 