### PR TITLE
front: reducers: fix offset error in generateGrantSelectProps

### DIFF
--- a/front/src/common/authorization/utils/generateGrantSelectProps.ts
+++ b/front/src/common/authorization/utils/generateGrantSelectProps.ts
@@ -77,7 +77,7 @@ const generateGrantSelectProps = ({
   if (userPrivileges.has('can_share_ownership') === false) {
     const filteredOptions = allowedOptions.filter((_, index) => index >= subjectValueIndex);
     return {
-      value: filteredOptions[subjectValueIndex],
+      value: allowedOptions[subjectValueIndex],
       options: filteredOptions,
       // readonly if there is only one option left and it is already selected
       readOnly: filteredOptions.length === 1,


### PR DESCRIPTION
Using `subjectValueIndex` to perform a lookup in `filteredOptions` is wrong. Use it on the original `allowedOptions` array.

Alternatively, we could use `filteredOptions[0]` instead.