### PR TITLE
Speed up op cache loading

### DIFF
--- a/editoast/editoast_models/src/infra_objects.rs
+++ b/editoast/editoast_models/src/infra_objects.rs
@@ -269,6 +269,7 @@ pub fn get_geometry_layer_table(object_type: &ObjectType) -> Option<&'static str
 
 impl OperationalPointModel {
     /// Retrieve a list of operational points from the database
+    #[tracing::instrument(skip(conn), err)]
     pub async fn retrieve_from_uic(
         conn: &mut DbConnection,
         infra_id: i64,
@@ -297,6 +298,7 @@ impl OperationalPointModel {
             .collect())
     }
 
+    #[tracing::instrument(skip(conn), err)]
     pub async fn retrieve_from_trigrams(
         conn: &mut DbConnection,
         infra_id: i64,
@@ -327,6 +329,7 @@ impl OperationalPointModel {
     ///
     /// Use this instead of [`OperationalPointModel::retrieve_batch_unchecked`]
     /// when all the operational points are known to be in the same infra.
+    #[tracing::instrument(skip(conn), err)]
     pub async fn retrieve_from_ids(
         conn: &mut DbConnection,
         infra_id: i64,

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -45,7 +45,7 @@ impl OperationalPointCache {
     /// how they were initially queried. This makes the cache API consistent:
     /// an operational point can be retrieved using any of its identifiers,
     /// not just the one used to build the cache.
-    #[tracing::instrument(skip(conn), err)]
+    #[tracing::instrument(skip(conn, path_items), err)]
     pub async fn load_path_items<L: Borrow<PathItemLocation> + std::fmt::Debug + Sync>(
         mut conn: DbConnection,
         infra_id: i64,

--- a/editoast/src/views/path/operational_point_cache.rs
+++ b/editoast/src/views/path/operational_point_cache.rs
@@ -10,6 +10,7 @@ use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use tracing::error;
 
 use crate::error::Result;
@@ -389,26 +390,30 @@ impl OperationalPointCache {
 fn collect_path_item_ids(
     operational_points: &[OperationalPointReference],
 ) -> (Vec<String>, Vec<u32>, Vec<String>) {
-    let mut trigrams: Vec<String> = Vec::new();
-    let mut ops_uic: Vec<u32> = Vec::new();
-    let mut ops_id: Vec<String> = Vec::new();
+    let mut trigrams: HashSet<String> = HashSet::new();
+    let mut ops_uic: HashSet<u32> = HashSet::new();
+    let mut ops_id: HashSet<String> = HashSet::new();
 
     for item in operational_points {
         match item {
             OperationalPointReference::Trigram { trigram, .. } => {
-                trigrams.push(trigram.clone().0);
+                trigrams.insert(trigram.clone().0);
             }
             OperationalPointReference::Uic { uic, .. } => {
-                ops_uic.push(*uic);
+                ops_uic.insert(*uic);
             }
             OperationalPointReference::Id {
                 operational_point, ..
             } => {
-                ops_id.push(operational_point.clone().0);
+                ops_id.insert(operational_point.clone().0);
             }
         }
     }
-    (trigrams, ops_uic, ops_id)
+    (
+        trigrams.into_iter().collect(),
+        ops_uic.into_iter().collect(),
+        ops_id.into_iter().collect(),
+    )
 }
 
 /// Retrieve operational points from operational point uic codes


### PR DESCRIPTION
The idea is to make the operational point cache loading faster.

I used the `simulation_summary` with a large number of trains within my request to benchmark it.

**Before**:

Small number of trains (20): ~7ms
Large number of trains (1000): ~120ms

**After**:

Small number of trains (20): ~7ms
Large number of trains (1000): ~90ms

The DB query that loads the operational point seems optimal. We do a simple index scan. The query takes time because of the amount of data to load. An idea would be to store less information within the `OperationalPointCache`. But this will require a more important refacto.