### PR TITLE
front: use Node's glob() in i18n-checker script

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -118,7 +118,6 @@
         "ansi-to-html": "^0.7.2",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "glob": "^13.0.6",
         "happy-dom": "^20.11.1",
         "i18next-fs-backend": "^2.6.6",
         "json-key-path-list": "^2.0.3",

--- a/front/package.json
+++ b/front/package.json
@@ -118,7 +118,6 @@
     "ansi-to-html": "^0.7.2",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "glob": "^13.0.6",
     "happy-dom": "^20.11.1",
     "i18next-fs-backend": "^2.6.6",
     "json-key-path-list": "^2.0.3",

--- a/front/scripts/i18n-checker.ts
+++ b/front/scripts/i18n-checker.ts
@@ -1,7 +1,6 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, glob } from 'node:fs/promises';
 import path from 'node:path';
 
-import { glob } from 'glob';
 import { jsonKeyPathList } from 'json-key-path-list';
 import * as ts from 'typescript';
 
@@ -71,20 +70,15 @@ async function readJsonFile<T extends { [key: string]: unknown }>(filePath: stri
  */
 async function getLocalesKeys(localePath: string, locale: string): Promise<Set<string>> {
   const pathForLocale = `${localePath}/${locale}/`;
-  const files = await glob(`${pathForLocale}/**/*.json`);
-  const allKeys = (
-    await Promise.all(
-      files.map(async (file) => {
-        const data = await readJsonFile(file);
-        const namespace = file.replace(pathForLocale, '').replace(/\.json$/, '');
-        return jsonKeyPathList(data).map(
-          (key: string) => `${namespace}:${key.replace(/_(zero|one|other|many)$/, '')}`
-        );
-      })
-    )
-  )
-    .flat()
-    .sort();
+  const allKeys = new Set<string>();
+  for await (const file of glob(`${pathForLocale}/**/*.json`)) {
+    const data = await readJsonFile(file);
+    const namespace = file.replace(pathForLocale, '').replace(/\.json$/, '');
+    const keys: string[] = jsonKeyPathList(data);
+    for (const key of keys) {
+      allKeys.add(`${namespace}:${key.replace(/_(zero|one|other|many)$/, '')}`);
+    }
+  }
   return new Set(allKeys);
 }
 


### PR DESCRIPTION
We don't need an external dependency, Node supports glob() natively since v22:
https://nodejs.org/api/fs.html#fspromisesglobpattern-options

Node's glob() returns an AsyncIterator which needs to be consumed with `for await`.

Drop the .sort() since the order doesn't matter in the Set.