### PR TITLE
Scope TOD selection to one waypoint

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -85,7 +85,9 @@ import CurveSelectionSidePanel, {
 import canDragHoveredTrain from './helpers/canDragHoveredTrain';
 import cutSpaceTimeCurves from './helpers/cutSpaceTimeCurves';
 import formatSpaceTimeCurves from './helpers/formatSpaceTimeCurves';
-import getPanelOccurrenceCounts from './helpers/getPanelOccurrenceCounts';
+import getPanelOccurrenceCounts, {
+  getTodOccurrenceCounts,
+} from './helpers/getPanelOccurrenceCounts';
 import getTrainExceptionTypes from './helpers/getTrainExceptionTypes';
 import type { ExistingLinking } from './helpers/linkings';
 import makeProjectedTrains from './helpers/makeProjectedTrains';
@@ -272,6 +274,8 @@ const SpaceTimeChartWrapper = ({
 
   const [panelSelectionMode, setPanelSelectionMode] = useState<PanelSelectionMode>('compliant');
   const [lastClickedOccurrenceId, setLastClickedOccurrenceId] = useState<OccurrenceId>();
+  // The TOD waypoint the current 'tod' selection was made from.
+  const [selectedTrainWaypointId, setSelectedTrainWaypointId] = useState<string>();
 
   const translations = { linearMode: t('main.linearMode') };
 
@@ -443,6 +447,7 @@ const SpaceTimeChartWrapper = ({
         paths,
         activeWaypointRef,
         selectedTrain: selection,
+        selectedWaypointId: selectedTrainWaypointId,
         panelMode: panelSelectionMode,
         onCloseOccupancyLayer,
         handleWaypointClick,
@@ -466,6 +471,7 @@ const SpaceTimeChartWrapper = ({
       subCategories,
       trainSchedulesWithDetails,
       selection,
+      selectedTrainWaypointId,
       panelSelectionMode,
       onCloseOccupancyLayer,
       handleWaypointClick,
@@ -680,9 +686,17 @@ const SpaceTimeChartWrapper = ({
   const panelExceptionType: CurveStyleExceptionType =
     selectedTrainBy === 'tod' ? 'path_and_schedule' : 'start_time';
 
+  // A 'tod' selection counts occurrences actually present at that waypoint.
+  const activeWaypointZones =
+    selectedTrainBy === 'tod' && selectedTrainWaypointId
+      ? trackOccupancyDiagramsData?.find((wp) => wp.waypointId === selectedTrainWaypointId)?.zones
+      : undefined;
+
   const panelCounts =
     selectedTrain && isPacedTrainWithDetails(selectedTrain) && selectedTrainBy !== 'timetable'
-      ? getPanelOccurrenceCounts(selectedTrain.paced, panelExceptionType)
+      ? activeWaypointZones && selectedTrainScheduleId
+        ? getTodOccurrenceCounts(activeWaypointZones, selectedTrainScheduleId, panelExceptionType)
+        : getPanelOccurrenceCounts(selectedTrain.paced, panelExceptionType)
       : undefined;
   const showCurvePanel = !!panelCounts;
 
@@ -706,6 +720,7 @@ const SpaceTimeChartWrapper = ({
     setPanelSelectionMode(mode);
 
     const by = selectedTrainBy === 'tod' ? 'tod' : 'std';
+    // Switching panel mode stays on the same TOD waypoint when the selection came from one.
     if (mode === 'single') {
       const singleId =
         lastClickedOccurrenceId ??
@@ -722,10 +737,17 @@ const SpaceTimeChartWrapper = ({
     }
   };
 
-  const commitSelection = (id: TrainId, by: 'std' | 'tod', panelMode: PanelSelectionMode) => {
-    if (selectedTrainId === id && selectedTrainBy === by) return;
+  const commitSelection = (
+    id: TrainId,
+    by: 'std' | 'tod',
+    panelMode: PanelSelectionMode,
+    waypointId?: string
+  ) => {
+    if (selectedTrainId === id && selectedTrainBy === by && selectedTrainWaypointId === waypointId)
+      return;
     if (isOccurrenceId(id)) setLastClickedOccurrenceId(id);
     setPanelSelectionMode(panelMode);
+    setSelectedTrainWaypointId(waypointId);
     dispatch(updateSelectedTrain({ id, by }));
   };
 
@@ -767,9 +789,14 @@ const SpaceTimeChartWrapper = ({
 
     // Click on a TOD occupancy zone.
     if (isOccupancyPickingElement(element)) {
-      const { trainId } = parseOccupancyZonePathId(element.pathId);
+      const { trainId, waypointId } = parseOccupancyZonePathId(element.pathId);
       const { exception } = findTrainScheduleAndException(trainSchedulesWithDetails ?? [], trainId);
-      commitSelection(trainId, 'tod', exception?.path_and_schedule ? 'single' : 'compliant');
+      commitSelection(
+        trainId,
+        'tod',
+        exception?.path_and_schedule ? 'single' : 'compliant',
+        waypointId
+      );
     }
   };
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -371,9 +371,34 @@ const SpaceTimeChartWrapper = ({
     }));
   }, [waypointsPanelData, operationalPoints]);
 
+  // Revert a 'tod' selection back to the 'std' one when the waypoint is closed.
+  const closeTodSelectionIfWaypoint = useCallback(
+    (waypointId: string) => {
+      if (selectedTrainId && selectedTrainBy === 'tod' && selectedTrainWaypointId === waypointId) {
+        setSelectedTrainWaypointId(undefined);
+        dispatch(updateSelectedTrain({ id: selectedTrainId, by: 'std' }));
+      }
+    },
+    [selectedTrainId, selectedTrainBy, selectedTrainWaypointId, dispatch]
+  );
+
+  const handleCloseOccupancyLayer = useCallback(
+    (waypointId: string) => {
+      closeTodSelectionIfWaypoint(waypointId);
+      onCloseOccupancyLayer?.(waypointId);
+    },
+    [closeTodSelectionIfWaypoint, onCloseOccupancyLayer]
+  );
+
   const { waypointMenu, activeWaypointId, handleWaypointClick } = useWaypointMenu(
     activeWaypointRef,
-    waypointsPanelData
+    waypointsPanelData && {
+      ...waypointsPanelData,
+      toggleDeployedWaypoint: (waypointId: string, deployed?: boolean) => {
+        if (!deployed) handleCloseOccupancyLayer(waypointId);
+        waypointsPanelData.toggleDeployedWaypoint(waypointId, deployed);
+      },
+    }
   );
 
   const hoveredTrainIdForChart = useMemo(() => {
@@ -449,7 +474,7 @@ const SpaceTimeChartWrapper = ({
         selectedTrain: selection,
         selectedWaypointId: selectedTrainWaypointId,
         panelMode: panelSelectionMode,
-        onCloseOccupancyLayer,
+        onCloseOccupancyLayer: handleCloseOccupancyLayer,
         handleWaypointClick,
         activeWaypointId,
         hoveredTrainIdForChart,
@@ -473,7 +498,7 @@ const SpaceTimeChartWrapper = ({
       selection,
       selectedTrainWaypointId,
       panelSelectionMode,
-      onCloseOccupancyLayer,
+      handleCloseOccupancyLayer,
       handleWaypointClick,
       activeWaypointRef,
       hoveredTrainIdForChart,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/buildSplitPoints.tsx
@@ -45,6 +45,7 @@ type BuildSplitPointsProps = {
   paths: Path[];
   activeWaypointRef?: React.RefObject<HTMLDivElement | null>;
   selectedTrain?: SelectedTrain;
+  selectedWaypointId?: string;
   panelMode?: PanelSelectionMode;
   onCloseOccupancyLayer?: (waypointId: string) => void;
   handleWaypointClick?: (waypointId: string) => void;
@@ -68,6 +69,7 @@ export function buildSplitPoints({
   paths,
   activeWaypointRef,
   selectedTrain,
+  selectedWaypointId,
   panelMode,
   onCloseOccupancyLayer,
   handleWaypointClick,
@@ -119,6 +121,12 @@ export function buildSplitPoints({
       const baseZones = zones ?? [];
       const zonesCountByTrainScheduleId = countZonesByTrainScheduleId(baseZones);
 
+      // A 'tod' selection only stays 'active' on the TOD waypoint it was made from.
+      const waypointEffectiveSelection: SelectedTrain | undefined =
+        selectedTrain?.by === 'tod' && selectedWaypointId !== waypointId
+          ? { ...selectedTrain, by: 'std' }
+          : selectedTrain;
+
       let occupancyZones: (OccupancyZone & MovableOccupancyZone)[] = baseZones.flatMap((zone) => {
         const isHovered = hoveredTrainIdForChart === zone.trainId;
         let totalOccurrencesOnTrack = 0;
@@ -139,7 +147,7 @@ export function buildSplitPoints({
             train: isOccurrenceId(zone.trainId)
               ? { id: zone.trainId, relevantExceptionTypes: zone.exceptionTypes }
               : { id: zone.trainId },
-            selection: selectedTrain,
+            selection: waypointEffectiveSelection,
             panelMode,
             hover: curveHover,
           },

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPanelOccurrenceCounts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getPanelOccurrenceCounts.ts
@@ -1,7 +1,10 @@
 import { getOccurrencesNb } from 'modules/trainSchedule/helpers/pacedTrain';
 import type { PacedDetails } from 'modules/trainSchedule/types';
+import type { TrainScheduleId } from 'reducers/osrdconf/types';
+import { extractTrainScheduleIdFromTrainId } from 'utils/trainId';
 
 import type { CurveStyleExceptionType } from '../../../types';
+import type { MovableOccupancyZone } from './zones';
 
 /**
  * For the curve selection panel:
@@ -34,6 +37,25 @@ const getPanelOccurrenceCounts = (
   }
 
   return { compliant: active - nonCompliant, all: active };
+};
+
+/**
+ * Like getPanelOccurrenceCounts, but scoped to one TOD waypoint: only counts occurrences
+ * whose zone reaches that waypoint, since a reroute exception can skip it entirely.
+ */
+export const getTodOccurrenceCounts = (
+  zones: MovableOccupancyZone[],
+  trainScheduleId: TrainScheduleId,
+  exceptionType: CurveStyleExceptionType
+): { compliant: number; all: number } => {
+  const occurrenceZones = zones.filter(
+    (zone) => extractTrainScheduleIdFromTrainId(zone.trainId) === trainScheduleId
+  );
+  const nonCompliant = occurrenceZones.filter((zone) =>
+    zone.exceptionTypes.includes(exceptionType)
+  ).length;
+
+  return { compliant: occurrenceZones.length - nonCompliant, all: occurrenceZones.length };
 };
 
 export default getPanelOccurrenceCounts;

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/TrackOccupancyCanvas.tsx
@@ -22,7 +22,13 @@ const CloseButton = ({ position, onClose }: { position: number; onClose: () => v
     <button
       data-testid="close-track-occupancy-panel"
       className="close-track-occupancy-panel"
-      onClick={() => onClose()}
+      // This button is nested inside the chart, which has its own click listener. We use
+      // 'stopPropagation' because that listener would otherwise fire first and deselect the
+      // train before onClose runs.
+      onClickCapture={(e) => {
+        e.stopPropagation();
+        onClose();
+      }}
       style={{
         top: getSpacePixel(position),
       }}


### PR DESCRIPTION
Three TOD bugs here (https://github.com/OpenRailAssociation/osrd/issues/17538#issuecomment-5060520733) have the same root cause: the selection state had no notion of which waypoint it was made from.

Now:

- [x] Selecting in one TOD no longer shows as "active" in other open TOD.
- [x] The panel's occurrence count now reflects the occurrences actually present at that waypoint
- [x]  Closing the TOD that owns the active selection now reverts it to the STD (same train/occurrence), instead of losing it entirely.