### PR TITLE
editoast: use real start time for /search_journeys

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2813,6 +2813,7 @@ paths:
       description: |-
         The trains are not simulated, meaning each stop needs to be dated in order
         to be taken into account.
+        Until daily patterns are supported, timetables must be calendar anchored on 1970-01-01 UTC.
       requestBody:
         content:
           application/json:
@@ -11427,7 +11428,7 @@ components:
           type: integer
           format: int32
           description: |-
-            Amount of milliseconds from midnight UTC to the center of the start window.
+            Amount of milliseconds from 1970-01-01 00:00:00 UTC to the center of the start window.
 
             The start window is defined as the time between
             `start_sec - start_tolerance` and `start_sec + start_tolerance`.
@@ -11446,6 +11447,7 @@ components:
           items:
             type: integer
             format: int64
+          description: Until daily patterns are supported, timetables must be calendar anchored on 1970-01-01 UTC.
           uniqueItems: true
         transfer_ms:
           type: integer
@@ -16504,7 +16506,7 @@ components:
         time_ms:
           type: integer
           format: int32
-          description: Scheduled time of the step in milliseconds from midnight UTC.
+          description: Scheduled time of the step in milliseconds from 1970-01-01 00:00:00 UTC.
           minimum: 0
     TrainScheduleResponse:
       allOf:

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -4,12 +4,12 @@ use std::collections::HashSet;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
-use common::units::quantities::Offset;
 use editoast_derive::EditoastError;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
 use itertools::Itertools;
 use profile_connection_scan::Connection;
+use schemas::timetable_type::TimetableType;
 use schemas::train_schedule::OperationalPointPartReference;
 use schemas::train_schedule::OperationalPointReference;
 use schemas::train_schedule::PathItemLocation;
