### PR TITLE
editoast: handle project resources in the authz endpoints

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -254,7 +254,7 @@ pub enum ProjectPrivilege {
     HasAccess,
 }
 
-#[derive(EnumString, Serialize, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, EnumString, Eq, Hash, Serialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum ProjectGrant {

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -254,8 +254,7 @@ pub enum ProjectPrivilege {
     HasAccess,
 }
 
-#[derive(EnumString, Serialize)]
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(EnumString, Serialize, Debug, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum ProjectGrant {

--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -231,7 +231,19 @@ impl fga::model::Type for Role {
     }
 }
 
-#[derive(fga::Type, fga::Object, derive_more::FromStr, Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(
+    fga::Type,
+    fga::Object,
+    derive_more::Display,
+    derive_more::From,
+    derive_more::FromStr,
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    PartialEq,
+)]
 #[cfg_attr(test, derive(Ord, PartialOrd))]
 pub struct Project(pub i64);
 

--- a/editoast/models/src/project.rs
+++ b/editoast/models/src/project.rs
@@ -12,7 +12,7 @@ use crate::tags::Tags;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Model, ToSchema, PartialEq)]
 #[model(table = database::tables::project)]
-#[model(gen(ops = crud, list))]
+#[model(gen(ops = crud, batch_ops = r, list))]
 pub struct Project {
     pub id: i64,
     pub name: String,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6708,6 +6708,34 @@ components:
           type: string
           enum:
           - editoast:authz:Database
+    EditoastAuthzErrorIncompatibleGrant:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          title: EditoastAuthzErrorIncompatibleGrantContext
+          required:
+          - grant
+          - resource_type
+          properties:
+            grant:
+              type: object
+            resource_type:
+              type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 422
+        type:
+          type: string
+          enum:
+          - editoast:authz:IncompatibleGrant
     EditoastAuthzErrorUnknownIdentities:
       type: object
       required:
@@ -7289,6 +7317,7 @@ components:
       - $ref: '#/components/schemas/EditoastAuthorizationErrorOpenFga'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthenticated'
       - $ref: '#/components/schemas/EditoastAuthzErrorDatabase'
+      - $ref: '#/components/schemas/EditoastAuthzErrorIncompatibleGrant'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownIdentities'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownResource'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownSubject'

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -107,6 +107,7 @@ paths:
                 enum:
                 - infra
                 - rolling_stock
+                - project
         required: true
       responses:
         '200':
@@ -133,6 +134,7 @@ paths:
                   enum:
                   - infra
                   - rolling_stock
+                  - project
   /authz/me/groups:
     get:
       tags:
@@ -175,6 +177,7 @@ paths:
                 enum:
                 - infra
                 - rolling_stock
+                - project
         required: true
       responses:
         '200':
@@ -204,6 +207,7 @@ paths:
                   enum:
                   - infra
                   - rolling_stock
+                  - project
   /authz/user/info:
     post:
       tags:
@@ -13649,6 +13653,7 @@ components:
       enum:
       - infra
       - rolling_stock
+      - project
     RevokeBody:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -15535,6 +15535,7 @@ components:
       - can_delete
       - can_share_ownership
       - can_revoke
+      - has_access
     StartTimeChangeGroup:
       type: object
       required:

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -11,6 +11,7 @@ use ::authz;
 use ::authz::InfraGrant;
 use ::authz::InfraPrivilege;
 use ::authz::Role;
+use authz::ProjectPrivilege;
 use authz::RollingStockGrant;
 use authz::RollingStockPrivilege;
 use authz::v2;
@@ -29,6 +30,7 @@ use futures::TryStreamExt;
 use itertools::Itertools;
 use models::Group;
 use models::Infra;
+use models::Project;
 use models::RollingStock;
 use models::User;
 use models::authn::user::UserWithIdentities;
@@ -454,16 +456,20 @@ async fn retrieve_missing_resource_ids(
     let rolling_stock_ids = resources
         .remove(&ResourceType::RollingStock)
         .unwrap_or_default();
+    let project_ids = resources.remove(&ResourceType::Project).unwrap_or_default();
 
-    let mut infra_conn = conn.clone();
-    let ((_, missing_infras), (_, missing_rolling_stocks)) = tokio::try_join!(
-        Infra::retrieve_batch::<_, Vec<_>>(&mut infra_conn, infra_ids),
-        RollingStock::retrieve_batch::<_, Vec<_>>(&mut conn, rolling_stock_ids),
+    let mut rolling_stock_conn = conn.clone();
+    let mut project_conn = conn.clone();
+    let ((_, missing_infras), (_, missing_rolling_stocks), (_, missing_projects)) = tokio::try_join!(
+        Infra::retrieve_batch::<_, Vec<_>>(&mut conn, infra_ids),
+        RollingStock::retrieve_batch::<_, Vec<_>>(&mut rolling_stock_conn, rolling_stock_ids),
+        Project::retrieve_batch::<_, Vec<_>>(&mut project_conn, project_ids),
     )?;
 
     Ok(HashMap::from([
         (ResourceType::Infra, missing_infras),
         (ResourceType::RollingStock, missing_rolling_stocks),
+        (ResourceType::Project, missing_projects),
     ]))
 }
 
@@ -525,7 +531,11 @@ pub(in crate::views) async fn user_grants(
                     authz::RollingStock(*id),
                 )
                 .map_some_into::<StandardGrant>(),
-                ResourceType::Project => todo!(),
+                ResourceType::Project => authz::v2::project_effective_grant(
+                    authz::Subject::user(user),
+                    authz::Project(*id),
+                )
+                .map_some_into::<StandardGrant>(),
             }
             .authorize(&authorizer)
             .await?
@@ -544,6 +554,14 @@ pub(in crate::views) async fn user_grants(
                     rolling_stock,
                 )) => {
                     tracing::warn!(%rolling_stock, "user cannot read rolling stock — skipping");
+                    continue;
+                }
+                Err(Check::HasProjectPrivilege(
+                    Actor::Issuer,
+                    ProjectPrivilege::HasAccess,
+                    project,
+                )) => {
+                    tracing::warn!(%project, "user does not have access to project — skipping");
                     continue;
                 }
                 Err(_) => return Err(AuthorizationError::Forbidden.into()),
@@ -938,6 +956,7 @@ pub(in crate::views) async fn list_groups(
 
 #[cfg(test)]
 mod tests {
+    use authz::ProjectGrant;
     use authz::RollingStockGrant;
     use authz::v2::TestClientExt as _;
     use axum::http::StatusCode;
@@ -951,6 +970,7 @@ mod tests {
     use crate::error::InternalError;
     use crate::fixtures::create_empty_infra;
     use crate::fixtures::create_fast_rolling_stock;
+    use crate::fixtures::create_project;
     use crate::fixtures::create_small_infra;
     use crate::views::test_app::TestApp;
     use crate::views::test_app::TestRequestExt as _;
@@ -1146,12 +1166,15 @@ mod tests {
         let rs_with_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_with_grant").await;
         let rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let infra_no_grant = create_small_infra(&mut db_pool.get_ok()).await;
+        let project = create_project(&mut db_pool.get_ok(), "project_with_grant").await;
+        let project_no_grant = create_project(&mut db_pool.get_ok(), "project_no_grant").await;
 
         let user = app
             .user("test", "Test")
             .with_roles([Role::OperationalStudies])
             .with_infra_grant(infra.id, InfraGrant::Reader)
             .with_rolling_stock_grant(rs_with_grant.id, RollingStockGrant::Reader)
+            .with_project_grant(project.id, ProjectGrant::Owner)
             .create()
             .await;
 
@@ -1162,6 +1185,7 @@ mod tests {
             .json(&json!({
                 "infra": [infra.id],
                 "rolling_stock": [rs_with_grant.id],
+                "project": [project.id]
             }))
             .await
             .assert_status_ok()
@@ -1182,11 +1206,19 @@ mod tests {
                 grant: StandardGrant::Reader
             }]
         );
+        assert_eq!(
+            response.get(&ResourceType::Project).unwrap(),
+            &[UserResourceGrant {
+                id: project.id,
+                grant: StandardGrant::Owner
+            }]
+        );
 
         app.group("Group")
             .with_members([&user])
             .with_infra_grant(infra.id, InfraGrant::Writer)
             .with_rolling_stock_grant(rs_with_grant.id, RollingStockGrant::Writer)
+            .with_project_grant(project.id, ProjectGrant::Owner)
             .create()
             .await;
 
@@ -1197,6 +1229,7 @@ mod tests {
             .json(&json!({
                 "infra": [infra.id, infra_no_grant.id, infra_no_grant.id + 1000],
                 "rolling_stock": [rs_with_grant.id, rs_no_grant.id, rs_no_grant.id + 1000],
+                "project": [project.id, project_no_grant.id, project_no_grant.id + 1000]
             }))
             .await
             .assert_status_ok()
@@ -1218,6 +1251,39 @@ mod tests {
                 grant: StandardGrant::Writer
             }]
         );
+        assert_eq!(
+            response.get(&ResourceType::Project).unwrap(),
+            &[UserResourceGrant {
+                id: project.id,
+                grant: StandardGrant::Owner
+            }]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn authz_me_grants_user_without_grants() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
+        let project = create_project(&mut db_pool.get_ok(), "project").await;
+        let user_no_grants = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+        let response: HashMap<ResourceType, Vec<UserResourceGrant>> = app
+            .post("/authz/me/grants")
+            .by_user(user_no_grants.as_ref())
+            .json(&json!({
+                "infra": [infra.id],
+                "rolling_stock": [rolling_stock.id],
+                "project": [project.id]
+            }))
+            .await
+            .assert_status_ok()
+            .json();
+        assert_eq!(response, HashMap::new());
     }
 
     // TODO rewrite the test and check which users have grants on which resources.

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -371,7 +371,9 @@ pub(in crate::views) async fn user_privileges(
                         .collect_into::<HashSet<StandardPrivilege>>()
                         .zip(v2::Protected::value(resource))
                 }
-                _resource @ Resource::Project(_project) => todo!(),
+                resource @ Resource::Project(project) => v2::project_privileges(*user, project)
+                    .collect_into::<HashSet<StandardPrivilege>>()
+                    .zip(v2::Protected::value(resource)),
             });
             let authorizer = authn_state.authorizer(&openfga);
             let accesses = authorizer.authorize_all(protected_privileges).await?;
