### PR TITLE
front: fix typo "tables" in scenario header

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -10,7 +10,7 @@
     "map": "Karte",
     "sdd": "GWD",
     "std": "WZD",
-    "tables": "Fahrpläne",
+    "table": "Fahrplan",
     "trains": "Züge"
   },
   "importTrainScheduleSet": {

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -11,7 +11,7 @@
     "map": "Map",
     "sdd": "SDD",
     "std": "STD",
-    "tables": "Tables",
+    "table": "Table",
     "trains": "Trains"
   },
   "importTrainScheduleSet": {

--- a/front/public/locales/es/operational-studies.json
+++ b/front/public/locales/es/operational-studies.json
@@ -9,7 +9,7 @@
     "map": "Mapa",
     "sdd": "DEV",
     "std": "DET",
-    "tables": "Cuadros",
+    "table": "Cuadro",
     "trains": "Trenes"
   },
   "importTrainScheduleSet": {

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -11,7 +11,7 @@
     "map": "Carte",
     "sdd": "GEV",
     "std": "GET",
-    "tables": "Tableaux",
+    "table": "Tableau",
     "trains": "Trains"
   },
   "importTrainScheduleSet": {

--- a/front/public/locales/it/operational-studies.json
+++ b/front/public/locales/it/operational-studies.json
@@ -2,7 +2,7 @@
   "boards": {
     "conflicts": "Conflitti",
     "map": "Mappa",
-    "tables": "Tabelle",
+    "table": "Tabella",
     "trains": "Treni"
   },
   "importTrainScheduleSet": {

--- a/front/public/locales/nl/operational-studies.json
+++ b/front/public/locales/nl/operational-studies.json
@@ -5,7 +5,7 @@
     "map": "Kaart",
     "sdd": "GEB",
     "std": "STB",
-    "tables": "Tabellen",
+    "table": "Tabellen",
     "trains": "Treinen"
   },
   "importTrainScheduleSet": {

--- a/front/public/locales/pt/operational-studies.json
+++ b/front/public/locales/pt/operational-studies.json
@@ -5,7 +5,7 @@
     "map": "Mapa",
     "sdd": "GEV",
     "std": "GET",
-    "tables": "Tabelas",
+    "table": "Tabela",
     "trains": "Comboios"
   },
   "importTrainScheduleSet": {

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -33,7 +33,7 @@ export type Board =
   | 'macro'
   | 'std'
   | 'sdd'
-  | 'tables'
+  | 'table'
   | 'conflicts'
   | 'chronogram';
 

--- a/front/src/applications/operationalStudies/views/Scenario/ScenarioView.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/ScenarioView.tsx
@@ -13,7 +13,7 @@ const Scenario = () => {
   const { activeBoards, toggleBoard } = usePersistScenarioHeader(scenario?.id, [
     'trains',
     'std',
-    'tables',
+    'table',
     'sdd',
     'map',
   ]);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import type { Operation, NetzgrafikDto } from '@osrd-project/netzgrafik-frontend';
+import type { NetzgrafikDto, Operation } from '@osrd-project/netzgrafik-frontend';
 import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
@@ -95,8 +95,8 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
   const closeViewAndOpenTableBoard = useCallback(
     (closeView: () => void) => {
       closeView();
-      if (!activeBoards.has('tables')) {
-        toggleBoard('tables');
+      if (!activeBoards.has('table')) {
+        toggleBoard('table');
       }
       setIsScrollingToTimeStopsTable(true);
     },
@@ -156,7 +156,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
     ]
   );
 
-  const simulationResultBoards = ['std', 'tables', 'sdd', 'map'] as Board[];
+  const simulationResultBoards: Board[] = ['std', 'table', 'sdd', 'map'];
   const isBoardSimulationResultsActive = simulationResultBoards.some((board) =>
     activeBoards.has(board)
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioHeader.tsx
@@ -17,7 +17,7 @@ import InfraLoadingState from './InfraLoadingState';
 const BOARDS: Board[] = [
   'trains',
   'std',
-  'tables',
+  'table',
   'sdd',
   'map',
   'macro',

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { ChevronLeft, ChevronRight, Eye } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
@@ -304,7 +304,7 @@ const SimulationResults = ({
       {simulationResults && (
         <BoardWrapper
           ref={timeStopsTableRef}
-          hidden={!activeBoards.has('tables')}
+          hidden={!activeBoards.has('table')}
           name={simulationResults.train.train_name}
           items={[
             {

--- a/front/tests/pages/operational-studies/scenario-page.ts
+++ b/front/tests/pages/operational-studies/scenario-page.ts
@@ -56,7 +56,7 @@ class ScenarioPage extends CommonPage {
     this.conflictsButton = page.getByTestId('conflicts-button');
     this.trainsButton = page.getByTestId('trains-button');
     this.simulationMapButton = page.getByTestId('map-button');
-    this.timeStopsOutputsButton = page.getByTestId('tables-button');
+    this.timeStopsOutputsButton = page.getByTestId('table-button');
     this.macroEditorButton = page.getByTestId('macro-button');
     this.stdButton = page.getByTestId('std-button');
     this.sddButton = page.getByTestId('sdd-button');


### PR DESCRIPTION
It should be singular.

Caught by @thibautsailly 