### PR TITLE
front: fix drag-and-drop in TOD for OPs not found in infra

### DIFF
--- a/front/src/applications/operationalStudies/hooks/usePathProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/usePathProjection.ts
@@ -67,7 +67,7 @@ const createVirtualOp = (
     id: virtualId,
     name: virtualName,
     uic: opRef.type === 'uic' ? opRef.uic : 0,
-    secondary_code: (opRef.type !== 'id' && opRef.secondary_code) || '',
+    secondary_code: (opRef.type !== 'id' && opRef.secondary_code) || null,
     main_code: opRef.type === 'trigram' ? opRef.trigram : '',
     position,
     weight,


### PR DESCRIPTION
The train schedule path contains a null secondary code, but createVirtualOp() falls back to an empty string. matchPathStepAndOp() compares secondary codes, so it doesn't return true.

secondary_code is optional, so stop filling it with a bogus empty string.

To reproduce, open the network graph, create nodes "A" and "B", create two train schedules. Then edit the first train schedule to go through track "V1" in "A", and the second train schedule to go through track "V2" in "A". Open the TOD, and drag these train schedules. Previously, an error was printed to the console and the drop was cancelled.