@@ -411,6 +413,19 @@ pub(in crate::views) async fn user_privileges(
                             },
                         );
                     }
+                    Err(Check::HasProjectPrivilege(
+                        Actor::Issuer,
+                        ProjectPrivilege::HasAccess,
+                        project,
+                    )) => {
+                        result
+                            .entry(ResourceType::Project)
+                            .or_default()
+                            .push(ResourcePrivileges {
+                                resource_id: project.0,
+                                privileges: HashSet::new(),
+                            })
+                    }
                     Err(_) => return Err(AuthorizationError::Forbidden.into()),
                 }
             }
@@ -426,6 +441,7 @@ pub(in crate::views) async fn user_privileges(
                 StandardPrivilege::CanShareOwnership,
                 StandardPrivilege::CanRevoke,
             ]);
+            let project_privilege = HashSet::from([StandardPrivilege::HasAccess]);
             for (resource_type, ids) in resources_ids {
                 let missing_ids = &missing_resources[&resource_type];
                 result.entry(resource_type).or_default().extend(
@@ -433,7 +449,11 @@ pub(in crate::views) async fn user_privileges(
                         .filter(|id| !missing_ids.contains(id))
                         .map(|resource_id| ResourcePrivileges {
                             resource_id,
-                            privileges: privileges.clone(),
+                            privileges: if resource_type == ResourceType::Project {
+                                project_privilege.clone()
+                            } else {
+                                privileges.clone()
+                            },
                         }),
                 );
             }
@@ -960,6 +980,7 @@ mod tests {
     use authz::RollingStockGrant;
     use authz::v2::TestClientExt as _;
     use axum::http::StatusCode;
+    use models::Project;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
@@ -986,11 +1007,19 @@ mod tests {
         let Infra {
             id: infra_unused, ..
         } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Project { id: project1, .. } =
+            create_project(&mut app.db_pool().get_ok(), "project1").await;
+        let Project { id: project2, .. } =
+            create_project(&mut app.db_pool().get_ok(), "project2").await;
+        let Project {
+            id: project_unused, ..
+        } = create_project(&mut app.db_pool().get_ok(), "project_unused").await;
         let toto = app
             .user("toto", "Toto")
             .with_infra_grant(infra1, InfraGrant::Owner)
             .with_infra_grant(infra2, InfraGrant::Writer)
             .with_infra_grant(infra3, InfraGrant::Reader)
+            .with_project_grant(project1, ProjectGrant::Owner)
             .create()
             .await;
 
@@ -998,11 +1027,13 @@ mod tests {
             .post("/authz/me/privileges")
             .by_user(toto.as_ref())
             .json(&json!({
-               "infra": [infra1, infra2, infra3, infra4, i64::MAX]
+               "infra": [infra1, infra2, infra3, infra4, i64::MAX],
+               "project": [project1, project2, i64::MAX],
             }))
             .await
             .assert_status_ok()
-            .json::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
+            .json::<HashMap<ResourceType, Vec<ResourcePrivileges>>>();
+        let mut infra_privileges = privileges
             .remove(&ResourceType::Infra)
             .unwrap()
             .into_iter()
@@ -1014,7 +1045,7 @@ mod tests {
             )
             .collect::<HashMap<_, _>>();
         assert_eq!(
-            privileges.remove(&infra1).unwrap(),
+            infra_privileges.remove(&infra1).unwrap(),
             HashSet::from([
                 StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
@@ -1027,7 +1058,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            privileges.remove(&infra2).unwrap(),
+            infra_privileges.remove(&infra2).unwrap(),
             HashSet::from([
                 StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
@@ -1037,16 +1068,38 @@ mod tests {
             ])
         );
         assert_eq!(
-            privileges.remove(&infra3).unwrap(),
+            infra_privileges.remove(&infra3).unwrap(),
             HashSet::from([
                 StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
                 StandardPrivilege::CanShareRead
             ])
         );
-        assert_eq!(privileges.remove(&infra4).unwrap(), HashSet::from([]));
-        assert!(!privileges.contains_key(&infra_unused));
-        assert!(!privileges.contains_key(&i64::MAX));
+        assert_eq!(infra_privileges.remove(&infra4).unwrap(), HashSet::from([]));
+        assert!(!infra_privileges.contains_key(&infra_unused));
+        assert!(!infra_privileges.contains_key(&i64::MAX));
+
+        let mut project_privileges = privileges
+            .remove(&ResourceType::Project)
+            .unwrap()
+            .into_iter()
+            .map(
+                |ResourcePrivileges {
+                     resource_id,
+                     privileges,
+                 }| (resource_id, privileges),
+            )
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            project_privileges.remove(&project1).unwrap(),
+            HashSet::from([StandardPrivilege::HasAccess])
+        );
+        assert_eq!(
+            project_privileges.remove(&project2).unwrap(),
+            HashSet::from([])
+        );
+        assert!(!project_privileges.contains_key(&project_unused));
+        assert!(!project_privileges.contains_key(&i64::MAX));
     }
 
     // TODO: merge with the previous test once test deadlocks are fixed
@@ -1124,15 +1177,19 @@ mod tests {
     async fn me_privileges_skip_authz() {
         let app = test_app!().build();
         let Infra { id: infra, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Project { id: project, .. } =
+            create_project(&mut app.db_pool().get_ok(), "project").await;
         let mut privileges = app
             .post("/authz/me/privileges")
             .skip_authz()
             .json(&json!({
-               "infra": [infra]
+               "infra": [infra],
+               "project": [project]
             }))
             .await
             .assert_status_ok()
-            .json::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
+            .json::<HashMap<ResourceType, Vec<ResourcePrivileges>>>();
+        let mut infra_privileges = privileges
             .remove(&ResourceType::Infra)
             .unwrap()
             .into_iter()
@@ -1144,7 +1201,7 @@ mod tests {
             )
             .collect::<HashMap<_, _>>();
         assert_eq!(
-            privileges.remove(&infra).unwrap(),
+            infra_privileges.remove(&infra).unwrap(),
             HashSet::from([
                 StandardPrivilege::CanRestrictedRead,
                 StandardPrivilege::CanRead,
@@ -1156,6 +1213,22 @@ mod tests {
                 StandardPrivilege::CanRevoke,
             ])
         );
+
+        let mut project_privileges = privileges
+            .remove(&ResourceType::Project)
+            .unwrap()
+            .into_iter()
+            .map(
+                |ResourcePrivileges {
+                     resource_id,
+                     privileges,
+                 }| (resource_id, privileges),
+            )
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            project_privileges.remove(&project).unwrap(),
+            HashSet::from([StandardPrivilege::HasAccess])
+        )
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -681,7 +681,24 @@ pub(in crate::views) async fn resource_granted_users(
                 .await?
                 .map_err(|_| AuthorizationError::Forbidden)?
         }
-        ResourceType::Project => todo!(),
+        ResourceType::Project => {
+            let project = authz::Project(resource_id);
+            Project::exists_or_fail(&mut conn, resource_id, || AuthzError::UnknownResource {
+                resource_id,
+            })
+            .await?;
+            let owners = authorizer
+                .authorize(authz::v2::project_granted_subjects(project))
+                .await?
+                .access()
+                .await?
+                .map_err(|_| AuthorizationError::Forbidden)?;
+
+            (
+                (Vec::<authz::Subject>::new(), Vec::<authz::Subject>::new()),
+                owners,
+            )
+        }
     };
 
     // NOTE: the same subject can appear in multiple lists. This can happen
@@ -1367,14 +1384,17 @@ mod tests {
         let app = test_app!().build();
         let db_pool = app.db_pool();
         let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
+        let project = create_project(&mut db_pool.get_ok(), "project").await;
+
         let user = app
             .user("authz", "Authz")
             .with_roles([Role::OperationalStudies])
             .with_infra_grant(infra.id, InfraGrant::Owner)
-            .with_rolling_stock_grant(infra.id, RollingStockGrant::Owner)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Owner)
+            .with_project_grant(project.id, ProjectGrant::Owner)
             .create()
             .await;
-        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
         for name in ["ben", "hal", "joe", "luc", "mar"] {
             app.user(name, name)
                 .with_roles([Role::OperationalStudies])
@@ -1389,31 +1409,41 @@ mod tests {
             app.user(name, name)
                 .with_roles([Role::OperationalStudies])
                 .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+                .with_project_grant(project.id, ProjectGrant::Owner)
                 .create()
                 .await;
         }
-        for resource_type in ResourceType::iter() {
+
+        for (resource_type, resource_id) in ResourceType::iter().map(|resource_type| {
+            let id = match resource_type {
+                ResourceType::Infra => infra.id,
+                ResourceType::RollingStock => rolling_stock.id,
+                ResourceType::Project => project.id,
+            };
+            (resource_type, id)
+        }) {
             let subjects: Vec<SubjectGrant> = app
-                .get(&format!("/authz/{}/{}", resource_type, infra.id))
+                .get(&format!("/authz/{}/{}", resource_type, resource_id))
                 .by_user(user.as_ref())
                 .await
                 .assert_status(StatusCode::OK)
                 .json();
-            match resource_type {
-                ResourceType::Infra => {
-                    assert_eq!(subjects.len(), 6);
+
+            assert_eq!(
+                subjects.len(),
+                match resource_type {
+                    ResourceType::Infra => 6,
+                    ResourceType::RollingStock => 8,
+                    ResourceType::Project => 3,
                 }
-                ResourceType::RollingStock => {
-                    assert_eq!(subjects.len(), 8);
-                }
-                ResourceType::Project => todo!(),
-            }
+            );
         }
     }
 
     #[rstest]
     #[case(ResourceType::Infra)]
     #[case(ResourceType::RollingStock)]
+    #[case(ResourceType::Project)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn users_grants_for_missing_resource_returns_not_found(
         #[case] resource_type: ResourceType,
@@ -1434,6 +1464,7 @@ mod tests {
     #[rstest]
     #[case(ResourceType::Infra)]
     #[case(ResourceType::RollingStock)]
+    #[case(ResourceType::Project)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn update_grants_for_missing_resource_returns_not_found(
         #[case] resource_type: ResourceType,
@@ -1453,7 +1484,7 @@ mod tests {
                     "subject_id": subject.id,
                     "resource_type": resource_type,
                     "resource_id": i64::MAX,
-                    "grant": StandardGrant::Reader,
+                    "grant": StandardGrant::Owner,
                 }]
             }))
             .await
@@ -1512,41 +1543,43 @@ mod tests {
         );
     }
 
+    // no test case for projects: they only have one grant level so they cannot be superseded or
+    // overridden. The only thing to check with them is whether they inherit grants from the
+    // projects they belong to.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn groups_grants_on_resource() {
         let app = test_app!().build();
-        let db_pool = app.db_pool();
         let infra = create_small_infra(&mut app.db_pool().get_ok()).await;
-        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
+        let rolling_stock = create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rs").await;
         let alice = app
             .user("alice", "Alice")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
             .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(infra.id, InfraGrant::Reader)
             .create()
             .await;
         let bob = app
             .user("bob", "Bob")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
             .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Owner)
+            .with_infra_grant(infra.id, InfraGrant::Owner)
             .create()
             .await;
         let tom = app
             .user("tom", "Tom")
-            .with_infra_grant(infra.id, InfraGrant::Owner)
             .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Owner)
+            .with_infra_grant(infra.id, InfraGrant::Owner)
             .create()
             .await;
         let jerry = app
             .user("jerry", "Jerry")
-            .with_infra_grant(infra.id, InfraGrant::Reader)
             .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_infra_grant(infra.id, InfraGrant::Reader)
             .create()
             .await;
         let alice_and_bob = app
             .group("Alice and Bob")
             .with_members([&alice, &bob])
-            .with_infra_grant(infra.id, InfraGrant::Writer)
             .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Writer)
+            .with_infra_grant(infra.id, InfraGrant::Writer)
             .create()
             .await;
         let tom_and_jerry = app
@@ -1554,19 +1587,17 @@ mod tests {
             .with_members([&tom, &jerry])
             .create()
             .await;
-        for resource_type in ResourceType::iter() {
-            let resource_id = match resource_type {
-                ResourceType::Infra => infra.id,
-                ResourceType::RollingStock => rolling_stock.id,
-                ResourceType::Project => todo!(),
-            };
+
+        for (resource_type, resource_id) in [
+            (ResourceType::Infra, infra.id),
+            (ResourceType::RollingStock, rolling_stock.id),
+        ] {
             let subjects: Vec<SubjectGrant> = app
                 .get(&format!("/authz/{}/{}", resource_type, resource_id))
                 .by_user(alice.as_ref())
                 .await
                 .assert_status(StatusCode::OK)
                 .json();
-
             let grants = subjects
                 .into_iter()
                 .map(|SubjectGrant { id, grant, .. }| (id, grant))
@@ -1579,6 +1610,43 @@ mod tests {
             assert_eq!(grants.get(&alice_and_bob.id), Some(&StandardGrant::Writer)); // group direct grant
             assert_eq!(grants.get(&tom_and_jerry.id), None); // no group grant (not even there in the response)
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn group_grants_on_project() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+        let project_id = create_project(&mut db_pool.get_ok(), "project").await.id;
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let user = app.user("user", "User").create().await;
+
+        // Sanity check, the endpoint should return no grants for the newly created user:
+        app.assert_project_grant(project_id, user.id, None).await;
+
+        // Add the user to a group with a direct grant on the project. The endpoint response should
+        // now contain a grant on the project for both the user (inherited) and its group (direct):
+        let group = app
+            .group("Loneliness group")
+            .with_members([&user])
+            .with_project_grant(project_id, ProjectGrant::Owner)
+            .create()
+            .await;
+        let subjects: Vec<SubjectGrant> = app
+            .get(&format!("/authz/{}/{}", ResourceType::Project, project_id))
+            .by_user(admin.as_ref())
+            .await
+            .assert_status(StatusCode::OK)
+            .json();
+        let grants = subjects
+            .into_iter()
+            .map(|SubjectGrant { id, grant, .. }| (id, grant))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(grants.get(&user.id), Some(&StandardGrant::Owner));
+        assert_eq!(grants.get(&group.id), Some(&StandardGrant::Owner));
     }
 
     #[rstest]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -53,13 +53,14 @@ enum SubjectType {
     Group,
 }
 
-#[derive(Display, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-#[cfg_attr(test, derive(Debug, EnumIter))]
+#[cfg_attr(test, derive(EnumIter))]
 pub(in crate::views) enum ResourceType {
     Infra,
     RollingStock,
+    Project,
 }
 
 #[derive(Debug, thiserror::Error, EditoastError)]
@@ -356,6 +357,7 @@ pub(in crate::views) async fn user_privileges(
                         ResourceType::RollingStock => {
                             Resource::RollingStock(authz::RollingStock(id))
                         }
+                        ResourceType::Project => Resource::Project(authz::Project(id)),
                     })
             });
             let protected_privileges = resources.into_iter().map(|resource| match resource {
@@ -367,6 +369,7 @@ pub(in crate::views) async fn user_privileges(
                         .collect_into::<HashSet<StandardPrivilege>>()
                         .zip(v2::Protected::value(resource))
                 }
+                _resource @ Resource::Project(_project) => todo!(),
             });
             let authorizer = authn_state.authorizer(&openfga);
             let accesses = authorizer.authorize_all(protected_privileges).await?;
@@ -517,12 +520,12 @@ pub(in crate::views) async fn user_grants(
                     authz::v2::infra_effective_grant(authz::Subject::user(user), authz::Infra(*id))
                         .map_some_into::<StandardGrant>()
                 }
-
                 ResourceType::RollingStock => authz::v2::rolling_stock_effective_grant(
                     authz::Subject::user(user),
                     authz::RollingStock(*id),
                 )
                 .map_some_into::<StandardGrant>(),
+                ResourceType::Project => todo!(),
             }
             .authorize(&authorizer)
             .await?
