### PR TITLE
front: set new train start time to relevant midnight

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
@@ -32,7 +32,11 @@ import RoundTripsModal from '../RoundTrips/RoundTripsModal';
 import FilterPanel from './FilterPanel';
 import SelectionToolBar from './TimetableSelectionToolbar';
 import type { TimetableFilters, TimetableMode } from './types';
-import { exportTrainSchedules, timetableHasInvalidTrainSchedule } from './utils';
+import {
+  computeLatestMidnight,
+  exportTrainSchedules,
+  timetableHasInvalidTrainSchedule,
+} from './utils';
 
 type TimetableToolbarProps = {
   timetableFilters: TimetableFilters;
@@ -70,7 +74,7 @@ const TimetableToolbar = ({
   const { t } = useTranslation(['operational-studies', 'translation'], { keyPrefix: 'main' });
   const dispatch = useAppDispatch();
 
-  const { infraId, timetableId } = useScenarioContext();
+  const { infraId, timetableId, scenario } = useScenarioContext();
   const { trainSchedules } = useTimetableContext();
 
   const { data: trainScheduleRoundTripsData } =
@@ -208,7 +212,14 @@ const TimetableToolbar = ({
             data-testid="scenarios-add-train-schedule-button"
             title={t('timetable.addTrainSchedule')}
             onClick={() => {
-              dispatch(resetItineraryForm());
+              dispatch(
+                resetItineraryForm({
+                  startTime:
+                    scenario.timetable_type === 'CALENDAR'
+                      ? computeLatestMidnight(trainSchedules, new Date())
+                      : undefined,
+                })
+              );
               setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.add);
             }}
             type="button"

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 
 import type { RoundTrips, TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import { Duration } from 'utils/duration';
 
-import { buildTimetableExportPayload } from '../utils';
+import { buildTimetableExportPayload, computeLatestMidnight } from '../utils';
 
 const buildTrainSchedule = (id: number): TrainScheduleResponse =>
   ({
@@ -39,5 +40,81 @@ describe('buildTimetableExportPayload', () => {
     });
 
     expect(payload.round_trips).toEqual([[0, null]]);
+  });
+});
+
+const buildTrainScheduleWithStartTime = (
+  id: number,
+  startTime: Date,
+  interval?: Duration,
+  timeWindow?: Duration,
+  exceptionsStartTimes?: Date[]
+): TrainScheduleResponse => ({
+  id,
+  train_schedule_set_id: 1,
+  constraint_distribution: 'STANDARD',
+  path: [],
+  rolling_stock_name: '',
+  start_time: +startTime,
+  train_name: '',
+  paced:
+    interval && timeWindow
+      ? {
+          interval: interval.toISOString(),
+          time_window: timeWindow.toISOString(),
+          exceptions:
+            exceptionsStartTimes?.map((exceptionStartTime, idx) => ({
+              id: idx,
+              key: `${idx}`,
+              start_time: { value: +exceptionStartTime },
+            })) ?? [],
+        }
+      : undefined,
+});
+
+describe('computeLatestMidnight', () => {
+  it('should return midnight from today if there is no train schedules given', () => {
+    const now = new Date(2026, 7, 4, 16, 43, 19, 444);
+    const result = computeLatestMidnight([], now);
+
+    expect(result).toEqual(new Date(2026, 7, 4, 0, 0, 0, 0));
+  });
+
+  it('should return midnight from the latest occurrence of a timetable with a service', () => {
+    const now = new Date(2026, 7, 4, 16, 43, 19, 444);
+
+    const result = computeLatestMidnight(
+      [
+        buildTrainScheduleWithStartTime(1, new Date(2026, 6, 29, 14, 12, 0, 0)),
+        buildTrainScheduleWithStartTime(
+          2,
+          new Date(2026, 6, 30, 9, 24, 0, 0),
+          new Duration({ hours: 12 }),
+          new Duration({ hours: 72 })
+        ),
+      ],
+      now
+    );
+
+    expect(result).toEqual(new Date(2026, 7, 1, 0, 0, 0, 0));
+  });
+
+  it('should return midnight from the latest exception or occurrence', () => {
+    const now = new Date(2026, 7, 4, 17, 57, 15, 555);
+
+    const result = computeLatestMidnight(
+      [
+        buildTrainScheduleWithStartTime(
+          1,
+          new Date(2026, 6, 30, 9, 24, 0, 0),
+          new Duration({ hours: 12 }),
+          new Duration({ hours: 72 }),
+          [new Date(2026, 7, 3, 9, 24, 0, 0)]
+        ),
+      ],
+      now
+    );
+
+    expect(result).toEqual(new Date(2026, 7, 3, 0, 0, 0, 0));
   });
 });

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { omit } from 'lodash';
 
+import { generateBareOccurrences } from 'applications/operationalStudies/helpers/generateBareOccurrences';
 import type { RoundTripsFromJson } from 'applications/operationalStudies/types';
 import type {
   TrainSchedule,
@@ -13,7 +14,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import isMainCategory from 'modules/rollingStock/helpers/category';
 import type { SimulationSummary, TrainScheduleWithDetails } from 'modules/trainSchedule/types';
-import type { Duration } from 'utils/duration';
+import { Duration } from 'utils/duration';
 
 import { specialCodeDictionary, TRAIN_MAIN_CATEGORY_CLASS } from './consts';
 
@@ -243,3 +244,43 @@ export const sortTrainScheduleSets = (
   if (name1 > name2) return 1;
   return 0;
 };
+
+/**
+ * Compute the latest midnight that happen before the last start time of a set of train schedules,
+ * including their occurrences and exceptions.
+ */
+export function computeLatestMidnight(trainSchedules: TrainScheduleResponse[], now: Date): Date {
+  if (trainSchedules.length === 0) {
+    const midnight = new Date(now);
+    midnight.setHours(0, 0, 0, 0);
+    return midnight;
+  }
+
+  const latestStartTime = trainSchedules.map(
+    (trainSchedule: TrainScheduleResponse): Date | undefined => {
+      if (!trainSchedule.paced) return new Date(trainSchedule.start_time);
+
+      const occurrences = generateBareOccurrences({
+        id: trainSchedule.id,
+        startTime: new Date(trainSchedule.start_time),
+        paced: {
+          timeWindow: Duration.parse(trainSchedule.paced.time_window),
+          interval: Duration.parse(trainSchedule.paced.interval),
+          exceptions: trainSchedule.paced.exceptions,
+        },
+      });
+
+      return occurrences
+        .map(({ startTime }) => startTime)
+        .toSorted((a, b) => +b - +a)
+        .at(0);
+    }
+  );
+
+  const midnight = new Date(
+    latestStartTime.toSorted((a, b) => (a && b ? +b - +a : 0)).at(0) ?? now
+  );
+  midnight.setHours(0, 0, 0, 0);
+
+  return midnight;
+}

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/itineraryReducer.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/itineraryReducer.ts
@@ -47,12 +47,13 @@ const testItineraryReducer = () => {
   it('should handle resetItineraryForm', () => {
     const pathSteps = testDataBuilder.buildPathSteps();
     const store = createStore({ pathSteps });
-    store.dispatch(resetItineraryForm());
+    store.dispatch(resetItineraryForm({ startTime: new Date(2026, 7, 4, 0, 0, 0) }));
     const state = getState();
     expect(state.category).toBe(operationalStudiesInitialConf.category);
     expect(state.rollingStockName).toBe(operationalStudiesInitialConf.rollingStockName);
     expect(state.name).toBe(operationalStudiesInitialConf.name);
     expect(state.pathSteps).toEqual(operationalStudiesInitialConf.pathSteps);
+    expect(state.startTime).toEqual(new Date(2026, 7, 4, 0, 0, 0));
   });
 };
 

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -99,11 +99,15 @@ export const operationalStudiesConfSlice = createSlice({
       }
     },
     // Clears stale data left by selectTrainToEdit/updateItineraryForm so a new train form starts empty
-    resetItineraryForm(state: Draft<OperationalStudiesConfState>) {
+    resetItineraryForm(
+      state: Draft<OperationalStudiesConfState>,
+      action: PayloadAction<{ startTime: Date | undefined }>
+    ) {
       return {
         ...operationalStudiesInitialConf,
         mapSettings: state.mapSettings,
         infraID: state.infraID,
+        startTime: action.payload.startTime ?? operationalStudiesInitialConf.startTime,
       };
     },
     // Use this action to transform an op to via from times and stop table or

--- a/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
+++ b/front/tests/02-operational-studies/paced-trains/001-paced-train-management.spec.ts
@@ -27,6 +27,7 @@ import test from '../../page-object-fixture';
 import { waitForInfraStateToBeCached } from '../../utils';
 import { getInfra } from '../../utils/api-utils';
 import { cleanWhitespace } from '../../utils/data-normalizer';
+import { createDateInSpecialTimeZone } from '../../utils/date-utils';
 import { readJsonFile } from '../../utils/file-utils';
 import createScenario from '../../utils/scenario';
 import sendTrains from '../../utils/send-trains';
@@ -100,7 +101,13 @@ test.describe('Paced train management', { tag: ['@op', '@paced-trains'] }, () =>
     });
 
     await test.step('Verify default inputs/buttons', async () => {
-      await operationalStudiesPage.checkInputsAndButtons(frTranslations, scenario.creation_date);
+      const midnight = createDateInSpecialTimeZone(scenario.creation_date, 'Europe/Paris')
+        .set('hours', 0)
+        .set('minutes', 0)
+        .set('seconds', 0)
+        .set('milliseconds', 0)
+        .toDate();
+      await operationalStudiesPage.checkInputsAndButtons(frTranslations, midnight.toISOString());
     });
 
     await test.step('Verify tabs default behavior', async () => {

--- a/front/tests/pages/operational-studies/operational-studies-page.ts
+++ b/front/tests/pages/operational-studies/operational-studies-page.ts
@@ -151,11 +151,11 @@ class OperationalStudiesPage extends ScenarioTimetableSection {
       await this.startTimeField.inputValue(),
       'Europe/Paris'
     ).toDate();
-    const scenarioCreationDate = new Date(date);
+    const expectedDate = new Date(date);
     const isSameDate =
-      startTimeDate.getFullYear() === scenarioCreationDate.getFullYear() &&
-      startTimeDate.getMonth() === scenarioCreationDate.getMonth() &&
-      startTimeDate.getDate() === scenarioCreationDate.getDate();
+      startTimeDate.getFullYear() === expectedDate.getFullYear() &&
+      startTimeDate.getMonth() === expectedDate.getMonth() &&
+      startTimeDate.getDate() === expectedDate.getDate();
     expect(isSameDate).toBe(true);
 
     await expect(this.initialSpeedInput).toBeVisible();


### PR DESCRIPTION
Closes #17555.

We now want the start time to be set to the midnight of the latest day of the current timetable (according to specs). Of course, this kind of thing is only relevant in calendar timetable types; in any other kind, we will use an offset of zero instead, as soon as we will support them.

It's basically a matter of creating a helper (`computeLatestMidnight`) that takes all the train schedules we have in the scenario and get the latest start time; the complexity is the handling of occurrences, that we have to quickly regenerate using `generateBareOccurrences` to get the data we need. The result of this computing is put into the modal's store; it's quite ironic because I'll get rid of that whole thing in my next PR, so I didn't thought _that_ much about that.