### PR TITLE
Fix speed limits extremity labels blinking in editor

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -127,6 +127,7 @@ export const SpeedSectionEditionLayers = () => {
     const context = {
       colors: colors[mapStyle],
       isEmphasized: true,
+      interactionType: interactionState.type,
       showIGNBDORTHO,
       layersSettings,
       issuesSettings,
@@ -144,7 +145,7 @@ export const SpeedSectionEditionLayers = () => {
       speedSectionLayerProps: speedSectionLayers,
       pslLayerProps: [...pslLayers, ...pslSignLayers],
     };
-  }, [mapStyle, showIGNBDORTHO, layersSettings, issuesSettings]);
+  }, [mapStyle, interactionState.type, showIGNBDORTHO, layersSettings, issuesSettings]);
 
   // Here is where we handle loading the TrackSections attached to the speed section:
   useEffect(() => {
@@ -291,7 +292,7 @@ export const SpeedSectionEditionLayers = () => {
         key="speed-section"
       >
         {speedSectionLayerProps.map((props, i) => (
-          <Layer {...props} key={i} />
+          <Layer {...props} key={`${i}-${interactionState.type}`} />
         ))}
       </Source>
       {/* complete routes (dashed) */}

--- a/front/src/common/Map/Layers/InfraObjectLayers/SpeedLimits.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/SpeedLimits.tsx
@@ -96,10 +96,12 @@ export function getSpeedSectionsLineLayerProps({
 export function getSpeedSectionsPointLayerProps({
   colors,
   sourceTable,
+  interactionType = 'idle',
   layersSettings,
 }: {
   colors: Theme;
   sourceTable?: string;
+  interactionType?: string;
   layersSettings: LayersSettings;
 }): OmitLayer<SymbolLayerSpecification> {
   const res: OmitLayer<SymbolLayerSpecification> = {
@@ -115,7 +117,7 @@ export function getSpeedSectionsPointLayerProps({
       'icon-allow-overlap': getAllowOverlap(15),
       'icon-ignore-placement': false,
       'text-justify': 'left',
-      'text-allow-overlap': getAllowOverlap(15),
+      'text-allow-overlap': interactionType === 'moveRangeExtremity' || getAllowOverlap(15),
       'text-ignore-placement': false,
     },
     paint: {


### PR DESCRIPTION
While dragging the extremity of speed limit ranges in the infrastructure editor, a bug occured that made the visuals blink.

This is fixed by allowing the text to overlap and triggering the render of the Layer when the `interactionState` type moves from any value to `moveRangeExtremity`.

My solution for the rendering trigger is to make the id change on update of this particular `interactionState` value.

It seems that I confused the problem with another and forgot about what was the original problem.

I still consider this is a part of https://github.com/OpenRailAssociation/osrd/issues/8188 but it won't close it, I'll check the other problems.