@@ -640,6 +643,7 @@ pub(in crate::views) async fn resource_granted_users(
                 .await?
                 .map_err(|_| AuthorizationError::Forbidden)?
         }
+        ResourceType::Project => todo!(),
     };
 
     // NOTE: the same subject can appear in multiple lists. This can happen
@@ -883,6 +887,7 @@ impl GrantBody {
             ResourceType::RollingStock => {
                 authz::v2::rolling_stock_set_grant(*subject, resource_id.into(), grant.into())
             }
+            ResourceType::Project => todo!(),
         })
     }
 }
@@ -905,6 +910,7 @@ impl RevokeBody {
             ResourceType::RollingStock => {
                 authz::v2::rolling_stock_revoke_grant(*subject, resource_id.into())
             }
+            ResourceType::Project => todo!(),
         })
     }
 }
@@ -1261,6 +1267,7 @@ mod tests {
                 ResourceType::RollingStock => {
                     assert_eq!(subjects.len(), 8);
                 }
+                ResourceType::Project => todo!(),
             }
         }
     }
@@ -1412,6 +1419,7 @@ mod tests {
             let resource_id = match resource_type {
                 ResourceType::Infra => infra.id,
                 ResourceType::RollingStock => rolling_stock.id,
+                ResourceType::Project => todo!(),
             };
             let subjects: Vec<SubjectGrant> = app
                 .get(&format!("/authz/{}/{}", resource_type, resource_id))
@@ -1503,6 +1511,7 @@ mod tests {
                     .await,
                 Some(RollingStockGrant::Writer)
             ),
+            ResourceType::Project => todo!(),
         }
 
         // Remove the user grant from the API
