### PR TITLE
editoast: add op_id and time in search_journeys endpoint response

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -16478,16 +16478,34 @@ components:
       - to
       properties:
         from:
-          type: integer
-          description: Index of the start path step in the train schedule's path
-          minimum: 0
+          $ref: '#/components/schemas/TrainSchedulePartBound'
+          description: Path step of the train_schedule where the part begins
         to:
-          type: integer
-          description: Index of the end path step in the train schedule's path
-          minimum: 0
+          $ref: '#/components/schemas/TrainSchedulePartBound'
+          description: Path step of the train_schedule where the part ends
         train_schedule_id:
           type: integer
           format: int64
+    TrainSchedulePartBound:
+      type: object
+      description: A step of the train schedule's path, with its identity and schedule.
+      required:
+      - path_step_index
+      - op_id
+      - time_ms
+      properties:
+        op_id:
+          type: string
+          description: Id of the operational point of the corresponding step in the train schedule's path.
+        path_step_index:
+          type: integer
+          description: Index of the path step in the train schedule's path
+          minimum: 0
+        time_ms:
+          type: integer
+          format: int32
+          description: Scheduled time of the step in milliseconds from midnight UTC.
+          minimum: 0
     TrainScheduleResponse:
       allOf:
       - $ref: '#/components/schemas/TrainSchedule'

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -70,16 +70,29 @@ pub(in crate::views) struct JourneySearchQuery {
     transfer_ms: u32,
 }
 
+/// A step of the train schedule's path, with its identity and schedule.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct TrainSchedulePartBound {
+    /// Index of the path step in the train schedule's path
+    path_step_index: usize,
+
+    /// Id of the operational point of the corresponding step in the train schedule's path.
+    op_id: String,
+
+    /// Scheduled time of the step in milliseconds from midnight UTC.
+    time_ms: u32,
+}
+
 /// A part of a train schedule, from one step of its path to another.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 struct TrainSchedulePart {
     train_schedule_id: i64,
 
-    /// Index of the start path step in the train schedule's path
-    from: usize,
+    /// Path step of the train_schedule where the part begins
+    from: TrainSchedulePartBound,
 
