### PR TITLE
front: add a RequestTimeColumnHeader with apply to all menu

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -839,16 +839,28 @@
     }
   },
   "timeStopTable": {
-    "arrivalTime": "requested arrival time",
     "calculatedArrivalTime": "calculated arrival time",
     "calculatedDepartureTime": "calculated depart. time",
     "calculatedDepartureTimeFull": "calculated departure time",
     "clearRequestedArrivalTime": "Clear the requested arrival time",
     "clearRequestedDepartureTime": "Clear the requested departure time",
     "clearStopDuration": "Clear the stopping time",
+    "columnHeader": {
+      "requestedArrival": {
+        "fillEmpty_one": "Apply computed arrival time to {{count}} not scheduled way point",
+        "fillEmpty_other": "Apply computed arrival times to {{count}} not scheduled way points",
+        "overwriteAll_one": "Apply computed arrival time to {{count}} way point",
+        "overwriteAll_other": "Apply computed arrival times to {{count}} way points"
+      },
+      "requestedDeparture": {
+        "fillEmpty_one": "Apply computed departure time to {{count}} not scheduled way point",
+        "fillEmpty_other": "Apply computed departure times to {{count}} not scheduled way points",
+        "overwriteAll_one": "Apply computed departure time to {{count}} way point",
+        "overwriteAll_other": "Apply computed departure times to {{count}} way points"
+      }
+    },
     "computedTheoreticalMargin": "computed theoretical margin",
     "dayCounter": "D+{{count}}",
-    "departureTime": "requested depart. time",
     "departureTimeFull": "requested departure time",
     "diffMargins": "margins diff.",
     "diffMarginsFull": "margins difference",
@@ -870,6 +882,8 @@
     "realMargin": "real margin",
     "receptionOnClosedSignal": "closed signal",
     "receptionOnClosedSignalFull": "reception on closed signal",
+    "requestedArrival": "requested arrival time",
+    "requestedDeparture": "requested depart. time",
     "requestedTheoreticalMargin": "requested theoretical margin",
     "secondaryCode": "secondary code",
     "shortSlipDistance": "short slip distance",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -846,6 +846,13 @@
     "clearRequestedDepartureTime": "Clear the requested departure time",
     "clearStopDuration": "Clear the stopping time",
     "columnHeader": {
+      "overwriteAllConfirm": {
+        "body_one": "This will overwrite the requested time of {{count}} way point with the computed time. Do you want to continue?",
+        "body_other": "This will overwrite the requested times of {{count}} way points with the computed times. Do you want to continue?",
+        "cancel": "Cancel",
+        "confirm": "Confirm",
+        "title": "Overwrite requested times"
+      },
       "requestedArrival": {
         "fillEmpty_one": "Apply computed arrival time to {{count}} not scheduled way point",
         "fillEmpty_other": "Apply computed arrival times to {{count}} not scheduled way points",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -846,6 +846,13 @@
     "clearRequestedDepartureTime": "Effacer le départ demandé",
     "clearStopDuration": "Effacer le temps d'arrêt",
     "columnHeader": {
+      "overwriteAllConfirm": {
+        "body_one": "Cela va écraser l'heure demandée de {{count}} point de passage avec l'heure calculée. Voulez-vous continuer ?",
+        "body_other": "Cela va écraser les heures demandées de {{count}} points de passage avec les heures calculées. Voulez-vous continuer ?",
+        "cancel": "Annuler",
+        "confirm": "Confirmer",
+        "title": "Écraser les heures demandées"
+      },
       "requestedArrival": {
         "fillEmpty_one": "Appliquer l'arrivée calculée à {{count}} point de passage non planifié",
         "fillEmpty_other": "Appliquer les arrivées calculées à {{count}} points de passage non planifiés",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -839,16 +839,28 @@
     }
   },
   "timeStopTable": {
-    "arrivalTime": "arrivée demandée",
     "calculatedArrivalTime": "arrivée calculée",
     "calculatedDepartureTime": "départ calculé",
     "calculatedDepartureTimeFull": "départ calculé",
     "clearRequestedArrivalTime": "Effacer l'arrivée demandée",
     "clearRequestedDepartureTime": "Effacer le départ demandé",
     "clearStopDuration": "Effacer le temps d'arrêt",
+    "columnHeader": {
+      "requestedArrival": {
+        "fillEmpty_one": "Appliquer l'arrivée calculée à {{count}} point de passage non planifié",
+        "fillEmpty_other": "Appliquer les arrivées calculées à {{count}} points de passage non planifiés",
+        "overwriteAll_one": "Appliquer l'arrivée calculée à {{count}} point de passage",
+        "overwriteAll_other": "Appliquer les arrivées calculées à {{count}} points de passage"
+      },
+      "requestedDeparture": {
+        "fillEmpty_one": "Appliquer le départ calculé à {{count}} point de passage non planifié",
+        "fillEmpty_other": "Appliquer les départs calculés à {{count}} points de passage non planifiés",
+        "overwriteAll_one": "Appliquer le départ calculé à {{count}} point de passage",
+        "overwriteAll_other": "Appliquer les départs calculés à {{count}} points de passage"
+      }
+    },
     "computedTheoreticalMargin": "marge théorique calculée",
     "dayCounter": "J+{{count}}",
-    "departureTime": "départ demandé",
     "departureTimeFull": "départ demandé",
     "diffMargins": "diff. marges",
     "diffMarginsFull": "différence entre les marges",
@@ -870,6 +882,8 @@
     "realMargin": "marge réelle",
     "receptionOnClosedSignal": "signal fermé",
     "receptionOnClosedSignalFull": "réception sur signal fermé",
+    "requestedArrival": "arrivée demandée",
+    "requestedDeparture": "départ demandé",
     "requestedTheoreticalMargin": "marge théorique demandée",
     "secondaryCode": "code secondaire",
     "shortSlipDistance": "faible glissement",

--- a/front/src/common/OSRDMenu.tsx
+++ b/front/src/common/OSRDMenu.tsx
@@ -6,6 +6,8 @@ export type OSRDMenuItem = {
   title: string;
   icon: React.ReactNode;
   onClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
   disabled?: boolean;
   disabledMessage?: string;
   dataTestID?: string;
@@ -27,6 +29,8 @@ const OSRDMenu = ({ menuRef, items, className }: OSRDMenuProps) => (
         disabled,
         disabledMessage,
         onClick,
+        onMouseEnter,
+        onMouseLeave,
         dataTestID,
         className: itemClassName,
       }) => (
@@ -37,6 +41,8 @@ const OSRDMenu = ({ menuRef, items, className }: OSRDMenuProps) => (
           type="button"
           className={cx('menu-item', itemClassName)}
           onClick={onClick}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
           data-testid={dataTestID}
         >
           <span className="icon">{icon}</span>

--- a/front/src/modules/timesStops/OverwriteAllConfirmDialog.tsx
+++ b/front/src/modules/timesStops/OverwriteAllConfirmDialog.tsx
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+
+import { Button, Dialog } from '@osrd-project/ui-core';
+import { useTranslation } from 'react-i18next';
+
+type OverwriteAllConfirmDialogProps = {
+  count: number;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+const OverwriteAllConfirmDialog = ({
+  count,
+  onCancel,
+  onConfirm,
+}: OverwriteAllConfirmDialogProps) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'timeStopTable.columnHeader.overwriteAllConfirm',
+  });
+
+  const header = useCallback(
+    () => <h5 data-testid="overwrite-all-confirm-header">{t('title')}</h5>,
+    [t]
+  );
+  const footer = useCallback(
+    () => (
+      <div className="buttons">
+        <Button
+          variant="Cancel"
+          label={t('cancel')}
+          onClick={onCancel}
+          dataTestID="overwrite-all-confirm-cancel-button"
+        />
+        <Button
+          variant="Destructive"
+          label={t('confirm')}
+          onClick={onConfirm}
+          dataTestID="overwrite-all-confirm-confirm-button"
+        />
+      </div>
+    ),
+    [onCancel, onConfirm, t]
+  );
+
+  return (
+    <Dialog header={header()} footer={footer()}>
+      <p className="overwrite-all-confirm-explanations" data-testid="overwrite-all-confirm-body">
+        {t('body', { count })}
+      </p>
+    </Dialog>
+  );
+};
+
+export default OverwriteAllConfirmDialog;

--- a/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
+++ b/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
@@ -8,6 +8,7 @@ import AnchoredMenu from 'common/AnchoredMenu';
 import OSRDMenu, { type OSRDMenuItem } from 'common/OSRDMenu';
 
 import { getRowsToUpdateFromSimulation } from './helpers/fillTimesFromSimulation';
+import OverwriteAllConfirmDialog from './OverwriteAllConfirmDialog';
 import type { RequestedTimeField, TimesStopsRowNew } from './types';
 
 type RequestedTimeColumnHeaderProps = {
@@ -36,6 +37,7 @@ const RequestedTimeColumnHeader = ({
   });
 
   const [isOpen, setOpen] = useState<boolean>(false);
+  const [isOverwriteAllConfirmOpen, setOverwriteAllConfirmOpen] = useState<boolean>(false);
 
   const fillRequestTimesCount = getRowsToUpdateFromSimulation(rows, field, 'fill').length;
   const overwriteRequestTimesCount = getRowsToUpdateFromSimulation(rows, field, 'overwrite').length;
@@ -46,8 +48,8 @@ const RequestedTimeColumnHeader = ({
       icon: <ArrowLeft />,
       onClick: () => {
         setOpen(false);
-        onOverwriteAll();
         onMouseLeave();
+        setOverwriteAllConfirmOpen(true);
       },
       onMouseEnter: () => {
         onMouseEnterOverwriteAll();
@@ -116,6 +118,16 @@ const RequestedTimeColumnHeader = ({
           </div>
         )}
       </AnchoredMenu>
+      {isOverwriteAllConfirmOpen && (
+        <OverwriteAllConfirmDialog
+          count={overwriteRequestTimesCount}
+          onCancel={() => setOverwriteAllConfirmOpen(false)}
+          onConfirm={() => {
+            onOverwriteAll();
+            setOverwriteAllConfirmOpen(false);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
+++ b/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
@@ -25,6 +25,8 @@ const RequestedTimeColumnHeader = ({
   field,
   isSimulationValid,
   rows,
+  onFillEmpty,
+  onOverwriteAll,
   onMouseEnterOverwriteAll,
   onMouseEnterFillEmpty,
   onMouseLeave,
@@ -42,7 +44,11 @@ const RequestedTimeColumnHeader = ({
     {
       title: `${t(`columnHeader.${field}.overwriteAll`, { count: overwriteRequestTimesCount })}`,
       icon: <ArrowLeft />,
-      onClick: () => {},
+      onClick: () => {
+        setOpen(false);
+        onOverwriteAll();
+        onMouseLeave();
+      },
       onMouseEnter: () => {
         onMouseEnterOverwriteAll();
       },
@@ -56,7 +62,11 @@ const RequestedTimeColumnHeader = ({
     items.push({
       title: `${t(`columnHeader.${field}.fillEmpty`, { count: fillRequestTimesCount })}`,
       icon: <ArrowLeft />,
-      onClick: () => {},
+      onClick: () => {
+        setOpen(false);
+        onFillEmpty();
+        onMouseLeave();
+      },
       onMouseEnter: () => {
         onMouseEnterFillEmpty();
       },

--- a/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
+++ b/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
@@ -1,0 +1,102 @@
+import { useRef, useState } from 'react';
+
+import { ArrowLeft, TriangleDown } from '@osrd-project/ui-icons';
+import cx from 'classnames';
+import { useTranslation } from 'react-i18next';
+
+import AnchoredMenu from 'common/AnchoredMenu';
+import OSRDMenu, { type OSRDMenuItem } from 'common/OSRDMenu';
+
+import { getRowsToUpdateFromSimulation } from './helpers/fillTimesFromSimulation';
+import type { RequestedTimeField, TimesStopsRowNew } from './types';
+
+type RequestedTimeColumnHeaderProps = {
+  field: RequestedTimeField;
+  isSimulationValid: boolean;
+  rows: TimesStopsRowNew[];
+  onFillEmpty: () => void;
+  onOverwriteAll: () => void;
+  onMouseEnterFillEmpty: () => void;
+  onMouseEnterOverwriteAll: () => void;
+  onMouseLeave: () => void;
+};
+
+const RequestedTimeColumnHeader = ({
+  field,
+  isSimulationValid,
+  rows,
+}: RequestedTimeColumnHeaderProps) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'timeStopTable',
+  });
+
+  const [isOpen, setOpen] = useState<boolean>(false);
+
+  const fillRequestTimesCount = getRowsToUpdateFromSimulation(rows, field, 'fill').length;
+  const overwriteRequestTimesCount = getRowsToUpdateFromSimulation(rows, field, 'overwrite').length;
+
+  const items: OSRDMenuItem[] = [
+    {
+      title: `${t(`columnHeader.${field}.overwriteAll`, { count: overwriteRequestTimesCount })}`,
+      icon: <ArrowLeft />,
+      onClick: () => {},
+      onMouseEnter: () => {},
+      onMouseLeave: () => {},
+    },
+  ];
+
+  if (fillRequestTimesCount !== 0 && fillRequestTimesCount !== overwriteRequestTimesCount) {
+    items.push({
+      title: `${t(`columnHeader.${field}.fillEmpty`, { count: fillRequestTimesCount })}`,
+      icon: <ArrowLeft />,
+      onClick: () => {},
+      onMouseEnter: () => {},
+      onMouseLeave: () => {},
+    });
+  }
+
+  const anchorRef = useRef<HTMLButtonElement>(null);
+
+  const isDisabled = !isSimulationValid || overwriteRequestTimesCount === 0;
+
+  return (
+    <div className="requested-time-column-header-wrapper">
+      <span>{t(field)}</span>
+      <button
+        ref={anchorRef}
+        type="button"
+        disabled={isDisabled}
+        className={cx('requested-time-column-header-toggle', {
+          'requested-time-column-header-toggle--disabled': isDisabled,
+        })}
+        onClick={() => setOpen(true)}
+      >
+        <TriangleDown
+          className={
+            isOpen
+              ? 'requested-time-column-header-toggle-icon-open'
+              : 'requested-time-column-header-toggle-icon-closed'
+          }
+        />
+      </button>
+      <AnchoredMenu
+        anchorRef={anchorRef}
+        onDismiss={() => setOpen(false)}
+        placement="below"
+        focusOnFirstElement={false}
+      >
+        {isOpen && (
+          <div
+            role="presentation"
+            className="requested-time-column-header-menu-wrapper"
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            <OSRDMenu items={items} className="requested-time-column-header-menu" />
+          </div>
+        )}
+      </AnchoredMenu>
+    </div>
+  );
+};
+
+export default RequestedTimeColumnHeader;

--- a/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
+++ b/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
@@ -25,6 +25,9 @@ const RequestedTimeColumnHeader = ({
   field,
   isSimulationValid,
   rows,
+  onMouseEnterOverwriteAll,
+  onMouseEnterFillEmpty,
+  onMouseLeave,
 }: RequestedTimeColumnHeaderProps) => {
   const { t } = useTranslation('translation', {
     keyPrefix: 'timeStopTable',
@@ -40,8 +43,12 @@ const RequestedTimeColumnHeader = ({
       title: `${t(`columnHeader.${field}.overwriteAll`, { count: overwriteRequestTimesCount })}`,
       icon: <ArrowLeft />,
       onClick: () => {},
-      onMouseEnter: () => {},
-      onMouseLeave: () => {},
+      onMouseEnter: () => {
+        onMouseEnterOverwriteAll();
+      },
+      onMouseLeave: () => {
+        onMouseLeave();
+      },
     },
   ];
 
@@ -50,8 +57,12 @@ const RequestedTimeColumnHeader = ({
       title: `${t(`columnHeader.${field}.fillEmpty`, { count: fillRequestTimesCount })}`,
       icon: <ArrowLeft />,
       onClick: () => {},
-      onMouseEnter: () => {},
-      onMouseLeave: () => {},
+      onMouseEnter: () => {
+        onMouseEnterFillEmpty();
+      },
+      onMouseLeave: () => {
+        onMouseLeave();
+      },
     });
   }
 

--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -14,6 +14,7 @@ import { Duration, type StartTime, addDurationToStartTime, startTimeToMs } from 
 
 import { ONE_DAY } from './consts';
 import { computeOptimisticRow, propagationToEdits } from './helpers/cellUpdate';
+import { getRowsToUpdateFromSimulation } from './helpers/fillTimesFromSimulation';
 import { computePowerRestrictionWarnings } from './helpers/powerRestrictionIncompatibility';
 import { propagateStopDuration } from './helpers/stopDurationPropagation';
 import { propagateTime } from './helpers/timePropagation';
@@ -29,6 +30,9 @@ import {
   type MarginValue,
   type TimesStopsRowNew,
   type UpdateCellStatus,
+  type TimeFillMode,
+  type RequestedTimeField,
+  type BatchTimesUpdate,
 } from './types';
 
 type TimeStopsTableWrapperProps = {
@@ -170,6 +174,7 @@ const TimeStopsTableWrapper = ({
     updateReceptionSignal,
     updateRequestedMargin,
     updatePowerRestrictions,
+    updateMultipleTimes,
   } = useUpdateTimesStopsTable(selectedTrain, rows, trainSchedulesWithDetails);
 
   // True if we are still waiting for fresh simulation data after a user edit.
@@ -228,7 +233,7 @@ const TimeStopsTableWrapper = ({
 
   const buildEditsForUpdate = (
     singleEdit: PendingEdit,
-    update: CellUpdate & { propagationMode: PropagationMode }
+    update: Exclude<CellUpdate, BatchTimesUpdate> & { propagationMode: PropagationMode }
   ): PendingEdit[] => {
     const propagationResult = propagateTime(update, selectedTrain, scenario.timetable_type);
     if (!propagationResult) return [singleEdit];
@@ -388,6 +393,19 @@ const TimeStopsTableWrapper = ({
       updatePowerRestrictions(row, value)
     );
 
+  const handleApplyTimesFromSimulation = (field: RequestedTimeField, mode: TimeFillMode): void => {
+    const computedField = field === 'requestedArrival' ? 'computedArrival' : 'computedDeparture';
+    const targetRows = getRowsToUpdateFromSimulation(rows, field, mode).filter(
+      (row) => row.opOnPathIndex !== 0
+    );
+    const edits: PendingEdit[] = targetRows.map((row) => ({
+      rowId: row.id,
+      field,
+      value: row[computedField],
+    }));
+    commitEdit(edits, () => updateMultipleTimes(targetRows, field));
+  };
+
   return (
     <TimesStopsTable
       rows={optimisticRows}
@@ -403,6 +421,7 @@ const TimeStopsTableWrapper = ({
       onReceptionSignalChange={handleReceptionSignalChange}
       onRequestedMarginChange={handleRequestedMarginChange}
       onPowerRestrictionChange={handlePowerRestrictionChange}
+      onApplyTimesFromSimulation={handleApplyTimesFromSimulation}
     />
   );
 };

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -73,6 +73,7 @@ declare module '@tanstack/react-table' {
     onReceptionSignalChange: (row: TimesStopsRowNew, signal: ReceptionSignal | undefined) => void;
     onRequestedMarginChange: (row: TimesStopsRowNew, requestedMargin: MarginValue | null) => void;
     onPowerRestrictionChange: (row: TimesStopsRowNew, value: string | null) => void;
+    onApplyTimesFromSimulation: (field: RequestedTimeField, mode: TimeFillMode) => void;
   }
 }
 
@@ -160,6 +161,7 @@ type TimesStopsTableProps = {
   onReceptionSignalChange: (row: TimesStopsRowNew, signal: ReceptionSignal | undefined) => void;
   onRequestedMarginChange: (row: TimesStopsRowNew, value: MarginValue | null) => void;
   onPowerRestrictionChange: (row: TimesStopsRowNew, value: string | null) => void;
+  onApplyTimesFromSimulation: (field: RequestedTimeField, mode: TimeFillMode) => void;
 };
 
 const columnHelper = createColumnHelper<TimesStopsRowNew>();
@@ -195,6 +197,7 @@ const TimesStopsTable = ({
   onReceptionSignalChange,
   onRequestedMarginChange,
   onPowerRestrictionChange,
+  onApplyTimesFromSimulation,
 }: TimesStopsTableProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable' });
   const dateTimeLocale = useDateTimeLocale();
@@ -567,8 +570,10 @@ const TimesStopsTable = ({
           field={field}
           isSimulationValid={isValid}
           rows={allRows}
-          onFillEmpty={() => {}}
-          onOverwriteAll={() => {}}
+          onFillEmpty={() => info.table.options.meta!.onApplyTimesFromSimulation(field, 'fill')}
+          onOverwriteAll={() =>
+            info.table.options.meta!.onApplyTimesFromSimulation(field, 'overwrite')
+          }
           onMouseEnterFillEmpty={() => onMouseEnterTimeColumnMenu(allRows, field, 'fill')}
           onMouseEnterOverwriteAll={() => onMouseEnterTimeColumnMenu(allRows, field, 'overwrite')}
           onMouseLeave={() => setHighlightedRowIds(new Set())}
@@ -747,6 +752,7 @@ const TimesStopsTable = ({
       onReceptionSignalChange,
       onRequestedMarginChange,
       onPowerRestrictionChange,
+      onApplyTimesFromSimulation,
     },
   });
 

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, Fragment, useMemo, useRef } from 'react';
+import React, { useCallback, Fragment, useMemo, useRef, useState } from 'react';
 
 import { Checkbox } from '@osrd-project/ui-core';
 import { Alert, Moon, TriangleDown } from '@osrd-project/ui-icons';
@@ -24,6 +24,7 @@ import { useDateTimeLocale } from 'utils/date';
 import { type Duration, type StartTime, subtractStartTime } from 'utils/duration';
 
 import DurationCell, { type DurationCellHandle } from './DurationCell';
+import { getRowsToUpdateFromSimulation } from './helpers/fillTimesFromSimulation';
 import type { PowerRestrictionBlockInfo } from './helpers/powerRestrictionIncompatibility';
 import { onStopSignalToReceptionSignal, truncateStartTimeToDay } from './helpers/utils';
 import MarginCell from './MarginCell';
@@ -35,6 +36,7 @@ import type {
   PropagationMode,
   RequestedTimeField,
   StopPropagationMode,
+  TimeFillMode,
   TimesStopsRowNew,
 } from './types';
 
@@ -202,6 +204,9 @@ const TimesStopsTable = ({
   const cellTabOrderRef = useRef<Map<string, TimeCellTabEntry>>(new Map());
   const startTimeCellType: 'time' | 'duration' =
     scenario.timetable_type === 'CALENDAR' ? 'time' : 'duration';
+
+  const [highlightedRowIds, setHighlightedRowIds] = useState<Set<string>>(new Set());
+  const [mouseOverTimeField, setMouseOverTimeField] = useState<RequestedTimeField>();
 
   const registerTimeCellRef = useCallback(
     (rowIndex: number, columnId: string) => (handle: TabbableCellHandle | null) => {
@@ -543,6 +548,17 @@ const TimesStopsTable = ({
     );
   };
 
+  const onMouseEnterTimeColumnMenu = (
+    allRows: TimesStopsRowNew[],
+    field: RequestedTimeField,
+    mode: TimeFillMode
+  ) => {
+    const rowsToHighlight = getRowsToUpdateFromSimulation(allRows, field, mode);
+
+    setHighlightedRowIds(new Set(rowsToHighlight.map((row) => row.id)));
+    setMouseOverTimeField(field);
+  };
+
   const returnRequestedTimeHeader = (field: RequestedTimeField) => {
     const requestedTimeHeader = (info: HeaderContext<TimesStopsRowNew, Date | null>) => {
       const { allRows } = info.table.options.meta!;
@@ -553,9 +569,9 @@ const TimesStopsTable = ({
           rows={allRows}
           onFillEmpty={() => {}}
           onOverwriteAll={() => {}}
-          onMouseEnterFillEmpty={() => {}}
-          onMouseEnterOverwriteAll={() => {}}
-          onMouseLeave={() => {}}
+          onMouseEnterFillEmpty={() => onMouseEnterTimeColumnMenu(allRows, field, 'fill')}
+          onMouseEnterOverwriteAll={() => onMouseEnterTimeColumnMenu(allRows, field, 'overwrite')}
+          onMouseLeave={() => setHighlightedRowIds(new Set())}
         />
       );
     };
@@ -862,6 +878,15 @@ const TimesStopsTable = ({
             const dayOffset = effectiveDayOffsets[rowIndex];
             const prevDayOffset = rowIndex > 0 ? effectiveDayOffsets[rowIndex - 1] : 0;
             const hasDayChanged = dayOffset > prevDayOffset;
+            const nextDayOffset =
+              rowIndex < tableRows.length - 1 ? effectiveDayOffsets[rowIndex + 1] : dayOffset;
+            const nextHasDayChanged = nextDayOffset > dayOffset;
+
+            const isCellHighlighted = (idx: number, field: string) =>
+              mouseOverTimeField === field &&
+              idx >= 0 &&
+              idx < tableRows.length &&
+              highlightedRowIds.has(tableRows[idx].original.id);
 
             let dayChangeLabel = null;
             if (hasDayChanged) {
@@ -921,6 +946,18 @@ const TimesStopsTable = ({
                           cell.column.id === 'powerRestriction' &&
                           table.options.meta!.powerRestrictionBlocks.get(row.original.id)
                             ?.hasWarning,
+                        'requested-cell-highlighted-arrival':
+                          cell.column.id === 'requestedArrival' &&
+                          highlightedRowIds.has(row.original.id) &&
+                          mouseOverTimeField === 'requestedArrival',
+                        'requested-cell-highlighted-departure':
+                          cell.column.id === 'requestedDeparture' &&
+                          highlightedRowIds.has(row.original.id) &&
+                          mouseOverTimeField === 'requestedDeparture',
+                        'requested-cell-highlighted--connect-top':
+                          !hasDayChanged && isCellHighlighted(rowIndex - 1, cell.column.id),
+                        'requested-cell-highlighted--connect-bottom':
+                          !nextHasDayChanged && isCellHighlighted(rowIndex + 1, cell.column.id),
                       })}
                       data-testid={cell.column.columnDef.meta?.['data-testid']}
                     >

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -8,6 +8,7 @@ import {
   getCoreRowModel,
   useReactTable,
   type CellContext,
+  type HeaderContext,
   type Row,
   type RowData,
 } from '@tanstack/react-table';
@@ -26,9 +27,16 @@ import DurationCell, { type DurationCellHandle } from './DurationCell';
 import type { PowerRestrictionBlockInfo } from './helpers/powerRestrictionIncompatibility';
 import { onStopSignalToReceptionSignal, truncateStartTimeToDay } from './helpers/utils';
 import MarginCell from './MarginCell';
+import RequestedTimeColumnHeader from './RequestedTimeColumnHeader';
 import StartTimeCell from './StartTimeCell';
 import type { TimeCellHandle } from './TimeCell';
-import type { MarginValue, PropagationMode, StopPropagationMode, TimesStopsRowNew } from './types';
+import type {
+  MarginValue,
+  PropagationMode,
+  RequestedTimeField,
+  StopPropagationMode,
+  TimesStopsRowNew,
+} from './types';
 
 declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -535,6 +543,26 @@ const TimesStopsTable = ({
     );
   };
 
+  const returnRequestedTimeHeader = (field: RequestedTimeField) => {
+    const requestedTimeHeader = (info: HeaderContext<TimesStopsRowNew, Date | null>) => {
+      const { allRows } = info.table.options.meta!;
+      return (
+        <RequestedTimeColumnHeader
+          field={field}
+          isSimulationValid={isValid}
+          rows={allRows}
+          onFillEmpty={() => {}}
+          onOverwriteAll={() => {}}
+          onMouseEnterFillEmpty={() => {}}
+          onMouseEnterOverwriteAll={() => {}}
+          onMouseLeave={() => {}}
+        />
+      );
+    };
+    requestedTimeHeader.displayName = 'RequestedTimeHeader';
+    return requestedTimeHeader;
+  };
+
   const columns = useMemo(
     () => [
       columnHelper.display({
@@ -570,12 +598,12 @@ const TimesStopsTable = ({
         },
       }),
       columnHelper.accessor('requestedArrival', {
-        header: () => t('arrivalTime'),
+        header: returnRequestedTimeHeader('requestedArrival'),
         cell: returnArrivalTimeCell,
         meta: {
           className: 'col-requested-arrival col-with-clock-time',
           tabbable: true,
-          title: t('arrivalTime'),
+          title: t('requestedArrival'),
         },
       }),
       columnHelper.accessor('computedArrival', {
@@ -596,12 +624,12 @@ const TimesStopsTable = ({
         },
       }),
       columnHelper.accessor('requestedDeparture', {
-        header: () => t('departureTime'),
+        header: returnRequestedTimeHeader('requestedDeparture'),
         cell: returnDepartureTimeCell,
         meta: {
           className: 'col-requested-departure col-with-clock-time',
           tabbable: true,
-          title: t('departureTime'),
+          title: t('requestedDeparture'),
         },
       }),
       columnHelper.accessor('computedDeparture', {

--- a/front/src/modules/timesStops/helpers/__tests__/fillTimesFromSimulation.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/fillTimesFromSimulation.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+import type { TimesStopsRowNew } from '../../types';
+import { getRowsToUpdateFromSimulation } from '../fillTimesFromSimulation';
+
+const _10H00 = new Date('2025-01-01T10:00:00Z');
+const _10H30 = new Date('2025-01-01T10:30:00Z');
+
+const buildRow = (overrides: Partial<TimesStopsRowNew> = {}): TimesStopsRowNew => ({
+  id: 'row-1',
+  pathStepId: 'step-1',
+  opOnPathIndex: 0,
+  stepStatus: 'allHonored',
+  name: 'Some station',
+  track: 'track',
+  hasRequestedTrack: false,
+  location: {} as TimesStopsRowNew['location'],
+  requestedArrival: null,
+  computedArrival: _10H00,
+  stopDuration: null,
+  requestedDeparture: null,
+  computedDeparture: _10H30,
+  powerRestriction: null,
+  requestedTheoreticalMargin: undefined,
+  isTheoreticalMarginBoundary: undefined,
+  computedTheoreticalMarginSeconds: undefined,
+  realMargin: undefined,
+  marginsDifference: undefined,
+  timeFromPreviousOp: null,
+  totalTravelTime: null,
+  ...overrides,
+});
+
+describe('getRowsToUpdateFromSimulation', () => {
+  it('excludes rows without a pathStepId', () => {
+    const rows = [buildRow({ pathStepId: null })];
+
+    expect(getRowsToUpdateFromSimulation(rows, 'requestedArrival', 'fill')).toEqual([]);
+  });
+
+  it('excludes rows without a computed value for the target field', () => {
+    const rows = [buildRow({ computedArrival: null })];
+
+    expect(getRowsToUpdateFromSimulation(rows, 'requestedArrival', 'fill')).toEqual([]);
+    expect(getRowsToUpdateFromSimulation(rows, 'requestedArrival', 'overwrite')).toEqual([]);
+  });
+
+  describe('fill mode', () => {
+    it('includes rows whose requested field is null', () => {
+      const rows = [buildRow({ requestedArrival: null })];
+
+      expect(getRowsToUpdateFromSimulation(rows, 'requestedArrival', 'fill')).toEqual(rows);
+    });
+
+    it('excludes rows whose requested field is already set', () => {
+      const rows = [buildRow({ requestedArrival: _10H00 })];
+
+      expect(getRowsToUpdateFromSimulation(rows, 'requestedArrival', 'fill')).toEqual([]);
+    });
+  });
+
+  describe('overwrite mode', () => {
+    it('includes rows regardless of an existing requested value', () => {
+      const rows = [buildRow({ requestedArrival: _10H00 })];
+
+      expect(getRowsToUpdateFromSimulation(rows, 'requestedArrival', 'overwrite')).toEqual(rows);
+    });
+
+    it('includes rows whose requested field is null', () => {
+      const rows = [buildRow({ requestedArrival: null })];
+
+      expect(getRowsToUpdateFromSimulation(rows, 'requestedArrival', 'overwrite')).toEqual(rows);
+    });
+  });
+});

--- a/front/src/modules/timesStops/helpers/fillTimesFromSimulation.ts
+++ b/front/src/modules/timesStops/helpers/fillTimesFromSimulation.ts
@@ -1,0 +1,15 @@
+import type { TimesStopsRowNew, RequestedTimeField, TimeFillMode } from '../types';
+
+export const getRowsToUpdateFromSimulation = (
+  rows: TimesStopsRowNew[],
+  field: RequestedTimeField,
+  mode: TimeFillMode
+): TimesStopsRowNew[] => {
+  const computedField = field === 'requestedArrival' ? 'computedArrival' : 'computedDeparture';
+  return rows.filter(
+    (row) =>
+      row.pathStepId !== null &&
+      row[computedField] !== null &&
+      (mode === 'overwrite' || row[field] === null)
+  );
+};

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -8,12 +8,19 @@ import {
 } from 'utils/duration';
 
 import { ONE_DAY } from '../consts';
-import type { ArrivalUpdate, CellUpdate, PropagationMode, PropagationResult } from '../types';
+import type {
+  ArrivalUpdate,
+  BatchTimesUpdate,
+  CellUpdate,
+  PropagationMode,
+  PropagationResult,
+} from '../types';
 import { propagateStopDuration } from './stopDurationPropagation';
 import { truncateStartTimeToSecond, formatSignedDelta } from './utils';
 
-const isOriginArrivalUpdate = (update: CellUpdate): update is ArrivalUpdate =>
-  update.field === 'requestedArrival' && update.row.opOnPathIndex === 0;
+const isOriginArrivalUpdate = (
+  update: Exclude<CellUpdate, BatchTimesUpdate>
+): update is ArrivalUpdate => update.field === 'requestedArrival' && update.row.opOnPathIndex === 0;
 
 const toHmsDuration = (date: StartTime) =>
   date instanceof Date
@@ -186,7 +193,7 @@ export const adjustFollowingWaypointsForMidnight = (
 };
 
 export const propagateTime = (
-  update: CellUpdate,
+  update: Exclude<CellUpdate, BatchTimesUpdate>,
   selectedTrain: Train,
   timetableType: TimetableType
 ): PropagationResult | undefined => {

--- a/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
+++ b/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
@@ -164,7 +164,7 @@ export const useTimesStopsColumns = <T extends TimesStopsRow>(
       },
       {
         ...keyColumn('arrival', timeColumn(isOutputTable)),
-        title: t('arrivalTime'),
+        title: t('requestedArrival'),
         headerClassName: 'padded-header',
         ...fixedWidth(isOutputTable ? 105 : 125),
 
@@ -180,7 +180,7 @@ export const useTimesStopsColumns = <T extends TimesStopsRow>(
       },
       {
         ...keyColumn('departure', timeColumn(isOutputTable)),
-        title: headerWithTitleTagIfShortened(t('departureTime'), t('departureTimeFull')),
+        title: headerWithTitleTagIfShortened(t('requestedDeparture'), t('departureTimeFull')),
         headerClassName: 'padded-header',
         ...fixedWidth(isOutputTable ? 105 : 125),
 

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -56,6 +56,8 @@ import type {
   MarginValue,
   TimesStopsRowNew,
   UpdateCellStatus,
+  BatchTimesUpdate,
+  RequestedTimeField,
 } from '../types';
 
 const formatRequestedMargin = (requestedMargin: MarginValue | null) => {
@@ -125,7 +127,7 @@ const useUpdateTimesStopsTable = (
    */
   const computeUpdatedPathAndSchedule = useCallback(
     (
-      update: Exclude<CellUpdate, PowerRestrictionUpdate>
+      update: Exclude<CellUpdate, PowerRestrictionUpdate | BatchTimesUpdate>
     ):
       | {
           updatedPath: PathItem[];
@@ -267,6 +269,68 @@ const useUpdateTimesStopsTable = (
     };
   };
 
+  const computeUpdateWithBatch = (update: Exclude<CellUpdate, PowerRestrictionUpdate>) => {
+    if ('rows' in update) {
+      let updatedSchedule = selectedTrain.schedule ?? [];
+      let currentPath = selectedTrain.path;
+
+      const startTime =
+        scenario.timetable_type === 'CALENDAR'
+          ? new Date(selectedTrain.start_time)
+          : new Duration({ milliseconds: selectedTrain.start_time });
+
+      for (const row of update.rows) {
+        const { pathStepId, updatedPath: updatedPathForRow } = upsertPathStep(
+          row,
+          currentPath,
+          allRows
+        );
+        currentPath = updatedPathForRow;
+        const existingItemIndex = updatedSchedule.findIndex((item) => item.at === pathStepId);
+
+        const edit: Exclude<OptimisticEdit, { field: 'powerRestriction' }> =
+          update.field === 'requestedArrival'
+            ? {
+                field: 'requestedArrival',
+                value: row.computedArrival,
+              }
+            : {
+                field: 'requestedDeparture',
+                value: row.computedDeparture,
+              };
+
+        const newState = applyScheduleEdit(
+          { arrival: row.requestedArrival, stop: row.stopDuration },
+          edit
+        );
+
+        const { arrival: newArrival, stop_for: newStopFor } = scheduleStateToApiFields(
+          newState,
+          startTime
+        );
+
+        if (existingItemIndex >= 0) {
+          // Update existing schedule item
+          updatedSchedule = replaceElementAtIndex(updatedSchedule, existingItemIndex, {
+            ...updatedSchedule[existingItemIndex],
+            arrival: newArrival,
+            stop_for: newStopFor,
+          });
+        } else {
+          // Insert new schedule item in path order
+          const newItem: ScheduleItem = { at: pathStepId };
+          if (newArrival !== null) newItem.arrival = newArrival;
+          if (newStopFor !== null) newItem.stop_for = newStopFor;
+          updatedSchedule = insertScheduleItemInOrder(updatedSchedule, newItem, currentPath);
+        }
+      }
+
+      return { updatedPath: currentPath, updatedSchedule, updatedMargins: selectedTrain.margins };
+    } else {
+      return computeUpdatedPathAndSchedule(update);
+    }
+  };
+
   /**
    * Handle update when the selected train is an occurrence of a PacedTrain.
    * Uses exception-specific endpoints instead of updating the full paced train.
@@ -319,7 +383,7 @@ const useUpdateTimesStopsTable = (
           powerRestrictions,
         });
       } else {
-        const result = computeUpdatedPathAndSchedule(update);
+        const result = computeUpdateWithBatch(update);
         if (!result) return 'skipped';
 
         const trainWithUpdatedMargins = {
@@ -384,7 +448,7 @@ const useUpdateTimesStopsTable = (
         });
       }
 
-      const result = computeUpdatedPathAndSchedule(update);
+      const result = computeUpdateWithBatch(update);
       if (!result) return 'skipped';
 
       return persistTrain({
@@ -471,6 +535,11 @@ const useUpdateTimesStopsTable = (
     [updateCell]
   );
 
+  const updateMultipleTimes = useCallback(
+    (rows: TimesStopsRowNew[], field: RequestedTimeField) => updateCell({ rows, field }),
+    [updateCell]
+  );
+
   return {
     updateArrival,
     updateStopDuration,
@@ -478,6 +547,7 @@ const useUpdateTimesStopsTable = (
     updateReceptionSignal,
     updateRequestedMargin,
     updatePowerRestrictions,
+    updateMultipleTimes,
   };
 };
 

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -582,3 +582,10 @@
   height: 16px;
   border-radius: 8px;
 }
+
+.overwrite-all-confirm-explanations {
+  font-size: 1.1rem;
+  max-width: 500px;
+  margin-bottom: 0;
+  line-height: 24px;
+}

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -48,13 +48,39 @@
       th {
         background: color-mix(in srgb, var(--black100) 5%, var(--ambientB5) 100%);
 
-        .th-content {
+        // Exclude the requested time columns so the triangle button is not affected by the mask-image
+        .th-content:not(:has(.requested-time-column-header-wrapper)) {
           overflow: hidden;
           display: -webkit-box;
           -webkit-box-orient: vertical;
           -webkit-line-clamp: 2;
           line-clamp: 2;
           mask-image: linear-gradient(to right, black 80%, transparent 100%);
+        }
+      }
+    }
+
+    .requested-time-column-header-wrapper {
+      display: flex;
+      flex-direction: column;
+
+      .requested-time-column-header-toggle {
+        align-self: end;
+
+        // To be able to keep the same height for the header, the triangle button
+        // needs to slightly overflow the header title
+        margin: -5px -4px -5px;
+
+        &--disabled {
+          cursor: not-allowed;
+        }
+
+        .requested-time-column-header-toggle-icon-open {
+          color: var(--primary80);
+        }
+
+        .requested-time-column-header-toggle-icon-closed {
+          color: var(--black25);
         }
       }
     }

--- a/front/src/modules/timesStops/styles/_timesStopsTable.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsTable.scss
@@ -427,6 +427,34 @@
       }
     }
 
+    .requested-cell-highlighted-departure,
+    .requested-cell-highlighted-arrival {
+      --hl-top: 1;
+      --hl-right: 1;
+      --hl-bottom: 1;
+      --hl-left: 1;
+
+      box-shadow:
+        // inner ring, 1px inset
+        inset 0 calc(1px * var(--hl-top)) 0 0 var(--primary80),
+        inset calc(-1px * var(--hl-right)) 0 0 0 var(--primary80),
+        inset 0 calc(-1px * var(--hl-bottom)) 0 0 var(--primary80),
+        inset calc(1px * var(--hl-left)) 0 0 0 var(--primary80),
+        // outer ring, 4px inset
+        inset 0 calc(4px * var(--hl-top)) 0 0 var(--primary10),
+        inset calc(-4px * var(--hl-right)) 0 0 0 var(--primary10),
+        inset 0 calc(-4px * var(--hl-bottom)) 0 0 var(--primary10),
+        inset calc(4px * var(--hl-left)) 0 0 0 var(--primary10);
+
+      &.requested-cell-highlighted--connect-top {
+        --hl-top: 0;
+      }
+
+      &.requested-cell-highlighted--connect-bottom {
+        --hl-bottom: 0;
+      }
+    }
+
     /* Computed / uncomputed cells */
     td[class^='col-']::before {
       content: '';

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -212,3 +212,6 @@ export type MarginsCoreComputed = MarginsCoreBase & {
 };
 
 export type MarginsCore = null | MarginsCoreBase | MarginsCoreComputed;
+
+export type RequestedTimeField = 'requestedArrival' | 'requestedDeparture';
+export type TimeFillMode = 'fill' | 'overwrite';

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -174,13 +174,19 @@ export type PowerRestrictionUpdate = {
   value: string | null;
 };
 
+export type BatchTimesUpdate = {
+  rows: TimesStopsRowNew[];
+  field: RequestedTimeField;
+};
+
 export type CellUpdate =
   | ArrivalUpdate
   | StopDurationUpdate
   | DepartureUpdate
   | ReceptionSignalUpdate
   | RequestedMarginUpdate
-  | PowerRestrictionUpdate;
+  | PowerRestrictionUpdate
+  | BatchTimesUpdate;
 
 export type OptimisticEdit =
   | { field: 'requestedArrival'; value: StartTime | null }


### PR DESCRIPTION
Issue: https://github.com/osrd-project/osrd-confidential/issues/1626

---

This PR adds a new action menu inside the time stop table header to batch apply computed times to requested times.

To be able to reuse logic from useUpdateTimesStopsTable but apply changes in batch we wrapped existing code into a loop over rows.

We also highlight rows from the table when hovering the action in the menu. The highlight is done by splitting borders in 4 box shadows so the highlight is contigus over multiple rows.