@@ -48,9 +48,10 @@ enum Error {
 pub(in crate::views) struct JourneySearchQuery {
     infra_id: i64,
 
+    /// Until daily patterns are supported, timetables must be calendar anchored on 1970-01-01 UTC.
     timetable_ids: HashSet<i64>,
 
-    /// Amount of milliseconds from midnight UTC to the center of the start window.
+    /// Amount of milliseconds from 1970-01-01 00:00:00 UTC to the center of the start window.
     ///
     /// The start window is defined as the time between
     /// `start_sec - start_tolerance` and `start_sec + start_tolerance`.
@@ -81,7 +82,7 @@ struct TrainSchedulePartBound {
     /// Id of the operational point of the corresponding step in the train schedule's path.
     op_id: String,
 
-    /// Scheduled time of the step in milliseconds from midnight UTC.
+    /// Scheduled time of the step in milliseconds from 1970-01-01 00:00:00 UTC.
     time_ms: u32,
 }
 
@@ -135,6 +136,7 @@ struct PathIndexedConnection {
 ///
 /// The trains are not simulated, meaning each stop needs to be dated in order
 /// to be taken into account.
+/// Until daily patterns are supported, timetables must be calendar anchored on 1970-01-01 UTC.
 #[editoast_derive::route]
 #[utoipa::path(
     post, path = "",
@@ -167,9 +169,15 @@ pub(in crate::views) async fn search_journeys(
         train_schedule_futs.spawn(
             async move {
                 let conn = db_pool.get().await?;
-                let train_schedules = retrieve_trains(conn, timetable_id).await?;
+                let (timetable_type, train_schedules) = retrieve_trains(conn, timetable_id).await?;
 
-                Ok::<_, InternalError>(train_schedules)
+                if timetable_type != TimetableType::Calendar {
+                    Err(Error::InvalidInput {
+                        message: "only calendar timetables are supported",
+                    })?;
+                }
+
+                Ok::<_, InternalError>((timetable_type, train_schedules))
             }
             .instrument(span),
         );
@@ -243,7 +251,7 @@ pub(in crate::views) async fn search_journeys(
     let journeys = tokio::task::spawn_blocking(move || {
         let mut train_schedule_ids = Vec::new();
         let mut path_indexed_connections: Vec<PathIndexedConnection> = Vec::new();
-        for (timetable_type, train_schedules) in timetables {
+        for (_, train_schedules) in timetables {
             let index_offset = train_schedule_ids.len();
 
             train_schedule_ids.extend(
@@ -255,16 +263,9 @@ pub(in crate::views) async fn search_journeys(
             path_indexed_connections.extend(
                 train_schedules.into_iter().zip(index_offset..).flat_map(
                     |(train_schedule, train_schedule_index)| {
-                        let offset_ms = match timetable_type {
-                            schemas::timetable_type::TimetableType::Calendar => {
-                                // TODO this handles badly train schedules that span longer than a day
-                                datetime_millis_from_midnight(train_schedule.start_time)
-                            }
-                            schemas::timetable_type::TimetableType::Hourly => u32::try_from(
-                                common::units::millisecond::i64::from(train_schedule.start_time),
-                            )
-                            .unwrap(),
-                        };
+                        // Timetables are only Calendar so we can use the raw start_time
+                        let offset_ms =
+                            common::units::millisecond::i64::from(train_schedule.start_time);
 
                         // avoid moving them into the filter_map closure
                         let op_index_by_id = &op_index_by_id;
@@ -275,8 +276,8 @@ pub(in crate::views) async fn search_journeys(
                             .into_iter()
                             .enumerate()
                             .filter_map(move |(i, path_item)| {
-                                let arrival_ms: u32;
-                                let stop_for_ms: u32;
+                                let arrival_ms: i64;
+                                let stop_for_ms: i64;
 
                                 if i == 0 {
                                     arrival_ms = offset_ms;
@@ -287,12 +288,9 @@ pub(in crate::views) async fn search_journeys(
                                         .iter()
                                         .find(|schedule_item| schedule_item.at == path_item.id)?;
 
-                                    arrival_ms = offset_ms
-                                        + u32::try_from(schedule_item.arrival?.num_milliseconds())
-                                            .unwrap();
-                                    stop_for_ms =
-                                        u32::try_from(schedule_item.stop_for?.num_milliseconds())
-                                            .unwrap();
+                                    arrival_ms =
+                                        offset_ms + schedule_item.arrival?.num_milliseconds();
+                                    stop_for_ms = schedule_item.stop_for?.num_milliseconds();
                                 }
 
                                 let PathItemLocation::OperationalPointPartReference(op_ref) =
@@ -307,11 +305,14 @@ pub(in crate::views) async fn search_journeys(
                                     &op_ref.operational_point,
                                 )?;
 
+                                // Timetables must be anchored on 1970-01-01 so arrival_ms and departure_ms
+                                // overflow u32 only for schedules absurdly far in the future.
+                                // We drop the step rather than failing the whole request.
                                 Some(ScheduleStep {
                                     path_index: i,
                                     op_index,
-                                    arrival_ms,
-                                    departure_ms: arrival_ms + stop_for_ms,
+                                    arrival_ms: u32::try_from(arrival_ms).ok()?,
+                                    departure_ms: u32::try_from(arrival_ms + stop_for_ms).ok()?,
                                 })
                             })
                             .tuple_windows()
@@ -440,9 +441,4 @@ where
             }
         }
     })
-}
-
-fn datetime_millis_from_midnight(t: Offset) -> u32 {
-    const MS_IN_DAY: i64 = 24 * 60 * 60 * 1000;
-    (common::units::millisecond::i64::from(t) % MS_IN_DAY) as u32
 }

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -177,7 +177,7 @@ pub(in crate::views) async fn search_journeys(
                     })?;
                 }
 
-                Ok::<_, InternalError>((timetable_type, train_schedules))
+                Ok::<_, InternalError>(train_schedules)
             }
             .instrument(span),
         );
@@ -194,15 +194,17 @@ pub(in crate::views) async fn search_journeys(
     })
     .await?;
 
-    let timetables = JoinSetStream::new(train_schedule_futs)
+    let train_schedules: Vec<_> = JoinSetStream::new(train_schedule_futs)
         // Converts `Result<Result<_, InternalError>, JoinError>` into `Result<_, InternalError>`
         .map(|fut| fut?)
         .collect::<Result<Vec<_>>>()
-        .await?;
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
 
-    let op_references: Vec<&OperationalPointPartReference> = timetables
+    let op_references: Vec<&OperationalPointPartReference> = train_schedules
         .iter()
-        .flat_map(|(_, train_schedules)| train_schedules)
         .flat_map(|train_schedule| &train_schedule.path)
         .filter_map(|path_item| match &path_item.location {
             PathItemLocation::OperationalPointPartReference(op_ref) => Some(op_ref),
@@ -249,105 +251,92 @@ pub(in crate::views) async fn search_journeys(
     };
 
     let journeys = tokio::task::spawn_blocking(move || {
-        let mut train_schedule_ids = Vec::new();
-        let mut path_indexed_connections: Vec<PathIndexedConnection> = Vec::new();
-        for (_, train_schedules) in timetables {
-            let index_offset = train_schedule_ids.len();
+        let train_schedule_ids: Vec<i64> = train_schedules
+            .iter()
+            .map(|train_schedule| train_schedule.id)
+            .collect();
 
-            train_schedule_ids.extend(
-                train_schedules
-                    .iter()
-                    .map(|train_schedule| train_schedule.id),
-            );
+        let mut path_indexed_connections: Vec<PathIndexedConnection> = train_schedules
+            .into_iter()
+            .enumerate()
+            .flat_map(|(train_schedule_index, train_schedule)| {
+                // Timetables are only Calendar so we can use the raw start_time
+                let offset_ms = common::units::millisecond::i64::from(train_schedule.start_time);
 
-            path_indexed_connections.extend(
-                train_schedules.into_iter().zip(index_offset..).flat_map(
-                    |(train_schedule, train_schedule_index)| {
-                        // Timetables are only Calendar so we can use the raw start_time
-                        let offset_ms =
-                            common::units::millisecond::i64::from(train_schedule.start_time);
+                // avoid moving them into the filter_map closure
+                let op_index_by_id = &op_index_by_id;
+                let op_cache = &op_cache;
 
-                        // avoid moving them into the filter_map closure
-                        let op_index_by_id = &op_index_by_id;
-                        let op_cache = &op_cache;
+                train_schedule
+                    .path
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(move |(i, path_item)| {
+                        let arrival_ms: i64;
+                        let stop_for_ms: i64;
 
-                        train_schedule
-                            .path
-                            .into_iter()
-                            .enumerate()
-                            .filter_map(move |(i, path_item)| {
-                                let arrival_ms: i64;
-                                let stop_for_ms: i64;
+                        if i == 0 {
+                            arrival_ms = offset_ms;
+                            stop_for_ms = 0;
+                        } else {
+                            let schedule_item = train_schedule
+                                .schedule
+                                .iter()
+                                .find(|schedule_item| schedule_item.at == path_item.id)?;
 
-                                if i == 0 {
-                                    arrival_ms = offset_ms;
-                                    stop_for_ms = 0;
-                                } else {
-                                    let schedule_item = train_schedule
-                                        .schedule
-                                        .iter()
-                                        .find(|schedule_item| schedule_item.at == path_item.id)?;
+                            arrival_ms = offset_ms + schedule_item.arrival?.num_milliseconds();
+                            stop_for_ms = schedule_item.stop_for?.num_milliseconds();
+                        }
 
-                                    arrival_ms =
-                                        offset_ms + schedule_item.arrival?.num_milliseconds();
-                                    stop_for_ms = schedule_item.stop_for?.num_milliseconds();
-                                }
+                        let PathItemLocation::OperationalPointPartReference(op_ref) =
+                            path_item.location
+                        else {
+                            return None;
+                        };
 
-                                let PathItemLocation::OperationalPointPartReference(op_ref) =
-                                    path_item.location
-                                else {
-                                    return None;
-                                };
+                        let op_index =
+                            find_op_index(op_cache, op_index_by_id, &op_ref.operational_point)?;
 
-                                let op_index = find_op_index(
-                                    op_cache,
-                                    op_index_by_id,
-                                    &op_ref.operational_point,
-                                )?;
+                        // Timetables must be anchored on 1970-01-01 so arrival_ms and departure_ms
+                        // overflow u32 only for schedules absurdly far in the future.
+                        // We drop the step rather than failing the whole request.
+                        Some(ScheduleStep {
+                            path_index: i,
+                            op_index,
+                            arrival_ms: u32::try_from(arrival_ms).ok()?,
+                            departure_ms: u32::try_from(arrival_ms + stop_for_ms).ok()?,
+                        })
+                    })
+                    .tuple_windows()
+                    .map(move |(departure, arrival)| PathIndexedConnection {
+                        connection: Connection {
+                            trip: train_schedule_index,
+                            departure: departure.op_index,
+                            departure_ms: departure.departure_ms,
+                            arrival: arrival.op_index,
+                            arrival_ms: arrival.arrival_ms,
+                        },
+                        departure_path_index: departure.path_index,
+                        arrival_path_index: arrival.path_index,
+                    })
+                    .filter(|path_indexed_connection| {
+                        // Simple filters to reduce the size of the problem.
 
-                                // Timetables must be anchored on 1970-01-01 so arrival_ms and departure_ms
-                                // overflow u32 only for schedules absurdly far in the future.
-                                // We drop the step rather than failing the whole request.
-                                Some(ScheduleStep {
-                                    path_index: i,
-                                    op_index,
-                                    arrival_ms: u32::try_from(arrival_ms).ok()?,
-                                    departure_ms: u32::try_from(arrival_ms + stop_for_ms).ok()?,
-                                })
-                            })
-                            .tuple_windows()
-                            .map(move |(departure, arrival)| PathIndexedConnection {
-                                connection: Connection {
-                                    trip: train_schedule_index,
-                                    departure: departure.op_index,
-                                    departure_ms: departure.departure_ms,
-                                    arrival: arrival.op_index,
-                                    arrival_ms: arrival.arrival_ms,
-                                },
-                                departure_path_index: departure.path_index,
-                                arrival_path_index: arrival.path_index,
-                            })
-                            .filter(|path_indexed_connection| {
-                                // Simple filters to reduce the size of the problem.
+                        // The connection isn't too early for the traveler to take it
+                        let departs_late_enough = (start_ms as i64 - start_tolerance as i64)
+                            <= path_indexed_connection.connection.departure_ms as i64;
 
-                                // The connection isn't too early for the traveler to take it
-                                let departs_late_enough = (start_ms as i64
-                                    - start_tolerance as i64)
-                                    <= path_indexed_connection.connection.departure_ms as i64;
+                        // If the connection departs from the source OP, it
+                        // doesn't depart too late for the traveler to take it
+                        let departs_early_enough = path_indexed_connection.connection.departure
+                            != origin_index
+                            || path_indexed_connection.connection.departure_ms
+                                <= start_ms + start_tolerance;
 
-                                // If the connection departs from the source OP, it
-                                // doesn't depart too late for the traveler to take it
-                                let departs_early_enough =
-                                    path_indexed_connection.connection.departure != origin_index
-                                        || path_indexed_connection.connection.departure_ms
-                                            <= start_ms + start_tolerance;
-
-                                departs_early_enough && departs_late_enough
-                            })
-                    },
-                ),
-            );
-        }
+                        departs_early_enough && departs_late_enough
+                    })
+            })
+            .collect();
 
         // Sort train connections by *decreasing* departure time.
         path_indexed_connections.sort_unstable_by(|a, b| {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4450,7 +4450,7 @@ export type TrainSchedulePartBound = {
   op_id: string;
   /** Index of the path step in the train schedule's path */
   path_step_index: number;
-  /** Scheduled time of the step in milliseconds from midnight UTC. */
+  /** Scheduled time of the step in milliseconds from 1970-01-01 00:00:00 UTC. */
   time_ms: number;
 };
 export type TrainSchedulePart = {
@@ -4468,7 +4468,7 @@ export type JourneySearchQuery = {
   destination: OperationalPointPartReference;
   infra_id: number;
   origin: OperationalPointPartReference;
-  /** Amount of milliseconds from midnight UTC to the center of the start window.
+  /** Amount of milliseconds from 1970-01-01 00:00:00 UTC to the center of the start window.
     
     The start window is defined as the time between
     `start_sec - start_tolerance` and `start_sec + start_tolerance`. */
@@ -4478,6 +4478,7 @@ export type JourneySearchQuery = {
     The start window is defined as the time between
     `start_sec - start_tolerance` and `start_sec + start_tolerance`. */
   start_tolerance: number;
+  /** Until daily patterns are supported, timetables must be calendar anchored on 1970-01-01 UTC. */
   timetable_ids: number[];
   /** Constant time for a transfer/footpath in the same stop in milliseconds.
     

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -4200,7 +4200,7 @@ class TrainSchedulePartBound(BaseModel):
     """
     time_ms: Annotated[int, Field(ge=0)]
     """
-    Scheduled time of the step in milliseconds from midnight UTC.
+    Scheduled time of the step in milliseconds from 1970-01-01 00:00:00 UTC.
     """
 
 
@@ -6208,7 +6208,7 @@ class JourneySearchQuery(BaseModel):
     origin: OperationalPointPartReference
     start_ms: Annotated[int, Field(ge=0)]
     """
-    Amount of milliseconds from midnight UTC to the center of the start window.
+    Amount of milliseconds from 1970-01-01 00:00:00 UTC to the center of the start window.
 
     The start window is defined as the time between
     `start_sec - start_tolerance` and `start_sec + start_tolerance`.
@@ -6221,6 +6221,9 @@ class JourneySearchQuery(BaseModel):
     `start_sec - start_tolerance` and `start_sec + start_tolerance`.
     """
     timetable_ids: list[int]
+    """
+    Until daily patterns are supported, timetables must be calendar anchored on 1970-01-01 UTC.
+    """
     transfer_ms: Annotated[int, Field(ge=0)]
     """
     Constant time for a transfer/footpath in the same stop in milliseconds.


### PR DESCRIPTION
The first commit changes the management of start time in`/search_journeys` to use real start times instead of folding it modulo a day, which handled badly the pass midnight.
Every time of the endpoint is now an offset from `1970-01-01 00:00:00 UTC`, so calendar timetables must be
anchored there until daily patterns are supported and hourly ones are now rejected.

The second commit removes the per-timetable grouping that we don't need anymore and simplifies the code accordingly (hide whitespace for review).