### PR TITLE
editoast: use `JoinSetStream` and drop the `mut`

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -137,7 +137,9 @@ tempfile = "3.20.0" # redis-test (crate cache) isn't up to date
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.17"
-tokio-stream = "0.1.18"
+tokio-stream = { version = "0.1.19", default-features = false, features = [
+  "rt",
+] }
 tracing = { version = "0.1.44", default-features = false, features = [
   "attributes",
   "log",

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -16,6 +16,8 @@ use schemas::train_schedule::PathItemLocation;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::task::JoinSet;
+use tokio_stream::StreamExt as _;
+use tokio_stream::wrappers::JoinSetStream;
 use tracing::Instrument as _;
 use utoipa::ToSchema;
 
@@ -171,10 +173,11 @@ pub(in crate::views) async fn search_journeys(
     })
     .await?;
 
-    let mut timetables = Vec::new();
-    while let Some(ts_fut_result) = train_schedule_futs.join_next().await {
-        timetables.push(ts_fut_result??);
-    }
+    let timetables = JoinSetStream::new(train_schedule_futs)
+        // Converts `Result<Result<_, InternalError>, JoinError>` into `Result<_, InternalError>`
+        .map(|fut| fut?)
+        .collect::<Result<Vec<_>>>()
+        .await?;
 
     let op_references: Vec<&OperationalPointPartReference> = timetables
         .iter()


### PR DESCRIPTION
The last version of `tokio-stream` offers a `Stream` wrapper for `JoinSet` that can be used to our advantage.