### PR TITLE
core, editoast: enable work schedules failure explainer 

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
@@ -16,6 +16,7 @@ import fr.sncf.osrd.api.stdcm.stdcmRequestAdapter
 import fr.sncf.osrd.cli.ValidateInfra.parseRailJSONFromFile
 import fr.sncf.osrd.pathfinding.Pathfinding
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
+import fr.sncf.osrd.stdcm.STDCMCompleteResult
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.findPath
@@ -232,11 +233,12 @@ class BenchSTDCM : CliCommand {
                             ),
                             FailureExplainer(request.startTime, infra.rawInfra, infra.blockInfra),
                         )
-                    if (path != null && hasDuplicateTracks(infra, path.trainPath)) path = null
+                    if (path !is STDCMCompleteResult || hasDuplicateTracks(infra, path.trainPath))
+                        path = null
                 } catch (e: Exception) {
                     results["error"] = e.toString()
                 }
-                if (path != null) {
+                if (path as STDCMCompleteResult? != null) {
                     results["result_time"] = path.envelope.totalTime
                     results["result_distance"] = path.trainPath.getLength().meters
                 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/OutputSimDebugData.kt
@@ -19,7 +19,7 @@ import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.ZoneId
-import fr.sncf.osrd.stdcm.STDCMResult
+import fr.sncf.osrd.stdcm.STDCMCompleteResult
 import fr.sncf.osrd.stdcm.graph.EngineeringAllowanceRange
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
@@ -82,7 +82,7 @@ data class ZoneLocation(
 
 fun generateDebugData(
     rawInfra: RawInfra,
-    path: STDCMResult,
+    path: STDCMCompleteResult,
     simulationResponse: SimulationSuccess,
     departureTime: ZonedDateTime,
     requirements: Map<ZoneId, List<STDCMTimetableData.DetailedRequirement>>,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -161,7 +161,8 @@ class STDCMEndpoint(
                     consistSchedules.rollingStocks.map { it.length },
                 )
             val requirements = getRequirements(request, infra, timetableCacheManager)
-            val failureExplainer =
+
+            val fullFailureExplainer =
                 FailureExplainer(request.startTime, infra.rawInfra, infra.blockInfra)
 
             var callback: ProgressCallback? = null
@@ -192,10 +193,10 @@ class STDCMEndpoint(
                     Pathfinding.TIMEOUT,
                     temporarySpeedLimitManager,
                     STDCMGraph.SearchMetadata(request.startTime, requirements.metadata, s3Context),
-                    failureExplainer = failureExplainer,
+                    fullFailureExplainer,
                     callback,
                 )
-            failureExplainer.saveReport(s3Context)
+            fullFailureExplainer.saveReport(s3Context)
             if (path == null || hasDuplicateTracks(infra, path.trainPath)) {
                 val result = PathNotFound()
                 val response = STDCMFinalResult(status = STDCMProgressStatus.DONE, result = result)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -165,6 +165,15 @@ class STDCMEndpoint(
             val fullFailureExplainer =
                 FailureExplainer(request.startTime, infra.rawInfra, infra.blockInfra)
 
+            val workSchedulesFailureExplainer =
+                FailureExplainer(
+                    request.startTime,
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    maxLargestConflicts = 2,
+                    maxClosestConflicts = 1,
+                )
+
             var callback: ProgressCallback? = null
             if (ctx != null) {
                 callback = { progressCallback(ctx.chan, ctx.replyTo, ctx.correlationId, it) }
@@ -194,6 +203,7 @@ class STDCMEndpoint(
                     temporarySpeedLimitManager,
                     STDCMGraph.SearchMetadata(request.startTime, requirements.metadata, s3Context),
                     fullFailureExplainer,
+                    workSchedulesFailureExplainer,
                     callback,
                 )
             fullFailureExplainer.saveReport(s3Context)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -37,7 +37,8 @@ import fr.sncf.osrd.standalone_sim.makeElectricalProfiles
 import fr.sncf.osrd.standalone_sim.makeMRSPResponse
 import fr.sncf.osrd.standalone_sim.result.ElectrificationRange
 import fr.sncf.osrd.standalone_sim.runScheduleMetadataExtractor
-import fr.sncf.osrd.stdcm.STDCMResult
+import fr.sncf.osrd.stdcm.STDCMCompleteResult
+import fr.sncf.osrd.stdcm.STDCMPartialResult
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.checkPlannedStepsAndMaybeIndex
 import fr.sncf.osrd.stdcm.graph.findPath
@@ -212,12 +213,47 @@ class STDCMEndpoint(
                 val response = STDCMFinalResult(status = STDCMProgressStatus.DONE, result = result)
                 return RsJson(RsWithBody(STDCMFinalResult.adapter.toJson(response)))
             }
-            val pathfindingResponse =
-                runPathfindingBlockPostProcessing(
-                    infra,
-                    path.trainPath,
-                    path.waypointOffsets,
-                    path.backtrackIndexes,
+
+            val report = workSchedulesFailureExplainer.makeReport()
+            val mostBlockingWorkSchedules =
+                report.largestConflicts.map { ConflictingWorkSchedule(it.source.id, it.lastOPId) }
+            val nearestToDestinationWorkSchedules =
+                report.closestConflicts.map { ConflictingWorkSchedule(it.source.id, it.lastOPId) }
+            var partialPathfindingResult: PathfindingBlockResponse? = null
+            var lastReachedOperationalPoint: LastReachedOperationalPoint? = null
+
+            // No solution was found, but STDCM managed to go up to a certain point: return the
+            // corresponding partial path.
+            if (path is STDCMPartialResult) {
+                partialPathfindingResult =
+                    runPathfindingBlockPostProcessing(
+                        infra,
+                        path.trainPath,
+                        path.waypointOffsets,
+                        path.backtrackIndexes,
+                    )
+                val id =
+                    path.trainPath
+                        .getOperationalPointParts()
+                        .asSequence()
+                        .map {
+                            infra.rawInfra.getOperationalPointPartOpId(it.value)
+                        }
+                        .last()
+                val arrivalTime =
+                    request.startTime.plus(Duration.ofSeconds(path.earliestReachableTime.toLong()))
+                lastReachedOperationalPoint =
+                    LastReachedOperationalPoint(id, path.geoPoint, arrivalTime)
+            }
+            // STDCM found a valid solution, but it found unavoidable conflicts in the
+            // post-processing. Return the corresponding blocking work schedules.
+            // TODO : check with PO for this behaviour
+            val result =
+                PathNotFound(
+                    mostBlockingWorkSchedules.distinct(),
+                    nearestToDestinationWorkSchedules,
+                    partialPathfindingResult,
+                    lastReachedOperationalPoint,
                 )
 
             val simulationResponse =
@@ -257,7 +293,7 @@ class STDCMEndpoint(
          */
         fun logDebugData(
             infra: RawInfra,
-            path: STDCMResult,
+            path: STDCMCompleteResult,
             simulationResponse: SimulationSuccess,
             departureTime: ZonedDateTime,
             requirements: Map<ZoneId, List<STDCMTimetableData.DetailedRequirement>>,
@@ -280,7 +316,7 @@ class STDCMEndpoint(
         /** Build the simulation part of the response */
         fun buildSimResponse(
             infra: FullInfra,
-            path: STDCMResult,
+            path: STDCMCompleteResult,
             speedLimitTag: String?,
             temporarySpeedLimitManager: TemporarySpeedLimitManager?,
             comfort: Comfort,
@@ -338,7 +374,7 @@ class STDCMEndpoint(
 
         /** Build the electrical profiles from the path */
         fun buildSTDCMElectricalProfiles(
-            path: STDCMResult,
+            path: STDCMCompleteResult,
             rollingStocks: DistanceRangeMap<RollingStock>,
             comfort: Comfort,
         ): RangeValues<ElectricalProfileValue> {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -11,6 +11,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.*
+import fr.sncf.osrd.api.pathfinding.PathfindingBlockResponse
 import fr.sncf.osrd.api.pathfinding.findStopPositionAtEndOfBlockConsideringRollingStock
 import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
 import fr.sncf.osrd.api.pathfinding.hasDuplicateTracks
@@ -62,6 +63,7 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.io.File
+import java.time.Duration
 import java.time.Duration.between
 import java.time.Duration.ofMillis
 import java.time.LocalDateTime
@@ -207,9 +209,41 @@ class STDCMEndpoint(
                     workSchedulesFailureExplainer,
                     callback,
                 )
+
             fullFailureExplainer.saveReport(s3Context)
-            if (path == null || hasDuplicateTracks(infra, path.trainPath)) {
-                val result = PathNotFound()
+            // STDCM has found a valid solution: return the result with the complete path and
+            // simulation.
+            if (path is STDCMCompleteResult && !hasDuplicateTracks(infra, path.trainPath)) {
+                val pathfindingResponse =
+                    runPathfindingBlockPostProcessing(
+                        infra,
+                        path.trainPath,
+                        path.waypointOffsets,
+                        path.backtrackIndexes,
+                    )
+
+                val simulationResponse =
+                    buildSimResponse(
+                        infra,
+                        path,
+                        request.consistSchedule.values[0].speedLimitTag,
+                        temporarySpeedLimitManager,
+                        request.comfort,
+                    )
+
+                val departureTime =
+                    request.startTime.plus(ofMillis((path.departureTime * 1000).toLong()))
+
+                logDebugData(
+                    infra.rawInfra,
+                    path,
+                    simulationResponse,
+                    departureTime,
+                    requirements.metadata,
+                    s3Context,
+                )
+
+                val result = STDCMSuccess(simulationResponse, pathfindingResponse, departureTime)
                 val response = STDCMFinalResult(status = STDCMProgressStatus.DONE, result = result)
                 return RsJson(RsWithBody(STDCMFinalResult.adapter.toJson(response)))
             }
@@ -255,29 +289,6 @@ class STDCMEndpoint(
                     partialPathfindingResult,
                     lastReachedOperationalPoint,
                 )
-
-            val simulationResponse =
-                buildSimResponse(
-                    infra,
-                    path,
-                    request.consistSchedule.values[0].speedLimitTag,
-                    temporarySpeedLimitManager,
-                    request.comfort,
-                )
-
-            val departureTime =
-                request.startTime.plus(ofMillis((path.departureTime * 1000).toLong()))
-
-            logDebugData(
-                infra.rawInfra,
-                path,
-                simulationResponse,
-                departureTime,
-                requirements.metadata,
-                s3Context,
-            )
-
-            val result = STDCMSuccess(simulationResponse, pathfindingResponse, departureTime)
             val response = STDCMFinalResult(status = STDCMProgressStatus.DONE, result = result)
             RsJson(RsWithBody(STDCMFinalResult.adapter.toJson(response)))
         } catch (ex: Throwable) {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMResponse.kt
@@ -22,7 +22,26 @@ class STDCMSuccess(
     @Json(name = "departure_time") var departureTime: ZonedDateTime,
 ) : STDCMResponse
 
-class PathNotFound : STDCMResponse
+class LastReachedOperationalPoint(
+    var id: String,
+    var coordinates: Point,
+    @Json(name = "arrival_time") var arrivalTime: ZonedDateTime,
+)
+
+class ConflictingWorkSchedule(
+    var id: String,
+    @Json(name = "last_op_id") var lastOPId: String,
+)
+
+class PathNotFound(
+    @Json(name = "most_blocking_work_schedules")
+    var mostBlockingWorkSchedules: List<ConflictingWorkSchedule>,
+    @Json(name = "nearest_to_destination_work_schedules")
+    var nearestToDestinationWorkSchedules: List<ConflictingWorkSchedule>,
+    @Json(name = "partial_path") var partialPath: PathfindingBlockResponse? = null,
+    @Json(name = "last_reached_operational_point")
+    var lastReachedOperationalPoint: LastReachedOperationalPoint? = null,
+) : STDCMResponse
 
 val polymorphicSTDCMResponseAdapter: PolymorphicJsonAdapterFactory<STDCMResponse> =
     PolymorphicJsonAdapterFactory.of(STDCMResponse::class.java, "status")

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMResponse.kt
@@ -11,6 +11,7 @@ import fr.sncf.osrd.api.standalone_sim.SimulationSuccess
 import fr.sncf.osrd.api.standalone_sim.polymorphicElectricalProfileAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSimulationResponseAdapter
 import fr.sncf.osrd.api.standalone_sim.polymorphicSpeedLimitSourceAdapter
+import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import java.time.ZonedDateTime
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.stdcm
 
 import fr.sncf.osrd.envelope.Envelope
+import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.path.interfaces.PhysicsPath
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.sim_infra.api.RouteId
@@ -10,18 +11,38 @@ import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.units.Offset
 
+/** Generic result of an STDCM computation. */
+interface STDCMResult {
+    val trainPath: TrainPath
+    val waypointOffsets: List<Offset<PhysicsPath>>
+    val backtrackIndexes: List<Int>
+}
+
 /**
- * This is the result of the STDCM computation. It is made of a physical path part and envelope, as
- * well as different representations of the same data that can be reused in later steps.
+ * This is the result of a successful STDCM computation. It is made of a physical path part and
+ * envelope, as well as different representations of the same data that can be reused in later
+ * steps.
  */
-data class STDCMResult(
+data class STDCMCompleteResult(
+    override val trainPath: TrainPath,
+    override val waypointOffsets: List<Offset<PhysicsPath>>,
+    override val backtrackIndexes: List<Int>,
     val envelope: Envelope,
-    val trainPath: TrainPath,
     val rollingStocks: DistanceRangeMap<RollingStock>,
     val routePath: List<RouteId>,
     val departureTime: Double,
     val stopResults: List<TrainStop>,
-    val waypointOffsets: List<Offset<PhysicsPath>>,
-    val backtrackIndexes: List<Int>,
     val engineeringAllowanceRanges: List<EngineeringAllowanceRange>,
-)
+) : STDCMResult
+
+/**
+ * This is the result of a failed STDCM computation. It contains the farthest point the simulation
+ * has reached with its corresponding path information.
+ */
+data class STDCMPartialResult(
+    override val trainPath: TrainPath,
+    override val waypointOffsets: List<Offset<PhysicsPath>>,
+    override val backtrackIndexes: List<Int>,
+    val earliestReachableTime: Double,
+    val geoPoint: Point,
+) : STDCMResult

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm.graph
 
+import fr.sncf.osrd.conflicts.RequirementType
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
@@ -26,6 +27,7 @@ internal constructor(
     // Margin added to every occupancy, to account for binary search tolerance
     private val internalMargin: Double,
     private val fullFailureExplainer: FailureExplainer?,
+    private val workSchedulesFailureExplainer: FailureExplainer?,
 ) {
     /**
      * Returns one value per "opening" (interval between two unavailable times). Always returns the
@@ -59,6 +61,13 @@ internal constructor(
                                     cause.duration,
                                     cause.cause,
                                 )
+                                if (cause.cause.type == RequirementType.WORK_SCHEDULE) {
+                                    workSchedulesFailureExplainer?.conflictCallback(
+                                        prevNode,
+                                        cause.duration,
+                                        cause.cause,
+                                    )
+                                }
                             }
                         }
                         availability.maximumDelay + internalMargin
@@ -71,6 +80,13 @@ internal constructor(
         }
         prevConflict?.causes?.forEach { cause ->
             fullFailureExplainer?.conflictCallback(prevNode, cause.duration, cause.cause)
+            if (cause.cause.type == RequirementType.WORK_SCHEDULE) {
+                workSchedulesFailureExplainer?.conflictCallback(
+                    prevNode,
+                    cause.duration,
+                    cause.cause,
+                )
+            }
         }
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -25,7 +25,7 @@ internal constructor(
     private val graph: STDCMGraph,
     // Margin added to every occupancy, to account for binary search tolerance
     private val internalMargin: Double,
-    private val failureExplainer: FailureExplainer?,
+    private val fullFailureExplainer: FailureExplainer?,
 ) {
     /**
      * Returns one value per "opening" (interval between two unavailable times). Always returns the
@@ -54,7 +54,7 @@ internal constructor(
                         if (availability.maximumDelay >= internalMargin) {
                             res.add(time - startTime)
                             prevConflict?.causes?.forEach { cause ->
-                                failureExplainer?.conflictCallback(
+                                fullFailureExplainer?.conflictCallback(
                                     prevNode,
                                     cause.duration,
                                     cause.cause,
@@ -70,7 +70,7 @@ internal constructor(
                 }
         }
         prevConflict?.causes?.forEach { cause ->
-            failureExplainer?.conflictCallback(prevNode, cause.duration, cause.cause)
+            fullFailureExplainer?.conflictCallback(prevNode, cause.duration, cause.cause)
         }
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -50,6 +50,7 @@ class STDCMGraph(
     val temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
     val searchMetadata: SearchMetadata?,
     fullFailureExplainer: FailureExplainer?,
+    workSchedulesFailureExplainer: FailureExplainer?,
 ) : Graph<STDCMNode, STDCMEdge> {
     val rawInfra = fullInfra.rawInfra
     val blockInfra = fullInfra.blockInfra
@@ -62,6 +63,7 @@ class STDCMGraph(
             this,
             timeStep,
             fullFailureExplainer,
+            workSchedulesFailureExplainer,
         )
     val allowanceManager = EngineeringAllowanceManager(this)
     val backtrackingManager: BacktrackingManager = BacktrackingManager(this)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -49,7 +49,7 @@ class STDCMGraph(
     val standardAllowance: AllowanceValue?,
     val temporarySpeedLimitManager: TemporarySpeedLimitManager = TemporarySpeedLimitManager(),
     val searchMetadata: SearchMetadata?,
-    failureExplainer: FailureExplainer?,
+    fullFailureExplainer: FailureExplainer?,
 ) : Graph<STDCMNode, STDCMEdge> {
     val rawInfra = fullInfra.rawInfra
     val blockInfra = fullInfra.blockInfra
@@ -61,7 +61,7 @@ class STDCMGraph(
             blockAvailability,
             this,
             timeStep,
-            failureExplainer,
+            fullFailureExplainer,
         )
     val allowanceManager = EngineeringAllowanceManager(this)
     val backtrackingManager: BacktrackingManager = BacktrackingManager(this)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -34,7 +34,11 @@ import org.slf4j.LoggerFactory
 
 data class EdgeLocation(val edge: STDCMEdge, val offset: Offset<STDCMEdge>)
 
-data class Result(
+data class Result(val node: STDCMNode) {
+    val hasReachedDestination = node.infraExplorer.getStepTracker().hasReachedDestination()
+}
+
+data class PathResult(
     val edges: List<STDCMEdge>, // Full path as a list of edges
     val waypoints: List<EdgeLocation>,
 )
@@ -134,17 +138,18 @@ class STDCMPathfinding(
 
         assert(steps.last().stop) { "The last stop is supposed to be an actual stop" }
         starts = getStartNodes(graph, consistSchedule)
-        val path = findPathImpl()
+        val result = findPathImpl()
         graph.stdcmSimulations.logWarnings()
-        if (path == null) {
-            logger.info("Failed to find a path")
-            return null
+        if (!result.hasReachedDestination) {
+            logger.info("Failed to reach destination, start postprocessing partial result")
+            return STDCMPostProcessing(graph).makePartialResult(fullInfra, result.node)
         }
-        logger.info("Path found, start postprocessing")
 
+        logger.info("Reached destination, start postprocessing")
+        val path = buildPath(result.node)
         val res =
             STDCMPostProcessing(graph)
-                .makeResult(
+                .makeCompleteResult(
                     fullInfra,
                     path,
                     graph.standardAllowance,
@@ -204,7 +209,7 @@ class STDCMPathfinding(
         }
     }
 
-    private fun findPathImpl(): Result? {
+    private fun findPathImpl(): Result {
         val queue = PriorityQueue<STDCMNode>()
 
         val progressLogger = ProgressLogger(graph, callback = progressCallback)
@@ -215,13 +220,14 @@ class STDCMPathfinding(
         }
         val start = Instant.now()
         var lastFValue = Double.NEGATIVE_INFINITY
+        var closestNode: STDCMNode = queue.peek()
         while (true) {
             if (Duration.between(start, Instant.now()).toSeconds() >= pathfindingTimeout)
                 throw OSRDError(ErrorType.PathfindingTimeoutError)
             val endNode = queue.poll()
             if (endNode == null) {
                 fValueLogger.logAggregatedSummary()
-                return null
+                return Result(closestNode)
             }
             if (endNode.getMinTotalSimulationTime(graph.remainingTimeEstimator) > maxRunTime)
                 continue
@@ -237,9 +243,12 @@ class STDCMPathfinding(
 
             progressLogger.processNode(endNode)
             if (endNode.infraExplorer.getStepTracker().hasReachedDestination()) {
-                return buildResult(endNode)
+                return Result(endNode)
             }
             queue += getAdjacentNodes(endNode)
+            if (endNode.remainingTimeEstimation < closestNode.remainingTimeEstimation) {
+                closestNode = endNode
+            }
         }
     }
 
@@ -251,7 +260,7 @@ class STDCMPathfinding(
             .filter { graph.tryMarkPending(it) }
     }
 
-    private fun buildResult(node: STDCMNode): Result {
+    private fun buildPath(node: STDCMNode): PathResult {
         var mutLastEdge: STDCMEdge? = node.previousEdge
         val edges = ArrayDeque<STDCMEdge>()
 
@@ -269,7 +278,7 @@ class STDCMPathfinding(
             node.infraExplorer.getStepTracker().iterateReachedStepsBackwards().toList().asReversed()
         val waypoints = makeWaypoints(edgeList, reachedSteps)
 
-        return Result(edgeList, waypoints)
+        return PathResult(edgeList, waypoints)
     }
 
     /** Converts start locations into starting nodes. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -63,6 +63,7 @@ fun findPath(
     temporarySpeedLimitManager: TemporarySpeedLimitManager,
     searchMetadata: STDCMGraph.SearchMetadata? = null,
     fullFailureExplainer: FailureExplainer? = null,
+    workSchedulesFailureExplainer: FailureExplainer? = null,
     progressCallback: ProgressCallback? = null,
 ): STDCMResult? {
     return STDCMPathfinding(
@@ -81,6 +82,7 @@ fun findPath(
             temporarySpeedLimitManager,
             searchMetadata,
             fullFailureExplainer,
+            workSchedulesFailureExplainer,
             progressCallback,
         )
         .findPath()
@@ -102,6 +104,7 @@ class STDCMPathfinding(
     temporarySpeedLimitManager: TemporarySpeedLimitManager,
     searchMetadata: STDCMGraph.SearchMetadata?,
     fullFailureExplainer: FailureExplainer?,
+    workSchedulesFailureExplainer: FailureExplainer?,
     private val progressCallback: ProgressCallback? = null,
 ) {
 
@@ -122,6 +125,7 @@ class STDCMPathfinding(
             temporarySpeedLimitManager,
             searchMetadata,
             fullFailureExplainer,
+            workSchedulesFailureExplainer,
         )
 
     @WithSpan(value = "STDCM pathfinding", kind = SpanKind.SERVER)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -62,7 +62,7 @@ fun findPath(
     pathfindingTimeout: Double,
     temporarySpeedLimitManager: TemporarySpeedLimitManager,
     searchMetadata: STDCMGraph.SearchMetadata? = null,
-    failureExplainer: FailureExplainer? = null,
+    fullFailureExplainer: FailureExplainer? = null,
     progressCallback: ProgressCallback? = null,
 ): STDCMResult? {
     return STDCMPathfinding(
@@ -80,7 +80,7 @@ fun findPath(
             pathfindingTimeout,
             temporarySpeedLimitManager,
             searchMetadata,
-            failureExplainer,
+            fullFailureExplainer,
             progressCallback,
         )
         .findPath()
@@ -101,7 +101,7 @@ class STDCMPathfinding(
     private val pathfindingTimeout: Double = Pathfinding.TIMEOUT,
     temporarySpeedLimitManager: TemporarySpeedLimitManager,
     searchMetadata: STDCMGraph.SearchMetadata?,
-    failureExplainer: FailureExplainer?,
+    fullFailureExplainer: FailureExplainer?,
     private val progressCallback: ProgressCallback? = null,
 ) {
 
@@ -121,7 +121,7 @@ class STDCMPathfinding(
             standardAllowance,
             temporarySpeedLimitManager,
             searchMetadata,
-            failureExplainer,
+            fullFailureExplainer,
         )
 
     @WithSpan(value = "STDCM pathfinding", kind = SpanKind.SERVER)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -138,6 +138,10 @@ class STDCMPathfinding(
 
         assert(steps.last().stop) { "The last stop is supposed to be an actual stop" }
         starts = getStartNodes(graph, consistSchedule)
+
+        // If we are in a dead end, and the destination is not reached, the pathfinding should fail
+        if (starts.isEmpty()) return null
+
         val result = findPathImpl()
         graph.stdcmSimulations.logWarnings()
         if (!result.hasReachedDestination) {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -4,10 +4,12 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
+import fr.sncf.osrd.path.interfaces.BlockRange
 import fr.sncf.osrd.path.interfaces.TrainPath
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
-import fr.sncf.osrd.stdcm.STDCMResult
+import fr.sncf.osrd.stdcm.STDCMCompleteResult
+import fr.sncf.osrd.stdcm.STDCMPartialResult
 import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
@@ -15,6 +17,7 @@ import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.arePositionsEqual
 import fr.sncf.osrd.utils.isTimeStrictlyPositive
+import fr.sncf.osrd.utils.toGeoPoint
 import fr.sncf.osrd.utils.units.meters
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -27,35 +30,25 @@ import kotlin.math.min
  */
 class STDCMPostProcessing(private val graph: STDCMGraph) {
     /**
-     * Builds the STDCM result object from the raw pathfinding result. This is the only non-private
-     * method of this class, the rest is implementation detail.
+     * Builds the STDCM result object from the raw pathfinding result. This is called when STDCM
+     * finds a path. We're gathering all the necessary information for the response.
      */
     @WithSpan(value = "STDCM post processing", kind = SpanKind.SERVER)
-    fun makeResult(
+    fun makeCompleteResult(
         infra: FullInfra,
-        path: Result,
+        path: PathResult,
         standardAllowance: AllowanceValue?,
         rollingStocks: List<RollingStock>,
         timeStep: Double,
         comfort: Comfort?,
         maxRunTime: Double,
         blockAvailability: BlockAvailabilityInterface,
-    ): STDCMResult? {
+    ): STDCMCompleteResult? {
         val edges = path.edges
         val lastExplorer = edges.last().infraExplorer
-        val blockRanges = lastExplorer.getAllBlocks().toList()
         val routes = lastExplorer.getExploredRoutes()
         val seenSteps = lastExplorer.getStepTracker().getSeenSteps().toList()
-        val trainPath =
-            buildTrainPathFromBlockRanges(
-                infra.rawInfra,
-                infra.blockInfra,
-                blockRanges,
-                seenSteps.mapNotNull { step ->
-                    if (step.isBacktracking) step.travelledPathOffset else null
-                },
-                routes = routes,
-            )
+        val trainPath = lastExplorer.buildFullPath(infra.rawInfra, infra.blockInfra)
 
         val updatedTimeData = computeTimeData(edges)
         val stops = makeStops(edges, updatedTimeData)
@@ -78,21 +71,20 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 updatedTimeData,
             )
         val res =
-            STDCMResult(
-                withAllowance.envelope,
+            STDCMCompleteResult(
                 trainPath,
-                path.edges.last().infraExplorerWithNewEnvelope.getFullRollingStockRangeMap()
-                    as DistanceRangeMap<RollingStock>,
-                routes,
-                updatedTimeData.departureTime,
-
-                // Allow us to display OP, a hack that will be fixed
-                // after the redesign of simulation data models
-                makePathStops(stops, trainPath),
                 seenSteps.map { it.travelledPathOffset },
                 seenSteps.mapIndexedNotNull { index, step ->
                     if (step.isBacktracking) index else null
                 },
+                withAllowance.envelope,
+                path.edges.last().infraExplorerWithNewEnvelope.getFullRollingStockRangeMap()
+                    as DistanceRangeMap<RollingStock>,
+                routes,
+                updatedTimeData.departureTime,
+                // Allow us to display OP, a hack that will be fixed
+                // after the redesign of simulation data models
+                makePathStops(stops, trainPath),
                 withAllowance.engineeringAllowanceRanges,
             )
         return if (res.envelope.totalTime > maxRunTime) {
@@ -100,6 +92,56 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
             // as we only check the time at the start of an edge when exploring the graph
             null
         } else res
+    }
+
+    /**
+     * Builds the STDCM Partial result object from the last node explored. This is called when STDCM
+     * doesn't find a path. We're gathering all the necessary information for the response.
+     */
+    fun makePartialResult(
+        infra: FullInfra,
+        lastNode: STDCMNode,
+    ): STDCMPartialResult {
+        val lastExplorer = lastNode.infraExplorer
+        val reachedSteps =
+            lastExplorer.getStepTracker().iterateReachedStepsBackwards().toList().asReversed()
+        val predecessorBlocks = lastExplorer.getPredecessorBlocks().toList()
+        val blockRanges = predecessorBlocks.ifEmpty {
+            val currentBlockRange = lastExplorer.getCurrentBlockRange()
+            listOf(
+                BlockRange(
+                    currentBlockRange.value,
+                    currentBlockRange.objectBegin,
+                    currentBlockRange.objectEnd,
+                    currentBlockRange.pathBegin,
+                    currentBlockRange.pathEnd,
+                    currentBlockRange.objectLength,
+                )
+            )
+        }
+        // TODO: Send only simulated routes, and not all explored ones
+        val trainPath =
+            buildTrainPathFromBlockRanges(
+                infra.rawInfra,
+                infra.blockInfra,
+                blockRanges,
+                reachedSteps.mapNotNull { step ->
+                    if (step.isBacktracking) step.travelledPathOffset else null
+                },
+                lastExplorer.getExploredRoutes(),
+            )
+        val earliestReachableTime = lastNode.timeData.earliestReachableTime
+        val geoPoint =
+            lastNode.toGeoPoint(infra.rawInfra, infra.blockInfra, useLocationOnEdge = true)
+        return STDCMPartialResult(
+            trainPath,
+            reachedSteps.map { it.travelledPathOffset },
+            reachedSteps.mapIndexedNotNull { index, step ->
+                if (step.isBacktracking) index else null
+            },
+            earliestReachableTime,
+            geoPoint,
+        )
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
@@ -6,6 +6,8 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.S3Context
 import fr.sncf.osrd.conflicts.RequirementId
+import fr.sncf.osrd.path.implementations.buildTrainPathFromBlockRanges
+import fr.sncf.osrd.path.interfaces.BlockRange
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
@@ -16,6 +18,7 @@ import java.io.File
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.util.PriorityQueue
+import kotlin.collections.ifEmpty
 
 /**
  * Keep track of some of the most relevant conflicts encountered during the search.
@@ -103,7 +106,7 @@ class FailureExplainer(
                 cause,
                 geoPoint.lat,
                 geoPoint.lon,
-                lastOPName,
+                lastOPId,
                 pathGeometry,
             )
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/tracing/FailureExplainer.kt
@@ -52,15 +52,42 @@ class FailureExplainer(
         ): ConflictReport {
             val remainingTime = parentNode.remainingTimeEstimation
             val travelTime = parentNode.timeData.totalRunningTime
-            val geoPoint = parentNode.toGeoPoint(rawInfra, blockInfra)
-            val trainPath = parentNode.infraExplorer.buildFullPath(rawInfra, blockInfra)
-            val lastOPName =
-                trainPath
+            val geoPoint = parentNode.toGeoPoint(rawInfra, blockInfra, useLocationOnEdge = true)
+            val infraExplorer = parentNode.infraExplorer
+            val reachedSteps =
+                infraExplorer.getStepTracker().iterateReachedStepsBackwards().toList().asReversed()
+            val predecessorBlocks = infraExplorer.getPredecessorBlocks().toList()
+            val blockRanges = predecessorBlocks.ifEmpty {
+                val currentBlockRange = infraExplorer.getCurrentBlockRange()
+                listOf(
+                    BlockRange(
+                        currentBlockRange.value,
+                        currentBlockRange.objectBegin,
+                        currentBlockRange.objectEnd,
+                        currentBlockRange.pathBegin,
+                        currentBlockRange.pathEnd,
+                        currentBlockRange.objectLength,
+                    )
+                )
+            }
+            // TODO: Send only simulated routes, and not all explored ones
+            val reachedTrainPath =
+                buildTrainPathFromBlockRanges(
+                    parentNode.graph!!.rawInfra,
+                    parentNode.graph.blockInfra,
+                    blockRanges,
+                    reachedSteps.mapNotNull { step ->
+                        if (step.isBacktracking) step.travelledPathOffset else null
+                    },
+                    infraExplorer.getExploredRoutes(),
+                )
+            val lastOPId =
+                reachedTrainPath
                     .getOperationalPointParts()
                     .asSequence()
-                    .mapNotNull { rawInfra.getOperationalPointPartProps(it.value)["identifier"] }
-                    .lastOrNull()
-            val geoLineString = trainPath.getGeo()
+                    .map { rawInfra.getOperationalPointPartOpId(it.value) }
+                    .last()
+            val geoLineString = reachedTrainPath.getGeo()
             val pathGeometry =
                 RJSLineString(
                     "LineString",
@@ -119,7 +146,7 @@ class FailureExplainer(
         val source: RequirementId,
         val lat: Double,
         val lon: Double,
-        val lastOPName: String?,
+        val lastOPId: String,
         @Json(name = "path_geometry") val pathGeometry: RJSLineString,
     )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/DebugUtils.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.path.implementations.buildTrainPathFromBlock
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.stdcm.graph.STDCMNode
+import fr.sncf.osrd.utils.units.Offset
 import java.io.BufferedWriter
 import java.io.File
 
@@ -48,11 +49,17 @@ class CSVLogger(filename: String, private val keys: List<String>) {
 }
 
 /** Return the geo coordinates of a node. */
-fun STDCMNode.toGeoPoint(rawInfra: RawInfra, blockInfra: BlockInfra): Point {
+fun STDCMNode.toGeoPoint(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    useLocationOnEdge: Boolean = false,
+): Point {
     val blockRange = infraExplorer.getCurrentBlockRange()
     val geo = buildTrainPathFromBlock(rawInfra, blockInfra, blockRange.value, listOf()).getGeo()
     val blockLength = blockInfra.getBlockLength(blockRange.value)
-    val blockOffset = blockRange.offsetFromTrainPath(infraExplorer.getSimulatedLength())
+    val blockOffset =
+        if (useLocationOnEdge) locationOnEdge ?: Offset.zero()
+        else blockRange.offsetFromTrainPath(infraExplorer.getSimulatedLength())
     // TODO interpolate at the track-section level, as the geo length is not guaranteed equal to
     //   the topo length for all track-sections
     var p = geo.interpolateNormalized(blockOffset.meters / blockLength.meters)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -42,10 +42,13 @@ class BacktrackingTests {
                 null,
             )!!
         val runTime = firstBlockEnvelope.totalTime
+        // Backtracking to correct the speed adds a bit more than 25s to the block's envelope end
+        // time.
+        // Test success with runTime +30s.
         val occupancyGraph =
             ImmutableMultimap.of(
                 block,
-                OccupancySegment(runTime + 1, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+                OccupancySegment(runTime + 30, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
             )
         val res =
             STDCMPathfindingBuilder()
@@ -57,6 +60,20 @@ class BacktrackingTests {
         Assertions.assertTrue(res is STDCMCompleteResult)
         val resSuccess = res as STDCMCompleteResult
         occupancyTest(resSuccess, occupancyGraph)
+        // Test failure with runTime + 25s.
+        val occupancyGraphFail =
+            ImmutableMultimap.of(
+                block,
+                OccupancySegment(runTime + 25, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+            )
+        val resFail =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(BlockLocation(block, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(block, Offset(1000.meters))))
+                .setUnavailableTimes(occupancyGraphFail)
+                .run() ?: return
+        Assertions.assertTrue(resFail is STDCMPartialResult)
     }
 
     /**
@@ -70,9 +87,8 @@ class BacktrackingTests {
          */
         val infra = DummyInfra()
         val firstBlock = infra.addBlock("a", "b", 1000.meters)
-        infra.addBlock("b", "c", 10.meters)
-        infra.addBlock("c", "d", 10.meters)
-        val lastBlock = infra.addBlock("d", "e", 10.meters)
+        val secondBlock = infra.addBlock("b", "c", 10.meters)
+        val lastBlock = infra.addBlock("c", "d", 10.meters)
         val firstBlockEnvelope =
             simulateBlock(
                 infraExplorerFromBlock(
@@ -90,11 +106,51 @@ class BacktrackingTests {
                 null,
                 null,
             )!!
-        val runTime = firstBlockEnvelope.totalTime
+        val secondBlockEnvelope =
+            simulateBlock(
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    secondBlock,
+                ),
+                firstBlockEnvelope.endSpeed,
+                Offset(0.meters),
+                TestTrains.REALISTIC_FAST_TRAIN,
+                Comfort.STANDARD,
+                2.0,
+                null,
+                null,
+                null,
+            )!!
+        val lastBlockEnvelope =
+            simulateBlock(
+                infraExplorerFromBlock(
+                    infra,
+                    infra,
+                    TestTrains.REALISTIC_FAST_TRAIN.length.meters,
+                    lastBlock,
+                ),
+                secondBlockEnvelope.endSpeed,
+                Offset(0.meters),
+                TestTrains.REALISTIC_FAST_TRAIN,
+                Comfort.STANDARD,
+                2.0,
+                null,
+                null,
+                null,
+            )!!
+        val runTime =
+            listOf(firstBlockEnvelope, secondBlockEnvelope, lastBlockEnvelope).sumOf {
+                it.totalTime
+            }
+        // Backtracking to correct the speed adds a bit more than 25s to the blocks' envelope end
+        // time.
+        // Test success with runTime +30s.
         val occupancyGraph =
             ImmutableMultimap.of(
                 lastBlock,
-                OccupancySegment(runTime + 10, Double.POSITIVE_INFINITY, 0.meters, 10.meters),
+                OccupancySegment(runTime + 30, Double.POSITIVE_INFINITY, 0.meters, 10.meters),
             )
         val res =
             STDCMPathfindingBuilder()
@@ -106,6 +162,20 @@ class BacktrackingTests {
         Assertions.assertTrue(res is STDCMCompleteResult)
         val resSuccess = res as STDCMCompleteResult
         occupancyTest(resSuccess, occupancyGraph)
+        // Test failure with runTime + 25s.
+        val occupancyGraphFail =
+            ImmutableMultimap.of(
+                lastBlock,
+                OccupancySegment(runTime + 25, Double.POSITIVE_INFINITY, 0.meters, 10.meters),
+            )
+        val resFail =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(lastBlock, Offset(5.meters))))
+                .setUnavailableTimes(occupancyGraphFail)
+                .run() ?: return
+        Assertions.assertTrue(resFail is STDCMPartialResult)
     }
 
     /**
@@ -138,21 +208,38 @@ class BacktrackingTests {
                 null,
             )!!
         val runTime = firstBlockEnvelope.totalTime
-        val occupancyGraph =
+        // Backtracking to correct the speed adds a bit more than 20s to the first block's envelope
+        // end time.
+        // Test success with runTime +25s.
+        val occupancyGraphSuccess =
             ImmutableMultimap.of(
                 firstBlock,
-                OccupancySegment(runTime + 22, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+                OccupancySegment(runTime + 25, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
             )
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(5.meters))))
-                .setUnavailableTimes(occupancyGraph)
+                .setUnavailableTimes(occupancyGraphSuccess)
                 .run() ?: return
         Assertions.assertTrue(res is STDCMCompleteResult)
         val resSuccess = res as STDCMCompleteResult
-        occupancyTest(resSuccess, occupancyGraph)
+        occupancyTest(resSuccess, occupancyGraphSuccess)
+        // Test failure with runTime + 20s.
+        val occupancyGraphFail =
+            ImmutableMultimap.of(
+                firstBlock,
+                OccupancySegment(runTime + 20, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+            )
+        val resFail =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(BlockLocation(secondBlock, Offset(5.meters))))
+                .setUnavailableTimes(occupancyGraphFail)
+                .run() ?: return
+        Assertions.assertTrue(resFail is STDCMPartialResult)
     }
 
     /** Test that we can backtrack several times over the same edges */

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -54,7 +54,9 @@ class BacktrackingTests {
                 .setEndLocations(setOf(BlockLocation(block, Offset(1000.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /**
@@ -101,7 +103,9 @@ class BacktrackingTests {
                 .setEndLocations(setOf(BlockLocation(lastBlock, Offset(5.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /**
@@ -137,7 +141,7 @@ class BacktrackingTests {
         val occupancyGraph =
             ImmutableMultimap.of(
                 firstBlock,
-                OccupancySegment(runTime + 10, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+                OccupancySegment(runTime + 22, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
             )
         val res =
             STDCMPathfindingBuilder()
@@ -146,7 +150,9 @@ class BacktrackingTests {
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(5.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run() ?: return
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** Test that we can backtrack several times over the same edges */
@@ -169,6 +175,6 @@ class BacktrackingTests {
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
                 .setEndLocations(setOf(BlockLocation(lastBlock, Offset(1000.meters))))
                 .run()!!
-        Assertions.assertTrue(res.envelope.continuous)
+        Assertions.assertTrue(res is STDCMCompleteResult && res.envelope.continuous)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
@@ -9,8 +9,6 @@ import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class ConditionalOccupancyTests {
@@ -46,14 +44,14 @@ class ConditionalOccupancyTests {
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(block2, Offset(50.meters))))
                 .run()
-        assertNotNull(res1)
+        assertTrue(res1 is STDCMCompleteResult)
 
         // Conflict
         val res2 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(unavailableBlock, Offset(50.meters))))
                 .run()
-        assertNull(res2)
+        assertTrue(res2 is STDCMPartialResult)
     }
 
     @Test
@@ -91,14 +89,14 @@ class ConditionalOccupancyTests {
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(block2, Offset(50.meters))))
                 .run()
-        assertNotNull(res1)
+        assertTrue(res1 is STDCMCompleteResult)
 
         // Conflict
         val res2 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(unavailableBlock, Offset(50.meters))))
                 .run()
-        assertNull(res2)
+        assertTrue(res2 is STDCMPartialResult)
     }
 
     @Test
@@ -177,28 +175,28 @@ class ConditionalOccupancyTests {
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(block2, Offset(50.meters))))
                 .run()
-        assertNotNull(res1)
+        assertTrue(res1 is STDCMCompleteResult)
 
         // End location on d --> e: no conflict
         val res2 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(block4, Offset(50.meters))))
                 .run()
-        assertNotNull(res2)
+        assertTrue(res2 is STDCMCompleteResult)
 
         // End location on g --> h: no conflict
         val res3 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(block7, Offset(50.meters))))
                 .run()
-        assertNotNull(res3)
+        assertTrue(res3 is STDCMCompleteResult)
 
         // End location on g --> i: conflict
         val res4 =
             initBuilder(infra.fullInfra(), occupancyGraph, block1)
                 .setEndLocations(setOf(BlockLocation(unavailableBlock, Offset(50.meters))))
                 .run()
-        assertNull(res4)
+        assertTrue(res4 is STDCMPartialResult)
     }
 
     @Test
@@ -229,7 +227,9 @@ class ConditionalOccupancyTests {
                 .setStartLocations(setOf(BlockLocation(blocks[0], Offset(0.meters))))
                 .setEndLocations(setOf(BlockLocation(blocks[2], Offset(50.meters))))
                 .run()!!
-        assertTrue { res.departureTime + res.envelope.totalTime >= 3600 }
+        assertTrue {
+            res is STDCMCompleteResult && res.departureTime + res.envelope.totalTime >= 3600
+        }
     }
 
     private fun initBuilder(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -32,11 +31,13 @@ class DepartureTimeShiftTests {
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                 .run()!!
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
         val secondBlockEntryTime =
-            (res.departureTime +
-                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).meters))
+            (resSuccess.departureTime +
+                resSuccess.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).meters))
         Assertions.assertTrue(secondBlockEntryTime >= 3600)
-        occupancyTest(res, occupancyGraph)
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** Test that we can add delays to avoid several occupied blocks */
@@ -65,11 +66,13 @@ class DepartureTimeShiftTests {
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                 .run()!!
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
         val secondBlockEntryTime =
-            (res.departureTime +
-                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).meters))
+            (resSuccess.departureTime +
+                resSuccess.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).meters))
         Assertions.assertTrue(secondBlockEntryTime >= 3600)
-        occupancyTest(res, occupancyGraph)
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /**
@@ -104,7 +107,9 @@ class DepartureTimeShiftTests {
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
                 .setEndLocations(setOf(BlockLocation(lastBlock, Offset(1000.meters))))
                 .run()!!
-        val blocks = res.trainPath.getBlocks().map { infra.getBlockName(it.value) }.toSet()
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        val blocks = resSuccess.trainPath.getBlocks().map { infra.getBlockName(it.value) }.toSet()
         Assertions.assertTrue(blocks.contains("b->c2"))
         Assertions.assertTrue(blocks.contains("c2->d"))
         Assertions.assertFalse(blocks.contains("b->c1"))
@@ -148,7 +153,9 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(lastBlock, Offset(1000.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        val blocks = res.trainPath.getBlocks().map { infra.getBlockName(it.value) }.toSet()
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        val blocks = resSuccess.trainPath.getBlocks().map { infra.getBlockName(it.value) }.toSet()
         Assertions.assertTrue(blocks.contains("b->c1"))
         Assertions.assertTrue(blocks.contains("c1->d"))
         Assertions.assertFalse(blocks.contains("b->c2"))
@@ -201,7 +208,7 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(100.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()
-        Assertions.assertNull(res)
+        Assertions.assertTrue(res is STDCMPartialResult)
     }
 
     /**
@@ -243,7 +250,9 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(thirdBlock, Offset(50.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** This is the same test as the one above, but with the split on the first block. */
@@ -279,7 +288,9 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** This is the same test as the one above, but with the split on the last block. */
@@ -310,7 +321,9 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** Test that we keep track of how much we can shift the departure time over several blocks */
@@ -353,7 +366,7 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(forthBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()
-        Assertions.assertNull(res)
+        Assertions.assertTrue(res is STDCMPartialResult)
     }
 
     /**
@@ -403,7 +416,7 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(forthBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()
-        Assertions.assertNull(res)
+        Assertions.assertTrue(res is STDCMPartialResult)
     }
 
     /** Test that we can consider more than two openings */
@@ -449,7 +462,9 @@ class DepartureTimeShiftTests {
                 .setEndLocations(setOf(BlockLocation(thirdBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** Test that we don't add more delay than specified */
@@ -481,6 +496,6 @@ class DepartureTimeShiftTests {
                 .setTimeStep(timeStep)
                 .setMaxDepartureDelay(1000 - 2 * timeStep)
                 .run()
-        assertNull(res)
+        Assertions.assertTrue(res is STDCMPartialResult)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -487,7 +487,7 @@ class EngineeringAllowanceTests {
         val firstBlock = infra.addBlock("a", "b")
         val secondBlock = infra.addBlock("b", "c")
         val thirdBlock = infra.addBlock("c", "d")
-        val forthBlock = infra.addBlock("d", "e")
+        val fourthBlock = infra.addBlock("d", "e")
         val occupancyGraph =
             ImmutableMultimap.of(
                 firstBlock,
@@ -496,14 +496,14 @@ class EngineeringAllowanceTests {
                 OccupancySegment(0.0, 800.0, 0.meters, 100.meters),
                 thirdBlock,
                 OccupancySegment(0.0, 1_200.0, 0.meters, 100.meters),
-                forthBlock,
+                fourthBlock,
                 OccupancySegment(0.0, 1_200.0, 0.meters, 100.meters),
             )
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(0.meters))))
-                .setEndLocations(setOf(BlockLocation(forthBlock, Offset(1.meters))))
+                .setEndLocations(setOf(BlockLocation(fourthBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .setMaxRunTime(POSITIVE_INFINITY)
                 .run()

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -93,7 +93,9 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
     }
 
     /**
@@ -183,8 +185,10 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
-        Assertions.assertEquals(0.0, res.departureTime, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
+        Assertions.assertEquals(0.0, resSuccess.departureTime, 2 * timeStep)
     }
 
     /** Test that allowances don't cause new conflicts */
@@ -280,8 +284,10 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
-        Assertions.assertEquals(0.0, res.departureTime, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
+        Assertions.assertEquals(0.0, resSuccess.departureTime, 2 * timeStep)
     }
 
     /**
@@ -328,9 +334,11 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
-        Assertions.assertEquals((3600 * 2).toDouble(), res.departureTime, 2 * timeStep)
-        Assertions.assertTrue(res.departureTime <= 3600 * 2)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
+        Assertions.assertEquals((3600 * 2).toDouble(), resSuccess.departureTime, 2 * timeStep)
+        Assertions.assertTrue(resSuccess.departureTime <= 3600 * 2)
     }
 
     /** The allowance happens in an area where we have added delay by shifting the departure time */
@@ -379,7 +387,9 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
     }
 
     /**
@@ -446,7 +456,9 @@ class EngineeringAllowanceTests {
                 .setMaxRunTime(POSITIVE_INFINITY)
                 .setMaxDepartureDelay(0.0)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /**
@@ -494,9 +506,11 @@ class EngineeringAllowanceTests {
                 .setEndLocations(setOf(BlockLocation(forthBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .setMaxRunTime(POSITIVE_INFINITY)
-                .run() ?: return // No solution found is valid here (and expected)
+                .run()
+        // No solution found is valid here (and expected)
+        if (res == null || res is STDCMPartialResult) return
         // But if we find a solution there must be no conflict
-        occupancyTest(res, occupancyGraph)
+        occupancyTest(res as STDCMCompleteResult, occupancyGraph)
     }
 
     /** Test that we return null with no crash when we can't slow down fast enough */
@@ -540,7 +554,7 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setMaxDepartureDelay(POSITIVE_INFINITY)
                 .run()
-        Assertions.assertNull(res)
+        Assertions.assertTrue(res is STDCMPartialResult)
     }
 
     @Test
@@ -630,8 +644,10 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
-        Assertions.assertEquals(3600.0, res.departureTime, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
+        Assertions.assertEquals(3600.0, resSuccess.departureTime, 2 * timeStep)
     }
 
     /**
@@ -714,7 +730,9 @@ class EngineeringAllowanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
     }
 
     /**
@@ -754,6 +772,8 @@ class EngineeringAllowanceTests {
                 .setRollingStocks(listOf(VERY_LONG_FAST_TRAIN))
                 .setStandardAllowance(AllowanceValue.Percentage(10.0))
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -195,7 +195,7 @@ class FullSTDCMTests {
                 .setEndLocations(end.blockLocations)
                 .setBlockAvailability(blockAvailability)
                 .run()!!
-        assertTrue(res.departureTime >= 3600)
+        assertTrue(res is STDCMCompleteResult && res.departureTime >= 3600)
     }
 
     /** Test that we properly account for start or end scheduled step. */
@@ -222,12 +222,18 @@ class FullSTDCMTests {
         if (hasStandardAllowance)
             builder = builder.setStandardAllowance(AllowanceValue.Percentage(5.0))
         val res = builder.run()!!
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
         if (startPlannedTimingData != null) {
-            assertEquals(expectedPassageTime, res.departureTime)
+            assertEquals(expectedPassageTime, resSuccess.departureTime)
         } else {
-            assertEquals(expectedPassageTime, res.departureTime + res.envelope.totalTime, timeStep)
+            assertEquals(
+                expectedPassageTime,
+                resSuccess.departureTime + resSuccess.envelope.totalTime,
+                timeStep,
+            )
         }
-        assertTrue(res.departureTime <= 12_000.0) // Max departure delay
+        assertTrue(resSuccess.departureTime <= 12_000.0) // Max departure delay
     }
 
     /**
@@ -296,7 +302,9 @@ class FullSTDCMTests {
                 .setMaxRunTime(Double.POSITIVE_INFINITY)
                 .setMaxDepartureDelay(0.0)
                 .run()!!
-        assertTrue(res.stopResults.first().duration > 5_000.0) {
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        assertTrue(resSuccess.stopResults.first().duration > 5_000.0) {
             "if a solution can be found without lengthening the stop, the test itself is broken"
         }
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/PerformanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/PerformanceTests.kt
@@ -57,7 +57,9 @@ class PerformanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
     }
 
     @Test
@@ -156,7 +158,9 @@ class PerformanceTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancyGraph, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, 2 * timeStep)
     }
 
     @Disabled("Requires at least one bugfix (and likely more): this starts an infinite loop")

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -86,7 +86,7 @@ fun simulateBlock(
  * search inaccuracies
  */
 fun occupancyTest(
-    res: STDCMResult,
+    res: STDCMCompleteResult,
     occupancyGraph: ImmutableMultimap<BlockId, OccupancySegment>,
     tolerance: Double = 0.0,
 ) {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
@@ -52,7 +52,9 @@ class STDCMPathfindingTests {
                 .setStartLocations(setOf(BlockLocation(firstBlock, Offset(30.meters))))
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(30.meters))))
                 .run()!!
-        assertEquals(Offset<PhysicsPath>(100.meters), res.trainPath.getLength())
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        assertEquals(Offset<PhysicsPath>(100.meters), resSuccess.trainPath.getLength())
     }
 
     /** Look for a path where the blocks are occupied before and after */
@@ -83,7 +85,9 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** Test that no path is found when the blocks aren't connected */
@@ -135,7 +139,7 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()
-        assertNull(res)
+        assertTrue(res is STDCMPartialResult)
     }
 
     /** Test that we can find a path even if the last block is occupied when the train starts */
@@ -156,7 +160,9 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** Test that the path can change depending on the occupancy */
@@ -204,14 +210,20 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(lastBlock, Offset(50.meters))))
                 .setUnavailableTimes(occupancyGraph2)
                 .run()!!
-        val blocks1 = res1.trainPath.getBlocks().map { infra.getBlockName(it.value) }
-        val blocks2 = res2.trainPath.getBlocks().map { infra.getBlockName(it.value) }
+
+        assertTrue(res1 is STDCMCompleteResult)
+        val res1Success = res1 as STDCMCompleteResult
+        assertTrue(res2 is STDCMCompleteResult)
+        val res2Success = res2 as STDCMCompleteResult
+
+        val blocks1 = res1Success.trainPath.getBlocks().map { infra.getBlockName(it.value) }
+        val blocks2 = res2Success.trainPath.getBlocks().map { infra.getBlockName(it.value) }
         assertFalse(blocks1.contains("b->c1"))
         assertTrue(blocks1.contains("b->c2"))
-        occupancyTest(res1, occupancyGraph1)
+        occupancyTest(res1Success, occupancyGraph1)
         assertFalse(blocks2.contains("b->c2"))
         assertTrue(blocks2.contains("b->c1"))
-        occupancyTest(res2, occupancyGraph2)
+        occupancyTest(res2Success, occupancyGraph2)
     }
 
     /** Test that everything works well when the train is at max speed during block transitions */
@@ -277,7 +289,7 @@ class STDCMPathfindingTests {
                 .setStartLocations(setOf(BlockLocation(firstLoop, Offset(0.meters))))
                 .setEndLocations(setOf(BlockLocation(disconnectedBlock, Offset(0.meters))))
                 .run()
-        assertNull(res)
+        assertTrue(res is STDCMPartialResult)
     }
 
     /**
@@ -298,7 +310,7 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(block, Offset(10000.meters))))
                 .setMaxRunTime(100.0)
                 .run()
-        assertNull(res)
+        assertTrue(res is STDCMPartialResult)
     }
 
     /**
@@ -321,7 +333,7 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(blocks[9], Offset(1000.meters))))
                 .setMaxRunTime(100.0)
                 .run()
-        assertNull(res)
+        assertTrue(res is STDCMPartialResult)
     }
 
     /** Test that the start delay isn't included in the total run time */
@@ -430,7 +442,9 @@ class STDCMPathfindingTests {
                 .setUnavailableTimes(occupancyGraph)
                 .setMaxRunTime(runTime + 60) // We add a margin for the stop time
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
     }
 
     /** Test that we return the earliest path among the fastest ones */
@@ -457,7 +471,9 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(blocks[0], Offset(100.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        occupancyTest(res, occupancyGraph)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph)
         assertTrue(res.departureTime < 300)
     }
 
@@ -497,7 +513,7 @@ class STDCMPathfindingTests {
                     )
                 )
                 .run()
-        assertNull(res)
+        assertTrue(res is STDCMPartialResult)
     }
 
     /** Start and end are on the same block, but reversed */
@@ -587,10 +603,12 @@ class STDCMPathfindingTests {
                 )
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
         if (isFirstPath) {
-            assertTrue(res.departureTime < 17.0)
+            assertTrue(resSuccess.departureTime < 17.0)
         } else {
-            assertEquals(17.0, res.departureTime)
+            assertEquals(17.0, resSuccess.departureTime)
         }
     }
 
@@ -631,7 +649,7 @@ class STDCMPathfindingTests {
                 )
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        assertTrue(res.departureTime < 19.0)
+        assertTrue(res is STDCMCompleteResult && res.departureTime < 19.0)
     }
 
     /**
@@ -676,7 +694,9 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(blocks[0], Offset(100.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        assertEquals(departureTime, res.departureTime)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        assertEquals(departureTime, resSuccess.departureTime)
     }
 
     /**
@@ -698,7 +718,9 @@ class STDCMPathfindingTests {
                 )
                 .setEndLocations(setOf(BlockLocation(blocks[0], Offset(100.meters))))
                 .run()!!
-        assertEquals(plannedStepArrivalTime, res.departureTime)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        assertEquals(plannedStepArrivalTime, resSuccess.departureTime)
     }
 
     /**
@@ -729,7 +751,9 @@ class STDCMPathfindingTests {
                 .setEndLocations(setOf(BlockLocation(blocks[0], Offset(100.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
-        assertEquals(maxPossibleDelay, res.departureTime)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        assertEquals(maxPossibleDelay, resSuccess.departureTime)
     }
 
     /**
@@ -749,7 +773,9 @@ class STDCMPathfindingTests {
                 )
                 .setEndLocations(setOf(BlockLocation(blocks[0], Offset(100.meters))))
                 .run()!!
-        assertEquals(0.0, res.departureTime)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        assertEquals(0.0, resSuccess.departureTime)
     }
 
     /**
@@ -782,7 +808,9 @@ class STDCMPathfindingTests {
                 .setUnavailableTimes(occupancyGraph)
                 .run()!!
 
-        assertEquals(totalDelay, res.departureTime)
+        assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        assertEquals(totalDelay, resSuccess.departureTime)
     }
 
     /**

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -102,8 +102,8 @@ class StandardAllowanceTests {
                     .setEndLocations(setOf(BlockLocation(secondBlock, Offset(50.meters))))
                     .setStandardAllowance(allowance)
             )
-        Assertions.assertNotNull(res.withoutAllowance!!)
-        Assertions.assertNotNull(res.withAllowance!!)
+        Assertions.assertNotNull(res.withoutAllowance!! as STDCMCompleteResult)
+        Assertions.assertNotNull(res.withAllowance!! as STDCMCompleteResult)
         val secondBlockEntryTime =
             (res.withAllowance.departureTime +
                 res.withAllowance.envelope.interpolateArrivalAt(
@@ -136,8 +136,8 @@ class StandardAllowanceTests {
                     .setEndLocations(setOf(BlockLocation(block, Offset(10000.meters))))
                     .setStandardAllowance(allowance)
             )
-        Assertions.assertNotNull(res.withoutAllowance!!)
-        Assertions.assertNotNull(res.withAllowance!!)
+        Assertions.assertNotNull(res.withoutAllowance!! as STDCMCompleteResult)
+        Assertions.assertNotNull(res.withAllowance!! as STDCMCompleteResult)
         val timeEnterOccupiedSection =
             (res.withAllowance.departureTime +
                 res.withAllowance.envelope.interpolateArrivalAt(5000.0))
@@ -187,8 +187,11 @@ class StandardAllowanceTests {
                 .setEndLocations(setOf(BlockLocation(blocks[2], Offset(1000.meters))))
                 .setStandardAllowance(allowance)
                 .run()!!
-        occupancyTest(res, occupancyGraph, TIME_STEP)
-        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateArrivalAt(11000.0))
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, TIME_STEP)
+        val thirdBlockEntryTime =
+            (resSuccess.departureTime + resSuccess.envelope.interpolateArrivalAt(11000.0))
         Assertions.assertEquals(
             1000.0,
             thirdBlockEntryTime,
@@ -236,8 +239,11 @@ class StandardAllowanceTests {
                 .setEndLocations(setOf(BlockLocation(blocks[2], Offset(1.meters))))
                 .setStandardAllowance(allowance)
                 .run()!!
-        occupancyTest(res, occupancyGraph, TIME_STEP)
-        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateArrivalAt(10001.0))
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, TIME_STEP)
+        val thirdBlockEntryTime =
+            (resSuccess.departureTime + resSuccess.envelope.interpolateArrivalAt(10001.0))
         Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP)
     }
 
@@ -314,9 +320,9 @@ class StandardAllowanceTests {
                     .setUnavailableTimes(occupancyGraph)
                     .setStandardAllowance(allowance)
             )
-        Assertions.assertNotNull(res.withoutAllowance)
-        Assertions.assertNotNull(res.withAllowance)
-        occupancyTest(res.withAllowance!!, occupancyGraph, TIME_STEP)
+        Assertions.assertNotNull(res.withoutAllowance as STDCMCompleteResult)
+        Assertions.assertNotNull(res.withAllowance as STDCMCompleteResult)
+        occupancyTest(res.withAllowance, occupancyGraph, TIME_STEP)
         checkAllowanceResult(res, allowance)
     }
 
@@ -364,8 +370,11 @@ class StandardAllowanceTests {
                 .setEndLocations(setOf(BlockLocation(blocks[2], Offset(1000.meters))))
                 .setStandardAllowance(allowance)
                 .run()!!
-        occupancyTest(res, occupancyGraph, TIME_STEP)
-        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateArrivalAt(11000.0))
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancyGraph, TIME_STEP)
+        val thirdBlockEntryTime =
+            (resSuccess.departureTime + resSuccess.envelope.interpolateArrivalAt(11000.0))
         // 2 allowances + the extra safety TIME_STEP added when avoiding conflicts gives us 3 *
         // TIME_STEP
         Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP)
@@ -474,9 +483,9 @@ class StandardAllowanceTests {
                     .setUnavailableTimes(occupancyGraph)
                     .setStandardAllowance(allowance)
             )
-        Assertions.assertNotNull(res.withoutAllowance)
-        Assertions.assertNotNull(res.withAllowance)
-        occupancyTest(res.withAllowance!!, occupancyGraph, TIME_STEP)
+        Assertions.assertNotNull(res.withoutAllowance as STDCMCompleteResult)
+        Assertions.assertNotNull(res.withAllowance as STDCMCompleteResult)
+        occupancyTest(res.withAllowance, occupancyGraph, TIME_STEP)
 
         // We need a high tolerance because there are several binary searches
         checkAllowanceResult(res, allowance, 4 * TIME_STEP)
@@ -529,8 +538,11 @@ class StandardAllowanceTests {
                     .setUnavailableTimes(occupancyGraph)
                     .setStandardAllowance(allowance)
             )
-        Assertions.assertEquals(0.0, res.withAllowance!!.envelope.endSpeed)
-        Assertions.assertEquals(0.0, res.withoutAllowance!!.envelope.endSpeed)
+        Assertions.assertEquals(0.0, (res.withAllowance!! as STDCMCompleteResult).envelope.endSpeed)
+        Assertions.assertEquals(
+            0.0,
+            (res.withoutAllowance!! as STDCMCompleteResult).envelope.endSpeed,
+        )
         occupancyTest(res.withAllowance, occupancyGraph, 2 * TIME_STEP)
 
         // We need a high tolerance because there are several binary searches
@@ -562,8 +574,8 @@ class StandardAllowanceTests {
                 .setStandardAllowance(AllowanceValue.Percentage(5.0))
         val res = runWithAndWithoutAllowance(builder)
         val step = 1_000
-        val envelopeWithAllowances = res.withAllowance!!.envelope
-        val fastestEnvelope = res.withoutAllowance!!.envelope
+        val envelopeWithAllowances = (res.withAllowance!! as STDCMCompleteResult).envelope
+        val fastestEnvelope = (res.withoutAllowance!! as STDCMCompleteResult).envelope
         for (start in 0..envelopeWithAllowances.endPos.roundToInt() step step) {
             for (end in (start + step)..envelopeWithAllowances.endPos.roundToInt() step step) {
                 fun getTime(envelope: Envelope): Double {
@@ -610,11 +622,11 @@ class StandardAllowanceTests {
         ) {
             var mutTolerance = tolerance
             if (java.lang.Double.isNaN(mutTolerance)) mutTolerance = 2 * TIME_STEP
-            val baseEnvelope = results.withoutAllowance!!.envelope
+            val baseEnvelope = (results.withoutAllowance!! as STDCMCompleteResult).envelope
             val extraTime =
                 value.getAllowanceTime(baseEnvelope.totalTime, baseEnvelope.totalDistance)
             val baseTime = baseEnvelope.totalTime
-            val actualTime = results.withAllowance!!.envelope.totalTime
+            val actualTime = (results.withAllowance!! as STDCMCompleteResult).envelope.totalTime
             Assertions.assertEquals(baseTime + extraTime, actualTime, mutTolerance)
         }
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
@@ -20,7 +20,6 @@ import fr.sncf.osrd.utils.units.seconds
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -52,13 +51,18 @@ class StopTests {
                 .run()!!
         val expectedOffset = 150.0
 
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
         // Check that we stop
-        Assertions.assertTrue(areSpeedsEqual(0.0, res.envelope.interpolateSpeed(expectedOffset)))
+        Assertions.assertTrue(
+            areSpeedsEqual(0.0, resSuccess.envelope.interpolateSpeed(expectedOffset))
+        )
 
         // Check that the stop is properly returned
         Assertions.assertEquals(
             listOf(TrainStop(expectedOffset, 10000.0, SHORT_SLIP_STOP)),
-            res.stopResults,
+            resSuccess.stopResults,
         )
     }
 
@@ -95,9 +99,12 @@ class StopTests {
                 )
                 .run()!!
 
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
         // Check that we stop
         for (offset in stopsOffsets) Assertions.assertTrue(
-            areSpeedsEqual(0.0, res.envelope.interpolateSpeed(100.0 + offset.meters))
+            areSpeedsEqual(0.0, resSuccess.envelope.interpolateSpeed(100.0 + offset.meters))
         )
     }
 
@@ -121,7 +128,9 @@ class StopTests {
                     ExplorerStep(setOf(BlockLocation(secondBlock, Offset(100.meters))), 0.0, true)
                 )
                 .run()!!
-        checkStop(res, listOf(TrainStop(100.0, 10000.0, SHORT_SLIP_STOP)))
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        checkStop(resSuccess, listOf(TrainStop(100.0, 10000.0, SHORT_SLIP_STOP)))
     }
 
     /** Look for a path in an empty timetable, with a stop at the end of a block */
@@ -148,7 +157,9 @@ class StopTests {
                     ExplorerStep(setOf(BlockLocation(secondBlock, Offset(100.meters))), 0.0, true)
                 )
                 .run()!!
-        checkStop(res, listOf(TrainStop(100.0, 10000.0, SHORT_SLIP_STOP)))
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        checkStop(resSuccess, listOf(TrainStop(100.0, 10000.0, SHORT_SLIP_STOP)))
     }
 
     /** Checks that we can make a detour to pass by an intermediate step */
@@ -190,10 +201,13 @@ class StopTests {
                     )
                 )
                 .run()!!
-        val blocks = res.trainPath.getBlocks().map { infra.getBlockName(it.value) }
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
+        val blocks = resSuccess.trainPath.getBlocks().map { infra.getBlockName(it.value) }
         Assertions.assertEquals(listOf("a->b", "b->x", "x->d", "d->e"), blocks)
-        Assertions.assertNotEquals(stop, res.stopResults.isEmpty())
-        Assertions.assertEquals(stop, res.envelope.interpolateSpeed(101100.0) == 0.0)
+        Assertions.assertNotEquals(stop, resSuccess.stopResults.isEmpty())
+        Assertions.assertEquals(stop, resSuccess.envelope.interpolateSpeed(101100.0) == 0.0)
     }
 
     /**
@@ -229,7 +243,7 @@ class StopTests {
                 )
                 .setUnavailableTimes(unavailableTimes)
                 .run()
-        assertNull(res)
+        Assertions.assertTrue(res is STDCMPartialResult)
     }
 
     /** Checks that we add the right amount of delay with a stop */
@@ -262,8 +276,10 @@ class StopTests {
                 .addStep(ExplorerStep(setOf(BlockLocation(blocks[2], Offset(1.meters))), 0.0, true))
                 .setUnavailableTimes(occupancy)
                 .run()!!
-        checkStop(res, listOf(TrainStop(50.0, 10000.0, SHORT_SLIP_STOP)))
-        occupancyTest(res, occupancy)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        checkStop(resSuccess, listOf(TrainStop(50.0, 10000.0, SHORT_SLIP_STOP)))
+        occupancyTest(resSuccess, occupancy)
     }
 
     /** Checks that we can handle a standard allowance with a stop */
@@ -321,9 +337,10 @@ class StopTests {
                         ExplorerStep(setOf(BlockLocation(blocks[3], Offset(1.meters))), 0.0, true)
                     )
             )
+
         val expectedStops = listOf(TrainStop(51.0, 1000.0, SHORT_SLIP_STOP))
-        checkStop(res.withAllowance!!, expectedStops)
-        checkStop(res.withoutAllowance!!, expectedStops)
+        checkStop(res.withAllowance!! as STDCMCompleteResult, expectedStops)
+        checkStop(res.withoutAllowance!! as STDCMCompleteResult, expectedStops)
         occupancyTest(res.withAllowance, occupancy, 2 * timeStep)
         occupancyTest(res.withoutAllowance, occupancy, 2 * timeStep)
         checkAllowanceResult(res, allowance, 4 * timeStep)
@@ -397,8 +414,8 @@ class StopTests {
                     )
             )
         val expectedStops = listOf(TrainStop(51.0, 1000.0, SHORT_SLIP_STOP))
