### PR TITLE
front: make useSpeedLimitTags infra agnostic

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLeftPanel.tsx
@@ -98,7 +98,7 @@ const SpeedSectionEditionLeftPanel = () => {
     });
   };
 
-  const speedLimitTags = useSpeedLimitTags();
+  const speedLimitTags = useSpeedLimitTags(infraID);
 
   const updateSpeedSectionExtensions = (
     extensions: SpeedSectionEntity['properties']['extensions']

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { CategoryColors } from 'applications/operationalStudies/types';
 import type { LightRollingStockWithLiveries, SubCategory } from 'common/api/osrdEditoastApi';
+import { useInfraID } from 'common/osrdContext';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import useStoreDataForRollingStockSelector from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import isMainCategory from 'modules/rollingStock/helpers/category';
@@ -110,7 +111,8 @@ const ItineraryModalFormHeader = ({
   };
 
   // Composition code/speed limit by tag
-  const speedLimitTags = useSpeedLimitTags();
+  const infraID = useInfraID();
+  const speedLimitTags = useSpeedLimitTags(infraID);
 
   // Train schedule name error
   const [isNameBlurred, setIsNameBlurred] = useState(false);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/ManageTrainSchedule.tsx
@@ -12,7 +12,7 @@ import simulationSettings from 'assets/pictures/components/simulationSettings.sv
 import rollingStockPic from 'assets/pictures/components/train.svg';
 import { type Comfort, type LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
 import { type MarkerInformation, MARKER_TYPE } from 'common/Map/components/ItineraryMarkers';
-import { useOsrdConfActions } from 'common/osrdContext';
+import { useInfraID, useOsrdConfActions } from 'common/osrdContext';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import Tabs from 'common/Tabs';
@@ -94,7 +94,8 @@ const ManageTrainSchedule = () => {
   const constraintDistribution = useSelector(getConstraintDistribution);
   const startTime = useSelector(getStartTime);
 
-  const speedLimitTags = useSpeedLimitTags();
+  const infraID = useInfraID();
+  const speedLimitTags = useSpeedLimitTags(infraID);
   const { rollingStockComfort, rollingStock } = useStoreDataForRollingStockSelector({
     rollingStockId,
   });

--- a/front/src/common/Map/components/LayersModal.tsx
+++ b/front/src/common/Map/components/LayersModal.tsx
@@ -67,10 +67,10 @@ const LayersModal = ({
 }: LayersModalProps) => {
   const { t } = useTranslation();
 
-  const { layersSettings, updateMapSettings } = useMapContext();
+  const { infraId, layersSettings, updateMapSettings } = useMapContext();
   const [selectedLayers, setSelectedLayers] = useState<LayersSettings>(layersSettings);
 
-  const speedLimitTags = useSpeedLimitTags();
+  const speedLimitTags = useSpeedLimitTags(infraId);
   const DEFAULT_SPEED_LIMIT_TAG = useMemo(() => t('mapSettings.noSpeedLimitByTag'), [t]);
 
   const speedLimitOptions = useMemo(

--- a/front/src/common/SpeedLimitTagSelector/useSpeedLimitTags.ts
+++ b/front/src/common/SpeedLimitTagSelector/useSpeedLimitTags.ts
@@ -5,7 +5,6 @@ import { uniq } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useInfraID } from 'common/osrdContext';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
@@ -17,11 +16,9 @@ import { castErrorToFailure } from 'utils/error';
  * some speed limit tags should be available for users (stored in the stdcm
  * environment configuration)
  */
-const useSpeedLimitTags = () => {
+const useSpeedLimitTags = (infraID: number | undefined) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation('operational-studies', { keyPrefix: 'manageTrainSchedule' });
-
-  const infraID = useInfraID();
 
   const { data: speedLimitsTagsByInfraId = [], error } =
     osrdEditoastApi.endpoints.getInfraByInfraIdSpeedLimitTags.useQuery(

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -21,6 +21,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import type { Comfort, ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
 import Banner from 'common/Banner';
+import { useInfraID } from 'common/osrdContext';
 import useSpeedLimitTags from 'common/SpeedLimitTagSelector/useSpeedLimitTags';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import isMainCategory, { checkCategoryWarning } from 'modules/rollingStock/helpers/category';
@@ -217,7 +218,8 @@ const ExpandedTrainForm = ({
   onItineraryOpened,
 }: ExpandedTrainFormProps) => {
   const { t } = useTranslation(['operational-studies', 'translation']);
-  const speedLimitTags = useSpeedLimitTags();
+  const infraID = useInfraID();
+  const speedLimitTags = useSpeedLimitTags(infraID);
   const categoryOptions = useCategoryOptions();
 
   const { filteredRollingStockList: rollingStocks } = useFilterRollingStock();


### PR DESCRIPTION
`useSpeedLimitTags` now receives infraId as a parameter from its caller instead of retrieving it from the global context. Existing pages keep the same behavior, while the hook becomes reusable outside this specific React context.