### PR TITLE
front: map: pass infraId as a prop to SNCF_PSL_Signs

### DIFF
--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
@@ -214,7 +214,12 @@ const SNCF_PSL = ({ colors, layerOrder, punctualLayerOrder, highlightedArea }: S
           layerOrder={layerOrder}
         />
       </Source>
-      <SNCF_PSL_Signs colors={colors} layerOrder={punctualLayerOrder} filter={speedSectionFilter} />
+      <SNCF_PSL_Signs
+        colors={colors}
+        infraId={infraId}
+        layerOrder={punctualLayerOrder}
+        filter={speedSectionFilter}
+      />
     </>
   );
 };

--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSLSigns.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSLSigns.tsx
@@ -5,7 +5,6 @@ import { Source } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
 import type { Theme } from 'common/Map/theme';
-import { useInfraID } from 'common/osrdContext';
 
 import OrderedLayer from '../../../OrderedLayer';
 import type { LayerContext } from '../../../types';
@@ -14,6 +13,7 @@ import getMastLayerProps from '../../getMastLayerProps';
 
 type SNCF_PSL_SignsProps = {
   colors: Theme;
+  infraId: number | undefined;
   layerOrder?: number;
   filter: FilterSpecification;
 };
@@ -63,8 +63,7 @@ export function getPSLSignsLayerProps({
 }
 
 export default function SNCF_PSL_Signs(props: SNCF_PSL_SignsProps) {
-  const infraID = useInfraID();
-  const { colors, layerOrder, filter } = props;
+  const { colors, infraId, layerOrder, filter } = props;
 
   const signsParams: LayerProps = getPSLSignsLayerProps({
     sourceTable: 'psl_signs',
@@ -81,12 +80,12 @@ export default function SNCF_PSL_Signs(props: SNCF_PSL_SignsProps) {
     sourceTable: 'psl_signs',
   });
 
-  if (isNil(infraID)) return null;
+  if (isNil(infraId)) return null;
   return (
     <Source
       id="osrd_sncf_psl_signs_geo"
       type="vector"
-      url={`${MAP_URL}/layer/psl_signs/mvt/geo/?infra=${infraID}`}
+      url={`${MAP_URL}/layer/psl_signs/mvt/geo/?infra=${infraId}`}
     >
       <OrderedLayer {...mastsParams} layerOrder={layerOrder} filter={filter} />
       <OrderedLayer {...signsParams} layerOrder={layerOrder} filter={filter} />


### PR DESCRIPTION
`SNCF_PSL` already had access to the correct infraId through the map context, but did not pass it to `SNCF_PSL_Signs`. The child component therefore retrieved it through `useInfraID`(), which depends on OsrdContextLayout and caused crashes on pages where that context was unavailable.

infraId is now passed explicitly from SNCF_PSL to SNCF_PSL_Signs, removing the implicit context dependency while keeping the existing behavior unchanged.