-        checkStop(res.withAllowance!!, expectedStops)
-        checkStop(res.withoutAllowance!!, expectedStops)
+        checkStop(res.withAllowance!! as STDCMCompleteResult, expectedStops)
+        checkStop(res.withoutAllowance!! as STDCMCompleteResult, expectedStops)
         occupancyTest(res.withAllowance, occupancy, 2 * timeStep)
         occupancyTest(res.withoutAllowance, occupancy, 2 * timeStep)
     }
@@ -451,7 +468,7 @@ class StopTests {
                 .setUnavailableTimes(occupancy)
                 .setMaxDepartureDelay(0.0) // Prevents the train from starting after the conflict
                 .run()
-        assertNull(res)
+        Assertions.assertTrue(res is STDCMPartialResult)
     }
 
     /** Checks that we can make the stop longer to avoid conflicts */
@@ -502,18 +519,23 @@ class StopTests {
         val resWithoutConflict = builderWithoutConflict.run()!!
         val resWithConflict = builderWithConflict.run()!!
 
+        Assertions.assertTrue(resWithoutConflict is STDCMCompleteResult)
+        val resWithoutConflictSuccess = resWithoutConflict as STDCMCompleteResult
+        Assertions.assertTrue(resWithConflict is STDCMCompleteResult)
+        val resWithConflictSuccess = resWithConflict as STDCMCompleteResult
+
         // Check that there's no slowing down, no engineering allowance
-        val resTravelTime = resWithConflict.envelope.totalTime
-        assertEquals(resWithoutConflict.envelope.totalTime, resTravelTime, timeStep)
+        val resTravelTime = resWithConflictSuccess.envelope.totalTime
+        assertEquals(resWithoutConflictSuccess.envelope.totalTime, resTravelTime, timeStep)
 
         // Check that the stop is long enough
         assert(
             10_000 <=
-                resWithConflict.envelope.interpolateArrivalAt(200.0) +
-                    resWithConflict.stopResults.first().duration +
+                resWithConflictSuccess.envelope.interpolateArrivalAt(200.0) +
+                    resWithConflictSuccess.stopResults.first().duration +
                     3 * timeStep
         )
-        occupancyTest(resWithConflict, occupancy)
+        occupancyTest(resWithConflictSuccess, occupancy)
     }
 
     /** Checks that we can follow start scheduled points and adjust stop durations */
