### PR TITLE
front: fix track occupancy diagram for custom path items

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useTrackOccupancy.ts
@@ -340,8 +340,7 @@ const useTrackOccupancy = ({
 
         res.push({
           waypointId,
-          // The TOD can't be opened on a trackoffset waypoint so opId is always defined
-          operationalPointId: op.opId!,
+          operationalPointId: op.waypointId,
           operationalPointPosition: op.position,
           operationalPointName: op.name,
           zones: resolvedZones,

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useWaypointMenu.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useWaypointMenu.tsx
@@ -93,7 +93,7 @@ const useWaypointMenu = (
       (waypoint) => waypoint.waypointId === activeWaypointId
     );
 
-    if (typeof activeWaypoint?.opId === 'string') {
+    if (activeWaypoint?.location.type !== 'track_offset') {
       const isDeployed = deployedWaypoints.has(activeWaypointId);
 
       menuItems.push({


### PR DESCRIPTION
Since commit 183bd6e, virtual op (custom path item) ids have changed and are split into 3 kind of ids : waypointId (the custom id of virtual ops), pathItemId (corresponding to its related path item id) and opId which is now null (but was previously corresponding to the virtual op custom id).

In useWaypointMenu, to display the button opening the track occupancy diagram (TOD) of a waypoint, we were counting on the fact that opId was a string because it was null only for track offset path items for which we don't want the TOD to be openable. Now that virtual op ids are also null, this introduces the lack of the TOD opening button for these kind of waypoints.

Also fixes an assertation in useTrackOccupancy were we were asserting that opId was always defined since there wasn't any track offset waypoint in deployedWaypoints. Changed the id for waypointId since it is not used anywehre anyway.

fix #17924

> [!NOTE]
> Since `deployedWaypoints` now receive a waypoint id maybe we could have renamed the field (was a bit lazy) 🤔  