### PR TITLE
editoast: views: infra: stop skipping authorization in the endpoint tests and test 403 forbidden cases

### DIFF
--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -125,6 +125,8 @@ mod tests {
 
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
+    use authz::InfraGrant;
     use editoast_models::Infra;
     use editoast_models::prelude::*;
     use schemas::infra::Detector;
@@ -134,20 +136,25 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_attached_detector() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let pool = app.db_pool();
-
-        // Create empty infra
-        let empty_infra = Infra::changeset()
+        let infra_id = Infra::changeset()
             .name("test_infra".to_owned())
             .last_railjson_version()
             .create(&mut pool.get_ok())
             .await
-            .expect("Failed to create infra");
+            .expect("Failed to create infra")
+            .id;
+
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         // Create a track and a detector on it
         let track = TrackSection::default().into();
-        apply_create_operation(&track, empty_infra.id, &mut pool.get_ok())
+        apply_create_operation(&track, infra_id, &mut pool.get_ok())
             .await
             .expect("Failed to create track object");
 
@@ -156,14 +163,49 @@ mod tests {
             ..Default::default()
         }
         .into();
-        apply_create_operation(&detector, empty_infra.id, &mut pool.get_ok())
+        apply_create_operation(&detector, infra_id, &mut pool.get_ok())
             .await
             .expect("Failed to create detector object");
 
         let response: HashMap<ObjectType, Vec<String>> = app
-            .get(format!("/infra/{}/attached/{}/", empty_infra.id, track.get_id()).as_str())
+            .get(format!("/infra/{}/attached/{}/", infra_id, track.get_id()).as_str())
+            .by_user(user.as_ref())
             .await
+            .assert_status_ok()
             .json();
         assert_eq!(response.get(&ObjectType::Detector).unwrap().len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_attached_detector_requires_can_read() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let infra_id = Infra::changeset()
+            .name("test_infra".to_owned())
+            .last_railjson_version()
+            .create(&mut pool.get_ok())
+            .await
+            .expect("Failed to create infra")
+            .id;
+        let track = TrackSection::default().into();
+        apply_create_operation(&track, infra_id, &mut pool.get_ok())
+            .await
+            .expect("Failed to create track object");
+
+        let user_no_grant = app.user("alice", "Alice").create().await;
+        let user_reader = app
+            .user("bob", "Bob")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
+
+        app.get(format!("/infra/{}/attached/{}/", infra_id, track.get_id()).as_str())
+            .by_user(user_no_grant.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.get(format!("/infra/{}/attached/{}/", infra_id, track.get_id()).as_str())
+            .by_user(user_reader.as_ref())
+            .await
+            .assert_status_ok();
     }
 }

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -346,6 +346,7 @@ pub enum AutoFixesEditoastError {
 
 #[cfg(test)]
 mod tests {
+    use authz::InfraGrant;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use schemas::infra::BufferStop;
@@ -367,6 +368,7 @@ mod tests {
     use crate::views::infra::errors::query_errors;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt as _;
     use schemas::infra::ApplicableDirectionsTrackRange;
     use schemas::infra::Detector;
     use schemas::infra::Electrification;
@@ -396,13 +398,19 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_no_fix() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(small_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -411,12 +419,30 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_auto_fixes_requires_can_read() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
+
+        app.auto_fixes_request(small_infra.id)
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fix_invalid_ref_punctual_objects() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let mut small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
         let mut infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
             .await
             .expect("Failed to get infra cache");
@@ -460,6 +486,7 @@ mod tests {
         // WHEN
         let operations: Vec<Operation> = app
             .auto_fixes_request(small_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -488,10 +515,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fix_invalid_ref_route_entry_exit() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
         // Remove a buffer stop
         let deletion = Operation::Delete(DeleteOperation {
             obj_id: "buffer_stop.4".to_string(),
@@ -504,6 +536,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(small_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -716,10 +749,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn invalid_switch_ports() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let ports = HashMap::from([
             ("WRONG".into(), TrackEndpoint::new("TA1", Endpoint::End)),
@@ -742,6 +780,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(small_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -754,10 +793,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn odd_buffer_stop_location() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         // Create an odd buffer stops (to a track endpoint linked by a switch)
         let track: InfraObject = TrackSection {
@@ -795,6 +839,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(empty_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -807,10 +852,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn empty_object() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let electrification: InfraObject = Electrification::default().into();
         let operational_point = OperationalPoint::default().into();
@@ -830,6 +880,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(empty_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -849,10 +900,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn out_of_range_must_be_ignored() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let track: InfraObject = TrackSection {
             id: "test_track".into(),
@@ -896,6 +952,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(empty_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -914,10 +971,15 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(1250., 5)]
     async fn out_of_range_must_be_deleted(#[case] pos: f64, #[case] error_count: usize) {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let track: InfraObject = TrackSection {
             id: "test_track".into(),
@@ -959,6 +1021,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(empty_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -977,10 +1040,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn out_of_range_must_be_updated() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let track: InfraObject = TrackSection {
             id: "test_track".into(),
@@ -1017,6 +1085,7 @@ mod tests {
 
         let operations: Vec<Operation> = app
             .auto_fixes_request(empty_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -1035,10 +1104,15 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn missing_track_extremity_buffer_stop_fix() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let track: InfraObject = TrackSection {
             id: "track_with_no_buffer_stops".into(),
@@ -1053,6 +1127,7 @@ mod tests {
         // WHEN
         let operations: Vec<Operation> = app
             .auto_fixes_request(empty_infra_id)
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -512,6 +512,9 @@ mod tests {
     use crate::fixtures::create_small_infra;
     use crate::views::infra::delimited_area::DelimitedAreaResponse;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
+    use authz::InfraGrant;
+    use authz::Role;
     use editoast_models::Infra;
 
     use schemas::infra::Direction;
@@ -527,11 +530,18 @@ mod tests {
         entries: Vec<DirectedLocation>,
         exits: Vec<DirectedLocation>,
     ) -> Vec<DirectionalTrackRange> {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let pool = app.db_pool();
         let Infra { id: infra_id, .. } = create_small_infra(&mut pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
         let DelimitedAreaResponse { track_ranges } = app
             .get(&format!("/infra/{infra_id}/delimited_area"))
+            .by_user(user.as_ref())
             .json(&json!({
                 "infra_id": infra_id,
                 "entries": entries,
@@ -542,6 +552,43 @@ mod tests {
             .assert_status_ok()
             .json();
         track_ranges
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delimited_area_requires_operational_studies_and_can_read() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let Infra { id: infra_id, .. } = create_small_infra(&mut pool.get_ok()).await;
+        let user_no_role = app
+            .user("alice", "Alice")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
+        let user_no_grant = app
+            .user("bob", "Bob")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+        app.get(&format!("/infra/{infra_id}/delimited_area"))
+            .by_user(user_no_role.as_ref())
+            .json(&json!({
+                "infra_id": infra_id,
+                "entries": [],
+                "exits": [],
+            }
+            ))
+            .await
+            .assert_status_forbidden();
+        app.get(&format!("/infra/{infra_id}/delimited_area"))
+            .by_user(user_no_grant.as_ref())
+            .json(&json!({
+                "infra_id": infra_id,
+                "entries": [],
+                "exits": [],
+            }
+            ))
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -968,6 +968,9 @@ enum EditionError {
 
 #[cfg(test)]
 pub mod tests {
+    use authz::InfraGrant;
+    use authz::Role;
+    use authz::identity::User;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -977,29 +980,42 @@ pub mod tests {
     use crate::views::infra::errors::query_errors;
     use crate::views::test_app;
     use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt as _;
     use editoast_models::infra::ObjectQueryable;
 
-    async fn setup_split_track_test() -> (TestApp, Infra) {
-        let app = test_app!().skip_authz().build();
+    async fn setup_split_track_test() -> (TestApp, Infra, User) {
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let authorized_user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, InfraGrant::Writer)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         app.post(format!("/infra/refresh/?infras={}&force=true", small_infra.id).as_str())
+            .by_user(authorized_user.as_ref())
             .await
             .assert_status_ok();
 
-        (app, small_infra)
+        (app, small_infra, authorized_user)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_return_404_with_bad_infra() {
-        // Init
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         // Make a call with a bad infra ID
 
         // Check that we receive a 404
         app.post("/infra/123456789/split_track_section/")
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": String::from("INVALID-ID"),
                 "offset": 1,
@@ -1009,16 +1025,67 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn split_track_section_should_return_404_with_bad_id() {
-        // Init
-        let app = test_app!().skip_authz().build();
+    async fn edition_endpoints_require_writer_grant_and_operational_studies() {
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user_missing_writer = app
+            .user("alice", "Alice")
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+        let user_missing_operational_studies = app
+            .user("bob", "Bob")
+            .with_infra_grant(small_infra.id, InfraGrant::Writer)
+            .create()
+            .await;
+
+        app.post(format!("/infra/{}/", small_infra.id).as_str())
+            .by_user(user_missing_writer.as_ref())
+            .json(&Vec::<Operation>::new())
+            .await
+            .assert_status_forbidden();
+        app.post(format!("/infra/{}/", small_infra.id).as_str())
+            .by_user(user_missing_operational_studies.as_ref())
+            .json(&Vec::<Operation>::new())
+            .await
+            .assert_status_forbidden();
+
+        let split_payload = json!({
+            "track": "TA0",
+            "offset": 1,
+        });
+        app.post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user_missing_writer.as_ref())
+            .json(&split_payload)
+            .await
+            .assert_status_forbidden();
+        app.post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user_missing_operational_studies.as_ref())
+            .json(&split_payload)
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn split_track_section_should_return_404_with_bad_id() {
+        // Init
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, InfraGrant::Writer)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         // Make a call with a bad ID
 
         // Check that we receive a 404
         app.post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track":"INVALID-ID",
                 "offset": 1,
@@ -1030,14 +1097,21 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_fail_with_bad_distance() {
         // Init
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, InfraGrant::Writer)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         // Make a call with a bad distance
 
         // Check that we receive an error
         app.post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": "TA0",
                 "offset": 5000000,
@@ -1051,7 +1125,7 @@ pub mod tests {
     #[case("TD1", 15500000)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn split_track_section_should_work(#[case] track: &str, #[case] offset: u64) {
-        let (app, small_infra) = setup_split_track_test().await;
+        let (app, small_infra, user) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
         // Get infra errors
@@ -1060,6 +1134,7 @@ pub mod tests {
         // Make a call to split the track section
         let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": track,
                 "offset": offset,
@@ -1087,7 +1162,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_edition_updates_modification_date() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let mut small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let mut infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
@@ -1129,7 +1204,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn apply_edit_transaction_should_work() {
         // Init
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let conn = &mut db_pool.get().await.unwrap();
 
@@ -1172,7 +1247,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn apply_edit_transaction_should_rollback() {
         // Init
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let conn = &mut db_pool.get().await.unwrap();
         let mut small_infra = create_small_infra(conn).await;
@@ -1236,11 +1311,12 @@ pub mod tests {
         #[case] expected_position: f64,
         #[case] expected_track_index: usize, // 0 for left, 1 for right
     ) {
-        let (app, small_infra) = setup_split_track_test().await;
+        let (app, small_infra, user) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
         let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": "TD0",
                 "offset": offset,
@@ -1277,11 +1353,12 @@ pub mod tests {
         #[case] expected_position: f64,
         #[case] expected_track_index: usize, // 0 for left, 1 for right
     ) {
-        let (app, small_infra) = setup_split_track_test().await;
+        let (app, small_infra, user) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
         let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": "TD0",
                 "offset": 15_000_000,
@@ -1312,11 +1389,12 @@ pub mod tests {
         #[case] expected_position: f64,
         #[case] expected_track_index: usize, // 0 for left, 1 for right
     ) {
-        let (app, small_infra) = setup_split_track_test().await;
+        let (app, small_infra, user) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
         let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": track,
                 "offset": offset,
@@ -1345,11 +1423,12 @@ pub mod tests {
         #[case] expected_position: f64,
         #[case] expected_track_index: usize, // 0 for left, 1 for right
     ) {
-        let (app, small_infra) = setup_split_track_test().await;
+        let (app, small_infra, user) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
         let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": "TA6",
                 "offset": 2_000_000,
@@ -1379,11 +1458,12 @@ pub mod tests {
         #[case] expected_position: f64,
         #[case] expected_track_index: usize, // 0 for left, 1 for right
     ) {
-        let (app, small_infra) = setup_split_track_test().await;
+        let (app, small_infra, user) = setup_split_track_test().await;
         let db_pool = app.db_pool();
 
         let res: Vec<String> = app
             .post(format!("/infra/{}/split_track_section", small_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&json!({
                 "track": track,
                 "offset": offset,

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -133,12 +133,19 @@ mod tests {
 
     use crate::fixtures::create_empty_infra;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
+    use authz::InfraGrant;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_errors_get() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let error_type = "overlapping_electrifications";
         let level = "warnings";
@@ -150,7 +157,21 @@ mod tests {
             )
             .as_str(),
         )
+        .by_user(user.as_ref())
         .await
         .assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_errors_requires_can_read() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
+
+        app.get(format!("/infra/{}/errors", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
     }
 }

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -81,6 +81,7 @@ pub(in crate::views) async fn get_line_bbox(
 
 #[cfg(test)]
 mod tests {
+    use authz::InfraGrant;
     use geos::geojson::Geometry;
     use pretty_assertions::assert_eq;
 
@@ -92,15 +93,21 @@ mod tests {
     use crate::fixtures::create_empty_infra;
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
     use schemas::infra::TrackSection;
     use schemas::infra::TrackSectionExtensions;
     use schemas::primitives::BoundingBox;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_correct_bbox_for_existing_line_code() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let line_code = 1234;
         let geometry_json = json!({
@@ -127,6 +134,7 @@ mod tests {
 
         let bounding_box: BoundingBox = app
             .get(format!("/infra/{}/lines/{line_code}/bbox/", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -143,9 +151,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn returns_bad_request_when_line_code_not_found() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let not_existing_line_code = 123456789;
         app.get(
@@ -155,7 +168,21 @@ mod tests {
             )
             .as_str(),
         )
+        .by_user(user.as_ref())
         .await
         .assert_status_bad_request();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_line_bbox_requires_can_read() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
+
+        app.get(format!("/infra/{}/lines/1/bbox/", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
     }
 }

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1058,8 +1058,27 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_list() {
-        let app = test_app!().skip_authz().build();
-        app.get("/infra/").await.assert_status_ok();
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra_granted = create_small_infra(&mut db_pool.get_ok()).await;
+        let _ = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_granted.id, InfraGrant::Reader)
+            .create()
+            .await;
+        let InfraListResponse {
+            results: infras, ..
+        } = app
+            .get("/infra/")
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(
+            infras.iter().map(|infra| infra.id).collect_vec(),
+            vec![infra_granted.id]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1172,36 +1191,49 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get() {
-        let core_client = CoreClient::Mocked(MockingClient::default());
-
-        let app = test_app!().skip_authz().core_client(core_client).build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
-        app.get(format!("/infra/{}", empty_infra.id).as_str())
+        let infra: Infra = app
+            .get(format!("/infra/{}", infra_id).as_str())
+            .by_user(user.as_ref())
             .await
-            .assert_status_ok();
+            .assert_status_ok()
+            .json();
 
-        empty_infra.delete(&mut db_pool.get_ok()).await.unwrap();
+        infra.delete(&mut db_pool.get_ok()).await.unwrap();
 
-        app.get(format!("/infra/{}", empty_infra.id).as_str())
+        app.get(format!("/infra/{}", infra_id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_rename() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
-
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_id, InfraGrant::Writer)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
         let infra: Infra = app
-            .put(format!("/infra/{}", empty_infra.id).as_str())
+            .put(format!("/infra/{}", infra_id).as_str())
             .json(&json!({"name": "rename_test"}))
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
-
+        assert_eq!(infra.id, infra.id);
         assert_eq!(infra.name, "rename_test");
     }
 
@@ -1212,52 +1244,85 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_refresh() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         let refreshed_infras: InfraRefreshedResponse = app
-            .post(format!("/infra/refresh/?infras={}", empty_infra.id).as_str())
+            .post(format!("/infra/refresh/?infras={}", infra_id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
-        assert_eq!(refreshed_infras.infra_refreshed, vec![empty_infra.id]);
+        assert_eq!(refreshed_infras.infra_refreshed, vec![infra_id]);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    // Slow test
-    // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     async fn infra_refresh_force() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
+        // First call to refresh after creation, the infra should be refreshed
         let refreshed_infras: InfraRefreshedResponse = app
-            .post(format!("/infra/refresh/?infras={}&force=true", empty_infra.id).as_str())
+            .post(format!("/infra/refresh/?infras={}", infra_id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
-        assert!(refreshed_infras.infra_refreshed.contains(&empty_infra.id));
+        assert_eq!(refreshed_infras.infra_refreshed, vec![infra_id]);
+        // Second refresh call, nothing to refresh
+        let refreshed_infras: InfraRefreshedResponse = app
+            .post(format!("/infra/refresh/?infras={}", infra_id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(refreshed_infras.infra_refreshed, Vec::<i64>::new());
+        // Third call with the force option enabled, the infra should be refreshed
+        let refreshed_infras: InfraRefreshedResponse = app
+            .post(format!("/infra/refresh/?infras={}&force=true", infra_id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(refreshed_infras.infra_refreshed, vec![infra_id]);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_speed_limit_tags() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let builtin_tags = app.speed_limit_tag_ids();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let speed_section = SpeedSection {
             speed_limit_by_tag: HashMap::from([("test_tag".into(), Speed(10.))]),
             ..Default::default()
         }
         .into();
-        apply_create_operation(&speed_section, empty_infra.id, &mut db_pool.get_ok())
+        apply_create_operation(&speed_section, infra_id, &mut db_pool.get_ok())
             .await
             .expect("Failed to create speed section object");
 
         let mut speed_limit_tags: Vec<String> = app
-            .get(format!("/infra/{}/speed_limit_tags/", empty_infra.id).as_str())
+            .get(format!("/infra/{}/speed_limit_tags/", infra_id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -1269,13 +1334,34 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_get_speed_limit_tags_needs_reader_grant() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user_reader = app
+            .user("alice", "Alice")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
+        let user_no_grant = app.user("bob", "Bob").create().await;
+        app.get(format!("/infra/{}/speed_limit_tags/", infra_id).as_str())
+            .by_user(user_no_grant.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.get(format!("/infra/{}/speed_limit_tags/", infra_id).as_str())
+            .by_user(user_reader.as_ref())
+            .await
+            .assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_all_voltages() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra_1 = create_empty_infra(&mut db_pool.get_ok()).await;
         let infra_2 = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
 
-        // Create electrifications
         let electrification_1 = Electrification {
             id: "test1".into(),
             voltage: "0V".into(),
@@ -1296,19 +1382,22 @@ pub mod tests {
             .await
             .expect("Failed to create electrification_2 object");
 
-        // Create rolling_stock
-        let _rolling_stock = create_rolling_stock_with_energy_sources(
+        // Create a rolling stock with a 25000V mode
+        let _ = create_rolling_stock_with_energy_sources(
             &mut db_pool.get_ok(),
             "other_rolling_stock_infra_get_all_voltages",
         )
         .await;
 
-        let voltages: Vec<String> = app.get("/infra/voltages/").await.assert_status_ok().json();
+        let mut voltages: Vec<String> = app
+            .get("/infra/voltages/")
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
 
-        assert!(voltages.len() >= 3);
-        assert!(voltages.contains(&String::from("0V")));
-        assert!(voltages.contains(&String::from("1V")));
-        assert!(voltages.contains(&String::from("25000V")));
+        voltages.sort();
+        assert_eq!(&voltages, &["0V", "1V", "25000V"]);
     }
 
     #[rstest]
@@ -1317,11 +1406,15 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[case(false)]
     async fn infra_get_voltages(#[case] include_rolling_stock_modes: bool) {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
-        // Create electrification
         let electrification = Electrification {
             id: "test".into(),
             voltage: "0".into(),
@@ -1332,14 +1425,14 @@ pub mod tests {
             .await
             .expect("Failed to create electrification object");
 
-        // Create rolling_stock
-        let _rolling_stock = create_rolling_stock_with_energy_sources(
+        // Create a rolling stock with a 25000V mode
+        let _ = create_rolling_stock_with_energy_sources(
             &mut db_pool.get_ok(),
             "other_rolling_stock_infra_get_voltages",
         )
         .await;
 
-        let voltages: Vec<String> = app
+        let mut voltages: Vec<String> = app
             .get(
                 format!(
                     "/infra/{}/voltages/?include_rolling_stock_modes={}",
@@ -1347,27 +1440,56 @@ pub mod tests {
                 )
                 .as_str(),
             )
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
+        voltages.sort();
 
         if !include_rolling_stock_modes {
-            assert_eq!(voltages[0], "0");
-            assert_eq!(voltages.len(), 1);
+            assert_eq!(&voltages, &["0"]);
         } else {
-            assert!(voltages.contains(&String::from("25000V")));
-            assert!(voltages.len() >= 2);
+            assert_eq!(&voltages, &["0", "25000V"]);
         }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_get_voltages_needs_reader_grant() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+
+        let user_no_grant = app.user("alice", "Alice").create().await;
+        let user_reader = app
+            .user("bob", "Bob")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
+
+        app.get(format!("/infra/{infra_id}/voltages/",).as_str())
+            .by_user(user_no_grant.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.get(format!("/infra/{infra_id}/voltages/",).as_str())
+            .by_user(user_reader.as_ref())
+            .await
+            .assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_get_switch_types() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let switch_types: Vec<SwitchType> = app
             .get(format!("/infra/{}/switch_types/", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -1377,31 +1499,37 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn infra_lock() {
-        let core_client = CoreClient::Mocked(MockingClient::default());
-
-        let app = test_app!().skip_authz().core_client(core_client).build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra_id, InfraGrant::Writer)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         // Lock infra
-        app.post(format!("/infra/{}/lock/", empty_infra.id).as_str())
+        app.post(format!("/infra/{}/lock/", infra_id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_no_content();
 
         // Check lock
-        let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
+        let infra = Infra::retrieve(db_pool.get_ok(), infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
         assert!(infra.locked);
 
         // Unlock infra
-        app.post(format!("/infra/{}/unlock/", empty_infra.id).as_str())
+        app.post(format!("/infra/{}/unlock/", infra_id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_no_content();
 
         // Check lock
-        let infra = Infra::retrieve(db_pool.get_ok(), empty_infra.id)
+        let infra = Infra::retrieve(db_pool.get_ok(), infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1409,13 +1537,46 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_lock_requires_writer_grant_and_operational_studies() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra_id = create_empty_infra(&mut db_pool.get_ok()).await.id;
+        let user_missing_writer = app
+            .user("alice", "Alice")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+        let user_missing_operational_studies = app
+            .user("bob", "Bob")
+            .with_infra_grant(infra_id, InfraGrant::Reader)
+            .create()
+            .await;
+        app.post(format!("/infra/{infra_id}/lock/").as_str())
+            .by_user(user_missing_writer.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.post(format!("/infra/{infra_id}/lock/").as_str())
+            .by_user(user_missing_operational_studies.as_ref())
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn match_operational_points() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let mut infra = create_small_infra(&mut db_pool.get_ok()).await;
         let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &infra)
             .await
             .unwrap();
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
         infra
             .refresh(db_pool.clone(), false, &infra_cache)
             .await
@@ -1438,6 +1599,7 @@ pub mod tests {
             .json(&json!({
                 "operational_point_references": operational_point_references,
             }))
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -1469,9 +1631,15 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn match_operational_point_input_with_incompatible_op_id_gets_filtered_out() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
         let operational_point_references = vec![
             OperationalPointReference::Uic {
                 uic: 8,
@@ -1487,6 +1655,7 @@ pub mod tests {
             .json(&json!({
                 "operational_point_references": operational_point_references,
             }))
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -1500,8 +1669,36 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn match_operational_points_requires_reader_and_operational_studies() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user_no_grant = app
+            .user("alice", "Alice")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+        let user_no_role = app
+            .user("bob", "Bob")
+            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .create()
+            .await;
+        app.post(format!("/infra/{}/match_operational_points", infra.id).as_str())
+            .json(&json!({"operational_point_references": []}))
+            .by_user(user_no_grant.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.post(format!("/infra/{}/match_operational_points", infra.id).as_str())
+            .json(&json!({"operational_point_references": []}))
+            .by_user(user_no_role.as_ref())
+            .await
+            .assert_status_forbidden();
+    }
+
+    // TODO: move it to the infra_cache crate
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_infra_cache() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let infra_caches = dashmap::DashMap::new();
@@ -1527,9 +1724,10 @@ pub mod tests {
         assert_eq!(infra_caches.len(), 1);
     }
 
+    // TODO: move it to the infra_cache crate
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn load_infra_cache_mut() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = DbConnectionPoolV2::for_tests();
         let infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let infra_caches = dashmap::DashMap::new();

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -153,6 +153,7 @@ pub(in crate::views) async fn list_objects_ids(
 
 #[cfg(test)]
 mod tests {
+    use authz::InfraGrant;
     use pretty_assertions::assert_eq;
 
     use schemas::primitives::Identifier;
@@ -163,17 +164,24 @@ mod tests {
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::views::infra::objects::ObjectQueryable;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
     use schemas::infra::Switch;
     use schemas::infra::SwitchType;
     use schemas::primitives::OSRDIdentified;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_invalid_ids() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         app.post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&["invalid_id"])
             .await
             .assert_status_bad_request();
@@ -181,11 +189,17 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_no_ids() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         app.post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&vec![""; 0])
             .await
             .assert_status_ok();
@@ -194,9 +208,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_should_return_switch() {
         // GIVEN
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let switch = Switch {
             id: "switch_001".into(),
@@ -216,6 +235,7 @@ mod tests {
         // THEN
         let switch_object: Vec<ObjectQueryable> = app
             .post(format!("/infra/{}/objects/Switch", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&vec!["switch_001"])
             .await
             .assert_status_ok()
@@ -238,11 +258,17 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_objects_duplicate_ids() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         app.post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&vec!["id"; 2])
             .await
             .assert_status_bad_request();
@@ -250,9 +276,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_switch_types() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         // Add a switch type
         let switch_type = SwitchType::default();
@@ -266,6 +297,7 @@ mod tests {
 
         let switch_type_object: Vec<ObjectQueryable> = app
             .post(format!("/infra/{}/objects/SwitchType", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .json(&vec![switch_type.id.clone()])
             .await
             .assert_status_ok()
@@ -284,9 +316,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_list_ids() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         // Add two switch types
         let switch_type_a = SwitchType {
@@ -307,6 +344,7 @@ mod tests {
 
         let response = app
             .get(format!("/infra/{}/objects/SwitchType/ids", empty_infra.id).as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json::<JsonValue>();
@@ -323,5 +361,24 @@ mod tests {
         ids.sort();
 
         assert_eq!(ids, vec!["A", "B"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn object_endpoints_require_can_read() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
+
+        app.post(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&Vec::<String>::new())
+            .await
+            .assert_status_forbidden();
+
+        app.get(format!("/infra/{}/objects/TrackSection/ids", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
     }
 }

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -419,11 +419,16 @@ fn build_path_output(path: &[PathfindingStep], infra_cache: &InfraCache) -> Path
 mod tests {
     use std::collections::HashMap;
 
+    use serde_json::json;
+
     use super::compute_path;
+    use crate::fixtures::create_empty_infra;
     use crate::infra_cache::Graph;
     use crate::infra_cache::tests::create_small_infra_cache;
     use crate::views::infra::pathfinding::InfraPathfindingInput;
     use crate::views::infra::pathfinding::PathfindingTrackLocationInput;
+    use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
     use schemas::infra::Direction;
     use schemas::infra::DirectionalTrackRange;
     use schemas::primitives::Identifier;
@@ -463,6 +468,23 @@ mod tests {
         assert_eq!(path.track_ranges, expected_path());
         assert_eq!(path.detectors, vec!["D1".into()]);
         assert_eq!(path.switches_directions, expected_switches());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn pathfinding_requires_can_read() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
+
+        app.post(format!("/infra/{}/pathfinding/", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&json!({
+                "starting": { "track": "A", "position": 0.0 },
+                "ending": { "track": "B", "position": 0.0 },
+            }))
+            .await
+            .assert_status_forbidden();
     }
 
     #[test]

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -273,10 +273,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
-    async fn test_get_railjson() {
-        let app = test_app!().skip_authz().build();
+    async fn get_railjson() {
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         apply_create_operation(
             &SwitchType::default().into(),
@@ -288,12 +293,26 @@ mod tests {
 
         let railjson: RailJson = app
             .get(&format!("/infra/{}/railjson", empty_infra.id))
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
 
         assert_eq!(railjson.version, RAILJSON_VERSION);
         assert_eq!(railjson.extended_switch_types.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_railjson_requires_can_read() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
+
+        app.get(&format!("/infra/{}/railjson", empty_infra.id))
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -335,5 +354,17 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_post_railjson_requires_operational_studies() {
+        let app = test_app!().build();
+        let user = app.user("user", "User").create().await;
+
+        app.post("/infra/railjson?name=post_railjson_forbidden_test")
+            .by_user(user.as_ref())
+            .json(&RailJson::default())
+            .await
+            .assert_status_forbidden();
     }
 }

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -299,6 +299,7 @@ pub(in crate::views) async fn get_routes_nodes(
 
 #[cfg(test)]
 mod tests {
+    use authz::InfraGrant;
     use pretty_assertions::assert_eq;
 
     use serde_json::json;
@@ -312,6 +313,7 @@ mod tests {
     use crate::views::infra::routes::RoutesResponse;
     use crate::views::infra::routes::WaypointType;
     use crate::views::test_app;
+    use crate::views::test_app::TestRequestExt as _;
     use schemas::infra::BufferStop;
     use schemas::infra::Detector;
     use schemas::infra::Route;
@@ -385,9 +387,14 @@ mod tests {
             ),
         ];
 
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(small_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         fn compare_result(got: RoutesFromNodesPositions, expected: RoutesFromNodesPositions) {
             let mut got_routes = got.routes;
@@ -426,6 +433,7 @@ mod tests {
             };
             let request = app
                 .post(&format!("/infra/{}/routes/nodes", small_infra.id))
+                .by_user(user.as_ref())
                 .json(&params);
             println!("{request:?}  body:\n    {params}");
 
@@ -436,10 +444,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_routes_should_return_routes_from_buffer_stop_and_detector() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
         let empty_infra_id = empty_infra.id;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra_id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let track = TrackSection {
             id: "track_001".into(),
@@ -492,6 +505,7 @@ mod tests {
         let waypoint_type = WaypointType::BufferStop;
         let routes: RoutesResponse = app
             .get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/bs_stop").as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -508,6 +522,7 @@ mod tests {
         let waypoint_type = WaypointType::Detector;
         let routes: RoutesResponse = app
             .get(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/detector_001").as_str())
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -523,9 +538,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_routes_should_return_empty_response() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(empty_infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         let waypoint_type = WaypointType::Detector;
         let routes: RoutesResponse = app
@@ -536,6 +556,7 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
@@ -547,5 +568,29 @@ mod tests {
                 ending: vec![]
             }
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn route_endpoints_require_can_read() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let user = app.user("user", "User").create().await;
+
+        app.get(format!("/infra/{}/routes/track_ranges?routes=route", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
+
+        app.post(format!("/infra/{}/routes/nodes", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .json(&json!({}))
+            .await
+            .assert_status_forbidden();
+
+        app.get(format!("/infra/{}/routes/Detector/detector", empty_infra.id).as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_forbidden();
     }
 }


### PR DESCRIPTION
Context: while working on https://github.com/osrd-project/osrd-confidential/issues/1641 I noticed that most of the infra views tests are skipping authorization. It could be handy to have their authorization tested for the mentioned issue.

Stop disabling authorization for those tests; query the endpoints with an authorized user instead.
- Send the queries with the required user, grants and roles instead of skipping authz.
- Add some new tests in order to make sure that the endpoints which enforce authorization do return a 403 Forbidden if the issuer is missing the correct privileges / roles.
- Do some misc refactoring along the way (remove dead code, strengthen some tests, etc).