@@ -582,9 +604,12 @@ class StopTests {
                 .setTimeStep(timeStep)
                 .setUnavailableTimes(occupancy)
                 .run()!!
-        occupancyTest(res, occupancy)
-        assertEquals(7_000.0, res.departureTime, timeStep)
-        assertEquals(5_000.0, res.stopResults.first().duration, timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
+        occupancyTest(resSuccess, occupancy)
+        assertEquals(7_000.0, resSuccess.departureTime, timeStep)
+        assertEquals(5_000.0, resSuccess.stopResults.first().duration, timeStep)
     }
 
     /** Checks that we can follow end scheduled points and adjust stop durations */
@@ -653,10 +678,14 @@ class StopTests {
                 .setUnavailableTimes(occupancy)
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancy)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancy)
         val arrivalTime =
-            res.departureTime + res.envelope.totalTime + res.stopResults.first().duration
-        assertTrue(res.departureTime >= 3_000.0)
+            resSuccess.departureTime +
+                resSuccess.envelope.totalTime +
+                resSuccess.stopResults.first().duration
+        assertTrue(resSuccess.departureTime >= 3_000.0)
         assertEquals(15_000.0, arrivalTime, 2 * timeStep)
     }
 
@@ -710,8 +739,10 @@ class StopTests {
                 .setMaxRunTime(5_000.0)
                 .setMaxDepartureDelay(Double.POSITIVE_INFINITY)
                 .run()!!
-        occupancyTest(res, occupancy)
-        assertEquals(res.stopResults[0].duration, 1.0, 2 * timeStep)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancy)
+        assertEquals(resSuccess.stopResults[0].duration, 1.0, 2 * timeStep)
     }
 
     /**
@@ -785,7 +816,9 @@ class StopTests {
                 )
                 .setTimeStep(timeStep)
                 .run()!!
-        occupancyTest(res, occupancy)
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        occupancyTest(resSuccess, occupancy)
     }
 
     /** First stop can be on different locations, its stop duration reproduces a bug */
