### PR TITLE
ci, e2e: shard end-to-end tests across 4 parallel jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -873,13 +873,19 @@ jobs:
 
   end_to_end_tests:
     runs-on: ubuntu-latest
-    name: End to end tests
+    name: End to end tests (shard ${{ matrix.shard }})
     needs:
       - build-core
       - build-editoast
       - build-osrdyne
       - build-gateway
       - build-front
+    strategy:
+      # Every shard brings up its own test infrastructure, so a failing shard
+      # tells us nothing about the others: let them all run to completion.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       # TODO: check if we can deduplicate the base steps from integration_tests_quality
       # https://www.jameskerr.blog/posts/sharing-steps-in-github-action-workflows/
@@ -974,48 +980,49 @@ jobs:
             echo "Running Playwright tests on Chromium only"
           fi
               # Run Playwright tests
+          # Each shard runs a disjoint subset of the tests and writes a blob
+          # report; end_to_end_tests_report merges them back into a single one.
+          mkdir -p front/blob-report
           docker run --init --name=playwright-test --net=host \
             -e CI=true \
             -e PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
             --ipc=host \
             -v "$PWD/front/test-results:/app/front/test-results" \
-            osrd-playwright:latest npx playwright test $TEST_PROJECT
+            -v "$PWD/front/blob-report:/app/front/blob-report" \
+            osrd-playwright:latest \
+            npx playwright test $TEST_PROJECT \
+              --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+              --reporter=blob,line
           exit $(docker wait playwright-test)
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: front/blob-report
+          # Only consumed by end_to_end_tests_report, within the same run.
+          retention-days: 1
 
       - name: Upload media artifact
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: playwright-media
+          name: playwright-media-${{ matrix.shard }}
           path: |
             front/test-results/**/video.webm
             front/test-results/**/*.png
+          if-no-files-found: ignore
           retention-days: 30
 
       - name: Upload trace artifact
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: playwright-traces
+          name: playwright-traces-${{ matrix.shard }}
           path: front/test-results/**/trace.zip
+          if-no-files-found: ignore
           retention-days: 30
-
-      - name: Generate GitHub Summary
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          set -eo pipefail
-          docker run --init --name=build-report --net=host \
-            --ipc=host \
-            -e GITHUB_TOKEN="$GITHUB_TOKEN" \
-            -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
-            -e GITHUB_RUN_ID="$GITHUB_RUN_ID" \
-            -v "$PWD/front/test-results:/app/front/test-results" \
-            osrd-playwright:latest npx tsx /app/front/tests/reporter/generate-github-summary.ts /app/front/test-results/personalized-report.json /app/front/test-results/summary.md
-          cat front/test-results/summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Save container logs
         run: docker compose logs > container-logs
@@ -1024,9 +1031,62 @@ jobs:
       - uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
-          name: e2e-container-logs
+          name: e2e-container-logs-${{ matrix.shard }}
           path: container-logs
           retention-days: 30
+
+  end_to_end_tests_report:
+    runs-on: ubuntu-latest
+    name: End to end tests report
+    # Failing shards still produce a blob report, and that is precisely when the
+    # summary is worth reading, so only skip when the front image is unusable.
+    if: ${{ !cancelled() && needs.build-front.result == 'success' }}
+    needs:
+      - build-front
+      - end_to_end_tests
+    steps:
+      - name: Download built front-tests image
+        if: needs.build-front.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: images-front
+          path: .
+
+      - name: Load built images
+        if: needs.build-front.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-front-tests.tar
+
+      - name: Download blob reports from all shards
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: blob-report-*
+          path: front/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports and generate GitHub Summary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -eo pipefail
+          mkdir -p front/test-results
+          # merge-reports replays every shard's blob through the personalized
+          # reporter, rebuilding a single personalized-report.json that the
+          # existing summary generator turns into markdown. This only needs the
+          # front-tests image: merging reports requires no browser.
+          docker run --init --name=merge-report --net=host \
+            --ipc=host \
+            -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+            -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
+            -e GITHUB_RUN_ID="$GITHUB_RUN_ID" \
+            -v "$PWD/front/all-blob-reports:/app/all-blob-reports" \
+            -v "$PWD/front/test-results:/app/test-results" \
+            ${{ fromJSON(needs.build-front.outputs.stable_tags).front-tests }} \
+            sh -c "npx playwright merge-reports --reporter=./tests/reporter/generate-personalized-report.ts ./all-blob-reports \
+              && npx tsx ./tests/reporter/generate-github-summary.ts ./test-results/personalized-report.json ./test-results/summary.md"
+          cat front/test-results/summary.md >> $GITHUB_STEP_SUMMARY
 
   check_reuse_compliance:
     runs-on: ubuntu-latest

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -175,6 +175,8 @@ clean up first:
 - Every test file is **incrementally numbered**.
 - Page Object = behavior + locators
 - Test = data + expectations
+- Keep spec files reasonably sized: CI shards the suite **per file**, never splitting one, so a
+  single oversized spec file becomes the critical path of the whole e2e job.
 
 ---
 
