### PR TITLE
e2e: add ingorePageErrors to paced train exception test

### DIFF
--- a/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/002-paced-train-exceptions.spec.ts
@@ -42,6 +42,8 @@ const frTranslations = {
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
 test.describe('Paced train exceptions', { tag: ['@op', '@paced-trains', '@exceptions'] }, () => {
+  //TODO: remove ignorePageErrors when issue #13066 is resolved
+  test.use({ ignorePageErrors: true });
   let project: Project;
   let study: Study;
   let infra: Infra;


### PR DESCRIPTION
The test failed with `Cannot convert undefined or null to object`, which is a known issue tracked in #13066
Example of a failed build: https://github.com/OpenRailAssociation/osrd/actions/runs/30793365525