### PR TITLE
editoast: fix schema for infra creation operations

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -12044,18 +12044,17 @@ components:
           description: Train schedule
     Operation:
       oneOf:
-      - type: object
+      - allOf:
+        - $ref: '#/components/schemas/InfraObject'
+        - type: object
+          required:
+          - operation_type
+          properties:
+            operation_type:
+              type: string
+              enum:
+              - CREATE
         title: OperationCreate
-        required:
-        - operation_type
-        - payload
-        properties:
-          operation_type:
-            type: string
-            enum:
-            - CREATE
-          payload:
-            $ref: '#/components/schemas/InfraObject'
       - allOf:
         - type: object
           required:

--- a/editoast/src/infra_cache/operation/mod.rs
+++ b/editoast/src/infra_cache/operation/mod.rs
@@ -72,6 +72,7 @@ impl utoipa::PartialSchema for Operation {
             Create {
                 #[schema(inline)]
                 operation_type: Create,
+                #[serde(flatten)]
                 payload: Box<InfraObject>,
             },
             Update {

--- a/front/src/applications/editor/data/utils.ts
+++ b/front/src/applications/editor/data/utils.ts
@@ -121,12 +121,10 @@ export function nestEntity(entity: EditorEntity, type: EditoastType): EditorEnti
 export function entityToCreateOperation(entity: EditorEntity): CreateOperation {
   return {
     operation_type: 'CREATE',
-    payload: {
-      obj_type: entity.objType,
-      railjson: {
-        ...entity.properties,
-        id: uuid(),
-      },
+    obj_type: entity.objType,
+    railjson: {
+      ...entity.properties,
+      id: uuid(),
     },
   } as CreateOperation;
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3432,10 +3432,9 @@ export type PatchOperation =
       op: 'test';
     });
 export type Operation =
-  | {
+  | (InfraObject & {
       operation_type: 'CREATE';
-      payload: InfraObject;
-    }
+    })
   | ({
       obj_id: string;
       obj_type: ObjectType;

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -2797,6 +2797,14 @@ class OccupancyBlocksTrainScheduleResult(BaseModel):
     """
 
 
+class OperationCreate1(BaseModel):
+    operation_type: Literal["CREATE"]
+
+
+class OperationCreate12(InfraObjectElectrification, OperationCreate1):
+    pass
+
+
 class OperationDelete(BaseModel):
     obj_id: str
     obj_type: ObjectType
@@ -5198,6 +5206,19 @@ class OccupancyBlockForm(BaseModel):
     timetable_id: int
 
 
+class InfraObjectLevelCrossing(BaseModel):
+    obj_type: Literal["LevelCrossing"]
+    railjson: LevelCrossing
+
+
+class OperationCreate7(InfraObjectSwitchType, OperationCreate1):
+    pass
+
+
+class OperationCreate13(InfraObjectLevelCrossing, OperationCreate1):
+    pass
+
+
 class OperationalPointPartExtension(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -6117,11 +6138,6 @@ class InfraObjectRoute(BaseModel):
     railjson: Route
 
 
-class InfraObjectLevelCrossing(BaseModel):
-    obj_type: Literal["LevelCrossing"]
-    railjson: LevelCrossing
-
-
 class JourneySearchQuery(BaseModel):
     destination: OperationalPointPartReference
     infra_id: int
@@ -6218,6 +6234,18 @@ class NeutralSectionExtensions(BaseModel):
         extra="forbid",
     )
     neutral_sncf: NeutralSectionNeutralSncfExtension | None = None
+
+
+class OperationCreate8(InfraObjectDetector, OperationCreate1):
+    pass
+
+
+class OperationCreate9(InfraObjectBufferStop, OperationCreate1):
+    pass
+
+
+class OperationCreate10(InfraObjectRoute, OperationCreate1):
+    pass
 
 
 class OperationUpdate(BaseModel):
@@ -6834,6 +6862,31 @@ class NeutralSection(BaseModel):
     track_ranges: list[DirectionalTrackRange]
 
 
+class InfraObjectNeutralSection(BaseModel):
+    obj_type: Literal["NeutralSection"]
+    railjson: NeutralSection
+
+
+class OperationCreate2(InfraObjectTrackSection, OperationCreate1):
+    pass
+
+
+class OperationCreate3(InfraObjectSignal, OperationCreate1):
+    pass
+
+
+class OperationCreate4(InfraObjectNeutralSection, OperationCreate1):
+    pass
+
+
+class OperationCreate5(InfraObjectSpeedSection, OperationCreate1):
+    pass
+
+
+class OperationCreate6(InfraObjectSwitch, OperationCreate1):
+    pass
+
+
 class OperationalPoint(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7032,14 +7085,41 @@ class TrainScheduleExceptionChangeGroups(BaseModel):
     train_name: TrainNameChangeGroup | None = None
 
 
-class InfraObjectNeutralSection(BaseModel):
-    obj_type: Literal["NeutralSection"]
-    railjson: NeutralSection
-
-
 class InfraObjectOperationalPoint(BaseModel):
     obj_type: Literal["OperationalPoint"]
     railjson: OperationalPoint
+
+
+class InfraObject(
+    RootModel[
+        InfraObjectTrackSection
+        | InfraObjectSignal
+        | InfraObjectNeutralSection
+        | InfraObjectSpeedSection
+        | InfraObjectSwitch
+        | InfraObjectSwitchType
+        | InfraObjectDetector
+        | InfraObjectBufferStop
+        | InfraObjectRoute
+        | InfraObjectOperationalPoint
+        | InfraObjectElectrification
+        | InfraObjectLevelCrossing
+    ]
+):
+    root: (
+        InfraObjectTrackSection
+        | InfraObjectSignal
+        | InfraObjectNeutralSection
+        | InfraObjectSpeedSection
+        | InfraObjectSwitch
+        | InfraObjectSwitchType
+        | InfraObjectDetector
+        | InfraObjectBufferStop
+        | InfraObjectRoute
+        | InfraObjectOperationalPoint
+        | InfraObjectElectrification
+        | InfraObjectLevelCrossing
+    )
 
 
 class InfraObjectWithGeometry(BaseModel):
@@ -7058,26 +7138,44 @@ class InfraObjectWithGeometry(BaseModel):
     railjson: dict[str, Any]
 
 
-class OperationCreate(BaseModel):
-    operation_type: Literal["CREATE"]
-    payload: (
-        InfraObjectTrackSection
-        | InfraObjectSignal
-        | InfraObjectNeutralSection
-        | InfraObjectSpeedSection
-        | InfraObjectSwitch
-        | InfraObjectSwitchType
-        | InfraObjectDetector
-        | InfraObjectBufferStop
-        | InfraObjectRoute
-        | InfraObjectOperationalPoint
-        | InfraObjectElectrification
-        | InfraObjectLevelCrossing
+class OperationCreate11(InfraObjectOperationalPoint, OperationCreate1):
+    pass
+
+
+class Operation(
+    RootModel[
+        OperationUpdate
+        | OperationDelete
+        | OperationCreate2
+        | OperationCreate3
+        | OperationCreate4
+        | OperationCreate5
+        | OperationCreate6
+        | OperationCreate7
+        | OperationCreate8
+        | OperationCreate9
+        | OperationCreate10
+        | OperationCreate11
+        | OperationCreate12
+        | OperationCreate13
+    ]
+):
+    root: (
+        OperationUpdate
+        | OperationDelete
+        | OperationCreate2
+        | OperationCreate3
+        | OperationCreate4
+        | OperationCreate5
+        | OperationCreate6
+        | OperationCreate7
+        | OperationCreate8
+        | OperationCreate9
+        | OperationCreate10
+        | OperationCreate11
+        | OperationCreate12
+        | OperationCreate13
     )
-
-
-class Operation(RootModel[OperationCreate | OperationUpdate | OperationDelete]):
-    root: OperationCreate | OperationUpdate | OperationDelete
 
 
 class PacedTrainException(BaseModel):


### PR DESCRIPTION
The schema did not match the serialized payload. Leading to an inconsistency between the frontend and the backend.

This PR fixes a bug. Trying to create any kind of object with the infrastructure editor used to lead to a 500 error.