-    /// Index of the end path step in the train schedule's path
-    to: usize,
+    /// Path step of the train_schedule where the part ends
+    to: TrainSchedulePartBound,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -196,10 +209,15 @@ pub(in crate::views) async fn search_journeys(
 
     let op_cache = OperationalPointCache::load_path_items(conn, infra_id, &path_items).await?;
 
-    let op_index_by_id: HashMap<String, usize> = op_references
+    let op_ids: Vec<String> = op_references
         .iter()
         .filter_map(|op_ref| op_cache.get_op_ref_id(&op_ref.operational_point))
         .unique()
+        .collect();
+
+    let op_index_by_id: HashMap<String, usize> = op_ids
+        .iter()
+        .cloned()
         .enumerate()
         .map(|(index, op_id)| (op_id, index))
         .collect();
@@ -339,7 +357,7 @@ pub(in crate::views) async fn search_journeys(
 
         let journeys =
             profile_connection_scan::journey_list(profile_connection_scan::JourneyListParams {
-                stop_count: op_index_by_id.len(),
+                stop_count: op_ids.len(),
                 trip_count: train_schedule_ids.len(),
                 connections,
                 start_ms,
@@ -360,8 +378,16 @@ pub(in crate::views) async fn search_journeys(
                     .map(|path_indexed_connection| TrainSchedulePart {
                         train_schedule_id: train_schedule_ids
                             [path_indexed_connection.connection.trip],
-                        from: path_indexed_connection.departure_path_index,
-                        to: path_indexed_connection.arrival_path_index,
+                        from: TrainSchedulePartBound {
+                            path_step_index: path_indexed_connection.departure_path_index,
+                            op_id: op_ids[path_indexed_connection.connection.departure].clone(),
+                            time_ms: path_indexed_connection.connection.departure_ms,
+                        },
+                        to: TrainSchedulePartBound {
+                            path_step_index: path_indexed_connection.arrival_path_index,
+                            op_id: op_ids[path_indexed_connection.connection.arrival].clone(),
+                            time_ms: path_indexed_connection.connection.arrival_ms,
+                        },
                     })
                     .collect()
             })

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4445,11 +4445,19 @@ export type SearchPayload = {
   /** The query to run */
   query: SearchQuery;
 };
+export type TrainSchedulePartBound = {
+  /** Id of the operational point of the corresponding step in the train schedule's path. */
+  op_id: string;
+  /** Index of the path step in the train schedule's path */
+  path_step_index: number;
+  /** Scheduled time of the step in milliseconds from midnight UTC. */
+  time_ms: number;
+};
 export type TrainSchedulePart = {
-  /** Index of the start path step in the train schedule's path */
-  from: number;
-  /** Index of the end path step in the train schedule's path */
-  to: number;
+  /** Path step of the train_schedule where the part begins */
+  from: TrainSchedulePartBound;
+  /** Path step of the train_schedule where the part ends */
+  to: TrainSchedulePartBound;
   train_schedule_id: number;
 };
 export type JourneyProposals = {

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -4185,20 +4185,23 @@ class TrainScheduleOptions(BaseModel):
     use_speed_limits_for_simulation: bool | None = None
 
 
-class TrainSchedulePart(BaseModel):
+class TrainSchedulePartBound(BaseModel):
     """
-    A part of a train schedule, from one step of its path to another.
+    A step of the train schedule's path, with its identity and schedule.
     """
 
-    from_: Annotated[int, Field(alias="from", ge=0)]
+    op_id: str
     """
-    Index of the start path step in the train schedule's path
+    Id of the operational point of the corresponding step in the train schedule's path.
     """
-    to: Annotated[int, Field(ge=0)]
+    path_step_index: Annotated[int, Field(ge=0)]
     """
-    Index of the end path step in the train schedule's path
+    Index of the path step in the train schedule's path
     """
-    train_schedule_id: int
+    time_ms: Annotated[int, Field(ge=0)]
+    """
+    Scheduled time of the step in milliseconds from midnight UTC.
+    """
 
 
 class TrainScheduleSet(BaseModel):
@@ -5081,13 +5084,6 @@ class InfraPathfindingInput(BaseModel):
     starting: PathfindingTrackLocationInput
 
 
-class JourneyProposals(BaseModel):
-    journeys: list[list[TrainSchedulePart]]
-    """
-    Each journey is a list of train schedule parts.
-    """
-
-
 class LevelCrossing(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5904,6 +5900,22 @@ class TrainCategoryMain(BaseModel):
     main_category: TrainMainCategory
 
 
+class TrainSchedulePart(BaseModel):
+    """
+    A part of a train schedule, from one step of its path to another.
+    """
+
+    from_: Annotated[TrainSchedulePartBound, Field(alias="from")]
+    """
+    Path step of the train_schedule where the part begins
+    """
+    to: TrainSchedulePartBound
+    """
+    Path step of the train_schedule where the part ends
+    """
+    train_schedule_id: int
+
+
 class WorkSchedule(BaseModel):
     end_date_time: AwareDatetime
     id: int
@@ -6181,6 +6193,13 @@ class InfraObjectBufferStop(BaseModel):
 class InfraObjectRoute(BaseModel):
     obj_type: Literal["Route"]
     railjson: Route
+
+
+class JourneyProposals(BaseModel):
+    journeys: list[list[TrainSchedulePart]]
+    """
+    Each journey is a list of train schedule parts.
+    """
 
 
 class JourneySearchQuery(BaseModel):


### PR DESCRIPTION
Give the `op_id` and the `time_ms` of each bound of a journey part in `/search_journeys` to make it easier for frontend to display it.