### PR TITLE
front: itinerary modal, enable cache for postSearch query

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useOperationalPointSearch.ts
+++ b/front/src/applications/operationalStudies/hooks/useOperationalPointSearch.ts
@@ -128,10 +128,13 @@ export const useOperationalPointSearch = ({
     };
 
     const search = async (searchPayload: SearchPayload) =>
-      (await postSearch({
-        searchPayload,
-        pageSize,
-      }).unwrap()) as SearchResultItemOperationalPoint[];
+      (await postSearch(
+        {
+          searchPayload,
+          pageSize,
+        },
+        true
+      ).unwrap()) as SearchResultItemOperationalPoint[];
 
     const searchOps = async () => {
       // 1) Large call on the entire query


### PR DESCRIPTION
fix https://github.com/OpenRailAssociation/osrd/issues/15039

Clicking the chevron to open the suggestion dropdown triggered an api call even when query didn't change.

Enable rtk query cache to save the suggestion list so we can display that instead of triggering a new api call every time