### PR TITLE
editoast: authz: add restricted reader grant / privilege levels

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -103,6 +103,7 @@ pub struct Group(pub i64);
 #[strum(serialize_all = "snake_case")]
 #[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
 pub enum InfraPrivilege {
+    CanRestrictedRead,
     CanRead,
     CanShareRead,
     CanWrite,
@@ -118,6 +119,7 @@ pub enum InfraPrivilege {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum InfraGrant {
+    RestrictedReader,
     Reader,
     Writer,
     Owner,
@@ -164,6 +166,7 @@ pub struct Infra(pub i64);
 #[strum(serialize_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum RollingStockPrivilege {
+    CanRestrictedRead,
     CanRead,
     CanShareRead,
     CanWrite,
@@ -179,6 +182,7 @@ pub enum RollingStockPrivilege {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum RollingStockGrant {
+    RestrictedReader,
     Reader,
     Writer,
     Owner,
@@ -244,10 +248,12 @@ fga::relations! {
         member: User
     },
     Infra {
+        restricted_reader: User,
         reader: User,
         writer:User,
         owner: User,
         // Computed
+        can_restricted_read: User,
         can_read: User,
         can_write: User,
         can_delete: User,
@@ -257,6 +263,7 @@ fga::relations! {
         can_revoke: User
     },
     RollingStock {
+        restricted_reader: User,
         reader: User,
         writer: User,
         owner: User,

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -186,6 +186,11 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Calling openfga with the appropriate privilege check
         let check = match privilege {
+            InfraPrivilege::CanRestrictedRead => {
+                self.openfga
+                    .check(model::Infra::can_restricted_read().check(user, infra))
+                    .await?
+            }
             InfraPrivilege::CanRead => {
                 self.openfga
                     .check(model::Infra::can_read().check(user, infra))

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -134,6 +134,9 @@ pub fn infra_set_grant(subject: Subject, infra: Infra, new_grant: InfraGrant) ->
         async move {
             let mut writes = openfga.prepare_writes();
             match (subject, new_grant) {
+                (Subject::User(user), InfraGrant::RestrictedReader) => {
+                    writes.push(&Infra::restricted_reader().tuple(&user, &infra))
+                }
                 (Subject::User(user), InfraGrant::Reader) => {
                     writes.push(&Infra::reader().tuple(&user, &infra))
                 }
@@ -143,6 +146,9 @@ pub fn infra_set_grant(subject: Subject, infra: Infra, new_grant: InfraGrant) ->
                 (Subject::User(user), InfraGrant::Owner) => {
                     writes.push(&Infra::owner().tuple(&user, &infra))
                 }
+                (Subject::Group(group), InfraGrant::RestrictedReader) => writes.push(
+                    &Infra::restricted_reader().tuple(Group::member().userset(&group), &infra),
+                ),
                 (Subject::Group(group), InfraGrant::Reader) => {
                     writes.push(&Infra::reader().tuple(Group::member().userset(&group), &infra))
                 }
@@ -160,6 +166,7 @@ pub fn infra_set_grant(subject: Subject, infra: Infra, new_grant: InfraGrant) ->
     });
 
     let share_privilege = match new_grant {
+        InfraGrant::RestrictedReader => InfraPrivilege::CanRestrictedRead,
         InfraGrant::Reader => InfraPrivilege::CanShareRead,
         InfraGrant::Writer => InfraPrivilege::CanShareWrite,
         InfraGrant::Owner => InfraPrivilege::CanShareOwnership,
@@ -213,6 +220,9 @@ pub fn infra_revoke_grant(subject: Subject, infra: Infra) -> Protected<bool> {
 
             let mut delete = openfga.prepare_deletes();
             match (subject, grant) {
+                (Subject::User(user), InfraGrant::RestrictedReader) => {
+                    delete.push(&Infra::restricted_reader().tuple(&user, &infra))
+                }
                 (Subject::User(user), InfraGrant::Reader) => {
                     delete.push(&Infra::reader().tuple(&user, &infra))
                 }
@@ -222,6 +232,9 @@ pub fn infra_revoke_grant(subject: Subject, infra: Infra) -> Protected<bool> {
                 (Subject::User(user), InfraGrant::Owner) => {
                     delete.push(&Infra::owner().tuple(&user, &infra))
                 }
+                (Subject::Group(group), InfraGrant::RestrictedReader) => delete.push(
+                    &Infra::restricted_reader().tuple(Group::member().userset(&group), &infra),
+                ),
                 (Subject::Group(group), InfraGrant::Reader) => {
                     delete.push(&Infra::reader().tuple(Group::member().userset(&group), &infra))
                 }
@@ -260,6 +273,7 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
         async move {
             let (
                 admin,
+                can_restricted_read,
                 can_read,
                 can_share_read,
                 can_write,
@@ -270,6 +284,7 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
             ) = openfga
                 .checks((
                     User::role().check(&Role::Admin, &user),
+                    Infra::can_restricted_read().check(&user, &infra),
                     Infra::can_read().check(&user, &infra),
                     Infra::can_share_read().check(&user, &infra),
                     Infra::can_write().check(&user, &infra),
@@ -280,6 +295,9 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
                 ))
                 .await?;
             let mut privileges = HashSet::new();
+            privileges.extend(
+                (admin || can_restricted_read).then_some(InfraPrivilege::CanRestrictedRead),
+            );
             privileges.extend((admin || can_read).then_some(InfraPrivilege::CanRead));
             privileges.extend((admin || can_share_read).then_some(InfraPrivilege::CanShareRead));
             privileges.extend((admin || can_write).then_some(InfraPrivilege::CanWrite));
@@ -308,6 +326,11 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
         Protected::new(move |openfga| {
             async move {
                 match grant {
+                    InfraGrant::RestrictedReader => {
+                        openfga
+                            .list_users(Infra::restricted_reader().query_users(&infra))
+                            .await
+                    }
                     InfraGrant::Reader => {
                         openfga
                             .list_users(Infra::reader().query_users(&infra))
@@ -331,6 +354,13 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
         Protected::new(move |openfga| {
             async move {
                 match grant {
+                    InfraGrant::RestrictedReader => {
+                        openfga
+                            .list_usersets(
+                                Infra::restricted_reader().query_usersets(Group::member(), &infra),
+                            )
+                            .await
+                    }
                     InfraGrant::Reader => {
                         openfga
                             .list_usersets(Infra::reader().query_usersets(Group::member(), &infra))
@@ -378,6 +408,11 @@ pub fn infra_list(user: User, privilege: InfraPrivilege) -> Protected<ResourcesL
                 return Ok(ResourcesList::All);
             }
             let authorized_infras = match privilege {
+                InfraPrivilege::CanRestrictedRead => {
+                    openfga
+                        .list_objects(Infra::can_restricted_read().query_objects(&user))
+                        .await?
+                }
                 InfraPrivilege::CanRead => {
                     openfga
                         .list_objects(Infra::can_read().query_objects(&user))
@@ -715,6 +750,7 @@ mod tests {
         assert_eq!(
             openfga.infra_privileges(User(1), Infra(1)).await,
             HashSet::from_iter([
+                InfraPrivilege::CanRestrictedRead,
                 InfraPrivilege::CanRead,
                 InfraPrivilege::CanShareRead,
                 InfraPrivilege::CanWrite,
@@ -738,6 +774,7 @@ mod tests {
         assert_eq!(
             openfga.infra_privileges(User(1), Infra(1)).await,
             HashSet::from_iter([
+                InfraPrivilege::CanRestrictedRead,
                 InfraPrivilege::CanRead,
                 InfraPrivilege::CanShareRead,
                 InfraPrivilege::CanWrite,

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -153,6 +153,9 @@ pub fn rolling_stock_set_grant(
             async move {
                 let mut writes = openfga.prepare_writes();
                 match (subject, new_grant) {
+                    (Subject::User(user), RollingStockGrant::RestrictedReader) => {
+                        writes.push(&RollingStock::restricted_reader().tuple(&user, &rolling_stock))
+                    }
                     (Subject::User(user), RollingStockGrant::Reader) => {
                         writes.push(&RollingStock::reader().tuple(&user, &rolling_stock))
                     }
@@ -162,6 +165,10 @@ pub fn rolling_stock_set_grant(
                     (Subject::User(user), RollingStockGrant::Owner) => {
                         writes.push(&RollingStock::owner().tuple(&user, &rolling_stock))
                     }
+                    (Subject::Group(group), RollingStockGrant::RestrictedReader) => writes.push(
+                        &RollingStock::restricted_reader()
+                            .tuple(Group::member().userset(&group), &rolling_stock),
+                    ),
                     (Subject::Group(group), RollingStockGrant::Reader) => writes.push(
                         &RollingStock::reader()
                             .tuple(Group::member().userset(&group), &rolling_stock),
@@ -182,6 +189,7 @@ pub fn rolling_stock_set_grant(
         });
 
     let share_privilege = match new_grant {
+        RollingStockGrant::RestrictedReader => RollingStockPrivilege::CanRestrictedRead,
         RollingStockGrant::Reader => RollingStockPrivilege::CanShareRead,
         RollingStockGrant::Writer => RollingStockPrivilege::CanShareWrite,
         RollingStockGrant::Owner => RollingStockPrivilege::CanShareOwnership,
@@ -239,6 +247,13 @@ pub fn rolling_stock_granted_subjects(
         Protected::new(move |openfga| {
             async move {
                 match grant {
+                    RollingStockGrant::RestrictedReader => {
+                        openfga
+                            .list_users(
+                                RollingStock::restricted_reader().query_users(&rolling_stock),
+                            )
+                            .await
+                    }
                     RollingStockGrant::Reader => {
                         openfga
                             .list_users(RollingStock::reader().query_users(&rolling_stock))
@@ -267,6 +282,14 @@ pub fn rolling_stock_granted_subjects(
         Protected::new(move |openfga| {
             async move {
                 match grant {
+                    RollingStockGrant::RestrictedReader => {
+                        openfga
+                            .list_usersets(
+                                RollingStock::restricted_reader()
+                                    .query_usersets(Group::member(), &rolling_stock),
+                            )
+                            .await
+                    }
                     RollingStockGrant::Reader => {
                         openfga
                             .list_usersets(
@@ -376,6 +399,9 @@ pub fn rolling_stock_revoke_grant(
 
             let mut delete = openfga.prepare_deletes();
             match (subject, grant) {
+                (Subject::User(user), RollingStockGrant::RestrictedReader) => {
+                    delete.push(&RollingStock::restricted_reader().tuple(&user, &rolling_stock))
+                }
                 (Subject::User(user), RollingStockGrant::Reader) => {
                     delete.push(&RollingStock::reader().tuple(&user, &rolling_stock))
                 }
@@ -385,6 +411,10 @@ pub fn rolling_stock_revoke_grant(
                 (Subject::User(user), RollingStockGrant::Owner) => {
                     delete.push(&RollingStock::owner().tuple(&user, &rolling_stock))
                 }
+                (Subject::Group(group), RollingStockGrant::RestrictedReader) => delete.push(
+                    &RollingStock::restricted_reader()
+                        .tuple(Group::member().userset(&group), &rolling_stock),
+                ),
                 (Subject::Group(group), RollingStockGrant::Reader) => delete.push(
                     &RollingStock::reader().tuple(Group::member().userset(&group), &rolling_stock),
                 ),

--- a/editoast/fga/src/client/queries.rs
+++ b/editoast/fga/src/client/queries.rs
@@ -404,6 +404,7 @@ impl_structured_checks!((bool, bool, bool, bool, bool), R1 R2 R3 R4 R5, U1 U2 U3
 impl_structured_checks!((bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6, U1 U2 U3 U4 U5 U6, a b c d e f);
 impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7, U1 U2 U3 U4 U5 U6 U7, a b c d e f g);
 impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7 R8, U1 U2 U3 U4 U5 U6 U7 U8, a b c d e f g h);
+impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7 R8 R9, U1 U2 U3 U4 U5 U6 U7 U8 U9, a b c d e f g h i);
 
 impl<R: Relation, U: AsUser<User = R::User>> Request for Check<'_, R, U> {
     type Response = bool;

--- a/editoast/fga_migrations/migrations/4_add_restricted_view.fga
+++ b/editoast/fga_migrations/migrations/4_add_restricted_view.fga
@@ -1,0 +1,56 @@
+model
+  schema 1.1
+
+type role # 3 roles in DB: role:OperationalStudies, role:Stdcm, role:Admin
+
+type user
+  relations
+    define role: [role] or role from group
+    define group: [group]
+    define manager: manager from group
+
+type group
+  relations
+    define role: [role]
+    define manager: [user]
+    define member: [user]
+
+type infra
+  relations
+    define restricted_reader: [user, group#member, group#manager, user#manager]
+    define reader: [user, group#member, group#manager, user#manager]
+    define writer: [user, group#member, group#manager, user#manager]
+    define owner: [user, group#member, group#manager, user#manager]
+
+    define can_restricted_read: restricted_reader or can_read
+    define can_read: reader or can_write
+    define can_write: writer or can_delete
+    define can_delete: owner
+
+    define can_share_read: can_read
+    define can_share_write: can_write
+    define can_share_ownership: owner
+    define can_revoke: owner
+
+type rolling_stock
+  relations
+    define restricted_reader: [user, group#member, group#manager, user#manager]
+    define reader: [user, group#member, group#manager, user#manager]
+    define writer: [user, group#member, group#manager, user#manager]
+    define owner: [user, group#member, group#manager, user#manager]
+
+    define can_restricted_read: restricted_reader or can_read
+    define can_read: reader or can_write
+    define can_write: writer or can_delete
+    define can_delete: owner
+
+    define can_share_read: can_read
+    define can_share_write: can_write
+    define can_share_ownership: owner
+    define can_revoke: owner
+
+type project
+  relations
+    define owner: [user, group#member, group#manager, user#manager]
+
+    define has_access: owner

--- a/editoast/fga_migrations/src/lib.rs
+++ b/editoast/fga_migrations/src/lib.rs
@@ -23,7 +23,8 @@ static OPENFGA_MIGRATIONS: LazyLock<IndexMap<&'static str, &'static str>> = Lazy
         "initial_model" => include_str!("../migrations/0_initial_model.fga"),
         "1_rolling_stock_model" => include_str!("../migrations/1_rolling_stock_model.fga"),
         "2_can_revoke_model" => include_str!("../migrations/2_can_revoke_model.fga"),
-        "3_project_model" => include_str!("../migrations/3_project_model.fga")
+        "3_project_model" => include_str!("../migrations/3_project_model.fga"),
+        "4_add_restricted_view" => include_str!("../migrations/4_add_restricted_view.fga")
     }
     #[cfg(test)]
     indexmap! {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -15252,12 +15252,14 @@ components:
     StandardGrant:
       type: string
       enum:
+      - RESTRICTED_READER
       - READER
       - WRITER
       - OWNER
     StandardPrivilege:
       type: string
       enum:
+      - can_restricted_read
       - can_read
       - can_share_read
       - can_write

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -1051,6 +1051,7 @@ mod tests {
         assert_eq!(
             privileges.remove(&infra1).unwrap(),
             HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
                 StandardPrivilege::CanShareRead,
                 StandardPrivilege::CanWrite,
@@ -1063,6 +1064,7 @@ mod tests {
         assert_eq!(
             privileges.remove(&infra2).unwrap(),
             HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
                 StandardPrivilege::CanShareRead,
                 StandardPrivilege::CanWrite,
@@ -1071,7 +1073,11 @@ mod tests {
         );
         assert_eq!(
             privileges.remove(&infra3).unwrap(),
-            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead])
+            HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead
+            ])
         );
         assert_eq!(privileges.remove(&infra4).unwrap(), HashSet::from([]));
         assert!(!privileges.contains_key(&infra_unused));
@@ -1117,16 +1123,25 @@ mod tests {
             .collect::<HashMap<_, _>>();
         assert_eq!(
             privileges.remove(&infra1).unwrap(),
-            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead])
+            HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead
+            ])
         );
         assert_eq!(privileges.remove(&infra2).unwrap(), HashSet::from([]));
         assert_eq!(
             privileges.remove(&infra3).unwrap(),
-            HashSet::from([StandardPrivilege::CanRead, StandardPrivilege::CanShareRead,])
+            HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
+                StandardPrivilege::CanRead,
+                StandardPrivilege::CanShareRead,
+            ])
         );
         assert_eq!(
             privileges.remove(&infra4).unwrap(),
             HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
                 StandardPrivilege::CanShareRead,
                 StandardPrivilege::CanWrite,

--- a/editoast/src/views/authz/resources.rs
+++ b/editoast/src/views/authz/resources.rs
@@ -33,6 +33,7 @@ impl Resource {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub(super) enum StandardGrant {
+    RestrictedReader,
     Reader,
     Writer,
     Owner,
@@ -43,6 +44,7 @@ pub(super) enum StandardGrant {
 #[strum(serialize_all = "snake_case")]
 #[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
 pub(super) enum StandardPrivilege {
+    CanRestrictedRead,
     CanRead,
     CanShareRead,
     CanWrite,
@@ -57,6 +59,7 @@ macro_rules! impl_standard_privilege_from_into {
         impl From<$ty> for StandardPrivilege {
             fn from(privilege: $ty) -> Self {
                 match privilege {
+                    <$ty>::CanRestrictedRead => Self::CanRestrictedRead,
                     <$ty>::CanRead => Self::CanRead,
                     <$ty>::CanShareRead => Self::CanShareRead,
                     <$ty>::CanWrite => Self::CanWrite,
@@ -71,6 +74,7 @@ macro_rules! impl_standard_privilege_from_into {
         impl From<StandardPrivilege> for $ty {
             fn from(privilege: StandardPrivilege) -> Self {
                 match privilege {
+                    StandardPrivilege::CanRestrictedRead => Self::CanRestrictedRead,
                     StandardPrivilege::CanRead => Self::CanRead,
                     StandardPrivilege::CanShareRead => Self::CanShareRead,
                     StandardPrivilege::CanWrite => Self::CanWrite,
@@ -89,6 +93,7 @@ macro_rules! impl_standard_grant_from_into {
         impl From<$ty> for StandardGrant {
             fn from(grant: $ty) -> Self {
                 match grant {
+                    <$ty>::RestrictedReader => Self::RestrictedReader,
                     <$ty>::Reader => Self::Reader,
                     <$ty>::Writer => Self::Writer,
                     <$ty>::Owner => Self::Owner,
@@ -99,6 +104,7 @@ macro_rules! impl_standard_grant_from_into {
         impl From<StandardGrant> for $ty {
             fn from(grant: StandardGrant) -> Self {
                 match grant {
+                    StandardGrant::RestrictedReader => Self::RestrictedReader,
                     StandardGrant::Reader => Self::Reader,
                     StandardGrant::Writer => Self::Writer,
                     StandardGrant::Owner => Self::Owner,

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -464,7 +464,8 @@
       "edit": "write",
       "full": "full access",
       "none": "no access",
-      "read": "read"
+      "read": "read",
+      "restricted_read": "restricted read"
     },
     "permission": "Permission",
     "permissionDenied": "You don't have permission to perform this action",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -464,7 +464,8 @@
       "edit": "écriture",
       "full": "accès total",
       "none": "pas d'accès",
-      "read": "lecture"
+      "read": "lecture",
+      "restricted_read": "lecture limitée"
     },
     "permission": "Permission",
     "permissionDenied": "Vous n'avez pas la permission de réaliser cette action",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2932,7 +2932,7 @@ export type PostWorkerLoadApiArg = {
     timetable_id?: number | null;
   };
 };
-export type StandardGrant = 'READER' | 'WRITER' | 'OWNER';
+export type StandardGrant = 'RESTRICTED_READER' | 'READER' | 'WRITER' | 'OWNER';
 export type ResourceType = 'infra' | 'rolling_stock';
 export type GrantBody = {
   grant: StandardGrant;
@@ -2947,6 +2947,7 @@ export type RevokeBody = {
 };
 export type Role = 'Admin' | 'Stdcm' | 'OperationalStudies';
 export type StandardPrivilege =
+  | 'can_restricted_read'
   | 'can_read'
   | 'can_share_read'
   | 'can_write'

--- a/front/src/common/authorization/consts.ts
+++ b/front/src/common/authorization/consts.ts
@@ -1,6 +1,7 @@
 // The order is important here, as it is used to determine the order of the grants
 export enum GRANTS_LABEL {
   NONE = 'none',
+  RESTRICTED_READER = 'restricted_read',
   READER = 'read',
   WRITER = 'edit',
   OWNER = 'full',

--- a/front/src/common/authorization/utils/generateGrantSelectProps.ts
+++ b/front/src/common/authorization/utils/generateGrantSelectProps.ts
@@ -6,6 +6,8 @@ import { GRANTS_LABEL } from '../consts';
 
 function getRequiredPrivilegesToAddGrant(grant: keyof typeof GRANTS_LABEL): Privilege[] {
   switch (grant) {
+    case 'RESTRICTED_READER':
+      return ['can_share_read'];
     case 'READER':
       return ['can_share_read'];
     case 'WRITER':

--- a/front/src/reducers/infra/generateGrantSelectProps.spec.ts
+++ b/front/src/reducers/infra/generateGrantSelectProps.spec.ts
@@ -5,9 +5,11 @@ import type { Grant, Privilege } from 'common/authorization/types';
 import generateGrantSelectProps from 'common/authorization/utils/generateGrantSelectProps';
 
 const GRANTS = {
-  READER: ['can_read', 'can_share_read'],
-  WRITER: ['can_read', 'can_share_read', 'can_write', 'can_share_write'],
+  RESTRICTED_READER: ['can_restricted_read'],
+  READER: ['can_restricted_read', 'can_read', 'can_share_read'],
+  WRITER: ['can_restricted_read', 'can_read', 'can_share_read', 'can_write', 'can_share_write'],
   OWNER: [
+    'can_restricted_read',
     'can_read',
     'can_share_read',
     'can_write',
@@ -31,6 +33,10 @@ describe('generateSelectPropsForGrant', () => {
       value: { label: 'authorization.grants.read', value: 'READER' },
       options: [
         { label: 'authorization.grants.none', value: undefined },
+        {
+          label: 'authorization.grants.restricted_read',
+          value: 'RESTRICTED_READER',
+        },
         { label: 'authorization.grants.read', value: 'READER' },
         { label: 'authorization.grants.edit', value: 'WRITER' },
         { label: 'authorization.grants.full', value: 'OWNER' },

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -3838,12 +3838,14 @@ class SpeedSectionPslSncfExtension(BaseModel):
 
 
 class StandardGrant(Enum):
+    RESTRICTED_READER = "RESTRICTED_READER"
     READER = "READER"
     WRITER = "WRITER"
     OWNER = "OWNER"
 
 
 class StandardPrivilege(Enum):
+    can_restricted_read = "can_restricted_read"
     can_read = "can_read"
     can_share_read = "can_share_read"
     can_write = "can_write"


### PR DESCRIPTION
Ref: https://github.com/osrd-project/osrd-confidential/issues/1641

Add a new level of grant `RestrictedReader` and privilege `CanRestrictedRead` lower than `Reader`. They will allow to read a subset of the information of their authorized resources types. In the future, this grant level will not allow some actions which are authorized for `Reader`s.

>[!NOTE] 
At the moment the PR uses the grant and privilege names given in the issue description but there was an unfinished debate at the time: other naming suggestions are welcome.