### PR TITLE
editoast: add endpoint `/train_schedules/linkings` to list linkings

### DIFF
--- a/editoast/editoast_models/src/train_schedule_linking.rs
+++ b/editoast/editoast_models/src/train_schedule_linking.rs
@@ -3,7 +3,7 @@ use editoast_derive::Model;
 #[derive(Debug, Clone, Model)]
 #[cfg_attr(test, derive(serde::Deserialize))]
 #[model(table = database::tables::train_schedule_linking)]
-#[model(gen(ops = crud, batch_ops = cd, list))]
+#[model(gen(ops = c, batch_ops = crd, list))]
 pub struct TrainScheduleLinking {
     pub id: i64,
     pub timetable_id: i64,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4240,6 +4240,53 @@ paths:
       responses:
         '204':
           description: All train schedules have been deleted
+  /train_schedules/linkings:
+    post:
+      tags:
+      - linkings
+      summary: List train schedule linkings whose target or source is part of the input train schedules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - timetable_id
+              - train_schedules
+              properties:
+                timetable_id:
+                  type: integer
+                  format: int64
+                train_schedules:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                  maxItems: 200
+        required: true
+      responses:
+        '200':
+          description: The linkings for a given timetable and given train schedules.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - id
+                  - source
+                  - target
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                    source:
+                      $ref: '#/components/schemas/LinkingOccurrenceId'
+                    target:
+                      $ref: '#/components/schemas/LinkingOccurrenceId'
+        '404':
+          description: Timetable doesn't exist.
   /train_schedules/move:
     patch:
       tags:
@@ -7261,6 +7308,8 @@ components:
       - $ref: '#/components/schemas/EditoastLevelCrossingErrorTrainBatchNotFound'
       - $ref: '#/components/schemas/EditoastLevelCrossingErrorUnsupportedTimetableType'
       - $ref: '#/components/schemas/EditoastLinesErrorsLineNotFound'
+      - $ref: '#/components/schemas/EditoastLinkingErrorDatabase'
+      - $ref: '#/components/schemas/EditoastLinkingErrorTimetableNotFound'
       - $ref: '#/components/schemas/EditoastListErrorsErrorsWrongErrorTypeProvided'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorDatabase'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorNotFound'
@@ -7835,6 +7884,51 @@ components:
           type: string
           enum:
           - editoast:infra:lines:LineNotFound
+    EditoastLinkingErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastLinkingErrorDatabaseContext
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule_linking:Database
+    EditoastLinkingErrorTimetableNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastLinkingErrorTimetableNotFoundContext
+          required:
+          - timetable_id
+          properties:
+            timetable_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule_linking:TimetableNotFound
     EditoastListErrorsErrorsWrongErrorTypeProvided:
       type: object
       required:
@@ -11636,6 +11730,70 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/RollingStockLivery'
+    LinkingOccurrenceId:
+      oneOf:
+      - type: object
+        title: LinkingOccurrenceIdUnique
+        required:
+        - train_schedule_id
+        - type
+        properties:
+          train_schedule_id:
+            type: integer
+            format: int64
+          train_schedule_instance_index:
+            type:
+            - integer
+            - 'null'
+            format: int64
+          type:
+            type: string
+            enum:
+            - unique
+      - type: object
+        title: LinkingOccurrenceIdPacedOccurrence
+        required:
+        - train_schedule_id
+        - occurrence_index
+        - type
+        properties:
+          occurrence_index:
+            type: integer
+            format: int64
+          train_schedule_id:
+            type: integer
+            format: int64
+          train_schedule_instance_index:
+            type:
+            - integer
+            - 'null'
+            format: int64
+          type:
+            type: string
+            enum:
+            - paced_occurrence
+      - type: object
+        title: LinkingOccurrenceIdAddedException
+        required:
+        - train_schedule_id
+        - added_exception_id
+        - type
+        properties:
+          added_exception_id:
+            type: integer
+            format: int64
+          train_schedule_id:
+            type: integer
+            format: int64
+          train_schedule_instance_index:
+            type:
+            - integer
+            - 'null'
+            format: int64
+          type:
+            type: string
+            enum:
+            - added_exception
     LoadingGaugeLimit:
       type: object
       required:

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -254,6 +254,7 @@ fn service_router() -> server::router::DocumentedRouter {
                         "/project_path_op",
                         post!(timetable::train_schedule::project_path_op),
                     )
+                    .route("/linkings", post!(timetable::linkings::list))
                 .nests("/{id}", |path| {
                     path.route("/", get!(timetable::train_schedule::get_by_id))
                         .route(

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,4 +1,5 @@
 pub mod conflicts;
+pub mod linkings;
 mod occupancy_blocks;
 pub mod similar_trains;
 pub mod simulation;

--- a/editoast/src/views/timetable/linkings.rs
+++ b/editoast/src/views/timetable/linkings.rs
@@ -146,3 +146,110 @@ pub(in crate::views) async fn list(
     let linkings = TrainScheduleLinking::list(conn, settings).await?;
     Ok(Json(linkings.into_iter().map_into().collect()))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use authz::Role;
+    use editoast_models::prelude::{Create, Model};
+    use reqwest::StatusCode;
+    use serde_json::json;
+
+    use crate::fixtures::create_simple_paced_train;
+    use crate::fixtures::create_timetable;
+    use crate::fixtures::create_timetable_with_train_schedule_set;
+    use crate::views::test_app::TestRequestExt as _;
+    use crate::views::test_app::test_app;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_list() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let conn = &mut pool.get_ok();
+
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        let (timetable, train_schedule_set) = create_timetable_with_train_schedule_set(conn).await;
+        let train_schedule_1 = create_simple_paced_train(conn, train_schedule_set.id).await;
+        let train_schedule_2 = create_simple_paced_train(conn, train_schedule_set.id).await;
+        let linking_1 = TrainScheduleLinking::changeset()
+            .timetable_id(timetable.id)
+            .source_train_schedule_id(train_schedule_1.id)
+            .source_occurrence_index(Some(1))
+            .target_train_schedule_id(train_schedule_1.id)
+            .target_occurrence_index(Some(2))
+            .create(conn)
+            .await
+            .expect("Failed to create a linking");
+        let linking_2 = TrainScheduleLinking::changeset()
+            .timetable_id(timetable.id)
+            .source_train_schedule_id(train_schedule_1.id)
+            .source_occurrence_index(Some(2))
+            .target_train_schedule_id(train_schedule_2.id)
+            .target_occurrence_index(Some(1))
+            .create(conn)
+            .await
+            .expect("Failed to create a linking");
+
+        let other_timetable = create_timetable(conn).await;
+        // Create another linking on an other timetable to make sure it doesn't appear in the requests
+        TrainScheduleLinking::changeset()
+            .timetable_id(other_timetable.id)
+            .source_train_schedule_id(train_schedule_1.id)
+            .source_occurrence_index(Some(0))
+            .target_train_schedule_id(train_schedule_2.id)
+            .target_occurrence_index(Some(0))
+            .create(conn)
+            .await
+            .expect("Failed to create a linking");
+
+        let request = ListLinkingsQuery {
+            timetable_id: timetable.id,
+            train_schedules: vec![train_schedule_1.id],
+        };
+
+        let response: Vec<LinkingResponse> = app
+            .post("/train_schedules/linkings")
+            .json(&json!(request))
+            .by_user(user.as_ref())
+            .await
+            .assert_status(StatusCode::OK)
+            .json();
+
+        assert_eq!(
+            response
+                .into_iter()
+                .map(|linking| linking.id)
+                .collect::<HashSet<i64>>(),
+            HashSet::from([linking_1.id, linking_2.id])
+        );
+
+        let request = ListLinkingsQuery {
+            timetable_id: timetable.id,
+            train_schedules: vec![train_schedule_2.id],
+        };
+
+        let response: Vec<LinkingResponse> = app
+            .post("/train_schedules/linkings")
+            .json(&json!(request))
+            .by_user(user.as_ref())
+            .await
+            .assert_status(StatusCode::OK)
+            .json();
+
+        assert_eq!(
+            response
+                .into_iter()
+                .map(|linking| linking.id)
+                .collect::<Vec<i64>>(),
+            vec![linking_2.id]
+        );
+    }
+}

--- a/editoast/src/views/timetable/linkings.rs
+++ b/editoast/src/views/timetable/linkings.rs
@@ -1,0 +1,148 @@
+use super::AppState;
+use axum::Json;
+use axum::extract::State;
+use editoast_derive::EditoastError;
+use editoast_models::Timetable;
+use editoast_models::TrainScheduleLinking;
+use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+use utoipa::ToSchema;
+
+use crate::error::Result;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct LinkingResponse {
+    pub id: i64,
+    pub source: LinkingOccurrenceId,
+    pub target: LinkingOccurrenceId,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[schema(title_variants)]
+pub enum LinkingOccurrenceId {
+    Unique {
+        train_schedule_id: i64,
+        train_schedule_instance_index: Option<i64>,
+    },
+    PacedOccurrence {
+        train_schedule_id: i64,
+        occurrence_index: i64,
+        train_schedule_instance_index: Option<i64>,
+    },
+    AddedException {
+        train_schedule_id: i64,
+        added_exception_id: i64,
+        train_schedule_instance_index: Option<i64>,
+    },
+}
+
+fn get_linking_occurrence_id(
+    train_schedule_id: i64,
+    occurrence_index: Option<i64>,
+    added_exception_id: Option<i64>,
+    train_schedule_instance_index: Option<i64>,
+) -> LinkingOccurrenceId {
+    match (occurrence_index, added_exception_id) {
+        (None, None) => LinkingOccurrenceId::Unique {
+            train_schedule_id,
+            train_schedule_instance_index,
+        },
+        (Some(occurrence_index), None) => LinkingOccurrenceId::PacedOccurrence {
+            train_schedule_id,
+            occurrence_index,
+            train_schedule_instance_index,
+        },
+        (None, Some(added_exception_id)) => LinkingOccurrenceId::AddedException {
+            train_schedule_id,
+            added_exception_id,
+            train_schedule_instance_index,
+        },
+        (Some(_), Some(_)) => {
+            unreachable!("A train can't be both a regular occurrence and an added exception")
+        }
+    }
+}
+
+impl From<TrainScheduleLinking> for LinkingResponse {
+    fn from(linking: TrainScheduleLinking) -> Self {
+        LinkingResponse {
+            id: linking.id,
+            source: get_linking_occurrence_id(
+                linking.source_train_schedule_id,
+                linking.source_occurrence_index,
+                linking.source_added_exception_id,
+                linking.source_train_schedule_instance_index,
+            ),
+            target: get_linking_occurrence_id(
+                linking.target_train_schedule_id,
+                linking.target_occurrence_index,
+                linking.target_added_exception_id,
+                linking.target_train_schedule_instance_index,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Error, EditoastError, Serialize, derive_more::From)]
+#[editoast_error(base_id = "train_schedule_linking")]
+enum LinkingError {
+    #[error("Timetable {timetable_id} does not exist")]
+    #[editoast_error(status = 404)]
+    TimetableNotFound { timetable_id: i64 },
+    #[error(transparent)]
+    #[from(forward)]
+    #[serde(skip)]
+    Database(editoast_models::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct ListLinkingsQuery {
+    pub timetable_id: i64,
+    #[schema(max_items = 200)]
+    pub train_schedules: Vec<i64>,
+}
+
+/// List train schedule linkings whose target or source is part of the input train schedules
+#[editoast_derive::route(authz::Role::OperationalStudies)]
+#[utoipa::path(
+    post, path = "",
+    tag = "linkings",
+    request_body = inline(ListLinkingsQuery),
+    responses(
+        (status = 200, description = "The linkings for a given timetable and given train schedules.", body = inline(Vec<LinkingResponse>)),
+        (status = 404, description = "Timetable doesn't exist.")
+    ),
+)]
+pub(in crate::views) async fn list(
+    State(AppState { db_pool, .. }): State<AppState>,
+    Json(ListLinkingsQuery {
+        timetable_id,
+        train_schedules,
+    }): Json<ListLinkingsQuery>,
+) -> Result<Json<Vec<LinkingResponse>>> {
+    use database::tables::train_schedule_linking::dsl;
+    use diesel::BoolExpressionMethods;
+    use diesel::prelude::*;
+    use editoast_models::prelude::*;
+
+    let conn = &mut db_pool.get().await?;
+    Timetable::exists_or_fail(conn, timetable_id, || LinkingError::TimetableNotFound {
+        timetable_id,
+    })
+    .await?;
+
+    let settings = SelectionSettings::new()
+        .filter(move || TrainScheduleLinking::TIMETABLE_ID.eq(timetable_id))
+        .filter(move || {
+            FilterSetting::<TrainScheduleLinking>::new(
+                dsl::source_train_schedule_id
+                    .eq_any(train_schedules.clone())
+                    .or(dsl::target_train_schedule_id.eq_any(train_schedules.clone())),
+            )
+        });
+    let linkings = TrainScheduleLinking::list(conn, settings).await?;
+    Ok(Json(linkings.into_iter().map_into().collect()))
+}

--- a/front/public/locales/de/errors.json
+++ b/front/public/locales/de/errors.json
@@ -315,6 +315,10 @@
       "TimetableNotFound": "Fahrplan '{{timetable_id}}' nicht gefunden",
       "TrainScheduleNotFound": "Zugfahrplan '{{train_schedule_id}}' nicht gefunden"
     },
+    "train_schedule_linking": {
+      "Database": "Interner Fehler (Datenbank)",
+      "TimetableNotFound": "Fahrplan '{{timetable_id}}' nicht gefunden"
+    },
     "train_schedule_set": {
       "CatalogEntryNotFound": "Katalogeintrag '{{catalog_entry_id}}' nicht gefunden",
       "Database": "Interner Fehler (Datenbank)",

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -330,6 +330,10 @@
       "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found",
       "TrainScheduleNotFound": "Train schedule '{{train_schedule_id}}' could not be found"
     },
+    "train_schedule_linking": {
+      "Database": "Internal error (database)",
+      "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found"
+    },
     "train_schedule_set": {
       "CatalogEntryNotFound": "Catalog entry '{{catalog_entry_id}}' could not be found",
       "Database": "Internal error (database)",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -330,6 +330,10 @@
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",
       "TrainScheduleNotFound": "La circulation '{{train_schedule_id}}' n’a pas été trouvée"
     },
+    "train_schedule_linking": {
+      "Database": "Erreur interne (base de données)",
+      "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée"
+    },
     "train_schedule_set": {
       "CatalogEntryNotFound": "Catalogue '{{catalog_entry_id}}' non trouvé",
       "Database": "Erreur interne (base de données)",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -32,6 +32,7 @@ export const addTagTypes = [
   'train_schedule_exceptions',
   'train_schedule_set',
   'train_schedule',
+  'linkings',
   'etcs_braking_curves',
   'work_schedules',
   'worker',
@@ -1382,6 +1383,17 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['timetable', 'train_schedule'],
       }),
+      postTrainSchedulesLinkings: build.query<
+        PostTrainSchedulesLinkingsApiResponse,
+        PostTrainSchedulesLinkingsApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/train_schedules/linkings`,
+          method: 'POST',
+          body: queryArg.body,
+        }),
+        providesTags: ['linkings'],
+      }),
       patchTrainSchedulesMove: build.mutation<
         PatchTrainSchedulesMoveApiResponse,
         PatchTrainSchedulesMoveApiArg
@@ -2691,6 +2703,18 @@ export type DeleteTrainSchedulesApiResponse = unknown;
 export type DeleteTrainSchedulesApiArg = {
   body: {
     ids: number[];
+  };
+};
+export type PostTrainSchedulesLinkingsApiResponse =
+  /** status 200 The linkings for a given timetable and given train schedules. */ {
+    id: number;
+    source: LinkingOccurrenceId;
+    target: LinkingOccurrenceId;
+  }[];
+export type PostTrainSchedulesLinkingsApiArg = {
+  body: {
+    timetable_id: number;
+    train_schedules: number[];
   };
 };
 export type PatchTrainSchedulesMoveApiResponse = unknown;
@@ -5135,6 +5159,24 @@ export type TrainScheduleSetUpdateForm = {
   name?: string | null;
   published: boolean;
 };
+export type LinkingOccurrenceId =
+  | {
+      train_schedule_id: number;
+      train_schedule_instance_index?: number | null;
+      type: 'unique';
+    }
+  | {
+      occurrence_index: number;
+      train_schedule_id: number;
+      train_schedule_instance_index?: number | null;
+      type: 'paced_occurrence';
+    }
+  | {
+      added_exception_id: number;
+      train_schedule_id: number;
+      train_schedule_instance_index?: number | null;
+      type: 'added_exception';
+    };
 export type CoreSignalUpdate = {
   /** The labels of the new aspect */
   aspect_label: string;

--- a/front/src/config/openapi-editoast-config.json
+++ b/front/src/config/openapi-editoast-config.json
@@ -24,7 +24,8 @@
         "postTrainSchedulesOccupancyBlocks",
         "postWorkSchedulesProjectPath",
         "postSearch",
-        "postTimetableByIdPathStepsLocalTrackNames"
+        "postTimetableByIdPathStepsLocalTrackNames",
+        "postTrainSchedulesLinkings"
       ],
       "type": "query"
     }

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -1162,6 +1162,29 @@ class EditoastLinesErrorsLineNotFound(BaseModel):
     type: Literal["editoast:infra:lines:LineNotFound"]
 
 
+class EditoastLinkingErrorDatabase(BaseModel):
+    context: Annotated[
+        dict[str, Any] | None, Field(title="EditoastLinkingErrorDatabaseContext")
+    ] = None
+    message: str
+    status: Literal[400]
+    type: Literal["editoast:train_schedule_linking:Database"]
+
+
+class EditoastLinkingErrorTimetableNotFoundContext(BaseModel):
+    timetable_id: int
+
+
+class EditoastLinkingErrorTimetableNotFound(BaseModel):
+    context: Annotated[
+        EditoastLinkingErrorTimetableNotFoundContext | None,
+        Field(title="EditoastLinkingErrorTimetableNotFoundContext"),
+    ] = None
+    message: str
+    status: Literal[404]
+    type: Literal["editoast:train_schedule_linking:TimetableNotFound"]
+
+
 class EditoastListErrorsErrorsWrongErrorTypeProvided(BaseModel):
     context: Annotated[
         dict[str, Any] | None,
@@ -2729,6 +2752,40 @@ class LightElectricalProfileSet(BaseModel):
 
 class LightModeEffortCurves(BaseModel):
     is_electric: bool
+
+
+class LinkingOccurrenceIdUnique(BaseModel):
+    train_schedule_id: int
+    train_schedule_instance_index: int | None = None
+    type: Literal["unique"]
+
+
+class LinkingOccurrenceIdPacedOccurrence(BaseModel):
+    occurrence_index: int
+    train_schedule_id: int
+    train_schedule_instance_index: int | None = None
+    type: Literal["paced_occurrence"]
+
+
+class LinkingOccurrenceIdAddedException(BaseModel):
+    added_exception_id: int
+    train_schedule_id: int
+    train_schedule_instance_index: int | None = None
+    type: Literal["added_exception"]
+
+
+class LinkingOccurrenceId(
+    RootModel[
+        LinkingOccurrenceIdUnique
+        | LinkingOccurrenceIdPacedOccurrence
+        | LinkingOccurrenceIdAddedException
+    ]
+):
+    root: (
+        LinkingOccurrenceIdUnique
+        | LinkingOccurrenceIdPacedOccurrence
+        | LinkingOccurrenceIdAddedException
+    )
 
 
 class LoadingGaugeType(Enum):
@@ -4666,6 +4723,8 @@ class EditoastError(
         | EditoastLevelCrossingErrorTrainBatchNotFound
         | EditoastLevelCrossingErrorUnsupportedTimetableType
         | EditoastLinesErrorsLineNotFound
+        | EditoastLinkingErrorDatabase
+        | EditoastLinkingErrorTimetableNotFound
         | EditoastListErrorsErrorsWrongErrorTypeProvided
         | EditoastMacroNodeErrorDatabase
         | EditoastMacroNodeErrorNotFound
@@ -4843,6 +4902,8 @@ class EditoastError(
         | EditoastLevelCrossingErrorTrainBatchNotFound
         | EditoastLevelCrossingErrorUnsupportedTimetableType
         | EditoastLinesErrorsLineNotFound
+        | EditoastLinkingErrorDatabase
+        | EditoastLinkingErrorTimetableNotFound
         | EditoastListErrorsErrorsWrongErrorTypeProvided
         | EditoastMacroNodeErrorDatabase
         | EditoastMacroNodeErrorNotFound


### PR DESCRIPTION
Add new endpoint `/train_schedules/linkings` to list linkings

- paginated listing
- use of `FilterSetting::<TrainScheduleLinking>::new` because `FilterSetting` doesn’t directly support `.or` method, which was necessary here


fix https://github.com/OpenRailAssociation/osrd/issues/17584

> [!IMPORTANT]
> The implementation didn’t follow the ticket on the structure of `source` and `target`: instead of a `struct`, we used an `enum` which allowed to show the incompatibility between the `occurrence_index` and `added_exception_id` fields 