### PR TITLE
front, test: setup i18n for tests

### DIFF
--- a/front/src/modules/rollingStock/hooks/__tests__/useCategoryOptions.spec.ts
+++ b/front/src/modules/rollingStock/hooks/__tests__/useCategoryOptions.spec.ts
@@ -7,20 +7,6 @@ import { useSubCategoryContext } from 'common/SubCategoryContext';
 import type { CategoryOptionWithId } from '../../types';
 import useCategoryOptions from '../useCategoryOptions';
 
-// TODO : use the dedicated helper when it will be available (see #16803)
-const { mockUseTranslation, tMock } = vi.hoisted(() => ({
-  mockUseTranslation: vi.fn(),
-  tMock: vi.fn((key: string) => key),
-}));
-
-vi.mock('react-i18next', () => ({
-  useTranslation: mockUseTranslation,
-}));
-
-mockUseTranslation.mockReturnValue({
-  t: tMock,
-});
-
 vi.mock('common/SubCategoryContext', () => ({
   useSubCategoryContext: vi.fn(),
 }));
@@ -46,19 +32,19 @@ const mockSubCategories: SubCategory[] = [
 
 const placeholder: CategoryOptionWithId = {
   id: 'placeholder',
-  label: tMock('rollingStock.categoriesOptions.choose'),
+  label: 'rollingStock.categoriesOptions.choose',
   category: null,
 };
 
 const options: CategoryOptionWithId[] = [
   {
     id: 'main:REGIONAL_TRAIN',
-    label: tMock('rollingStock.categoriesOptions.REGIONAL_TRAIN'),
+    label: 'rollingStock.categoriesOptions.REGIONAL_TRAIN',
     category: { main_category: 'REGIONAL_TRAIN' },
   },
   {
     id: 'main:FREIGHT_TRAIN',
-    label: tMock('rollingStock.categoriesOptions.FREIGHT_TRAIN'),
+    label: 'rollingStock.categoriesOptions.FREIGHT_TRAIN',
     category: { main_category: 'FREIGHT_TRAIN' },
   },
 ];

--- a/front/vitest.setup.ts
+++ b/front/vitest.setup.ts
@@ -1,3 +1,16 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 import { vi } from 'vitest';
+
+await i18n.use(initReactI18next).init({
+  lng: 'cimode',
+  debug: false,
+  interpolation: {
+    escapeValue: false,
+  },
+  react: {
+    useSuspense: false,
+  },
+});
 
 vi.mock('common/api/osrdEditoastApi');


### PR DESCRIPTION
following the [official doc](https://react.i18next.com/misc/testing#typescript)

no need for now to setup a full provider integration because we don't need to wrap any component, we actually test hooks, but in the future we could use `RenderHookWithStore()` and add `i18n` following the documentation in order to add component integration tests, we should maybe rename it by `RenderHookWithProviders()`.

not sure about the `i18nForTest.ts` folder `test_setup`, feel free if you have a better suggestion

close #16803 