### PR TITLE
front: wip: catch nge errors and display them

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
@@ -3,6 +3,10 @@ import { useEffect, useRef, useState } from 'react';
 import type { NetzgrafikDto, Operation } from '@osrd-project/netzgrafik-frontend';
 import { useTranslation } from 'react-i18next';
 
+import { setFailure } from 'reducers/main';
+import { useAppDispatch } from 'store';
+import { castErrorToFailure, getErrorMessage } from 'utils/error';
+
 import { EMPTY_DTO } from './consts';
 
 type NGEElement = HTMLElement & {
@@ -39,10 +43,12 @@ const frameSrc = `
  */
 const NGE = ({ activeFilterSettingId, dto, onOperation, onLoad }: NGEProps) => {
   const { i18n } = useTranslation();
+  const dispatch = useAppDispatch();
 
   const frameRef = useRef<HTMLIFrameElement>(null);
 
   const [ngeRootElement, setNgeRootElement] = useState<NGEElement | null>(null);
+  const [ngeError, setNgeError] = useState<unknown>();
 
   useEffect(() => {
     const frame = frameRef.current!;
@@ -74,8 +80,14 @@ const NGE = ({ activeFilterSettingId, dto, onOperation, onLoad }: NGEProps) => {
 
   useEffect(() => {
     if (ngeRootElement && dto) {
-      // eslint-disable-next-line react-hooks-js/immutability
-      ngeRootElement.netzgrafikDto = dto;
+      try {
+        // eslint-disable-next-line react-hooks-js/immutability
+        ngeRootElement.netzgrafikDto = dto;
+        setNgeError(undefined);
+      } catch (error) {
+        dispatch(setFailure(castErrorToFailure(error)));
+        setNgeError(error);
+      }
     }
   }, [dto, ngeRootElement]);
 
@@ -101,7 +113,13 @@ const NGE = ({ activeFilterSettingId, dto, onOperation, onLoad }: NGEProps) => {
     return () => {};
   }, [onOperation, ngeRootElement]);
 
-  return <iframe ref={frameRef} srcDoc={frameSrc} title="NGE" className="nge-iframe-container" />;
+  return !ngeError ? (
+    <iframe ref={frameRef} srcDoc={frameSrc} title="NGE" className="nge-iframe-container" />
+  ) : (
+    <div title="NGE" className="nge-error-container">
+      {getErrorMessage(ngeError)}
+    </div>
+  );
 };
 
 export default NGE;

--- a/front/src/styles/scss/applications/operationalStudies/_nge.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_nge.scss
@@ -3,3 +3,11 @@
   height: 100%;
   border-radius: 10px;
 }
+
+.nge-error-container {
+  width: 100%;
+  max-height: 20px;
+  border-radius: 10px;
+  padding: 4px;
+  color: var(--error80);
+}


### PR DESCRIPTION
Edit: done in https://github.com/OpenRailAssociation/osrd/pull/18285

Trying to fix part of https://github.com/OpenRailAssociation/osrd/issues/16007 (when only 2 repetitions and nge actually emits an error, when there's 3 repetitions and nge freezes there's not much we can do on this side)

Sometimes some "Cycle detected in trainrun" errors still get through, not sure if they come from some other useeffects I need to wrap or directly from the iframe. Tried to use an ErrorBoundary before starting using try catches but it did not help.

(Note that we also emit in osrd this same error, but it should already be caught.)