@@ -1536,6 +1545,7 @@ mod tests {
                     .await,
                 None
             ),
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -1604,6 +1614,7 @@ mod tests {
                 )
                 .await
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -1660,6 +1671,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, reader.id, None)
                     .await
             }
+            ResourceType::Project => todo!(),
         };
     }
 
@@ -1716,6 +1728,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, owner.id, None)
                     .await
             }
+            ResourceType::Project => todo!(),
         };
     }
 
@@ -1780,6 +1793,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, bob.id, Some(RollingStockGrant::Owner))
                     .await
             }
+            ResourceType::Project => todo!(),
         };
     }
 
@@ -1841,6 +1855,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -1909,6 +1924,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, bob.id, Some(RollingStockGrant::Owner))
                     .await
             }
+            ResourceType::Project => todo!(),
         }
 
         app.post("/authz/grants")
@@ -1942,6 +1958,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -1997,6 +2014,7 @@ mod tests {
                 )
                 .await
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2063,6 +2081,7 @@ mod tests {
                 )
                 .await
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2129,6 +2148,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
 
         app.post("/authz/grants")
@@ -2155,6 +2175,7 @@ mod tests {
                 )
                 .await
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2210,6 +2231,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2265,6 +2287,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2331,6 +2354,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2397,6 +2421,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2501,6 +2526,7 @@ mod tests {
                 )
                 .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2616,6 +2642,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, *alice, Some(RollingStockGrant::Owner))
                     .await; // inherited group grant superseded by direct user grant
             }
+            ResourceType::Project => todo!(),
         }
 
         app.post("/authz/grants")
@@ -2659,6 +2686,7 @@ mod tests {
                     Some(RollingStockGrant::Reader)
                 ); // bob's direct grant is still there
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2719,6 +2747,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, group.id, None)
                     .await;
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2869,6 +2898,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, user.0, None)
                     .await;
             }
+            ResourceType::Project => todo!(),
         }
         app.post("/authz/grants")
             .skip_authz()
@@ -2905,6 +2935,7 @@ mod tests {
                     Some(RollingStockGrant::Owner)
                 );
             }
+            ResourceType::Project => todo!(),
         }
     }
 
@@ -2947,6 +2978,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, user.0, Some(RollingStockGrant::Owner))
                     .await
             }
+            ResourceType::Project => todo!(),
         };
         app.post("/authz/grants")
             .skip_authz()
@@ -2968,6 +3000,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, user.0, None)
                     .await
             }
+            ResourceType::Project => todo!(),
         };
     }
 

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use crate::authorizers::SystemAuthorizer;
 use crate::error::Result;
+use crate::views::authz::resources::IncompatibleGrant;
 use crate::views::authz::resources::Resource;
 use crate::views::authz::resources::StandardGrant;
 use crate::views::authz::resources::StandardPrivilege;
@@ -11,6 +12,7 @@ use ::authz;
 use ::authz::InfraGrant;
 use ::authz::InfraPrivilege;
 use ::authz::Role;
+use authz::ProjectGrant;
 use authz::ProjectPrivilege;
 use authz::RollingStockGrant;
 use authz::RollingStockPrivilege;
@@ -80,6 +82,12 @@ enum AuthzError {
     #[error("Unknown user identities '{}'", identities.iter().format(", "))]
     #[editoast_error(status = 404)]
     UnknownIdentities { identities: HashSet<String> },
+    #[error("Incompatible grant {grant} for resource {resource_type}")]
+    #[editoast_error(status = 422)]
+    IncompatibleGrant {
+        grant: StandardGrant,
+        resource_type: ResourceType,
+    },
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] models::Error),
@@ -852,9 +860,13 @@ pub(in crate::views) async fn update_grants(
                 .await?
             }
         };
-        let missing_resource_id = [ResourceType::Infra, ResourceType::RollingStock]
-            .into_iter()
-            .find_map(|resource_type| missing_resources[&resource_type].iter().min().copied());
+        let missing_resource_id = [
+            ResourceType::Infra,
+            ResourceType::RollingStock,
+            ResourceType::Project,
+        ]
+        .into_iter()
+        .find_map(|resource_type| missing_resources[&resource_type].iter().min().copied());
         if let Some(resource_id) = missing_resource_id {
             return Err(AuthzError::UnknownResource { resource_id }.into());
         }
@@ -942,7 +954,15 @@ impl GrantBody {
             ResourceType::RollingStock => {
                 authz::v2::rolling_stock_set_grant(*subject, resource_id.into(), grant.into())
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => {
+                TryInto::<ProjectGrant>::try_into(grant).map_err(|IncompatibleGrant(grant)| {
+                    AuthzError::IncompatibleGrant {
+                        grant,
+                        resource_type,
+                    }
+                })?;
+                authz::v2::project_set_grant(*subject, resource_id.into())
+            }
         })
     }
 }
@@ -965,7 +985,7 @@ impl RevokeBody {
             ResourceType::RollingStock => {
                 authz::v2::rolling_stock_revoke_grant(*subject, resource_id.into())
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => authz::v2::project_revoke_grant(*subject, resource_id.into()),
         })
     }
 }
