### PR TITLE
editoast: change unique constraints on `train_schedule_linking`

### DIFF
--- a/editoast/migrations/2026-07-31-090747-0000_change-train-schedule-linking-unique-constraint/down.sql
+++ b/editoast/migrations/2026-07-31-090747-0000_change-train-schedule-linking-unique-constraint/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE train_schedule_linking
+DROP CONSTRAINT unique_source,
+DROP CONSTRAINT unique_target,
+ADD UNIQUE NULLS NOT DISTINCT (timetable_id, source_train_schedule_id, source_occurrence_index, source_added_exception_id),
+ADD UNIQUE NULLS NOT DISTINCT (timetable_id, target_train_schedule_id, target_occurrence_index, target_added_exception_id);

--- a/editoast/migrations/2026-07-31-090747-0000_change-train-schedule-linking-unique-constraint/up.sql
+++ b/editoast/migrations/2026-07-31-090747-0000_change-train-schedule-linking-unique-constraint/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE train_schedule_linking
+DROP CONSTRAINT train_schedule_linking_timetable_id_source_train_schedule_i_key,
+DROP CONSTRAINT train_schedule_linking_timetable_id_target_train_schedule_i_key,
+ADD CONSTRAINT unique_source UNIQUE NULLS NOT DISTINCT (timetable_id, source_train_schedule_id, source_occurrence_index, source_added_exception_id, source_train_schedule_instance_index),
+ADD CONSTRAINT unique_target UNIQUE NULLS NOT DISTINCT (timetable_id, target_train_schedule_id, target_occurrence_index, target_added_exception_id, target_train_schedule_instance_index);
+
+-- Add source_train_schedule_instance_index and target_train_schedule_instance_index to the UNIQUE constraints, with custom names


### PR DESCRIPTION
There was originally a mistake about the unique constraints on this issue: https://github.com/OpenRailAssociation/osrd/issues/17574

`source_train_schedule_instance_index` and `target_train_schedule_instance_index` were missing in the unique constraints. This PR adds them through a migration