### PR TITLE
editoast, front: enable restricted viewing of infras

### DIFF
--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -307,7 +307,7 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
     })
     .with_check(Check::HasInfraPrivilege(
         Actor::Issuer,
-        InfraPrivilege::CanRead,
+        InfraPrivilege::CanRestrictedRead,
         infra,
     ))
 }
@@ -902,7 +902,7 @@ mod tests {
     )]
     #[case::infra_privileges(
         infra_privileges(User(1), Infra(1)).checks,
-        &[Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1))]
+        &[Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRestrictedRead, Infra(1))]
     )]
     #[case::infra_privileges(
         infra_granted_subjects(Infra(1), InfraGrant::Owner).checks,

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -409,7 +409,7 @@ pub(in crate::views) async fn user_privileges(
                     }
                     Err(Check::HasInfraPrivilege(
                         Actor::Issuer,
-                        InfraPrivilege::CanRead,
+                        InfraPrivilege::CanRestrictedRead,
                         infra,
                     )) => {
                         result
@@ -438,6 +438,7 @@ pub(in crate::views) async fn user_privileges(
         }
         crate::authentication::State::Skip => {
             let privileges = HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
                 StandardPrivilege::CanShareRead,
                 StandardPrivilege::CanWrite,
@@ -1143,6 +1144,7 @@ mod tests {
         assert_eq!(
             privileges.remove(&infra).unwrap(),
             HashSet::from([
+                StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
                 StandardPrivilege::CanShareRead,
                 StandardPrivilege::CanWrite,

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -82,7 +82,10 @@ pub(in crate::views) async fn attached(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -107,7 +107,10 @@ pub(in crate::views) async fn list_auto_fixes(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -145,7 +145,10 @@ pub(in crate::views) async fn delimited_area(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -94,7 +94,10 @@ pub(in crate::views) async fn list_errors(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -54,7 +54,10 @@ pub(in crate::views) async fn get_line_bbox(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -198,7 +198,10 @@ pub(in crate::views) async fn list(
         crate::authentication::State::Authenticated { user, roles } => {
             let authorizer = UserAuthorizer::new(user, roles.clone(), regulator.openfga());
             let authorized_infras = authorizer
-                .authorize(authz::v2::infra_list(user, InfraPrivilege::CanRead))
+                .authorize(authz::v2::infra_list(
+                    user,
+                    InfraPrivilege::CanRestrictedRead,
+                ))
                 .await?
                 .access()
                 .await?
@@ -254,7 +257,10 @@ pub(in crate::views) async fn get(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -477,7 +483,10 @@ pub(in crate::views) async fn get_switch_types(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -528,7 +537,10 @@ pub(in crate::views) async fn get_speed_limit_tags(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -576,7 +588,10 @@ pub(in crate::views) async fn get_voltages(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -741,7 +756,10 @@ pub(in crate::views) async fn match_operational_points(
 ) -> Result<Json<MatchOperationalPointsResponse>> {
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -1173,7 +1191,7 @@ pub mod tests {
             let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
             let user = app
                 .user("user", "User")
-                .with_infra_grant(infra_id, InfraGrant::Reader)
+                .with_infra_grant(infra_id, InfraGrant::RestrictedReader)
                 .create()
                 .await;
 
@@ -1190,6 +1208,29 @@ pub mod tests {
                 .by_user(user.as_ref())
                 .await
                 .assert_status_not_found();
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_requires_can_restricted_read() {
+            let app = test_app!().build();
+            let db_pool = app.db_pool();
+            let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+
+            let user_restricted_reader = app
+                .user("alice", "Alice")
+                .with_infra_grant(infra_id, InfraGrant::RestrictedReader)
+                .create()
+                .await;
+            let user_no_grant = app.user("bob", "Bob").create().await;
+
+            app.get(format!("/infra/{}", infra_id).as_str())
+                .by_user(user_restricted_reader.as_ref())
+                .await
+                .assert_status_ok();
+            app.get(format!("/infra/{}", infra_id).as_str())
+                .by_user(user_no_grant.as_ref())
+                .await
+                .assert_status_forbidden();
         }
     }
 

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -71,7 +71,10 @@ pub(in crate::views) async fn get_objects(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -139,7 +142,10 @@ pub(in crate::views) async fn list_objects_ids(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -116,7 +116,10 @@ pub(in crate::views) async fn pathfinding_view(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -72,7 +72,10 @@ pub(in crate::views) async fn get_routes_from_waypoint(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(path.infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(path.infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -160,7 +163,10 @@ pub(in crate::views) async fn get_routes_track_ranges(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -227,7 +233,10 @@ pub(in crate::views) async fn get_routes_nodes(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -113,7 +113,10 @@ pub(in crate::views) async fn occupancy(
 ) -> Result<Json<HashMap<Identifier, Vec<LevelCrossingOccupancy>>>> {
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -245,7 +245,10 @@ pub(in crate::views) async fn post(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -100,7 +100,10 @@ pub(in crate::views) async fn post(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -181,7 +181,10 @@ pub(in crate::views) async fn search_journeys(
 
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -298,7 +298,10 @@ pub(in crate::views) async fn requirements(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -482,7 +485,10 @@ pub(in crate::views) async fn get_local_track_names(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -321,7 +321,10 @@ pub(in crate::views) async fn conflicts(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -215,7 +215,10 @@ pub(in crate::views) async fn stdcm(
     auth.clone()
         .check_authorization(async |authorizer| {
             authorizer
-                .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+                .authorize_infra(
+                    &authz::Infra(infra_id),
+                    authz::InfraPrivilege::CanRestrictedRead,
+                )
                 .await
         })
         .await?;

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -345,7 +345,10 @@ pub(in crate::views) async fn simulation_summary(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -618,7 +621,10 @@ pub(in crate::views) async fn get_path(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -744,7 +750,10 @@ pub(in crate::views) async fn simulation(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -878,7 +887,10 @@ pub(in crate::views) async fn etcs_braking_curves(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -1040,7 +1052,10 @@ pub(in crate::views) async fn project_path(
 
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -1168,7 +1183,10 @@ pub(in crate::views) async fn project_path_op(
 
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -1346,7 +1364,10 @@ pub(in crate::views) async fn occupancy_blocks(
 ) -> Result<Json<HashMap<i64, OccupancyBlocksTrainScheduleResult>>> {
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;
@@ -1510,7 +1531,10 @@ pub(in crate::views) async fn track_occupancy(
 ) -> Result<Json<Vec<TrackSectionOccupancy>>> {
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -92,7 +92,10 @@ pub(in crate::views) async fn worker_load(
     // Check user privilege on infra
     auth.check_authorization(async |authorizer| {
         authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
+            .authorize_infra(
+                &authz::Infra(infra_id),
+                authz::InfraPrivilege::CanRestrictedRead,
+            )
             .await
     })
     .await?;

--- a/front/src/common/authorization/components/GrantsManager.tsx
+++ b/front/src/common/authorization/components/GrantsManager.tsx
@@ -12,6 +12,7 @@ function getGrantLabel(userPrivileges: Set<Privilege>): keyof typeof GRANTS_LABE
   if (userPrivileges.has('can_delete')) return 'OWNER';
   if (userPrivileges.has('can_write')) return 'WRITER';
   if (userPrivileges.has('can_read')) return 'READER';
+  if (userPrivileges.has('can_restricted_read')) return 'RESTRICTED_READER';
   return 'NONE';
 }
 

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
@@ -169,7 +169,12 @@ const ActionsBar = ({
         className="infraslist-item-action copy"
         type="button"
         aria-label={t('infraManagement.actions.copy')}
-        title={t('infraManagement.actions.copy')}
+        title={
+          userPrivileges.has('can_read')
+            ? t('infraManagement.actions.copy')
+            : t('authorization.permissionDenied')
+        }
+        disabled={!userPrivileges.has('can_read')}
         onClick={handleDuplicate}
       >
         <Duplicate />
@@ -178,7 +183,12 @@ const ActionsBar = ({
         className="infraslist-item-action export"
         type="button"
         aria-label={t('infraManagement.actions.export')}
-        title={t('infraManagement.actions.export')}
+        title={
+          userPrivileges.has('can_read')
+            ? t('infraManagement.actions.export')
+            : t('authorization.permissionDenied')
+        }
+        disabled={!userPrivileges.has('can_read')}
         onClick={handleExport}
       >
         <Download />


### PR DESCRIPTION
>[!WARNING]
To be merged after https://github.com/OpenRailAssociation/osrd/pull/17879.

>[!NOTE]
The first commit is a cherry-pick from #17894.

Ref: https://github.com/osrd-project/osrd-confidential/issues/1641

Users now need to have the restricted read privilege on an infra to get information about an infra.

Note: the selection tool disabling is not implemented yet. This will be done in another PR.