@@ -1504,7 +1524,21 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    // When calling the update_grants endpoint and several resources are missing, the error response
+    // contains a single missing resource. The one it chooses returns should be deterministic:
+    // - The resource types have a priority order. The error will contain in priority:
+    //     1. A missing infra.
+    //     2. A missing rolling stock.
+    //     3. A missing project.
+    // - If there are several missing identifiers for the same resource type, the smallest missing
+    //   identifier is returned.
     async fn update_grants_reports_missing_resources_deterministically() {
+        // project_id < infra_id_smaller < infra_id_larger < rolling_stock_id
+        // - When calling the endpoint with those missing identifiers, we expect the error response
+        //   to contain infra_id_smaller, i.e. the smallest missing identifier of the highest priority
+        //   resource type.
+        // - When calling the endpoint with only the missing project and rolling stock idendifiers,
+        //   we expect the response to contain the missing rolling stock identifier.
         let app = test_app!().build();
         let owner = app
             .user("owner", "Owner")
@@ -1512,7 +1546,11 @@ mod tests {
             .create()
             .await;
         let subject = app.user("subject", "Subject").create().await;
-        let missing_infra_id = i64::MAX - 1;
+
+        let project_id = i64::MAX - 3;
+        let infra_id_smaller = i64::MAX - 2;
+        let infra_id_larger = i64::MAX - 1;
+        let rolling_stock_id = i64::MAX;
 
         let response: InternalError = app
             .post("/authz/grants")
@@ -1521,14 +1559,26 @@ mod tests {
                 "grant": [
                     {
                         "subject_id": subject.id,
-                        "resource_type": ResourceType::RollingStock,
-                        "resource_id": i64::MAX,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": infra_id_smaller,
                         "grant": StandardGrant::Reader,
                     },
                     {
                         "subject_id": subject.id,
                         "resource_type": ResourceType::Infra,
-                        "resource_id": missing_infra_id,
+                        "resource_id": infra_id_larger,
+                        "grant": StandardGrant::Reader,
+                    },
+                    {
+                        "subject_id": subject.id,
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id,
+                        "grant": StandardGrant::Reader,
+                    },
+                    {
+                        "subject_id": subject.id,
+                        "resource_type": ResourceType::RollingStock,
+                        "resource_id": rolling_stock_id,
                         "grant": StandardGrant::Reader,
                     },
                 ]
@@ -1537,9 +1587,41 @@ mod tests {
             .assert_status_not_found()
             .json();
 
+        // Check that:
+        // - The infra resource has the highest priority.
+        // - The lowest identifier value of a resource type is returned in priority.
         assert_eq!(
             response.context["resource_id"],
-            serde_json::Value::from(missing_infra_id)
+            serde_json::Value::from(infra_id_smaller)
+        );
+
+        let response: InternalError = app
+            .post("/authz/grants")
+            .by_user(owner.as_ref())
+            .json(&json!({
+                "grant": [
+                    {
+                        "subject_id": subject.id,
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id,
+                        "grant": StandardGrant::Reader,
+                    },
+                    {
+                        "subject_id": subject.id,
+                        "resource_type": ResourceType::RollingStock,
+                        "resource_id": rolling_stock_id,
+                        "grant": StandardGrant::Reader,
+                    },
+                ]
+            }))
+            .await
+            .assert_status_not_found()
+            .json();
+
+        // Check that rolling stocks are prioritized over projects:
+        assert_eq!(
+            response.context["resource_id"],
+            serde_json::Value::from(rolling_stock_id)
         );
     }
 
@@ -1718,7 +1800,7 @@ mod tests {
                     .await,
                 Some(RollingStockGrant::Writer)
             ),
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Irrelevant test for projects: only one project grant level and their owners cannot revoke grants
         }
 
         // Remove the user grant from the API
@@ -1752,7 +1834,7 @@ mod tests {
                     .await,
                 None
             ),
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Owners of a project cannot revoke grants on it
         }
     }
 
@@ -1821,7 +1903,8 @@ mod tests {
                 )
                 .await
             }
-            ResourceType::Project => todo!(),
+            // special case, skipped in this test: owners of a project cannot revoke grants on it
+            ResourceType::Project => (),
         }
     }
 
@@ -1846,12 +1929,22 @@ mod tests {
             .create()
             .await,
     )]
+    #[case::project(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        ResourceType::Project,
+        app
+            .user("owner", "Owner")
+            .with_project_grant(resource_id, ProjectGrant::Owner)
+            .create()
+            .await,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn admins_can_revoke_grants(
         #[case] app: TestApp,
         #[case] resource_id: i64,
         #[case] resource_type: ResourceType,
-        #[case] reader: authz::identity::User,
+        #[case] user: authz::identity::User,
     ) {
         let admin = app
             .user("admin", "Admin")
@@ -1863,7 +1956,7 @@ mod tests {
             .json(&json!({
                 "revoke": [
                     {
-                        "subject_id": reader.id,
+                        "subject_id": user.id,
                         "resource_type": resource_type,
                         "resource_id": resource_id
                     },
@@ -1873,12 +1966,12 @@ mod tests {
             .assert_status_no_content();
 
         match resource_type {
-            ResourceType::Infra => app.assert_infra_grant(resource_id, reader.id, None),
+            ResourceType::Infra => app.assert_infra_grant(resource_id, user.id, None),
             ResourceType::RollingStock => {
-                app.assert_rolling_stock_grant(resource_id, reader.id, None)
+                app.assert_rolling_stock_grant(resource_id, user.id, None)
                     .await
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => app.assert_project_grant(resource_id, user.id, None).await,
         };
     }
 
@@ -1900,6 +1993,16 @@ mod tests {
         app
             .user("owner", "Owner")
             .with_rolling_stock_grant(resource_id, RollingStockGrant::Owner)
+            .create()
+            .await,
+    )]
+    #[case::project(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        ResourceType::Project,
+        app
+            .user("owner", "Owner")
+            .with_project_grant(resource_id, ProjectGrant::Owner)
             .create()
             .await,
     )]
@@ -1935,7 +2038,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, owner.id, None)
                     .await
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => app.assert_project_grant(resource_id, owner.id, None).await,
         };
     }
 
@@ -1970,6 +2073,21 @@ mod tests {
             .create()
             .await,
     )]
+    #[case::project(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        ResourceType::Project,
+        app
+            .user("alice", "Alice")
+            .with_project_grant(resource_id, ProjectGrant::Owner)
+            .create()
+            .await,
+        app
+            .user("bob", "Bob")
+            .with_project_grant(resource_id, ProjectGrant::Owner)
+            .create()
+            .await,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn owner_cannot_revoke_another_resource_owner(
         #[case] app: TestApp,
@@ -2000,7 +2118,10 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, bob.id, Some(RollingStockGrant::Owner))
                     .await
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => {
+                app.assert_project_grant(resource_id, bob.id, Some(ProjectGrant::Owner))
+                    .await
+            }
         };
     }
 
@@ -2062,7 +2183,9 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            // The test is irrelevant for projects as they only have one grant level
+            // So the demotion cannot arise (the revokation can)
+            ResourceType::Project => (),
         }
     }
 
@@ -2131,10 +2254,12 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, bob.id, Some(RollingStockGrant::Owner))
                     .await
             }
-            ResourceType::Project => todo!(),
+            // The test is irrelevant for projects as they only have one grant level
+            ResourceType::Project => (),
         }
 
         app.post("/authz/grants")
+            .by_user(admin.as_ref())
             .json(&json!({
                 "grant": [{
                     "subject_id": bob.id,
@@ -2143,7 +2268,6 @@ mod tests {
                     "grant": StandardGrant::Writer
                 }]
             }))
-            .by_user(admin.as_ref())
             .await
             .assert_status(StatusCode::CREATED);
         match resource_type {
@@ -2165,7 +2289,7 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (),
         }
     }
 
@@ -2221,7 +2345,11 @@ mod tests {
                 )
                 .await
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => {
+                // The test is not relevant for projects: project owners should not be able to
+                // demote anyone anyway (including themselves).
+                unreachable!("This test should not check the project resource");
+            }
         }
     }
 
@@ -2288,7 +2416,8 @@ mod tests {
                 )
                 .await
             }
-            ResourceType::Project => todo!(),
+            // Owners cannot demote anyone anyway, tested separately
+            ResourceType::Project => (),
         }
     }
 
@@ -2324,6 +2453,7 @@ mod tests {
             .await,
     )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    // Note: this test is irrelevant to projects as their owners cannot demote anyone
     async fn owner_can_promote_and_demote_anyone_infra_grant(
         #[case] app: TestApp,
         #[case] resource_id: i64,
@@ -2355,7 +2485,7 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (),
         }
 
         app.post("/authz/grants")
@@ -2382,7 +2512,7 @@ mod tests {
                 )
                 .await
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (),
         }
     }
 
@@ -2438,7 +2568,7 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Project owners cannot demote anyone anyway, tested separately
         }
     }
 
@@ -2494,7 +2624,7 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Projects have only one grant level, there is no promotion
         }
     }
 
@@ -2561,7 +2691,7 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Project resources have no writers, only owners
         }
     }
 
@@ -2628,7 +2758,7 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Projects have one grant level, no promotion possible for them
         }
     }
 