@@ -348,6 +350,12 @@ You can also inspect traces in the browser by following [this url](https://trace
 
 In the CI those files are available as artifacts. You can view them in the Github summary.
 
+CI splits the suite across 4 parallel shards, so each artifact family is uploaded once per
+shard: `playwright-traces-1` … `playwright-traces-4`, and likewise for `playwright-media-*`
+and `e2e-container-logs-*`. The Github summary lists one link per shard. A failed test only
+has a trace in the shard that ran it, and the summary does not say which one that is, so
+open the shard whose job log shows the failure.
+
 ## UI Mode
 
 Use UI Mode when you want to explore, run, and debug tests visually.
@@ -395,7 +403,9 @@ npx playwright test --help
 - **Projects**: only `chromium` & `firefox` are available
 - **Locale**: `fr`
 - **Timezone**: `Europe/Paris`
-- **Reporter**: custom + HTML
+- **Reporter**: custom + HTML locally. In CI each shard writes a `blob` report instead, and a
+  dedicated `End to end tests report` job merges the 4 blobs back through the custom reporter
+  to produce a single Github summary
 - **Parallel workers**: no limit in CI, but technically `2` (and `30%` of logical CPU locally, after empirical tries)
 - **Screenshots**: on failure
 

--- a/front/tests/reporter/generate-github-summary.ts
+++ b/front/tests/reporter/generate-github-summary.ts
@@ -45,9 +45,29 @@ async function fetchArtifacts(
   }
 }
 
-function getArtifactIdByName(artifacts: Artifact[], name: string): string | null {
-  const match = artifacts.find((artifact) => artifact.name === name);
-  return match ? match.id.toString() : null;
+/**
+ * Collect every artifact belonging to a family, sharded or not.
+ * Sharded runs upload `playwright-traces-1`, `playwright-traces-2`, … so a
+ * single exact-name lookup would find nothing.
+ */
+function getArtifactLinks(artifacts: Artifact[], prefix: string): { label: string; url: string }[] {
+  return artifacts
+    .filter((artifact) => artifact.name === prefix || artifact.name.startsWith(`${prefix}-`))
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+    .map((artifact) => ({
+      label: artifact.name.slice(prefix.length).replace(/^-/, ''),
+      url: `https://github.com/${REPO}/actions/runs/${RUN_ID}/artifacts/${artifact.id}`,
+    }));
+}
+
+function formatArtifactLinks(
+  links: { label: string; url: string }[],
+  notFoundMessage: string
+): string {
+  if (links.length === 0) return notFoundMessage;
+  return links
+    .map(({ label, url }) => `[${label ? `shard ${label}` : 'download'}](${url})`)
+    .join(' · ');
 }
 
 function formatStatus(status: string): string {
@@ -78,16 +98,15 @@ await (async () => {
 
   const { artifacts } = await fetchArtifacts(REPO, RUN_ID, TOKEN);
 
-  const traceId = getArtifactIdByName(artifacts, 'playwright-traces');
-  const mediaId = getArtifactIdByName(artifacts, 'playwright-media');
+  const traceUrls = formatArtifactLinks(
+    getArtifactLinks(artifacts, 'playwright-traces'),
+    'Trace artifact not found'
+  );
 
-  const traceUrl = traceId
-    ? `https://github.com/${REPO}/actions/runs/${RUN_ID}/artifacts/${traceId}`
-    : 'Trace artifact not found';
-
-  const mediaUrl = mediaId
-    ? `https://github.com/${REPO}/actions/runs/${RUN_ID}/artifacts/${mediaId}`
-    : 'Video and screenshot artifact not found';
+  const mediaUrls = formatArtifactLinks(
+    getArtifactLinks(artifacts, 'playwright-media'),
+    'Video and screenshot artifact not found'
+  );
 
   let summaryMd = `
 ## 📊 Test Summary
@@ -108,8 +127,8 @@ await (async () => {
 
 > Each failed test includes a downloadable \`trace.zip\` file.
 > To view the trace, extract the archive and upload it to the 🎯 [Playwright Trace Viewer](https://trace.playwright.dev/)
-- 📦 [Download Traces](${traceUrl})
-- 🎥 [Download Videos and screenshots](${mediaUrl})
+- 📦 Download Traces: ${traceUrls}
+- 🎥 Download Videos and screenshots: ${mediaUrls}
 
 | Test Suite | Failed Test | Status | Error |
 |------------|-------------|:------:|-------|

--- a/front/tests/reporter/generate-personalized-report.ts
+++ b/front/tests/reporter/generate-personalized-report.ts
@@ -93,7 +93,28 @@ class GenerateReport implements Reporter {
       this.personalizedReport.results.summary.suites = this.countSuites(this.suite);
     }
 
+    this.applyTestTimeSpan();
     this.writeReportToFile(this.personalizedReport);
+  }
+
+  /**
+   * `playwright merge-reports` replays shard blobs long after the tests ran, so
+   * onBegin/onEnd wall-clock timestamps would report a near-zero duration.
+   * Falls back to those timestamps when tests carry no timing
+   */
+  private applyTestTimeSpan() {
+    const { summary, tests } = this.personalizedReport.results;
+
+    let start = Infinity;
+    let stop = -Infinity;
+    tests.forEach((test) => {
+      if (test.start !== undefined) start = Math.min(start, test.start);
+      if (test.stop !== undefined) stop = Math.max(stop, test.stop);
+    });
+
+    if (!Number.isFinite(start) || !Number.isFinite(stop)) return;
+    summary.start = start * 1000;
+    summary.stop = stop * 1000;
   }
 
   /** Process test cases in the suite and nested child suites.


### PR DESCRIPTION
 Each shard spins up its own infrastructure and generates a blob report.
A new `end_to_end_tests_report` job then merges these reports using the custom reporter to produce a single GitHub summary. Artifacts are uploaded per shard, so the summary includes one link for each shard.
The report duration is calculated from the test timestamps because `merge-reports` processes the blob reports long after the test run has completed.


Reference: https://playwright.dev/docs/test-sharding