### PR TITLE
front: bump nge for multiple fixes

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,7 +17,7 @@
         "@ag-media/react-pdf-table": "^2.0.3",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.5c700609576d06c32daf284bf5d55666d3141a2e",
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
@@ -3506,9 +3506,9 @@
       "link": true
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c.tgz",
-      "integrity": "sha512-PY+omXJiXSiaDdyyp9QVn3fvpALuzVhQ77Xb0KSfhaWOOsmsu3e1JG3MZ4vuERuvBMpFW6LU49S54FI2VxAJ7Q=="
+      "version": "0.0.0-snapshot.5c700609576d06c32daf284bf5d55666d3141a2e",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.5c700609576d06c32daf284bf5d55666d3141a2e.tgz",
+      "integrity": "sha512-lO5rbEA3QhuyCaEsiQQviipE6h33uMUMzl/zMhb+qlCdxZp536H2zzeE8/mZRr/KKRREwHAZ2SuWvwo73reUbg=="
     },
     "node_modules/@osrd-project/storybook": {
       "resolved": "ui/storybook",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@ag-media/react-pdf-table": "^2.0.3",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.54bfdd13fa74fb38ff1ee71f9f26231faf1abc4c",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.5c700609576d06c32daf284bf5d55666d3141a2e",
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",


### PR DESCRIPTION
Our [fork](https://github.com/[osrd-project/netzgrafik-editor-frontend](https://github.com/osrd-project/netzgrafik-editor-frontend)) was 15 commits late of [`origin`](https://github.com/[OpenRailAssociation/netzgrafik-editor-frontend](https://github.com/OpenRailAssociation/netzgrafik-editor-frontend)). This PR gets back bug fixes:
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/c6247d340b89ee435ae1988acd25751609d8d1b9
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/d2f10e3003cdcd23c2e957ff714a81ed3008e2f5
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/0657e34b71fe45fcee6b906848152efc1d0c74f5
- https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/commit/d196d9533e27daab579032358e9f88a255d46e9b

Close https://github.com/OpenRailAssociation/osrd/issues/17548