@@ -2733,7 +2863,7 @@ mod tests {
                 )
                 .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Projects have only one grant level, no demotion is possible
         }
     }
 
@@ -2759,6 +2889,12 @@ mod tests {
             .await,
     )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    // TODO split that test into smaller tests checking respectively that:
+    // - Admins can give grants to groups.
+    // - Admins can revoke grants to groups.
+    // - A user correctly inherits the grants coming from its groups.
+    // - Removing a grant on a group doesn't remove the direct grants its members might have on the
+    //   resource (?).
     async fn admin_can_give_grants_to_groups(
         #[case] app: TestApp,
         #[case] resource_id: i64,
@@ -2849,7 +2985,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, *alice, Some(RollingStockGrant::Owner))
                     .await; // inherited group grant superseded by direct user grant
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // Projects have only one grant, no writer or reader
         }
 
         app.post("/authz/grants")
@@ -2893,8 +3029,92 @@ mod tests {
                     Some(RollingStockGrant::Reader)
                 ); // bob's direct grant is still there
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => (), // projects have only one grant level and no writers
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn admin_can_give_project_grants_to_groups() {
+        let app = test_app!().build();
+        let openfga = app.openfga();
+
+        let project_id = create_project(&mut app.db_pool().get_ok(), "project")
+            .await
+            .id;
+
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let alice_info = app
+            .user("alice", "Alice")
+            .with_project_grant(project_id, ProjectGrant::Owner)
+            .create()
+            .await;
+        let bob = app.user("bob", "Bob").create().await;
+        let alice_and_bob = app
+            .group("Alice and Bob")
+            .with_members([&alice_info, &bob])
+            .create()
+            .await;
+
+        let alice = authz::Subject::user(alice_info.id);
+        let bob = authz::Subject::user(bob.id);
+        let alice_and_bob = authz::Subject::group(alice_and_bob.id);
+
+        app.post("/authz/grants")
+            .by_user(admin.as_ref())
+            .json(&json!({
+                "grant": [
+                    {
+                        "subject_id": alice_and_bob.id(),
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id,
+                        "grant": StandardGrant::Owner
+                    },
+                ]
+            }))
+            .await
+            .assert_status(StatusCode::CREATED);
+
+        let project = authz::Project(project_id);
+        assert_eq!(
+            openfga.project_direct_grant(alice, project).await,
+            Some(ProjectGrant::Owner)
+        );
+        assert_eq!(openfga.project_direct_grant(bob, project).await, None);
+        assert_eq!(
+            openfga.project_direct_grant(alice_and_bob, project).await,
+            Some(ProjectGrant::Owner)
+        );
+        app.assert_project_grant(project_id, alice.id(), Some(ProjectGrant::Owner))
+            .await;
+        app.assert_project_grant(project_id, bob.id(), Some(ProjectGrant::Owner))
+            .await;
+
+        app.post("/authz/grants")
+            .by_user(admin.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": alice_and_bob.id(),
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id
+                    }
+                ]
+            }))
+            .await
+            .assert_status_no_content();
+
+        assert_eq!(
+            openfga.project_direct_grant(alice_and_bob, project).await,
+            None
+        );
+        assert_eq!(
+            openfga.project_direct_grant(alice, project).await,
+            Some(ProjectGrant::Owner)
+        );
     }
 
     #[rstest]
@@ -2918,6 +3138,16 @@ mod tests {
             .create()
             .await,
     )]
+    #[case::project(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        ResourceType::Project,
+        app
+            .user("owner", "Owner")
+            .with_project_grant(resource_id, ProjectGrant::Owner)
+            .create()
+            .await,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn non_admin_forbidden_to_give_groups_any_grant(
         #[case] app: TestApp,
@@ -2936,7 +3166,7 @@ mod tests {
                         "subject_id": group.id,
                         "resource_type": resource_type,
                         "resource_id": resource_id,
-                        "grant": StandardGrant::Reader
+                        "grant": StandardGrant::Owner
                     }
                 ]
             }))
@@ -2954,7 +3184,10 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, group.id, None)
                     .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => {
+                app.assert_project_grant(resource_id, bob.id, None).await;
+                app.assert_project_grant(resource_id, group.id, None).await;
+            }
         }
     }
 
@@ -3090,6 +3323,11 @@ mod tests {
         create_fast_rolling_stock(&mut app.db_pool().get_ok(), "rolling_stock").await.id,
         ResourceType::RollingStock,
     )]
+    #[case::project(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        ResourceType::Project,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn skipped_authz_can_set_grants(
         #[case] app: TestApp,
@@ -3105,7 +3343,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, user.0, None)
                     .await;
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => app.assert_project_grant(resource_id, user.0, None).await,
         }
         app.post("/authz/grants")
             .skip_authz()
@@ -3142,7 +3380,17 @@ mod tests {
                     Some(RollingStockGrant::Owner)
                 );
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => {
+                assert_eq!(
+                    app.openfga()
+                        .project_direct_grant(
+                            authz::Subject::User(user),
+                            authz::Project(resource_id)
+                        )
+                        .await,
+                    Some(ProjectGrant::Owner)
+                );
+            }
         }
     }
 
@@ -3168,7 +3416,17 @@ mod tests {
                 .create()
                 .await,
         ),
-
+    )]
+    #[case::project(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        ResourceType::Project,
+        authz::User::from(
+            app.user("user", "User")
+                .with_project_grant(resource_id, ProjectGrant::Owner)
+                .create()
+                .await,
+        ),
     )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn skipped_authz_can_remove_grants(
@@ -3185,7 +3443,10 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, user.0, Some(RollingStockGrant::Owner))
                     .await
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => {
+                app.assert_project_grant(resource_id, user.0, Some(ProjectGrant::Owner))
+                    .await
+            }
         };
         app.post("/authz/grants")
             .skip_authz()
@@ -3207,7 +3468,7 @@ mod tests {
                 app.assert_rolling_stock_grant(resource_id, user.0, None)
                     .await
             }
-            ResourceType::Project => todo!(),
+            ResourceType::Project => app.assert_project_grant(resource_id, user.0, None).await,
         };
     }
 
@@ -3234,6 +3495,16 @@ mod tests {
             .create()
             .await,
     )]
+    #[case::project(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        ResourceType::Project,
+        app
+            .user("owner", "Owner")
+            .with_roles([Role::Admin])
+            .create()
+            .await,
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn remove_a_grant_that_doesnt_exist(
         #[case] app: TestApp,
@@ -3255,6 +3526,102 @@ mod tests {
             }))
             .await
             .assert_status_no_content();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_owner_cannot_remove_grant() {
+        let app = test_app!().build();
+        let project_id = create_project(&mut app.db_pool().get_ok(), "project")
+            .await
+            .id;
+        let owner = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(project_id, ProjectGrant::Owner)
+            .create()
+            .await;
+        let other = app.user("other", "Other").create().await;
+        app.post("/authz/grants")
+            .by_user(owner.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": other.id,
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id,
+                    }
+                ]
+            }))
+            .await
+            .assert_status_forbidden();
+
+        let other_owner = app
+            .user("other_owner", "OtherOwner")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(project_id, ProjectGrant::Owner)
+            .create()
+            .await;
+        app.post("/authz/grants")
+            .by_user(owner.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": other_owner.id,
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id,
+                    }
+                ]
+            }))
+            .await
+            .assert_status_forbidden();
+        app.post("/authz/grants")
+            .by_user(owner.as_ref())
+            .json(&json!({
+                "revoke": [
+                    {
+                        "subject_id": owner.id,
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id,
+                    }
+                ]
+            }))
+            .await
+            .assert_status_forbidden();
+    }
+
+    #[rstest]
+    #[case::restricted_reader(StandardGrant::RestrictedReader)]
+    #[case::reader(StandardGrant::Reader)]
+    #[case::writer(StandardGrant::Writer)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn invalid_project_grant(#[case] invalid_grant: StandardGrant) {
+        let app = test_app!().build();
+        let project_id = create_project(&mut app.db_pool().get_ok(), "project")
+            .await
+            .id;
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        let user_id = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await
+            .id;
+        app.post("/authz/grants")
+            .by_user(admin.as_ref())
+            .json(&json!({
+                    "grant": [{
+                        "subject_id": user_id,
+                        "resource_type": ResourceType::Project,
+                        "resource_id": project_id,
+                        "grant": invalid_grant,
+                    }]
+            }))
+            .await
+            .assert_status_unprocessable_entity();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/authz/resources.rs
+++ b/editoast/src/views/authz/resources.rs
@@ -1,6 +1,7 @@
 use authz::InfraGrant;
 use authz::InfraPrivilege;
 use authz::ProjectGrant;