@@ -841,7 +874,9 @@ class StopTests {
                     ExplorerStep(setOf(BlockLocation(lastBlock, Offset(100.meters))), 0.0, true)
                 )
                 .run()!!
-        val blocks = res.trainPath.getBlocks().map { infra.getBlockName(it.value) }
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+        val blocks = resSuccess.trainPath.getBlocks().map { infra.getBlockName(it.value) }
         val useBotPath = blocks.contains("x->y")
         assertTrue { useBotPath }
     }
@@ -849,7 +884,7 @@ class StopTests {
     companion object {
         /** Check that the train actually stops at the expected times and positions */
         private fun checkStop(
-            res: STDCMResult,
+            res: STDCMCompleteResult,
             expectedStops: List<TrainStop>,
             allowLonger: Boolean = true,
         ) {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/TemporarySpeedLimitTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/TemporarySpeedLimitTests.kt
@@ -15,6 +15,7 @@ import fr.sncf.osrd.utils.Helpers.smallInfra
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Speed
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class TemporarySpeedLimitTests {
@@ -67,8 +68,11 @@ class TemporarySpeedLimitTests {
             )
         val res =
             sendSTDCMWithTemporarySpeedLimits(smallInfra, temporarySpeedLimits, "DE3", "DF1_1")
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
         val resultSpeedLimits =
-            res.trainPath.getSpeedLimitProperties(
+            resSuccess.trainPath.getSpeedLimitProperties(
                 "",
                 buildTemporarySpeedLimitManager(smallInfra, temporarySpeedLimits),
             )
@@ -109,8 +113,11 @@ class TemporarySpeedLimitTests {
             )
         val res =
             sendSTDCMWithTemporarySpeedLimits(smallInfra, temporarySpeedLimits, "DE3", "DF1_1")
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
         val resultSpeedLimits =
-            res.trainPath.getSpeedLimitProperties(
+            resSuccess.trainPath.getSpeedLimitProperties(
                 "",
                 buildTemporarySpeedLimitManager(smallInfra, temporarySpeedLimits),
             )
@@ -154,8 +161,11 @@ class TemporarySpeedLimitTests {
             )
         val res =
             sendSTDCMWithTemporarySpeedLimits(smallInfra, temporarySpeedLimits, "DE3", "DF1_1")
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
         val resultSpeedLimits =
-            res.trainPath.getSpeedLimitProperties(
+            resSuccess.trainPath.getSpeedLimitProperties(
                 "",
                 buildTemporarySpeedLimitManager(smallInfra, temporarySpeedLimits),
             )
@@ -197,8 +207,11 @@ class TemporarySpeedLimitTests {
             )
         val res =
             sendSTDCMWithTemporarySpeedLimits(smallInfra, temporarySpeedLimits, "DE3", "DF1_1")
+        Assertions.assertTrue(res is STDCMCompleteResult)
+        val resSuccess = res as STDCMCompleteResult
+
         val resultSpeedLimits =
-            res.trainPath.getSpeedLimitProperties(
+            resSuccess.trainPath.getSpeedLimitProperties(
                 "",
                 buildTemporarySpeedLimitManager(smallInfra, temporarySpeedLimits),
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/ConsistChangeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/ConsistChangeTests.kt
@@ -13,6 +13,8 @@ import fr.sncf.osrd.envelope_sim.Comfort
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
+import fr.sncf.osrd.stdcm.STDCMCompleteResult
+import fr.sncf.osrd.stdcm.STDCMPartialResult
 import fr.sncf.osrd.stdcm.STDCMPathfindingBuilder
 import fr.sncf.osrd.stdcm.convertRouteLocation
 import fr.sncf.osrd.stdcm.infra_exploration.ExplorerStep
@@ -26,10 +28,8 @@ import fr.sncf.osrd.utils.units.meters
 import java.time.ZonedDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.assertNull
 
 class ConsistChangeTests {
     @Test
@@ -64,16 +64,21 @@ class ConsistChangeTests {
                 .setRollingStocks(listOf(slowTrain, mediumTrain, fastTrain))
                 .setBoundaries(listOf(1, 2))
                 .run()!!
-        val realStops = stdcmResult.stopResults.filter { it.duration > 0 }.toList()
+        Assertions.assertTrue(stdcmResult is STDCMCompleteResult)
+        val stdcmResultSuccess = stdcmResult as STDCMCompleteResult
+        val realStops = stdcmResultSuccess.stopResults.filter { it.duration > 0 }.toList()
         assertEquals(2, realStops.size)
         assertEquals(
             slowTrain.maxSpeed,
-            stdcmResult.envelope.maxSpeedInRange(0.0, realStops[0].position),
+            stdcmResultSuccess.envelope.maxSpeedInRange(0.0, realStops[0].position),
             0.01,
         )
         assertEquals(
             mediumTrain.maxSpeed,
-            stdcmResult.envelope.maxSpeedInRange(realStops[0].position, realStops[1].position),
+            stdcmResultSuccess.envelope.maxSpeedInRange(
+                realStops[0].position,
+                realStops[1].position,
+            ),
             0.01,
         )
         assertEquals(
@@ -119,11 +124,13 @@ class ConsistChangeTests {
                 .setRollingStocks(listOf(slowTrain, mediumTrain, fastTrain))
                 .setBoundaries(listOf(1, 2))
                 .run()!!
+        Assertions.assertTrue(stdcmResult is STDCMCompleteResult)
+        val stdcmResultSuccess = stdcmResult as STDCMCompleteResult
         val simulationResponse =
-            STDCMEndpoint.buildSimResponse(infra, stdcmResult, null, null, Comfort.STANDARD)
+            STDCMEndpoint.buildSimResponse(infra, stdcmResultSuccess, null, null, Comfort.STANDARD)
         STDCMEndpoint.logDebugData(
             infra.rawInfra,
-            stdcmResult,
+            stdcmResultSuccess,
             simulationResponse,
             ZonedDateTime.now(),
             mapOf(),
@@ -148,7 +155,7 @@ class ConsistChangeTests {
         val middle = convertRouteLocation(infra, "rt.DC0->DA3", Offset(100.meters))
         val end = convertRouteLocation(infra, "rt.DA3->buffer_stop.0", Offset(2000.meters))
         val requirements = emptyList<SpacingRequirement>()
-        assertNull(
+        Assertions.assertTrue(
             STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(start.blockLocations)
@@ -160,9 +167,9 @@ class ConsistChangeTests {
                     listOf(TestTrains.REALISTIC_FAST_TRAIN, TestTrains.FAST_ELECTRIC_TRAIN)
                 )
                 .setBoundaries(listOf(1))
-                .run()
+                .run() is STDCMPartialResult
         )
-        assertNotNull(
+        Assertions.assertTrue(
             STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(start.blockLocations)
@@ -174,7 +181,7 @@ class ConsistChangeTests {
                     listOf(TestTrains.FAST_ELECTRIC_TRAIN, TestTrains.REALISTIC_FAST_TRAIN)
                 )
                 .setBoundaries(listOf(1))
-                .run()
+                .run() is STDCMCompleteResult
         )
     }
 
@@ -263,24 +270,29 @@ class ConsistChangeTests {
                 .setRollingStocks(listOf(slowTrain, fastTrain))
                 .setBoundaries(listOf(2))
                 .run()!!
-        val realStops = stdcmResult.stopResults.filter { it.duration > 0 }.toList()
+        Assertions.assertTrue(stdcmResult is STDCMCompleteResult)
+        val stdcmResultSuccess = stdcmResult as STDCMCompleteResult
+        val realStops = stdcmResultSuccess.stopResults.filter { it.duration > 0 }.toList()
         assertEquals(2, realStops.size)
         // The first train should be used up to the second stop
         assertEquals(
             slowTrain.maxSpeed,
-            stdcmResult.envelope.maxSpeedInRange(0.0, realStops[0].position),
+            stdcmResultSuccess.envelope.maxSpeedInRange(0.0, realStops[0].position),
             0.01,
         )
         assertEquals(
             slowTrain.maxSpeed,
-            stdcmResult.envelope.maxSpeedInRange(realStops[0].position, realStops[1].position),
+            stdcmResultSuccess.envelope.maxSpeedInRange(
+                realStops[0].position,
+                realStops[1].position,
+            ),
             0.01,
         )
         assertEquals(
             fastTrain.maxSpeed,
-            stdcmResult.envelope.maxSpeedInRange(
+            stdcmResultSuccess.envelope.maxSpeedInRange(
                 realStops[1].position,
-                stdcmResult.envelope.endPos,
+                stdcmResultSuccess.envelope.endPos,
             ),
             0.01,
         )

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -146,6 +146,21 @@ pub struct ConsistSchedule {
     pub values: Vec<ConsistConfiguration>,
 }
 
+/// Represents the last reached operational point in a partial pathfinding result
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+pub struct LastReachedOperationalPoint {
+    pub id: String,
+    pub coordinates: ProgressCoordinates,
+    pub arrival_time: DateTime<Utc>,
+}
+
+/// Represents one conflicting work schedule in a partial pathfinding result
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+pub struct ConflictingWorkSchedule {
+    pub id: String,
+    pub last_op_id: String,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "status", rename_all = "SCREAMING_SNAKE_CASE")]
 #[allow(clippy::large_enum_variant)]
@@ -176,7 +191,12 @@ pub enum Response {
         path: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
     },
-    PathNotFound,
+    PathNotFound {
+        most_blocking_work_schedules: Vec<ConflictingWorkSchedule>,
+        nearest_to_destination_work_schedules: Vec<ConflictingWorkSchedule>,
+        partial_path: Option<PathfindingResultSuccess>,
+        last_reached_operational_point: Option<LastReachedOperationalPoint>,
+    },
 }
 
 impl AsCoreRequest<Json<Response>> for Request {

--- a/editoast/models/src/work_schedules.rs
+++ b/editoast/models/src/work_schedules.rs
@@ -49,7 +49,7 @@ pub enum WorkScheduleType {
     Track,
 }
 
-#[derive(Debug, Default, Clone, Model, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Default, Clone, Model, Serialize, Deserialize, ToSchema, PartialEq)]
 #[model(table = database::tables::work_schedule)]
 #[model(gen(batch_ops = c, list))]
 pub struct WorkSchedule {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -15576,6 +15576,37 @@ components:
           description: |-
             For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.
             For hourly timetables: elapsed ms since the timetable start.
+    StdcmConflictingWorkSchedule:
+      type: object
+      description: Represents one conflicting work schedule in a partial pathfinding result
+      required:
+      - start_date_time
+      - end_date_time
+      - last_op
+      properties:
+        end_date_time:
+          type: string
+          format: date-time
+        last_op:
+          $ref: '#/components/schemas/OperationalPoint'
+        start_date_time:
+          type: string
+          format: date-time
+    StdcmLastReachedOperationalPoint:
+      type: object
+      description: Represents the last reached operational point in a partial pathfinding result
+      required:
+      - geographic
+      - arrival_time
+      - operational_point
+      properties:
+        arrival_time:
+          type: string
+          format: date-time
+        geographic:
+          $ref: '#/components/schemas/GeoJsonPoint'
+        operational_point:
+          $ref: '#/components/schemas/OperationalPoint'
     StdcmPathfindingItem:
       type: object
       required:
@@ -15632,8 +15663,26 @@ components:
       - type: object
         title: StdcmResponsePathNotFound
         required:
+        - most_blocking_work_schedules
+        - nearest_to_destination_work_schedules
         - status
         properties:
+          last_reached_operational_point:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/StdcmLastReachedOperationalPoint'
+          most_blocking_work_schedules:
+            type: array
+            items:
+              $ref: '#/components/schemas/StdcmConflictingWorkSchedule'
+          nearest_to_destination_work_schedules:
+            type: array
+            items:
+              $ref: '#/components/schemas/StdcmConflictingWorkSchedule'
+          partial_pathfinding_result:
+            oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/CorePathfindingResultSuccess'
           status:
             type: string
             enum:

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -1,5 +1,15 @@
 pub(crate) mod request;
 
+use crate::AppState;
+use crate::authentication;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::views::AuthorizationError;
+use crate::views::path::pathfinding::TrainScheduleWithConsist;
+use crate::views::timetable::PhysicsConsistParameters;
+use crate::views::timetable::simulation;
+use crate::views::timetable::simulation::SimulationResponseSuccess;
+use crate::views::timetable::simulation::consist_train_simulation_batch;
 use authz;
 use authz::RollingStockPrivilege;
 use authz::v2;
@@ -19,24 +29,33 @@ use axum_streams::StreamBodyAs;
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
+use common::geometry::GeoJsonPoint;
 use common::units::millisecond;
 use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::InvalidPathItem;
 use core_client::pathfinding::PathfindingResultSuccess;
+use core_client::stdcm::ConflictingWorkSchedule;
 use core_client::stdcm::ConsistConfiguration;
 use core_client::stdcm::ConsistSchedule;
+use core_client::stdcm::LastReachedOperationalPoint;
 use core_client::stdcm::Request as StdcmRequest;
 use core_client::stdcm::UndirectedTrackRange;
-use database::DbConnectionPoolV2;
+use database::{DbConnection, DbConnectionPoolV2};
 use editoast_derive::EditoastError;
 use futures::StreamExt as _;
 use futures::stream;
 use geos::geojson::Geometry;
 use geos::geojson::Value;
 use itertools::Itertools as _;
+use models::Infra;
+use models::WorkSchedule;
+use models::prelude::*;
+use models::rolling_stock::RollingStock;
+use models::timetable::Timetable;
 use request::Request;
 use request::convert_steps;
+use schemas::infra::OperationalPoint;
 use schemas::primitives::PositiveDuration;
 use schemas::rolling_stock::RollingResistancePerWeight;
 use schemas::rolling_stock::RollingResistanceRaw;
@@ -47,6 +66,7 @@ use schemas::train_schedule::ScheduleItem;
 use schemas::train_schedule::TrainOccurrence;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::pin::pin;
 use std::sync::Arc;
@@ -58,21 +78,22 @@ use tracing::Span;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use crate::AppState;
-use crate::authentication;
-use crate::error::InternalError;
-use crate::error::Result;
-use crate::views::AuthorizationError;
-use crate::views::path::pathfinding::TrainScheduleWithConsist;
-use crate::views::timetable::PhysicsConsistParameters;
-use crate::views::timetable::simulation;
-use crate::views::timetable::simulation::SimulationResponseSuccess;
-use crate::views::timetable::simulation::consist_train_simulation_batch;
-use models::Infra;
-use models::WorkSchedule;
-use models::prelude::*;
-use models::rolling_stock::RollingStock;
-use models::timetable::Timetable;
+/// Represents the last reached operational point in a partial pathfinding result
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+pub struct StdcmLastReachedOperationalPoint {
+    #[schema(value_type = GeoJsonPoint)]
+    pub geographic: Geometry,
+    pub arrival_time: DateTime<Utc>,
+    pub operational_point: OperationalPoint,
+}
+
+/// Represents one conflicting work schedule in a partial pathfinding result
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+pub struct StdcmConflictingWorkSchedule {
+    pub start_date_time: DateTime<Utc>,
+    pub end_date_time: DateTime<Utc>,
+    pub last_op: OperationalPoint,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
 #[serde(tag = "status", rename_all = "snake_case")]
@@ -86,7 +107,12 @@ pub(in crate::views) enum StdcmResponse {
         pathfinding_result: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
     },
-    PathNotFound,
+    PathNotFound {
+        most_blocking_work_schedules: Vec<StdcmConflictingWorkSchedule>,
+        nearest_to_destination_work_schedules: Vec<StdcmConflictingWorkSchedule>,
+        partial_pathfinding_result: Option<PathfindingResultSuccess>,
+        last_reached_operational_point: Option<StdcmLastReachedOperationalPoint>,
+    },
     PreprocessingSimulationError {
         error: simulation::Response,
     },
@@ -371,7 +397,7 @@ pub(in crate::views) async fn stdcm(
             .get_temporary_speed_limits(&mut conn, total_simulation_run_time)
             .await?,
         comfort: request.comfort,
-        path_items: request.get_stdcm_path_items(conn, infra_id).await?,
+        path_items: request.get_stdcm_path_items(conn.clone(), infra_id).await?,
         start_time: earliest_departure_time,
         maximum_departure_delay: request.get_maximum_departure_delay(total_simulation_run_time),
         maximum_run_time: request.get_maximum_run_time(total_simulation_run_time),
@@ -379,6 +405,7 @@ pub(in crate::views) async fn stdcm(
         time_gap_after: request.time_gap_after,
         margin: request.margin,
         time_step: Some(2000),
+        // TODO: filter editoast work schedules according to time window and save as variable to be used later on in step 6
         work_schedules: work_schedules
             .iter()
             .filter_map(|ws| {
@@ -407,40 +434,98 @@ pub(in crate::views) async fn stdcm(
         };
 
         // 6. Handle STDCM Core Response
-        let result_stream = stream_stdcm_response.map(move |response| {
-            let response = response.map_err(InternalError::from);
+        let result_stream = stream_stdcm_response.then(move |response| {
+            let mut conn = conn.clone();
+            let infra = Clone::clone(&infra);
+            // TODO: use time filtered work schedules sent to core
+            let work_schedules = work_schedules.clone();
+            async move {
+                let response = response.map_err(InternalError::from);
 
-            let span = Span::current();
+                let span = Span::current();
 
-            match response {
-                Ok(result) => match result {
-                    core_client::stdcm::ProgressStatus::InProgress {
-                        point,
-                        best_travel_time,
-                    } => StdcmProgression::Ongoing(StdcmProgressionEvent {
-                        point: Geometry::new(Value::Point(vec![point.lon, point.lat])),
-                        best_travel_time,
-                    }),
-                    core_client::stdcm::ProgressStatus::Done { result } => match result {
-                        core_client::stdcm::Response::Success {
-                            simulation,
-                            path,
-                            departure_time,
-                        } => {
-                            span.record("path_found", true);
-                            StdcmProgression::Completed(StdcmResponse::Success {
-                                simulation: simulation.into(),
-                                pathfinding_result: path,
+                match response {
+                    Ok(result) => match result {
+                        core_client::stdcm::ProgressStatus::InProgress {
+                            point,
+                            best_travel_time,
+                        } => StdcmProgression::Ongoing(StdcmProgressionEvent {
+                            point: Geometry::new(Value::Point(vec![point.lon, point.lat])),
+                            best_travel_time,
+                        }),
+                        core_client::stdcm::ProgressStatus::Done { result } => match result {
+                            core_client::stdcm::Response::Success {
+                                simulation,
+                                path,
                                 departure_time,
-                            })
-                        }
-                        core_client::stdcm::Response::PathNotFound => {
-                            span.record("path_found", false);
-                            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
-                        }
+                            } => {
+                                span.record("path_found", true);
+                                StdcmProgression::Completed(StdcmResponse::Success {
+                                    simulation: simulation.into(),
+                                    pathfinding_result: path,
+                                    departure_time,
+                                })
+                            }
+                            core_client::stdcm::Response::PathNotFound {
+                                most_blocking_work_schedules,
+                                nearest_to_destination_work_schedules,
+                                partial_path,
+                                last_reached_operational_point,
+                            } => {
+                                span.record("path_found", false);
+                                let last_reached_operational_point =
+                                    match last_reached_operational_point {
+                                        Some(last_reached_op) => {
+                                            let op = fetch_operational_point(
+                                                &infra,
+                                                &mut conn,
+                                                &last_reached_op.id,
+                                            )
+                                            .await;
+                                            Some(as_stdcm_last_reached_operational_point(
+                                                last_reached_op,
+                                                op,
+                                            ))
+                                        }
+                                        None => None,
+                                    };
+
+                                let ws_map: HashMap<_, _> = work_schedules
+                                    .iter()
+                                    .map(|ws| (ws.obj_id.as_str(), ws))
+                                    .collect();
+                                let stdcm_most_blocking_work_schedules =
+                                    enrich_conflicting_work_schedules(
+                                        most_blocking_work_schedules,
+                                        &ws_map,
+                                        &infra,
+                                        &mut conn,
+                                    )
+                                    .await;
+                                let stdcm_nearest_to_destination_work_schedules =
+                                    enrich_conflicting_work_schedules(
+                                        nearest_to_destination_work_schedules,
+                                        &ws_map,
+                                        &infra,
+                                        &mut conn,
+                                    )
+                                    .await;
+
+                                StdcmProgression::Completed(StdcmResponse::PathNotFound {
+                                    most_blocking_work_schedules:
+                                        stdcm_most_blocking_work_schedules,
+                                    nearest_to_destination_work_schedules:
+                                        stdcm_nearest_to_destination_work_schedules,
+                                    partial_pathfinding_result: partial_path,
+                                    last_reached_operational_point,
+                                })
+                            }
+                        },
                     },
-                },
-                Err(e) => StdcmProgression::Completed(StdcmResponse::InternalError { error: e }),
+                    Err(e) => {
+                        StdcmProgression::Completed(StdcmResponse::InternalError { error: e })
+                    }
+                }
             }
         });
 
@@ -462,6 +547,45 @@ pub(in crate::views) async fn stdcm(
         StreamBodyAs::json_nl(stream),
     )
         .into_response())
+}
+
+async fn fetch_operational_point(
+    infra: &Infra,
+    conn: &mut DbConnection,
+    op_id: &str,
+) -> OperationalPoint {
+    infra
+        .get_objects(
+            conn,
+            schemas::primitives::ObjectType::OperationalPoint,
+            &vec![op_id.to_owned()],
+        )
+        .await
+        .ok()
+        .and_then(|objs| objs.into_iter().next())
+        .and_then(|obj| serde_json::from_value(obj.railjson).ok())
+         .expect("the operational point ID should exist since it has been sent to `core`, and returned back")
+}
+
+async fn enrich_conflicting_work_schedules(
+    conflicting_work_schedules: Vec<ConflictingWorkSchedule>,
+    work_shedule_map: &HashMap<&str, &WorkSchedule>,
+    infra: &Infra,
+    conn: &mut DbConnection,
+) -> Vec<StdcmConflictingWorkSchedule> {
+    let mut enriched = Vec::with_capacity(conflicting_work_schedules.len());
+    for ConflictingWorkSchedule { id, last_op_id } in conflicting_work_schedules {
+        let ws = work_shedule_map.get(id.as_str()).expect(
+            "the work schedule ID should exist since it has been sent to `core`, and returned back",
+        );
+        let op: OperationalPoint = fetch_operational_point(infra, conn, &last_op_id).await;
+        enriched.push(StdcmConflictingWorkSchedule {
+            start_date_time: ws.start_date_time,
+            end_date_time: ws.end_date_time,
+            last_op: op,
+        });
+    }
+    enriched
 }
 
 struct VirtualTrainRun {
@@ -604,6 +728,21 @@ pub fn as_core_work_schedule(
     })
 }
 
+/// Convert core_client LastReachedOperationalPoint to StdcmLastReachedOperationalPoint
+fn as_stdcm_last_reached_operational_point(
+    lrop: LastReachedOperationalPoint,
+    operational_point: OperationalPoint,
+) -> StdcmLastReachedOperationalPoint {
+    StdcmLastReachedOperationalPoint {
+        geographic: Geometry::new(Value::Point(vec![
+            lrop.coordinates.lon,
+            lrop.coordinates.lat,
+        ])),
+        arrival_time: lrop.arrival_time,
+        operational_point,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use authz::InfraGrant;
@@ -620,6 +759,7 @@ mod tests {
     use rstest::rstest;
     use schemas::fixtures::simple_rolling_stock;
     use schemas::fixtures::towed_rolling_stock;
+    use schemas::infra::OperationalPointPart;
     use schemas::rolling_stock::LoadingGaugeType;
     use schemas::rolling_stock::RollingResistanceRaw;
     use schemas::train_schedule::Comfort;
@@ -645,6 +785,7 @@ mod tests {
     use crate::fixtures::create_small_infra;
     use crate::fixtures::create_timetable;
     use crate::fixtures::create_towed_rolling_stock;
+    use crate::fixtures::create_work_schedules_fixture_set;
     use crate::views::path::pathfinding::PathfindingItem;
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app::TestRequestExt as _;
@@ -777,6 +918,90 @@ mod tests {
             path_item_positions: vec![0, 10],
             backtrack_path_items: Some(vec![]),
         }
+    }
+
+    fn pathfinding_result_partial() -> PathfindingResultSuccess {
+        PathfindingResultSuccess {
+            path: TrainPath {
+                blocks: vec![],
+                routes: vec![],
+                track_section_ranges: vec![],
+            },
+            length: 10,
+            path_item_positions: vec![0, 5],
+            backtrack_path_items: Some(vec![]),
+        }
+    }
+
+    fn last_reached_operational_point() -> LastReachedOperationalPoint {
+        LastReachedOperationalPoint {
+            id: "South_East_station".to_string(),
+            coordinates: core_client::stdcm::ProgressCoordinates { lat: 2.0, lon: 2.0 },
+            arrival_time: DateTime::from_str("2024-01-02T00:00:00Z")
+                .expect("Failed to parse datetime"),
+        }
+    }
+
+    fn new_ses_op() -> OperationalPoint {
+        OperationalPoint {
+            id: "South_East_station".into(),
+            parts: vec![OperationalPointPart {
+                track: "TH1".into(),
+                position: 4400.0,
+                local_track_name: "V1".into(),
+                ..Default::default()
+            }],
+            name: "South_East_station".into(),
+            uic: Some(8788),
+            country_code: "FR".into(),
+            main_code: "SES".into(),
+            secondary_code: Some("BV".into()),
+            is_passenger_station: true,
+            secondary_name: Some("0".into()),
+            ..Default::default()
+        }
+    }
+
+    fn new_ss_op() -> OperationalPoint {
+        OperationalPoint {
+            id: "South_station".into(),
+            parts: vec![OperationalPointPart {
+                track: "TF1".into(),
+                position: 4300.0,
+                local_track_name: "V1".into(),
+                ..Default::default()
+            }],
+            name: "South_station".into(),
+            uic: Some(8766),
+            country_code: "FR".into(),
+            main_code: "SS".into(),
+            secondary_code: Some("BV".into()),
+            is_passenger_station: true,
+            secondary_name: Some("0".into()),
+            ..Default::default()
+        }
+    }
+
+    fn new_work_schedule_changeset(obj_ids: Vec<String>) -> Vec<Changeset<WorkSchedule>> {
+        let track_ranges = vec![schemas::infra::TrackRange::new("d", 100.0, 150.0)];
+        let start_date_time = DateTime::parse_from_rfc3339("2024-03-13 06:00:00Z")
+            .unwrap()
+            .to_utc();
+        let end_date_time = DateTime::parse_from_rfc3339("2024-03-13 12:00:00Z")
+            .unwrap()
+            .to_utc();
+
+        obj_ids
+            .into_iter()
+            .map(|obj_id| {
+                WorkSchedule::changeset()
+                    .start_date_time(start_date_time)
+                    .end_date_time(end_date_time)
+                    .track_ranges(track_ranges.clone())
+                    .obj_id(obj_id)
+                    .work_schedule_type(models::work_schedules::WorkScheduleType::Track)
+            })
+            .collect()
     }
 
     fn simulation_empty_response() -> core_client::simulation::Response {
@@ -1164,7 +1389,24 @@ mod tests {
         core.stub("/stdcm")
             .response(StatusCode::OK)
             .json(core_client::stdcm::ProgressStatus::Done {
-                result: core_client::stdcm::Response::PathNotFound,
+                result: core_client::stdcm::Response::PathNotFound {
+                    most_blocking_work_schedules: vec![
+                        ConflictingWorkSchedule {
+                            id: "work_schedule_0".to_string(),
+                            last_op_id: "South_East_station".to_string(),
+                        },
+                        ConflictingWorkSchedule {
+                            id: "work_schedule_1".to_string(),
+                            last_op_id: "South_station".to_string(),
+                        },
+                    ],
+                    nearest_to_destination_work_schedules: vec![ConflictingWorkSchedule {
+                        id: "work_schedule_2".to_string(),
+                        last_op_id: "South_East_station".to_string(),
+                    }],
+                    partial_path: Some(pathfinding_result_partial()),
+                    last_reached_operational_point: Some(last_reached_operational_point()),
+                },
             })
             .finish();
 
@@ -1189,18 +1431,53 @@ mod tests {
             None,
             None,
         ));
+        let work_schedules_changeset = new_work_schedule_changeset(vec![
+            "work_schedule_0".to_string(),
+            "work_schedule_1".to_string(),
+            "work_schedule_2".to_string(),
+        ]);
+        let (_, work_schedules) =
+            create_work_schedules_fixture_set(&mut db_pool.get_ok(), work_schedules_changeset)
+                .await;
+        let (most_blocking_work_schedules, nearest_to_destination_work_schedules) =
+            work_schedules.split_at(2);
+        let stdcm_most_blocking_work_schedules = most_blocking_work_schedules
+            .iter()
+            .zip(vec![new_ses_op(), new_ss_op()])
+            .map(|(ws, op)| StdcmConflictingWorkSchedule {
+                start_date_time: ws.start_date_time,
+                end_date_time: ws.end_date_time,
+                last_op: op,
+            })
+            .collect();
+        let stdm_nearest_blocking_work_schedules = nearest_to_destination_work_schedules
+            .iter()
+            .map(|ws| StdcmConflictingWorkSchedule {
+                start_date_time: ws.start_date_time,
+                end_date_time: ws.end_date_time,
+                last_op: new_ses_op(),
+            })
+            .collect();
 
         let stdcm_response: StdcmProgression = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .by_user(user.as_ref())
-            .json(&get_stdcm_payload(None, consist_schedule))
+            .json(&get_stdcm_payload(Some(1), consist_schedule))
             .await
             .assert_status_ok()
             .last_jsonl();
 
         assert_eq!(
             stdcm_response,
-            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
+            StdcmProgression::Completed(StdcmResponse::PathNotFound {
+                most_blocking_work_schedules: stdcm_most_blocking_work_schedules,
+                nearest_to_destination_work_schedules: stdm_nearest_blocking_work_schedules,
+                partial_pathfinding_result: Some(pathfinding_result_partial()),
+                last_reached_operational_point: Some(as_stdcm_last_reached_operational_point(
+                    last_reached_operational_point(),
+                    new_ses_op()
+                )),
+            })
         );
     }
 
@@ -1299,7 +1576,24 @@ mod tests {
                 best_travel_time: 5,
             })
             .json(core_client::stdcm::ProgressStatus::Done {
-                result: core_client::stdcm::Response::PathNotFound,
+                result: core_client::stdcm::Response::PathNotFound {
+                    most_blocking_work_schedules: vec![
+                        ConflictingWorkSchedule {
+                            id: "work_schedule_0".to_string(),
+                            last_op_id: "South_station".to_string(),
+                        },
+                        ConflictingWorkSchedule {
+                            id: "work_schedule_1".to_string(),
+                            last_op_id: "South_East_station".to_string(),
+                        },
+                    ],
+                    nearest_to_destination_work_schedules: vec![ConflictingWorkSchedule {
+                        id: "work_schedule_2".to_string(),
+                        last_op_id: "South_station".to_string(),
+                    }],
+                    partial_path: Some(pathfinding_result_partial()),
+                    last_reached_operational_point: Some(last_reached_operational_point()),
+                },
             })
             .finish();
 
@@ -1324,11 +1618,38 @@ mod tests {
             None,
             None,
         ));
+        let work_schedules_changeset = new_work_schedule_changeset(vec![
+            "work_schedule_0".to_string(),
+            "work_schedule_1".to_string(),
+            "work_schedule_2".to_string(),
+        ]);
+        let (_, work_schedules) =
+            create_work_schedules_fixture_set(&mut db_pool.get_ok(), work_schedules_changeset)
+                .await;
+        let (most_blocking_work_schedules, nearest_to_destination_work_schedules) =
+            work_schedules.split_at(2);
+        let stdcm_most_blocking_work_schedules = most_blocking_work_schedules
+            .iter()
+            .zip(vec![new_ss_op(), new_ses_op()])
+            .map(|(ws, op)| StdcmConflictingWorkSchedule {
+                start_date_time: ws.start_date_time,
+                end_date_time: ws.end_date_time,
+                last_op: op,
+            })
+            .collect();
+        let stdcm_nearest_blocking_work_schedules = nearest_to_destination_work_schedules
+            .iter()
+            .map(|ws| StdcmConflictingWorkSchedule {
+                start_date_time: ws.start_date_time,
+                end_date_time: ws.end_date_time,
+                last_op: new_ss_op(),
+            })
+            .collect();
 
         let stdcm_response: Vec<StdcmProgression> = app
             .post(format!("/timetable/{}/stdcm?infra={}", timetable.id, small_infra.id).as_str())
             .by_user(user.as_ref())
-            .json(&get_stdcm_payload(None, consist_schedule))
+            .json(&get_stdcm_payload(Some(1), consist_schedule))
             .await
             .assert_status_ok()
             .jsonl();
@@ -1350,7 +1671,15 @@ mod tests {
         );
         assert_eq!(
             stdcm_response[2].clone(),
-            StdcmProgression::Completed(StdcmResponse::PathNotFound {})
+            StdcmProgression::Completed(StdcmResponse::PathNotFound {
+                most_blocking_work_schedules: stdcm_most_blocking_work_schedules,
+                nearest_to_destination_work_schedules: stdcm_nearest_blocking_work_schedules,
+                partial_pathfinding_result: Some(pathfinding_result_partial()),
+                last_reached_operational_point: Some(as_stdcm_last_reached_operational_point(
+                    last_reached_operational_point(),
+                    new_ses_op()
+                )),
+            }),
         );
     }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4923,6 +4923,16 @@ export type StdcmProgressionEvent = {
   best_travel_time: number;
   point: GeoJsonPoint;
 };
+export type StdcmLastReachedOperationalPoint = {
+  arrival_time: string;
+  geographic: GeoJsonPoint;
+  operational_point: OperationalPoint;
+};
+export type StdcmConflictingWorkSchedule = {
+  end_date_time: string;
+  last_op: OperationalPoint;
+  start_date_time: string;
+};
 export type InternalError = {
   context: {
     [key: string]: unknown;
@@ -4951,6 +4961,10 @@ export type StdcmResponse =
       status: 'success';
     }
   | {
+      last_reached_operational_point?: null | StdcmLastReachedOperationalPoint;
+      most_blocking_work_schedules: StdcmConflictingWorkSchedule[];
+      nearest_to_destination_work_schedules: StdcmConflictingWorkSchedule[];
+      partial_pathfinding_result?: null | CorePathfindingResultSuccess;
       status: 'path_not_found';
     }
   | {

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -4191,10 +4191,6 @@ class StartTimeChangeGroup(BaseModel):
     """
 
 
-class StdcmResponsePathNotFound(BaseModel):
-    status: Literal["path_not_found"] = "path_not_found"
-
-
 class StdcmResponseInternalError(BaseModel):
     error: InternalError
     status: Literal["internal_error"] = "internal_error"
@@ -7089,22 +7085,6 @@ class StdcmResponsePreprocessingSimulationError(BaseModel):
     status: Literal["preprocessing_simulation_error"] = "preprocessing_simulation_error"
 
 
-class StdcmResponse(
-    RootModel[
-        StdcmResponseSuccess
-        | StdcmResponsePathNotFound
-        | StdcmResponsePreprocessingSimulationError
-        | StdcmResponseInternalError
-    ]
-):
-    root: (
-        StdcmResponseSuccess
-        | StdcmResponsePathNotFound
-        | StdcmResponsePreprocessingSimulationError
-        | StdcmResponseInternalError
-    )
-
-
 class Switch(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7494,6 +7474,50 @@ class SimDebugData(BaseModel):
     train_positions: list[float]
     train_times: list[float]
     zone_locations: list[SimDebugZoneLocation]
+
+
+class StdcmConflictingWorkSchedule(BaseModel):
+    """
+    Represents one conflicting work schedule in a partial pathfinding result
+    """
+
+    end_date_time: AwareDatetime
+    last_op: OperationalPoint
+    start_date_time: AwareDatetime
+
+
+class StdcmLastReachedOperationalPoint(BaseModel):
+    """
+    Represents the last reached operational point in a partial pathfinding result
+    """
+
+    arrival_time: AwareDatetime
+    geographic: GeoJsonPoint
+    operational_point: OperationalPoint
+
+
+class StdcmResponsePathNotFound(BaseModel):
+    last_reached_operational_point: StdcmLastReachedOperationalPoint | None = None
+    most_blocking_work_schedules: list[StdcmConflictingWorkSchedule]
+    nearest_to_destination_work_schedules: list[StdcmConflictingWorkSchedule]
+    partial_pathfinding_result: CorePathfindingResultSuccess | None = None
+    status: Literal["path_not_found"] = "path_not_found"
+
+
+class StdcmResponse(
+    RootModel[
+        StdcmResponseSuccess
+        | StdcmResponsePathNotFound
+        | StdcmResponsePreprocessingSimulationError
+        | StdcmResponseInternalError
+    ]
+):
+    root: (
+        StdcmResponseSuccess
+        | StdcmResponsePathNotFound
+        | StdcmResponsePreprocessingSimulationError
+        | StdcmResponseInternalError
+    )
 
 
 class TrainScheduleExceptionChangeGroups(BaseModel):

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -275,6 +275,170 @@ def test_work_schedules(
     assert departure_time >= end_time.astimezone(departure_time.tzinfo)
 
 
+def test_work_schedules_failure_explainer(
+    small_infra: Infra, timetable_id: int, fast_rolling_stock: int, session: Session
+):
+    start_time = datetime.datetime(2024, 1, 1, 14, 0, 0, tzinfo=datetime.UTC)
+    end_time = start_time + datetime.timedelta(days=10)
+    now = datetime.datetime.now(tz=datetime.UTC)
+    work_schedules_r = session.post(
+        EDITOAST_URL + "work_schedules/",
+        json={
+            "work_schedule_group_name": f"generic_group_{now}",
+            "work_schedules": [
+                {
+                    "start_date_time": start_time.isoformat(),
+                    "end_date_time": end_time.isoformat(),
+                    "obj_id": "TD3",
+                    "track_ranges": [{"begin": 0, "end": 100, "track": "TD3"}],
+                    "work_schedule_type": "CATENARY",
+                }
+            ],
+        },
+    )
+    work_schedules_response = work_schedules_r.json()
+
+    stdcm_payload = {
+        "start_time": "2024-01-05T13:00:00+00:00",
+        "maximum_departure_delay": 7200000,
+        "maximum_run_time": 43200000,
+        "time_gap_before": 0,
+        "time_gap_after": 0,
+        "steps": [
+            {
+                "duration": None,
+                "pathfinding_item": {"location": _START, "can_backtrack": False},
+            },
+            {
+                "duration": 1,
+                "pathfinding_item": {"location": _STOP, "can_backtrack": False},
+            },
+        ],
+        "comfort": "STANDARD",
+        "margin": "0%",
+        "work_schedule_group_id": work_schedules_response["work_schedule_group_id"],
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": fast_rolling_stock,
+                }
+            ],
+        },
+    }
+    content = _get_stdcm_response(small_infra, timetable_id, stdcm_payload, session)
+
+    assert content["most_blocking_work_schedules"][0][
+        "start_date_time"
+    ] == start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert content["most_blocking_work_schedules"][0][
+        "end_date_time"
+    ] == end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert (
+        content["most_blocking_work_schedules"][0]["last_op"]["id"]
+        == "Mid_West_station_duplicate"
+    )
+
+    assert content["nearest_to_destination_work_schedules"][0][
+        "start_date_time"
+    ] == start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert content["nearest_to_destination_work_schedules"][0][
+        "end_date_time"
+    ] == end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert (
+        content["nearest_to_destination_work_schedules"][0]["last_op"]["id"]
+        == "Mid_West_station_duplicate"
+    )
+
+    assert content["partial_pathfinding_result"] is not None
+    assert (
+        content["last_reached_operational_point"]["operational_point"]["id"]
+        == "Mid_West_station_duplicate"
+    )
+
+
+def test_work_schedules_failure_explainer_at_departure(
+    small_infra: Infra, timetable_id: int, fast_rolling_stock: int, session: Session
+):
+    start_time = datetime.datetime(2024, 1, 1, 14, 0, 0, tzinfo=datetime.UTC)
+    end_time = start_time + datetime.timedelta(days=10)
+    now = datetime.datetime.now(tz=datetime.UTC)
+    work_schedules_r = session.post(
+        EDITOAST_URL + "work_schedules/",
+        json={
+            "work_schedule_group_name": f"generic_group_{now}",
+            "work_schedules": [
+                {
+                    "start_date_time": start_time.isoformat(),
+                    "end_date_time": end_time.isoformat(),
+                    "obj_id": "TA2",
+                    "track_ranges": [{"begin": 0, "end": 100, "track": "TA2"}],
+                    "work_schedule_type": "CATENARY",
+                }
+            ],
+        },
+    )
+    work_schedules_response = work_schedules_r.json()
+
+    stdcm_payload = {
+        "start_time": "2024-01-05T13:00:00+00:00",
+        "maximum_departure_delay": 7200000,
+        "maximum_run_time": 43200000,
+        "time_gap_before": 0,
+        "time_gap_after": 0,
+        "steps": [
+            {
+                "duration": None,
+                "pathfinding_item": {
+                    "location": {"type": "track_offset", "track": "TA2", "offset": 500},
+                    "can_backtrack": False,
+                },  # To start on the WS OP
+            },
+            {
+                "duration": 1,
+                "pathfinding_item": {"location": _STOP, "can_backtrack": False},
+            },
+        ],
+        "comfort": "STANDARD",
+        "margin": "0%",
+        "work_schedule_group_id": work_schedules_response["work_schedule_group_id"],
+        "consist_schedule": {
+            "boundaries": [],
+            "values": [
+                {
+                    "rolling_stock_id": fast_rolling_stock,
+                }
+            ],
+        },
+    }
+    content = _get_stdcm_response(small_infra, timetable_id, stdcm_payload, session)
+
+    assert content["most_blocking_work_schedules"][0][
+        "start_date_time"
+    ] == start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert content["most_blocking_work_schedules"][0][
+        "end_date_time"
+    ] == end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert content["most_blocking_work_schedules"][0]["last_op"]["id"] == "West_station"
+
+    assert content["nearest_to_destination_work_schedules"][0][
+        "start_date_time"
+    ] == start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert content["nearest_to_destination_work_schedules"][0][
+        "end_date_time"
+    ] == end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert (
+        content["nearest_to_destination_work_schedules"][0]["last_op"]["id"]
+        == "West_station"
+    )
+
+    assert content["partial_pathfinding_result"] is not None
+    assert (
+        content["last_reached_operational_point"]["operational_point"]["id"]
+        == "West_station"
+    )
+
+
 def test_mrsp_sources(
     small_infra: Infra,
     timetable_id: int,


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/17547 (editoast)
Closes https://github.com/OpenRailAssociation/osrd/issues/17549 (core)

You can read by service and commit by commit.

## Description

Add a work shedules failure explainer to display the 2 most largest conflict and the closest to destination conflict, and connect it to editoast.

> [!NOTE]
> The refactoring of failure explainer in core suggested in the implementation plan will be done later. In this MR, I focused on making the code work. See corresponding [issue](https://github.com/OpenRailAssociation/osrd/issues/18250).


## Implementation choices

### Core

I'm not sure about my choice in 49fe6c8bf041d52478c1b63a03485e3fd8ff24e3, which changes the `findPathImpl()` and  modifies `STDCMResult` into an interface, to have two implementation `STDCMCompleteResult` (the old `STDCMResult`) and `STDCMPartialResult`. 
This breaks a lot of tests because they return a partial result, instead of a complete one, so `findPathImpl()` might be wrong 🤔 For example `testBacktrackingMRSPDrop` fails because `STDCMPathfindingBuilder.run()` returns a `STDCMPartialResult` whereas I was expecting a `STDCMCompleteResult`.

## Tests 
- Check the integration test in `test_stdcm.py`
- I can provide an stdcm search env with work schedules