### PR TITLE
front: added placeholder for 'train-header-category-select'

### DIFF
--- a/front/public/locales/de/translation.json
+++ b/front/public/locales/de/translation.json
@@ -696,7 +696,8 @@
       "TRAM_TRAIN": "Tram-Train",
       "WORK_TRAIN": "Bauzug",
       "choose": "Kategorie auswählen",
-      "noCategory": "Keine Kategorie"
+      "noCategory": "Keine Kategorie",
+      "none": "Keiner"
     },
     "chooseRollingStock": "Wählen Sie ein Schienenfahrzeug aus, um dessen Informationen anzuzeigen",
     "comfort": "Komfort",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -707,7 +707,8 @@
       "TRAM_TRAIN": "Tram-Train",
       "WORK_TRAIN": "Work Train",
       "choose": "Choose a category",
-      "noCategory": "No category"
+      "noCategory": "No category",
+      "none": "None"
     },
     "chooseRollingStock": "Select a rolling stock to display information",
     "comfort": "Comfort",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -707,7 +707,8 @@
       "TRAM_TRAIN": "Tram-train",
       "WORK_TRAIN": "Train de travaux",
       "choose": "Choisissez une catégorie",
-      "noCategory": "Pas de catégorie"
+      "noCategory": "Pas de catégorie",
+      "none": "Aucun"
     },
     "chooseRollingStock": "Sélectionnez un matériel roulant pour en afficher les informations",
     "comfort": "Confort",

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -220,7 +220,7 @@ const ExpandedTrainForm = ({
   const { t } = useTranslation(['operational-studies', 'translation']);
   const infraID = useInfraID();
   const speedLimitTags = useSpeedLimitTags(infraID);
-  const categoryOptions = useCategoryOptions();
+  const categoryOptions = useCategoryOptions(false);
 
   const { filteredRollingStockList: rollingStocks } = useFilterRollingStock();
 
@@ -473,6 +473,7 @@ const ExpandedTrainForm = ({
             id="train-header-category-select"
             label={t('manageTrainSchedule.trainHeader.form.trainCategory')}
             small
+            placeholder={t('translation:rollingStock.categoriesOptions.none')}
             value={selectedCategoryOption}
             options={categoryOptions}
             getOptionLabel={(option) => option?.label ?? ''}


### PR DESCRIPTION
This is a minimalist change PR I could think with very few code change . So there are the changes .

1st -> added false in useCategoryOptions(false); , this false overrides the push a dummy placeholder logic in the useCategoryOptions Function.

2nd ->added  placeholder=placeholder={t('translation:rollingStock.categoriesOptions.none')} 

3rd -> added value of none in en/fr/de translation.json 

Fixes https://github.com/OpenRailAssociation/osrd/issues/17920 .

Supersedes The old pull request =>  #17966