+use authz::ProjectPrivilege;
 use authz::RollingStockGrant;
 use authz::RollingStockPrivilege;
 use serde::Deserialize;
@@ -106,6 +107,13 @@ macro_rules! impl_standard_grant_from_into {
 
 impl_standard_privilege_from_into!(RollingStockPrivilege);
 impl_standard_privilege_from_into!(InfraPrivilege);
+impl From<ProjectPrivilege> for StandardPrivilege {
+    fn from(privilege: ProjectPrivilege) -> Self {
+        match privilege {
+            ProjectPrivilege::HasAccess => Self::HasAccess,
+        }
+    }
+}
 impl_standard_grant_from_into!(RollingStockGrant);
 impl_standard_grant_from_into!(InfraGrant);
 impl From<ProjectGrant> for StandardGrant {

--- a/editoast/src/views/authz/resources.rs
+++ b/editoast/src/views/authz/resources.rs
@@ -17,6 +17,11 @@ pub enum Resource {
     Project(authz::Project),
 }
 
+/// Error returned when a [`StandardGrant`] cannot be converted to a resource-specific grant.
+///
+/// Keeps the rejected grant available so endpoints can turn it into the appropriate API error.
+pub(super) struct IncompatibleGrant(pub(super) StandardGrant);
+
 impl Resource {
     pub(super) fn id(&self) -> i64 {
         match self {
@@ -120,6 +125,19 @@ impl From<ProjectGrant> for StandardGrant {
     fn from(grant: ProjectGrant) -> Self {
         match grant {
             ProjectGrant::Owner => Self::Owner,
+        }
+    }
+}
+
+impl TryFrom<StandardGrant> for ProjectGrant {
+    type Error = IncompatibleGrant;
+
+    fn try_from(grant: StandardGrant) -> Result<Self, Self::Error> {
+        match grant {
+            StandardGrant::Owner => Ok(Self::Owner),
+            StandardGrant::RestrictedReader | StandardGrant::Reader | StandardGrant::Writer => {
+                Err(IncompatibleGrant(grant))
+            }
         }
     }
 }

--- a/editoast/src/views/authz/resources.rs
+++ b/editoast/src/views/authz/resources.rs
@@ -1,5 +1,6 @@
 use authz::InfraGrant;
 use authz::InfraPrivilege;
+use authz::ProjectGrant;
 use authz::RollingStockGrant;
 use authz::RollingStockPrivilege;
 use serde::Deserialize;
@@ -32,9 +33,9 @@ impl Resource {
     }
 }
 
-#[derive(Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema, Debug, Display)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 pub(super) enum StandardGrant {
     RestrictedReader,
     Reader,
@@ -55,6 +56,7 @@ pub(super) enum StandardPrivilege {
     CanDelete,
     CanShareOwnership,
     CanRevoke,
+    HasAccess,
 }
 
 macro_rules! impl_standard_privilege_from_into {
@@ -106,3 +108,10 @@ impl_standard_privilege_from_into!(RollingStockPrivilege);
 impl_standard_privilege_from_into!(InfraPrivilege);
 impl_standard_grant_from_into!(RollingStockGrant);
 impl_standard_grant_from_into!(InfraGrant);
+impl From<ProjectGrant> for StandardGrant {
+    fn from(grant: ProjectGrant) -> Self {
+        match grant {
+            ProjectGrant::Owner => Self::Owner,
+        }
+    }
+}

--- a/editoast/src/views/authz/resources.rs
+++ b/editoast/src/views/authz/resources.rs
@@ -12,6 +12,7 @@ use crate::views::authz::ResourceType;
 pub enum Resource {
     Infra(authz::Infra),
     RollingStock(authz::RollingStock),
+    Project(authz::Project),
 }
 
 impl Resource {
@@ -19,12 +20,14 @@ impl Resource {
         match self {
             Resource::Infra(authz::Infra(id)) => *id,
             Resource::RollingStock(authz::RollingStock(id)) => *id,
+            Resource::Project(authz::Project(id)) => *id,
         }
     }
     pub(super) fn get_type(&self) -> ResourceType {
         match self {
             Resource::Infra(_) => ResourceType::Infra,
             Resource::RollingStock(_) => ResourceType::RollingStock,
+            Resource::Project(_) => ResourceType::Project,
         }
     }
 }

--- a/editoast/src/views/authz/resources.rs
+++ b/editoast/src/views/authz/resources.rs
@@ -70,21 +70,6 @@ macro_rules! impl_standard_privilege_from_into {
                 }
             }
         }
-
-        impl From<StandardPrivilege> for $ty {
-            fn from(privilege: StandardPrivilege) -> Self {
-                match privilege {
-                    StandardPrivilege::CanRestrictedRead => Self::CanRestrictedRead,
-                    StandardPrivilege::CanRead => Self::CanRead,
-                    StandardPrivilege::CanShareRead => Self::CanShareRead,
-                    StandardPrivilege::CanWrite => Self::CanWrite,
-                    StandardPrivilege::CanShareWrite => Self::CanShareWrite,
-                    StandardPrivilege::CanDelete => Self::CanDelete,
-                    StandardPrivilege::CanShareOwnership => Self::CanShareOwnership,
-                    StandardPrivilege::CanRevoke => Self::CanRevoke,
-                }
-            }
-        }
     };
 }
 

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -446,6 +446,25 @@ impl TestApp {
             "Infra grant for subject '{subject_id}' on infra '{infra_id}' does not match"
         );
     }
+
+    pub async fn assert_project_grant(
+        &self,
+        project_id: i64,
+        subject_id: i64,
+        expected_grant: Option<ProjectGrant>,
+    ) {
+        let subject = self.authz_subject(subject_id);
+        let project = authz::Project(project_id);
+        let actual_grant = self
+            .openfga()
+            .project_effective_grant(subject, project)
+            .await;
+        pretty_assertions::assert_eq!(
+            actual_grant,
+            expected_grant,
+            "Project grant for subject '{subject_id}' on project {project_id} does not match"
+        );
+    }
 }
 
 pub struct UserBuilder<'a> {

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -2,6 +2,7 @@
 //! test axum server, database connection pool, and different mocking
 //! components.
 
+use authz::ProjectGrant;
 use authz::RollingStock;
 use authz::RollingStockGrant;
 use authz::v2;
@@ -453,6 +454,7 @@ pub struct UserBuilder<'a> {
     roles: HashSet<Role>,
     infras_grant: HashMap<i64, InfraGrant>,
     rolling_stock_grants: HashMap<i64, RollingStockGrant>,
+    project_grants: HashMap<i64, ProjectGrant>,
 }
 
 pub struct GroupBuilder<'a> {
@@ -462,6 +464,7 @@ pub struct GroupBuilder<'a> {
     members: HashSet<&'a authz::identity::User>,
     infras_grant: HashMap<i64, InfraGrant>,
     rolling_stock_grants: HashMap<i64, RollingStockGrant>,
+    project_grants: HashMap<i64, ProjectGrant>,
 }
 
 impl<'a> UserBuilder<'a> {
@@ -472,6 +475,7 @@ impl<'a> UserBuilder<'a> {
             roles: Default::default(),
             infras_grant: HashMap::default(),
             rolling_stock_grants: HashMap::default(),
+            project_grants: HashMap::default(),
         }
     }
 
@@ -494,6 +498,11 @@ impl<'a> UserBuilder<'a> {
         self
     }
 
