### PR TITLE
front: timetable, set isSelectMode to false after deleting all trains

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -27,6 +27,8 @@ type TimetableProps = {
   setSelectedTrainScheduleIds: React.Dispatch<React.SetStateAction<number[]>>;
   removeAndUnselectTrains: (trainIds: number[]) => void;
   handleDeleteTrainSchedules: () => void;
+  isSelectMode: boolean;
+  setIsSelectMode: (isSelectMode: boolean) => void;
   trainScheduleToEditData?: TrainScheduleToEditData;
   trainSchedules?: TrainScheduleResponse[];
   trainSchedulesWithDetails: TrainScheduleWithDetails[];
@@ -42,6 +44,8 @@ const Timetable = ({
   setSelectedTrainScheduleIds,
   removeAndUnselectTrains,
   handleDeleteTrainSchedules,
+  isSelectMode,
+  setIsSelectMode,
   trainScheduleToEditData,
   trainSchedules = NO_TRAIN_SCHEDULES,
   trainSchedulesWithDetails,
@@ -54,7 +58,6 @@ const Timetable = ({
   const { t } = useTranslation('operational-studies', { keyPrefix: 'main.timetable' });
 
   const [showTrainDetails, setShowTrainDetails] = useState(false);
-  const [isSelectMode, setIsSelectMode] = useState(false);
   const [timetableMode, setTimetableMode] = useState<TimetableMode>('calendar');
   const [expandedTrainScheduleSetIds, setExpandedTrainScheduleSetIds] = useState<Set<number>>(
     new Set()

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -64,6 +64,8 @@ const TimetableBoardWrapper = ({
   const subCategories = useSubCategoryContext();
 
   const dispatch = useAppDispatch();
+
+  const [isSelectMode, setIsSelectMode] = useState(false);
 
   const { totalPacedTrainCount, totalUniqueTrainCount } = useMemo(
     () =>
@@ -171,6 +173,10 @@ const TimetableBoardWrapper = ({
       }
 
       removeAndUnselectTrains(selectedTrainScheduleIds);
+
+      if (trainSchedules.length - selectedTrainScheduleIds.length === 0) {
+        setIsSelectMode(false);
+      }
 
       if (!hideToast) {
         dispatch(
@@ -295,6 +301,8 @@ const TimetableBoardWrapper = ({
       <Timetable
         selectedTrainScheduleIds={selectedTrainScheduleIds}
         setSelectedTrainScheduleIds={setSelectedTrainScheduleIds}
+        isSelectMode={isSelectMode}
+        setIsSelectMode={setIsSelectMode}
         setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
         upsertTrainSchedules={upsertTrainSchedules}
         setTrainScheduleToEditData={setTrainScheduleToEditData}


### PR DESCRIPTION
fix #15817

---

isSelectMode wasn't set to false after a deletion. This made the select mode reappear once we had trains in the timetable. Setting isSelectMode to false after deletion fix the issue.

---

# How to test

* Import this timetable: [timetable.json](https://github.com/user-attachments/files/30590424/timetable.json)
* Delete all trains
* Reimport the timetable or create a new train