+    pub fn with_project_grant(mut self, project_id: i64, grant: ProjectGrant) -> Self {
+        self.project_grants.insert(project_id, grant);
+        self
+    }
+
     pub async fn create(self) -> authz::identity::User {
         let Self {
             app,
@@ -501,9 +510,13 @@ impl<'a> UserBuilder<'a> {
             roles,
             infras_grant,
             rolling_stock_grants,
+            project_grants,
         } = self;
 
-        if (!roles.is_empty() || !infras_grant.is_empty() || !rolling_stock_grants.is_empty())
+        if (!roles.is_empty()
+            || !infras_grant.is_empty()
+            || !rolling_stock_grants.is_empty()
+            || !project_grants.is_empty())
             && !app.enable_authorization
         {
             panic!("An OpenFGA model must be provided to grant a user roles or infra grants");
@@ -522,25 +535,24 @@ impl<'a> UserBuilder<'a> {
                 .await;
 
             let system = SystemAuthorizer::new_infallible(&app.app_state.openfga);
+            let subject = authz::Subject::user(user.id);
             for (infra_id, grant) in infras_grant.into_iter() {
-                v2::infra_set_grant(
-                    authz::Subject::User(authz::User(user.id)),
-                    authz::Infra(infra_id),
-                    grant,
-                )
-                .authorize(&system)
-                .await
-                .expect("Infra grant should be given successfully")
-                .unwrap_authorized()
-                .await;
+                v2::infra_set_grant(subject, authz::Infra(infra_id), grant)
+                    .authorize(&system)
+                    .await
+                    .expect("Infra grant should be given successfully")
+                    .unwrap_authorized()
+                    .await;
             }
             for (rolling_stock_id, grant) in rolling_stock_grants.into_iter() {
                 app.openfga()
-                    .rolling_stock_set_grant(
-                        RollingStock(rolling_stock_id),
-                        authz::Subject::User(authz::User(user.id)),
-                        grant,
-                    )
+                    .rolling_stock_set_grant(RollingStock(rolling_stock_id), subject, grant)
+                    .await;
+            }
+            for (project_id, grant) in project_grants.into_iter() {
+                debug_assert!(matches!(grant, ProjectGrant::Owner));
+                app.openfga()
+                    .project_set_grant(subject, authz::Project(project_id))
                     .await;
             }
         }
@@ -557,6 +569,7 @@ impl<'a> GroupBuilder<'a> {
             members: Default::default(),
             infras_grant: HashMap::default(),
             rolling_stock_grants: HashMap::default(),
+            project_grants: HashMap::default(),
         }
     }
 
@@ -588,6 +601,11 @@ impl<'a> GroupBuilder<'a> {
         self
     }
 
+    pub fn with_project_grant(mut self, project_id: i64, grant: ProjectGrant) -> Self {
+        self.project_grants.insert(project_id, grant);
+        self
+    }
+
     pub async fn create(self) -> authz::identity::Group {
         let Self {
             app,
@@ -596,6 +614,7 @@ impl<'a> GroupBuilder<'a> {
             members,
             infras_grant,
             rolling_stock_grants,
+            project_grants,
         } = self;
         let needs_openfga = !roles.is_empty()
             || !members.is_empty()
@@ -648,6 +667,12 @@ impl<'a> GroupBuilder<'a> {
                 app.openfga()
                     .rolling_stock_set_grant(RollingStock(rolling_stock_id), subject, grant)
                     .await;
+            }
+            for (project_id, grant) in project_grants.into_iter() {
+                debug_assert!(matches!(grant, ProjectGrant::Owner));
+                app.openfga()
+                    .project_set_grant(subject, authz::Project(project_id))
+                    .await
             }
         }
         group

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -42,6 +42,7 @@
       "Database": "Internal error (database)",
       "Driver": "Authentication/authorization internal error, try again or contact support",
       "GrantsApiMisuse": "Improper API usage",
+      "IncompatibleGrant": "Authorization incompatible with the provided resource type",
       "NoSuchUser": "Unknown user",
       "UnknownIdentities": "Unknown identities '{{identities}}'",
       "UnknownResource": "Unknown resource",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -42,6 +42,7 @@
       "Database": "Internal error (database)",
       "Driver": "Erreur interne d'authentification ou d'autorisation, veuillez réessayer ou contacter le support",
       "GrantsApiMisuse": "Mauvaise utilisation de l'API d'autorisation",
+      "IncompatibleGrant": "Authorisation incompatible avec le type de resource associé",
       "NoSuchUser": "Utilisateur inconnu",
       "UnknownIdentities": "Identités inconnues '{{identities}}'",
       "UnknownResource": "Ressource inconnue",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2998,7 +2998,8 @@ export type StandardPrivilege =
   | 'can_share_write'
   | 'can_delete'
   | 'can_share_ownership'
-  | 'can_revoke';
+  | 'can_revoke'
+  | 'has_access';
 export type SubjectType = 'User' | 'Group';
 export type PaginationStats = {
   /** The total number of items */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2977,7 +2977,7 @@ export type PostWorkerLoadApiArg = {
   };
 };
 export type StandardGrant = 'RESTRICTED_READER' | 'READER' | 'WRITER' | 'OWNER';
-export type ResourceType = 'infra' | 'rolling_stock';
+export type ResourceType = 'infra' | 'rolling_stock' | 'project';
 export type GrantBody = {
   grant: StandardGrant;
   resource_id: number;

--- a/front/src/common/authorization/hooks/useAuthz.tsx
+++ b/front/src/common/authorization/hooks/useAuthz.tsx
@@ -101,17 +101,29 @@ export default function useAuthz() {
     async (resourceType: ResourceType, resourceId: number, privileges: Privilege[]) => {
       let infras: number[];
       let rolling_stocks: number[];
+      let projects: number[];
       switch (resourceType) {
         case 'rolling_stock':
           infras = [];
           rolling_stocks = [resourceId];
+          projects = [];
           break;
         case 'infra':
           infras = [resourceId];
           rolling_stocks = [];
+          projects = [];
+          break;
+        case 'project':
+          infras = [];
+          rolling_stocks = [];
+          projects = [resourceId];
           break;
       }
-      const result = await getUserPrivileges({ infra: infras, rolling_stock: rolling_stocks });
+      const result = await getUserPrivileges({
+        infra: infras,
+        rolling_stock: rolling_stocks,
+        project: projects,
+      });
       const userPrivileges = result[resourceType] ? result[resourceType][resourceId] : new Set();
       return privileges.every((privilege) => userPrivileges.has(privilege));
     },

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -612,6 +612,23 @@ class EditoastAuthzErrorDatabase(BaseModel):
     type: Literal["editoast:authz:Database"] = "editoast:authz:Database"
 
 
+class EditoastAuthzErrorIncompatibleGrantContext(BaseModel):
+    grant: dict[str, Any]
+    resource_type: dict[str, Any]
+
+
+class EditoastAuthzErrorIncompatibleGrant(BaseModel):
+    context: Annotated[
+        EditoastAuthzErrorIncompatibleGrantContext | None,
+        Field(title="EditoastAuthzErrorIncompatibleGrantContext"),
+    ] = None
+    message: str
+    status: Literal[422] = 422
+    type: Literal["editoast:authz:IncompatibleGrant"] = (
+        "editoast:authz:IncompatibleGrant"
+    )
+
+
 class EditoastAuthzErrorUnknownIdentitiesContext(BaseModel):
     identities: dict[str, Any]
 
@@ -4944,6 +4961,7 @@ class EditoastError(
         | EditoastAuthorizationErrorOpenFga
         | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorDatabase
+        | EditoastAuthzErrorIncompatibleGrant
         | EditoastAuthzErrorUnknownIdentities
         | EditoastAuthzErrorUnknownResource
         | EditoastAuthzErrorUnknownSubject
@@ -5122,6 +5140,7 @@ class EditoastError(
         | EditoastAuthorizationErrorOpenFga
         | EditoastAuthorizationErrorUnauthenticated
         | EditoastAuthzErrorDatabase
+        | EditoastAuthzErrorIncompatibleGrant
         | EditoastAuthzErrorUnknownIdentities
         | EditoastAuthzErrorUnknownResource
         | EditoastAuthzErrorUnknownSubject

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -4163,6 +4163,7 @@ class StandardPrivilege(Enum):
     can_delete = "can_delete"
     can_share_ownership = "can_share_ownership"
     can_revoke = "can_revoke"
+    has_access = "has_access"
 
 
 class StartTimeChangeGroup(BaseModel):

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -3591,6 +3591,7 @@ class RequirementType(Enum):
 class ResourceType(Enum):
     infra = "infra"
     rolling_stock = "rolling_stock"
+    project = "project"
 
 
 class RevokeBody(BaseModel):


### PR DESCRIPTION
Ref: #17546

Managing project permissions requires a new authorization resource type. Update the `authz` endpoints and their API so that they can handle project resources.

- Add a new resource type for projects to the `authz` endpoints API:
  - `views::authz::Resource`: add new `Resource::Project`
  - `views::authz::ResourceType`: add new `ResourceType::Project`
- Handle it in the `authz` endpoints:
  - `POST:/authz/me/privileges`: add the issuer privileges on projects to the response.
  - `POST:/authz/me/grants`: add the issuer grants on projects to the response.
  - `GET:/authz/{resource_type}/{resource_id}`: accept projects as a valid resource type.
  - `POST:/authz/grants`: allow to revoke and give grants on projects.