### PR TITLE
editoast: authz: remove DB checks in `Protected`

### DIFF
--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -17,16 +17,15 @@ use std::collections::HashSet;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 
-use crate::Group;
 use crate::Infra;
 use crate::InfraGrant;
 use crate::InfraPrivilege;
+use crate::Project;
 use crate::Role;
 use crate::RollingStock;
 use crate::RollingStockGrant;
 use crate::Subject;
 use crate::User;
-use crate::model::Project;
 use crate::model::RollingStockPrivilege;
 
 pub type OpenFgaError = fga::client::Error;
@@ -98,25 +97,6 @@ pub enum Check {
     SubjectEffectiveRollingStockGrantIsNot(RollingStockGrant, Subject, RollingStock),
     /// The subject must not be the last direct owner of the rolling stock
     IsNotLastRollingStockOwner(Subject, RollingStock),
-
-    /// The subject must exist in PostgreSQL
-    SubjectExists(Subject),
-    /// The infra must exist in PostgreSQL
-    InfraExists(Infra),
-    /// The rolling stock must exist in PostgreSQL
-    RollingStockExists(RollingStock),
-    /// The project must exist in PostgreSQL
-    ProjectExists(Project),
-}
-
-impl Check {
-    pub fn user(user: User) -> Self {
-        Check::SubjectExists(Subject::User(user))
-    }
-
-    pub fn group(group: Group) -> Self {
-        Check::SubjectExists(Subject::Group(group))
-    }
 }
 
 /// The result of authorizing a [Protected] operation via [Authorizer::authorize]

--- a/editoast/authz/src/v2/group.rs
+++ b/editoast/authz/src/v2/group.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use fga::client::UserList;
 use fga::model::Relation as _;
 use futures::FutureExt as _;
-use itertools::Itertools as _;
 
 use crate::Group;
 use crate::Role;
@@ -29,7 +28,6 @@ pub fn group_members(group: Group) -> Protected<Vec<User>> {
         }
         .boxed()
     })
-    .with_check(Check::group(group))
 }
 
 pub fn user_groups(user: User) -> Protected<Vec<Group>> {
@@ -47,15 +45,12 @@ pub fn user_groups(user: User) -> Protected<Vec<Group>> {
         }
         .boxed()
     })
-    .with_check(Check::user(user))
 }
 
 /// Adds some members to a group
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
-    let user_exists_checks = members.iter().map(|user| Check::user(*user)).collect_vec(); // members is moved in Protected
-
     group_members(group)
         .map(move |openfga, existing_members| {
             async move {
@@ -71,7 +66,6 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
             }
             .boxed()
         })
-        .with_check_iter(user_exists_checks)
         .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
 }
 
@@ -79,8 +73,6 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
 ///
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
-    let user_exists_checks = members.iter().map(|user| Check::user(*user)).collect_vec(); // members is moved in Protected
-
     group_members(group)
         .map(move |openfga, existing_members| {
             async move {
@@ -96,7 +88,6 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
             }
             .boxed()
         })
-        .with_check_iter(user_exists_checks)
         .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
 }
 
@@ -104,7 +95,6 @@ pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
 mod tests {
     use rstest::rstest;
 
-    use crate::Subject;
     use crate::v2::TestClientExt as _;
 
     use super::*;
@@ -233,31 +223,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case::group_members(
-        group_members(Group(1)).checks,
-        &[Check::SubjectExists(Subject::group(1))]
-    )]
-    #[case::user_groups(
-        user_groups(User(1)).checks,
-        &[Check::SubjectExists(Subject::user(1))]
-    )]
+    #[case::group_members(group_members(Group(1)).checks, &[])]
+    #[case::user_groups(user_groups(User(1)).checks, &[])]
     #[case::add_members(
         add_members(Group(1), HashSet::from([User(1), User(2)])).checks,
-        &[
-            Check::SubjectExists(Subject::group(1)),
-            Check::SubjectExists(Subject::user(1)),
-            Check::SubjectExists(Subject::user(2)),
-            Check::HasRole(Actor::Issuer, Role::Admin),
-        ]
+        &[Check::HasRole(Actor::Issuer, Role::Admin)]
     )]
     #[case::remove_members(
         remove_members(Group(1), HashSet::from([User(1), User(2)])).checks,
-        &[
-            Check::SubjectExists(Subject::group(1)),
-            Check::SubjectExists(Subject::user(1)),
-            Check::SubjectExists(Subject::user(2)),
-            Check::HasRole(Actor::Issuer, Role::Admin),
-        ]
+        &[Check::HasRole(Actor::Issuer, Role::Admin)]
     )]
     fn protected_contains_expected_checks(
         #[case] protected_checks: HashSet<Check>,

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -53,8 +53,6 @@ pub fn infra_direct_grant(subject: Subject, infra: Infra) -> Protected<Option<In
         }
         .boxed()
     })
-    .with_check(Check::SubjectExists(subject))
-    .with_check(Check::InfraExists(infra))
 }
 
 /// Returns the effective (maximum) grant a subject has on an [Infra], if any
@@ -117,8 +115,6 @@ pub fn infra_effective_grant(subject: Subject, infra: Infra) -> Protected<Option
         }
         .boxed()
     })
-    .with_check(Check::SubjectExists(subject))
-    .with_check(Check::InfraExists(infra))
     .with_check(Check::HasInfraPrivilege(
         Actor::Issuer,
         InfraPrivilege::CanRead,
@@ -184,8 +180,6 @@ pub fn infra_set_grant(subject: Subject, infra: Infra, new_grant: InfraGrant) ->
     //     5. **cannot** demote or promote any group [CanAlterSubjectInfraGrant]
     let prot = prot
         .reset_checks() // get rid of revoking-specific checks
-        .with_check(Check::SubjectExists(subject))
-        .with_check(Check::InfraExists(infra))
         .with_check(Check::HasInfraPrivilege(
             Actor::Issuer,
             share_privilege,
@@ -293,8 +287,6 @@ pub fn infra_privileges(user: User, infra: Infra) -> Protected<HashSet<InfraPriv
         }
         .boxed()
     })
-    .with_check(Check::InfraExists(infra))
-    .with_check(Check::SubjectExists(Subject::user(user)))
     .with_check(Check::HasInfraPrivilege(
         Actor::Issuer,
         InfraPrivilege::CanRead,
@@ -368,7 +360,6 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
             InfraPrivilege::CanRead,
             infra,
         ))
-        .with_check(Check::InfraExists(infra))
 }
 
 pub fn infra_list(user: User, privilege: InfraPrivilege) -> Protected<ResourcesList<Infra>> {
@@ -859,25 +850,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case::infra_direct_grant(
-        infra_direct_grant(Subject::user(1), Infra(1)).checks,
-        &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::InfraExists(Infra(1))])
-        ]
+    #[case::infra_direct_grant(infra_direct_grant(Subject::user(1), Infra(1)).checks, &[])]
     #[case::infra_effective_grant(
         infra_effective_grant(Subject::user(1), Infra(1)).checks,
-        &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::InfraExists(Infra(1)),
-            Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1)),
-        ]
+        &[Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1))]
     )]
     #[case::infra_revoke_grant(
         infra_revoke_grant(Subject::user(1), Infra(1)).checks,
         &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::InfraExists(Infra(1)),
             Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRevoke, Infra(1)),
             Check::IsNotLastInfraOwner(Subject::user(1), Infra(1)),
             Check::SubjectEffectiveInfraGrantIsNot(InfraGrant::Owner, Subject::user(1), Infra(1))
@@ -885,23 +865,13 @@ mod tests {
     )]
     #[case::infra_privileges(
         infra_privileges(User(1), Infra(1)).checks,
-        &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::InfraExists(Infra(1)),
-            Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1)),
-        ]
+        &[Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1))]
     )]
     #[case::infra_privileges(
         infra_granted_subjects(Infra(1), InfraGrant::Owner).checks,
-        &[
-            Check::InfraExists(Infra(1)),
-            Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1)),
-        ]
+        &[Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, Infra(1))]
     )]
-    #[case::infra_list(
-        infra_list(User(1), InfraPrivilege::CanRead).checks,
-        &[Check::SubjectExists(Subject::user(1))]
-    )]
+    #[case::infra_list(infra_list(User(1), InfraPrivilege::CanRead).checks, &[])]
     fn protected_contains_expected_checks(
         #[case] protected_checks: HashSet<Check>,
         #[case] expected_checks: &[Check],

--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -36,8 +36,6 @@ pub fn project_direct_grant(subject: Subject, project: Project) -> Protected<Opt
         }
         .boxed()
     })
-    .with_check(Check::SubjectExists(subject))
-    .with_check(Check::ProjectExists(project))
 }
 
 /// Returns the effective grant a subject has on an [Project]
@@ -62,8 +60,6 @@ pub fn project_effective_grant(
         }
         .boxed()
     })
-    .with_check(Check::SubjectExists(subject))
-    .with_check(Check::ProjectExists(project))
 }
 
 pub fn project_set_grant(subject: Subject, project: Project) -> Protected<()> {
@@ -140,6 +136,7 @@ mod tests {
     use crate::User;
     use crate::authz_client;
     use crate::model::Project;
+    use crate::v2::Check;
     use crate::v2::TestClientExt;
 
     use super::*;
@@ -456,31 +453,21 @@ mod tests {
     #[rstest::rstest]
     #[case::project_direct_grant(
         project_direct_grant(Subject::user(1), Project(1)).checks,
-        &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::ProjectExists(Project(1)),
-        ]
+        &[]
     )]
     #[case::project_effective_grant(
         project_effective_grant(Subject::user(1), Project(1)).checks,
-        &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::ProjectExists(Project(1)),
-        ]
+        &[]
     )]
     #[case::project_set_grant(
         project_set_grant(Subject::user(1), Project(1)).checks,
         &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::ProjectExists(Project(1)),
             Check::CanGiveSubjectProjectGrant(Subject::user(1), Project(1))
         ]
     )]
     #[case::project_revoke_grant(
         project_revoke_grant(Subject::user(1), Project(1)).checks,
         &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::ProjectExists(Project(1)),
             Check::HasRole(Actor::Issuer, Role::Admin),
         ]
     )]

--- a/editoast/authz/src/v2/roles.rs
+++ b/editoast/authz/src/v2/roles.rs
@@ -21,7 +21,6 @@ pub fn subject_roles(subject: Subject) -> Protected<Vec<Role>> {
         }
         .boxed()
     })
-    .with_check(Check::SubjectExists(subject))
 }
 
 /// Gives the subject the specified roles
@@ -307,23 +306,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case::subject_roles(
-        subject_roles(Subject::user(1)).checks,
-        &[Check::SubjectExists(Subject::user(1))]
-    )]
+    #[case::subject_roles(subject_roles(Subject::user(1)).checks, &[])]
     #[case::add_roles(
         add_roles(Subject::user(1), HashSet::from([Role::Admin, Role::Stdcm])).checks,
-        &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::HasRole(Actor::Issuer, Role::Admin)
-        ]
+        &[Check::HasRole(Actor::Issuer, Role::Admin)]
     )]
     #[case::remove_roles(
         remove_roles(Subject::user(1), HashSet::from([Role::Admin, Role::Stdcm])).checks,
-        &[
-            Check::SubjectExists(Subject::user(1)),
-            Check::HasRole(Actor::Issuer, Role::Admin)
-        ]
+        &[Check::HasRole(Actor::Issuer, Role::Admin)]
     )]
     fn protected_contains_expected_checks(
         #[case] protected_checks: HashSet<Check>,

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -59,8 +59,6 @@ pub fn rolling_stock_privileges(
         }
         .boxed()
     })
-    .with_check(Check::RollingStockExists(rolling_stock))
-    .with_check(Check::SubjectExists(Subject::user(user)))
     .with_check(Check::HasRollingStockPrivilege(
         Actor::Issuer,
         RollingStockPrivilege::CanRead,
@@ -131,8 +129,6 @@ pub fn rolling_stock_effective_grant(
         }
         .boxed()
     })
-    .with_check(Check::SubjectExists(subject))
-    .with_check(Check::RollingStockExists(rolling_stock))
     .with_check(Check::HasRollingStockPrivilege(
         Actor::Issuer,
         RollingStockPrivilege::CanRead,
@@ -206,8 +202,6 @@ pub fn rolling_stock_set_grant(
     //     5. **cannot** demote or promote any group [CanAlterSubjectRollingStockGrant]
     let prot = prot
         .reset_checks() // get rid of revoking-specific checks
-        .with_check(Check::SubjectExists(subject))
-        .with_check(Check::RollingStockExists(rolling_stock))
         .with_check(Check::HasRollingStockPrivilege(
             Actor::Issuer,
             share_privilege,
@@ -313,7 +307,6 @@ pub fn rolling_stock_granted_subjects(
             RollingStockPrivilege::CanRead,
             rolling_stock,
         ))
-        .with_check(Check::RollingStockExists(rolling_stock))
 }
 
 /// Returns the *direct grant* a subject has on a [RollingStock], if any
@@ -356,8 +349,6 @@ pub fn rolling_stock_direct_grant(
         }
         .boxed()
     })
-    .with_check(Check::SubjectExists(subject))
-    .with_check(Check::RollingStockExists(rolling_stock))
 }
 
 /// Revokes the (direct) grant a subject has on a [RollingStock], if any
@@ -792,26 +783,21 @@ mod tests {
     #[case::rolling_stock_privileges(
         rolling_stock_privileges(User(1), RollingStock(1)).checks,
         &[
-           Check::SubjectExists(Subject::user(1)),
-           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
-           Check::RollingStockExists(RollingStock(1))
+           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1))
         ]
     )]
     #[rstest]
     #[case::rolling_stock_effective_grant(
         rolling_stock_effective_grant(Subject::user(1), RollingStock(1)).checks,
         &[
-           Check::SubjectExists(Subject::user(1)),
-           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
-           Check::RollingStockExists(RollingStock(1))
+           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1))
         ]
     )]
     #[rstest]
     #[case::rolling_stock_granted_subjects(
         rolling_stock_granted_subjects(RollingStock(1), RollingStockGrant::Writer).checks,
         &[
-           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1)),
-           Check::RollingStockExists(RollingStock(1))
+           Check::HasRollingStockPrivilege(Actor::Issuer, RollingStockPrivilege::CanRead, RollingStock(1))
         ]
     )]
     fn protected_contains_expected_checks(

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -1,4 +1,5 @@
 use authz::Role;
+use authz::v2::Check;
 
 use crate::authorizers::SystemAuthorizer;
 use crate::authorizers::UserAuthorizer;
@@ -101,16 +102,12 @@ impl State {
     pub fn authorizer<'a>(
         &self,
         openfga: &'a fga::Client,
-        conn: database::DbConnection,
-    ) -> itertools::Either<UserAuthorizer<'a>, SystemAuthorizer<'a>> {
+    ) -> itertools::Either<UserAuthorizer<'a>, SystemAuthorizer<'a, Check>> {
         match self {
             State::Authenticated { user, roles } => {
-                itertools::Either::Left(UserAuthorizer::new(*user, roles.clone(), openfga, conn))
+                itertools::Either::Left(UserAuthorizer::new(*user, roles.clone(), openfga))
             }
-            State::Skip => itertools::Either::Right(SystemAuthorizer {
-                openfga,
-                conn: conn.clone(),
-            }),
+            State::Skip => itertools::Either::Right(SystemAuthorizer::new(openfga)),
         }
     }
 

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::marker::PhantomData;
 use std::ops::Not as _;
 
 use authz::ProjectGrant;
@@ -7,8 +8,6 @@ use authz::v2::Actor;
 use authz::v2::Authorizer;
 use authz::v2::Check;
 use authz::v2::Protected;
-use editoast_models::prelude::*;
-use futures::FutureExt as _;
 use futures::StreamExt as _;
 use futures::stream::FuturesUnordered;
 use tracing::Instrument as _;
@@ -19,49 +18,37 @@ use tracing::Instrument as _;
 /// system knows are correct. For example, attributing the first owner of a new resource.
 ///
 /// No user can be associated with this authorizer.
-pub struct SystemAuthorizer<'a> {
-    pub openfga: &'a fga::Client,
-    pub conn: database::DbConnection,
+///
+/// This authorizer performs no checks and thus [`Authorizer::authorize`] always succeeds
+/// and never rejects. But always setting the rejection type to [`Infallible`], while convenient
+/// when [`SystemAuthorizer`] is used directly, hurts authorizer production by
+/// [`State::authorizer`](crate::authentication::State::authorizer). So you can provide this type whichever
+/// rejection type you prefer.
+pub struct SystemAuthorizer<'a, R = Infallible> {
+    openfga: &'a fga::Client,
+    rejection: PhantomData<R>,
 }
 
-impl SystemAuthorizer<'_> {
-    #[tracing::instrument(target = "SystemAuthorizer::check", skip_all, fields(?check), ret(level = "trace"), err)]
-    async fn check<'ch>(&self, check: &'ch Check) -> Result<Option<&'ch Check>, Error> {
-        let conn = &mut self.conn.clone();
-        Ok(match check {
-            Check::SubjectExists(authz::Subject::User(user)) => {
-                (!editoast_models::User::exists(conn, **user).await?).then_some(check)
-            }
-            Check::SubjectExists(authz::Subject::Group(group)) => {
-                (!editoast_models::Group::exists(conn, **group).await?).then_some(check)
-            }
-            Check::InfraExists(infra) => {
-                (!editoast_models::Infra::exists(conn, **infra).await?).then_some(check)
-            }
-            Check::RollingStockExists(authz::RollingStock(rolling_stock_id)) => {
-                (!editoast_models::RollingStock::exists(conn, *rolling_stock_id).await?)
-                    .then_some(check)
-            }
-            Check::ProjectExists(authz::Project(project_id)) => {
-                (!editoast_models::Project::exists(conn, *project_id).await?).then_some(check)
-            }
-            // checked by UserAuthorizer
-            Check::HasRole(..)
-            | Check::HasInfraPrivilege(..)
-            | Check::HasRollingStockPrivilege(..)
-            | Check::CanAlterSubjectInfraGrant(..)
-            | Check::CanGiveSubjectProjectGrant(..)
-            | Check::SubjectEffectiveInfraGrantIsNot(..)
-            | Check::CanAlterSubjectRollingStockGrant(..)
-            | Check::SubjectEffectiveRollingStockGrantIsNot(..)
-            | Check::IsNotLastInfraOwner(..)
-            | Check::IsNotLastRollingStockOwner(..) => None,
-        })
+impl<'a, R> SystemAuthorizer<'a, R> {
+    pub fn new(openfga: &'a fga::Client) -> Self {
+        Self {
+            openfga,
+            rejection: PhantomData,
+        }
     }
 }
 
-impl Authorizer for SystemAuthorizer<'_> {
-    type Rejection = Check;
+impl<'a> SystemAuthorizer<'a, Infallible> {
+    /// Shortcut for `SystemAuthorizer::<Infallible>::new`.
+    ///
+    /// Avoids having to import the name.
+    pub fn new_infallible(openfga: &'a fga::Client) -> Self {
+        Self::new(openfga)
+    }
+}
+
+impl<R> Authorizer for SystemAuthorizer<'_, R> {
+    type Rejection = R;
     type Error = Error;
 
     #[tracing::instrument(skip_all)]
@@ -69,20 +56,6 @@ impl Authorizer for SystemAuthorizer<'_> {
         &'a self,
         data: Protected<T>,
     ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
-        {
-            // scoping to tell the borrow checker that checks is consumed before returning
-            // access_authorized which takes ownership of data
-            let mut checks = data
-                .checks
-                .iter()
-                .map(|check| self.check(check).in_current_span())
-                .collect::<FuturesUnordered<_>>();
-            while let Some(result) = checks.next().await {
-                if let Some(check) = result? {
-                    return Ok(Access::Denied { rejection: *check });
-                }
-            }
-        }
         Ok(data.access_authorized(self.openfga))
     }
 }
@@ -91,21 +64,14 @@ pub struct UserAuthorizer<'c> {
     pub user: authz::User,
     pub roles: Vec<authz::Role>, // TODO: use a SmallVec
     pub openfga: &'c fga::Client,
-    pub conn: database::DbConnection,
 }
 
 impl<'c> UserAuthorizer<'c> {
-    pub fn new(
-        user: authz::User,
-        roles: Vec<authz::Role>,
-        openfga: &'c fga::Client,
-        conn: database::DbConnection,
-    ) -> Self {
+    pub fn new(user: authz::User, roles: Vec<authz::Role>, openfga: &'c fga::Client) -> Self {
         Self {
             user,
             roles,
             openfga,
-            conn,
         }
     }
 
@@ -270,11 +236,6 @@ impl<'c> UserAuthorizer<'c> {
                 .await?;
                 (owners.len() == 1 && owners.contains(subject)).then_some(check)
             }
-            // checked by SystemAuthorizer
-            Check::SubjectExists(_)
-            | Check::InfraExists(_)
-            | Check::RollingStockExists(_)
-            | Check::ProjectExists(_) => None,
         })
     }
 }
@@ -288,25 +249,18 @@ impl Authorizer for UserAuthorizer<'_> {
         &'a self,
         data: Protected<T>,
     ) -> Result<Access<'a, T, Self::Rejection>, Self::Error> {
-        let system_authorizer = SystemAuthorizer {
-            openfga: self.openfga,
-            conn: self.conn.clone(),
-        };
         {
             // scoping to tell the borrow checker that checks is consumed before returning
             // access_authorized which takes ownership of data
-            // same thing for the system_authorizer
             let mut checks = FuturesUnordered::new();
-            for check in &data.checks {
-                checks.push(system_authorizer.check(check).in_current_span().boxed());
-            }
             if !self.roles.contains(&authz::Role::Admin) {
                 for check in &data.checks {
-                    checks.push(self.check(check).in_current_span().boxed());
+                    checks.push(self.check(check).in_current_span());
                 }
             }
             while let Some(result) = checks.next().await {
                 if let Some(check) = result? {
+                    tracing::error!(user = ?self.user, ?check, "authorization denied");
                     return Ok(Access::Denied { rejection: *check });
                 }
             }
@@ -316,22 +270,8 @@ impl Authorizer for UserAuthorizer<'_> {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error(transparent)]
-    Database(#[from] editoast_models::Error),
-    #[error(transparent)]
-    OpenFga(#[from] authz::v2::OpenFgaError),
-}
-
-/// Wraps [`unreachable!`] with a message specific to impossible checks
-macro_rules! impossible {
-    ($check:expr) => {
-        unreachable!(
-            "impossible check {:?} — if this occurs, some authz::Protected check handling has been overlooked", $check
-        )
-    };
-}
-pub(crate) use impossible;
+#[error(transparent)]
+pub struct Error(#[from] pub authz::v2::OpenFgaError);
 
 #[cfg(test)]
 mod tests {
@@ -395,149 +335,6 @@ mod tests {
             .unwrap()
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn existing_user() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        assert_eq!(authorize(&system, Check::user(user)).await, Ok(()));
-        assert_eq!(authorize(&user_authorizer, Check::user(user)).await, Ok(()));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn missing_user() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        let check = Check::user(authz::User(i64::MAX));
-        assert_eq!(authorize(&system, check).await, Err(check));
-        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn existing_group() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let group = create_group(&pool, "group").await;
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        assert_eq!(authorize(&system, Check::group(group)).await, Ok(()));
-        assert_eq!(
-            authorize(&user_authorizer, Check::group(group)).await,
-            Ok(())
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn missing_group() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        let check = Check::group(authz::Group(i64::MAX));
-        assert_eq!(authorize(&system, check).await, Err(check));
-        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn existing_infra() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let infra = authz::Infra(create_empty_infra(&mut pool.get_ok()).await.id);
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        assert_eq!(authorize(&system, Check::InfraExists(infra)).await, Ok(()));
-        assert_eq!(
-            authorize(&user_authorizer, Check::InfraExists(infra)).await,
-            Ok(())
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn missing_infra() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        let check = Check::InfraExists(authz::Infra(i64::MAX));
-        assert_eq!(authorize(&system, check).await, Err(check));
-        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn existing_rolling_stock() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let rolling_stock = authz::RollingStock(
-            create_fast_rolling_stock(&mut pool.get_ok(), "rolling_stock")
-                .await
-                .id,
-        );
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        assert_eq!(
-            authorize(&system, Check::RollingStockExists(rolling_stock)).await,
-            Ok(())
-        );
-        assert_eq!(
-            authorize(&user_authorizer, Check::RollingStockExists(rolling_stock)).await,
-            Ok(())
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn missing_rolling_stock() {
-        let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let user = create_user(&pool, "user").await;
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
-
-        let check = Check::RollingStockExists(authz::RollingStock(i64::MAX));
-        assert_eq!(authorize(&system, check).await, Err(check));
-        assert_eq!(authorize(&user_authorizer, check).await, Err(check));
-    }
-
     #[rstest]
     #[case::has_role(Check::HasRole(Actor::Issuer, Role::Admin))]
     #[case::has_infra_privilege(Check::HasInfraPrivilege(
@@ -578,11 +375,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn system_authorizer_ignores_non_sanity_checks(#[case] check: Check) {
         let openfga = openfga().await;
-        let pool = DbConnectionPoolV2::for_tests();
-        let system = SystemAuthorizer {
-            openfga: &openfga,
-            conn: pool.get_ok(),
-        };
+        let system = SystemAuthorizer::new_infallible(&openfga);
 
         assert_eq!(authorize(&system, check).await, Ok(()));
     }
@@ -592,12 +385,7 @@ mod tests {
         let openfga = openfga().await;
         let pool = DbConnectionPoolV2::for_tests();
         let user = create_user(&pool, "user").await;
-        let user_authorizer = UserAuthorizer::new(
-            user,
-            vec![Role::OperationalStudies],
-            &openfga,
-            pool.get_ok(),
-        );
+        let user_authorizer = UserAuthorizer::new(user, vec![Role::OperationalStudies], &openfga);
 
         let check = Check::HasRole(Actor::Issuer, Role::OperationalStudies);
         assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
@@ -616,7 +404,7 @@ mod tests {
             .write_tuples(&[authz::User::role().tuple(&Role::Stdcm, &target)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::HasRole(Actor::User(target), Role::Stdcm);
         assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
@@ -637,11 +425,11 @@ mod tests {
             .await
             .unwrap();
 
-        let user_authorizer = UserAuthorizer::new(owner, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(owner, vec![], &openfga);
         let check = Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanDelete, infra);
         assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
 
-        let user_authorizer = UserAuthorizer::new(no_grant, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(no_grant, vec![], &openfga);
         let check = Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanShareRead, infra);
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
     }
@@ -662,7 +450,7 @@ mod tests {
             .await
             .unwrap();
 
-        let user_authorizer = UserAuthorizer::new(owner, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(owner, vec![], &openfga);
         let check = Check::HasRollingStockPrivilege(
             Actor::Issuer,
             RollingStockPrivilege::CanDelete,
@@ -670,7 +458,7 @@ mod tests {
         );
         assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
 
-        let user_authorizer = UserAuthorizer::new(no_grant, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(no_grant, vec![], &openfga);
         let check = Check::HasRollingStockPrivilege(
             Actor::Issuer,
             RollingStockPrivilege::CanShareRead,
@@ -690,7 +478,7 @@ mod tests {
             .write_tuples(&[authz::Infra::writer().tuple(&target, &infra)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::HasInfraPrivilege(Actor::User(target), InfraPrivilege::CanWrite, infra);
         assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
@@ -781,8 +569,7 @@ mod tests {
             #[case] ok: bool,
         ) {
             let openfga = openfga().await;
-            let pool = DbConnectionPoolV2::for_tests();
-            let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+            let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
             openfga
                 .prepare_writes()
@@ -903,8 +690,7 @@ mod tests {
             #[case] ok: bool,
         ) {
             let openfga = openfga().await;
-            let pool = DbConnectionPoolV2::for_tests();
-            let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+            let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
             openfga
                 .prepare_writes()
@@ -966,7 +752,7 @@ mod tests {
             .write_tuples(&[authz::RollingStock::writer().tuple(&target, &rolling_stock)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::HasRollingStockPrivilege(
             Actor::User(target),
@@ -994,7 +780,7 @@ mod tests {
             .write_tuples(&[authz::Infra::owner().tuple(&target, &infra)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::SubjectEffectiveInfraGrantIsNot(
             InfraGrant::Owner,
@@ -1026,7 +812,7 @@ mod tests {
             .write_tuples(&[authz::RollingStock::owner().tuple(&target, &rolling_stock)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::SubjectEffectiveRollingStockGrantIsNot(
             RollingStockGrant::Owner,
@@ -1058,7 +844,7 @@ mod tests {
             .execute()
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::SubjectEffectiveInfraGrantIsNot(
             InfraGrant::Owner,
@@ -1090,7 +876,7 @@ mod tests {
             .execute()
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::SubjectEffectiveRollingStockGrantIsNot(
             RollingStockGrant::Owner,
@@ -1113,7 +899,7 @@ mod tests {
             .write_tuples(&[authz::Infra::owner().tuple(&owner, &infra)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::IsNotLastInfraOwner(authz::Subject::User(owner), infra);
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
@@ -1146,7 +932,7 @@ mod tests {
             .write_tuples(&[authz::RollingStock::owner().tuple(&owner, &rolling_stock)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::IsNotLastRollingStockOwner(authz::Subject::User(owner), rolling_stock);
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
@@ -1176,7 +962,7 @@ mod tests {
             ])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::IsNotLastInfraOwner(authz::Subject::Group(group), infra);
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
@@ -1198,7 +984,7 @@ mod tests {
                 .tuple(authz::Group::member().userset(&group), &rolling_stock)])
             .await
             .unwrap();
-        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(issuer, vec![], &openfga);
 
         let check = Check::IsNotLastRollingStockOwner(authz::Subject::Group(group), rolling_stock);
         assert_eq!(authorize(&user_authorizer, check).await, Err(check));
@@ -1246,7 +1032,7 @@ mod tests {
         let openfga = openfga().await;
         let pool = DbConnectionPoolV2::for_tests();
         let user = create_user(&pool, "admin").await;
-        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga, pool.get_ok());
+        let user_authorizer = UserAuthorizer::new(user, vec![Role::Admin], &openfga);
 
         assert_eq!(authorize(&user_authorizer, check).await, Ok(()));
     }

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -3,7 +3,6 @@ use anyhow::bail;
 use authz;
 use authz::Group;
 use authz::v2::Authorizer;
-use authz::v2::Check;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnectionPoolV2;
@@ -13,7 +12,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::authorizers::SystemAuthorizer;
-use crate::authorizers::impossible;
 
 use super::openfga_config::OpenfgaConfig;
 
@@ -97,10 +95,7 @@ pub async fn group_info(
 ) -> anyhow::Result<()> {
     let openfga = openfga_config.into_client().await?;
     let conn = pool.get().await?;
-    let system = SystemAuthorizer {
-        openfga: &openfga,
-        conn: conn.clone(),
-    };
+    let system = SystemAuthorizer::new_infallible(&openfga);
     let Some(editoast_models::Group {
         id: group_id,
         name: _,
@@ -113,16 +108,11 @@ pub async fn group_info(
         tracing::error!(group.id = group_id, "No such group");
         return Ok(());
     };
-    let user_ids = match system
+    let Ok(user_ids) = system
         .authorize(authz::v2::group_members(authz::Group(group_id)))
         .await?
         .access()
-        .await?
-    {
-        Ok(user_ids) => user_ids,
-        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
-        Err(check) => impossible!(check),
-    };
+        .await?;
 
     println!("id     : {group_id}");
     println!("name   : {}", group.name);
@@ -149,10 +139,7 @@ pub async fn exclude_group(
     }
 
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
-    let system = SystemAuthorizer {
-        openfga: regulator.openfga(),
-        conn: pool.get().await?,
-    };
+    let system = SystemAuthorizer::new_infallible(regulator.openfga());
 
     let group_id = editoast_models::Group::retrieve(pool.get().await?, group_name.clone())
         .await?
@@ -169,18 +156,15 @@ pub async fn exclude_group(
                 .ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
                 .id
         };
+        editoast_models::User::retrieve(pool.get().await?, uid)
+            .await?
+            .ok_or_else(|| anyhow!("No such user {uid}"))?;
         authz_users.insert(authz::User(uid));
     }
 
     let remove_member = authz::v2::remove_members(authz::Group(group_id), authz_users);
-    match system.authorize(remove_member).await?.access().await? {
-        Ok(()) => Ok(()),
-        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
-        Err(Check::SubjectExists(authz::Subject::User(user))) => {
-            bail!("No such user {user}")
-        }
-        Err(check) => impossible!(check),
-    }
+    let Ok(()) = system.authorize(remove_member).await?.access().await?;
+    Ok(())
 }
 
 /// Include users in a group
@@ -194,10 +178,7 @@ pub async fn include_group(
     }
 
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
-    let system = SystemAuthorizer {
-        openfga: regulator.openfga(),
-        conn: pool.get().await?,
-    };
+    let system = SystemAuthorizer::new_infallible(regulator.openfga());
 
     let group_id = editoast_models::Group::retrieve(pool.get().await?, group_name.clone())
         .await?
@@ -214,18 +195,15 @@ pub async fn include_group(
                 .ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
                 .id
         };
+        editoast_models::User::retrieve(pool.get().await?, uid)
+            .await?
+            .ok_or_else(|| anyhow!("No such user {uid}"))?;
         authz_users.insert(authz::User(uid));
     }
 
     let add_member = authz::v2::add_members(authz::Group(group_id), authz_users);
-    match system.authorize(add_member).await?.access().await? {
-        Ok(()) => Ok(()),
-        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
-        Err(Check::SubjectExists(authz::Subject::User(user))) => {
-            bail!("No such user {user}")
-        }
-        Err(check) => impossible!(check),
-    }
+    let Ok(()) = system.authorize(add_member).await?.access().await?;
+    Ok(())
 }
 
 pub async fn delete_group(
@@ -235,10 +213,7 @@ pub async fn delete_group(
 ) -> anyhow::Result<()> {
     let regulator = openfga_config.into_regulator(pool.clone()).await?;
     let mut conn = pool.get().await?;
-    let system = SystemAuthorizer {
-        openfga: regulator.openfga(),
-        conn: conn.clone(),
-    };
+    let system = SystemAuthorizer::new_infallible(regulator.openfga());
     let group_id = editoast_models::Group::retrieve(pool.get().await?, name.clone())
         .await?
         .ok_or_else(|| anyhow!("group '{name}' could not be deleted (not found)"))?
@@ -246,23 +221,14 @@ pub async fn delete_group(
     let group = Group(group_id);
 
     // Delete the relationships between the group to be deleted and its members
-    let users_in_group = match system
+    let Ok(users_in_group) = system
         .authorize(authz::v2::group_members(group))
         .await?
         .access()
-        .await?
-    {
-        Ok(user_ids) => HashSet::from_iter(user_ids),
-        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
-        Err(check) => impossible!(check),
-    };
+        .await?;
+    let users_in_group = HashSet::from_iter(users_in_group);
     let remove_member = authz::v2::remove_members(group, users_in_group);
-    match system.authorize(remove_member).await?.access().await? {
-        Ok(()) => {}
-        Err(Check::SubjectExists(authz::Subject::Group(_))) => unreachable!("tested above"),
-        Err(Check::SubjectExists(authz::Subject::User(_))) => unreachable!("tested above"),
-        Err(check) => impossible!(check),
-    }
+    let Ok(()) = system.authorize(remove_member).await?.access().await?;
 
     let deleted = editoast_models::Group::delete_static(&mut conn, group_id).await?;
     if deleted {

--- a/editoast/src/client/roles.rs
+++ b/editoast/src/client/roles.rs
@@ -9,7 +9,6 @@ use authz::Role;
 use authz::identity::GroupInfo;
 use authz::identity::UserInfo;
 use authz::v2::Authorizer;
-use authz::v2::Check;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnection;
@@ -21,7 +20,6 @@ use strum::IntoEnumIterator;
 use tracing::info;
 
 use crate::authorizers::SystemAuthorizer;
-use crate::authorizers::impossible;
 
 use super::openfga_config::OpenfgaConfig;
 
@@ -143,19 +141,11 @@ pub async fn list_subject_roles(
     pool: Arc<DbConnectionPoolV2>,
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
-    let system = SystemAuthorizer {
-        openfga: &openfga_config.into_client().await?,
-        conn: pool.get().await?,
-    };
+    let openfga = openfga_config.into_client().await?;
+    let system = SystemAuthorizer::new_infallible(&openfga);
     let subject = parse_and_fetch_subject(&subject, pool.get().await?).await?;
     let subject_roles = authz::v2::subject_roles(subject.clone().into_authz());
-    let roles = match system.authorize(subject_roles).await?.access().await? {
-        Ok(roles) => roles,
-        Err(Check::SubjectExists(_)) => {
-            unreachable!("checked by parse_and_fetch_subject")
-        }
-        Err(rejection) => impossible!(rejection),
-    };
+    let Ok(roles) = system.authorize(subject_roles).await?.access().await?;
 
     if roles.is_empty() {
         info!("{subject} has no roles assigned");
@@ -184,10 +174,7 @@ pub async fn add_roles(
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
     let openfga = &openfga_config.into_client().await?;
-    let system = SystemAuthorizer {
-        openfga,
-        conn: pool.get().await?,
-    };
+    let system = SystemAuthorizer::new_infallible(openfga);
 
     let roles = roles
         .iter()
@@ -204,13 +191,8 @@ pub async fn add_roles(
     );
     let subject = parse_and_fetch_subject(&subject, pool.get().await?).await?;
     let add_roles = authz::v2::add_roles(subject.into_authz(), roles);
-    match system.authorize(add_roles).await?.access().await? {
-        Ok(()) => Ok(()),
-        Err(Check::SubjectExists(_)) => {
-            unreachable!("checked by parse_and_fetch_subject")
-        }
-        Err(check) => impossible!(check),
-    }
+    let Ok(()) = system.authorize(add_roles).await?.access().await?;
+    Ok(())
 }
 
 pub async fn remove_roles(
@@ -219,10 +201,7 @@ pub async fn remove_roles(
     openfga_config: OpenfgaConfig,
 ) -> anyhow::Result<()> {
     let openfga = &openfga_config.into_client().await?;
-    let system = SystemAuthorizer {
-        openfga,
-        conn: pool.get().await?,
-    };
+    let system = SystemAuthorizer::new_infallible(openfga);
 
     let roles = roles
         .iter()
@@ -239,11 +218,6 @@ pub async fn remove_roles(
     );
     let subject = parse_and_fetch_subject(&subject, pool.get().await?).await?;
     let remove_roles = authz::v2::remove_roles(subject.into_authz(), roles);
-    match system.authorize(remove_roles).await?.access().await? {
-        Ok(()) => Ok(()),
-        Err(Check::SubjectExists(_)) => {
-            unreachable!("checked by parse_and_fetch_subject")
-        }
-        Err(check) => impossible!(check),
-    }
+    let Ok(()) = system.authorize(remove_roles).await?.access().await?;
+    Ok(())
 }

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use anyhow::bail;
 use authz;
 use authz::v2::Authorizer;
-use authz::v2::Check;
 use clap::Args;
 use clap::Subcommand;
 use database::DbConnectionPoolV2;
@@ -16,7 +15,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::authorizers::SystemAuthorizer;
-use crate::authorizers::impossible;
 
 use super::openfga_config::OpenfgaConfig;
 
@@ -84,10 +82,7 @@ pub async fn list_user(
     pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
     let openfga = openfga_config.into_client().await?;
-    let system = SystemAuthorizer {
-        openfga: &openfga,
-        conn: pool.get().await?,
-    };
+    let system = SystemAuthorizer::new_infallible(&openfga);
 
     let (users, groups) = tokio::join!(
         async {
@@ -112,13 +107,8 @@ pub async fn list_user(
         )
         .authorize(&system)
         .await?;
-        let group_members = match group_member_access.access().await? {
-            Ok(users) => users.into_iter().flatten().collect::<HashSet<_>>(),
-            Err(Check::SubjectExists(authz::Subject::Group(_))) => {
-                unreachable!("groups were listed from the database")
-            }
-            Err(rejection) => impossible!(rejection),
-        };
+        let Ok(group_members) = group_member_access.access().await?;
+        let group_members = group_members.into_iter().flatten().collect::<HashSet<_>>();
         users?
             .into_iter()
             .filter(|user| !group_members.contains(&authz::User(user.user.id)))
@@ -185,25 +175,17 @@ pub async fn user_info(
             .id
     };
     let openfga = openfga_config.into_client().await?;
-    let system = SystemAuthorizer {
-        openfga: &openfga,
-        conn: pool.get().await?,
-    };
+    let system = SystemAuthorizer::new_infallible(&openfga);
     let Some(user) = editoast_models::User::retrieve(pool.get().await?, uid).await? else {
         tracing::error!(user.id = uid, "User not found");
         return Ok(());
     };
     let identities = user.get_identities(pool.get().await?).await?;
-    let groups = match system
+    let Ok(groups) = system
         .authorize(authz::v2::user_groups(authz::User(uid)))
         .await?
         .access()
-        .await?
-    {
-        Ok(groups) => groups,
-        Err(Check::SubjectExists(authz::Subject::User(_))) => unreachable!("tested above"),
-        Err(check) => impossible!(check),
-    };
+        .await?;
     let conn = pool.get().await?;
 
     println!("id      : {uid}");

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -399,11 +399,8 @@ impl From<fga::client::Error> for InternalError {
 }
 
 impl From<crate::authorizers::Error> for InternalError {
-    fn from(value: crate::authorizers::Error) -> Self {
-        match value {
-            crate::authorizers::Error::Database(error) => error.into(),
-            crate::authorizers::Error::OpenFga(error) => error.into(),
-        }
+    fn from(crate::authorizers::Error(inner): crate::authorizers::Error) -> Self {
+        inner.into()
     }
 }
 

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::authorizers::SystemAuthorizer;
-use crate::authorizers::impossible;
 use crate::error::Result;
 use crate::views::authz::resources::Resource;
 use crate::views::authz::resources::StandardGrant;
@@ -164,20 +163,13 @@ pub(in crate::views) async fn user_groups(
     let user = authn_state
         .regular_user()
         .ok_or(AuthorizationError::Unauthenticated)?;
-    let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+    let authorizer = authn_state.authorizer(regulator.openfga());
     let user_groups = authz::v2::user_groups(user)
         .authorize(&authorizer)
         .await?
         .access()
         .await?
-        .map_err(|rejection| match rejection {
-            Check::SubjectExists(authz::Subject::User(authz::User(user_id))) => {
-                AuthzError::UnknownSubject {
-                    subject_id: user_id,
-                }
-            }
-            rejection => impossible!(rejection),
-        })?;
+        .map_err(|_| AuthorizationError::Forbidden)?;
 
     let groups_id = user_groups.into_iter().map(|authz::Group(id)| id);
     let (result, missing_ids) =
@@ -248,6 +240,16 @@ pub(in crate::views) async fn users_info(
         u1
     };
 
+    {
+        let found_ids = users
+            .iter()
+            .map(|user| user.user.id)
+            .collect::<HashSet<_>>();
+        if let Some(id) = ids.into_iter().find(|id| !found_ids.contains(id)) {
+            return Err(AuthzError::UnknownUser { id }.into());
+        }
+    }
+
     // Check for missing requested identities
     {
         let identities = HashSet::from_iter(identities.iter());
@@ -273,21 +275,8 @@ pub(in crate::views) async fn users_info(
         let user_groups = v2::user_groups(authz::User(user.user.id));
         v2::Protected::value(user).zip(user_groups)
     }));
-    let system = SystemAuthorizer {
-        openfga: regulator.openfga(),
-        conn,
-    };
-    let user_groups = system
-        .authorize(groups_prots)
-        .await?
-        .access()
-        .await?
-        .map_err(|rejection| match rejection {
-            Check::SubjectExists(authz::Subject::User(authz::User(user_id))) => {
-                AuthzError::UnknownUser { id: user_id }
-            }
-            rejection => impossible!(rejection),
-        })?;
+    let system = SystemAuthorizer::new_infallible(regulator.openfga());
+    let Ok(user_groups) = system.authorize(groups_prots).await?.access().await?;
 
     // Find groups that really exist (OpenFGA can be out of sync sometimes)
     let group_by_id = {
@@ -306,7 +295,7 @@ pub(in crate::views) async fn users_info(
     };
 
     // Fetch roles and build the response
-    let results = v2::Protected::from_iter(user_groups.into_iter().map(
+    let Ok(results) = v2::Protected::from_iter(user_groups.into_iter().map(
         |(
             UserWithIdentities {
                 user: editoast_models::User { id, name },
@@ -336,14 +325,7 @@ pub(in crate::views) async fn users_info(
     .authorize(&system)
     .await?
     .access()
-    .await?
-    .inspect_err(|rejection| match rejection {
-        Check::SubjectExists(authz::Subject::User(authz::User(_))) => {
-            unreachable!("checked while retrieving groups")
-        }
-        check => impossible!(check),
-    })
-    .expect("no rejections possible");
+    .await?;
 
     Ok(Json(results))
 }
@@ -380,16 +362,29 @@ pub(in crate::views) async fn user_privileges(
     Json(resources_ids): Json<HashMap<ResourceType, Vec<i64>>>,
 ) -> Result<Json<HashMap<ResourceType, Vec<ResourcePrivileges>>>> {
     let mut result = HashMap::<_, Vec<_>>::new();
-    let mut conn = db_pool.get().await?;
+    let missing_resources = retrieve_missing_resource_ids(
+        db_pool.get().await?,
+        resources_ids.iter().flat_map(|(resource_type, ids)| {
+            std::iter::repeat(*resource_type).zip(ids.iter().copied())
+        }),
+    )
+    .await?;
+
     match &authn_state {
         crate::authentication::State::Authenticated { user, .. } => {
             let resources = resources_ids.into_iter().flat_map(|(resource_type, ids)| {
-                ids.into_iter().map(move |id| match resource_type {
-                    ResourceType::Infra => Resource::Infra(authz::Infra(id)),
-                    ResourceType::RollingStock => Resource::RollingStock(authz::RollingStock(id)),
-                })
+                let missing_ids = &missing_resources[&resource_type];
+                // Missing resources are not an error under this API: omit them before authorization.
+                ids.into_iter()
+                    .filter(|id| !missing_ids.contains(id))
+                    .map(move |id| match resource_type {
+                        ResourceType::Infra => Resource::Infra(authz::Infra(id)),
+                        ResourceType::RollingStock => {
+                            Resource::RollingStock(authz::RollingStock(id))
+                        }
+                    })
             });
-            let protected_privileges = resources.map(|resource| match resource {
+            let protected_privileges = resources.into_iter().map(|resource| match resource {
                 resource @ Resource::Infra(infra) => v2::infra_privileges(*user, infra)
                     .collect_into::<HashSet<StandardPrivilege>>()
                     .zip(v2::Protected::value(resource)),
@@ -399,7 +394,7 @@ pub(in crate::views) async fn user_privileges(
                         .zip(v2::Protected::value(resource))
                 }
             });
-            let authorizer = authn_state.authorizer(regulator.openfga(), conn);
+            let authorizer = authn_state.authorizer(regulator.openfga());
             let accesses = authorizer.authorize_all(protected_privileges).await?;
             for access in v2::Access::access_all(accesses).await? {
                 match access {
@@ -411,10 +406,6 @@ pub(in crate::views) async fn user_privileges(
                                 resource_id: resource.id(),
                                 privileges,
                             });
-                    }
-                    Err(Check::InfraExists(_)) | Err(Check::RollingStockExists(_)) => {
-                        // not an error under the target API
-                        // (though maybe we should revisit it?)
                     }
                     Err(Check::HasInfraPrivilege(
                         Actor::Issuer,
@@ -441,14 +432,7 @@ pub(in crate::views) async fn user_privileges(
                             },
                         );
                     }
-                    Err(Check::SubjectExists(authz::Subject::User(_))) => {
-                        panic!("race condition: user deleted");
-                    }
-                    Err(check @ Check::HasInfraPrivilege(_, _, _))
-                    | Err(check @ Check::HasRollingStockPrivilege(_, _, _))
-                    | Err(check) => {
-                        impossible!(check)
-                    }
+                    Err(_) => return Err(AuthorizationError::Forbidden.into()),
                 }
             }
         }
@@ -463,37 +447,46 @@ pub(in crate::views) async fn user_privileges(
                 StandardPrivilege::CanRevoke,
             ]);
             for (resource_type, ids) in resources_ids {
-                let existing_ids: Vec<i64> = match resource_type {
-                    ResourceType::Infra => {
-                        Infra::retrieve_batch_unchecked::<_, Vec<_>>(&mut conn, ids)
-                            .await?
-                            .into_iter()
-                            .map(|i| i.id)
-                            .collect()
-                    }
-                    ResourceType::RollingStock => {
-                        RollingStock::retrieve_batch_unchecked::<_, Vec<_>>(&mut conn, ids)
-                            .await?
-                            .into_iter()
-                            .map(|rs| rs.id)
-                            .collect()
-                    }
-                };
-                result
-                    .entry(resource_type)
-                    .or_default()
-                    .extend(
-                        existing_ids
-                            .into_iter()
-                            .map(|resource_id| ResourcePrivileges {
-                                resource_id,
-                                privileges: privileges.clone(),
-                            }),
-                    );
+                let missing_ids = &missing_resources[&resource_type];
+                result.entry(resource_type).or_default().extend(
+                    ids.into_iter()
+                        .filter(|id| !missing_ids.contains(id))
+                        .map(|resource_id| ResourcePrivileges {
+                            resource_id,
+                            privileges: privileges.clone(),
+                        }),
+                );
             }
         }
     }
     Ok(Json(result))
+}
+
+async fn retrieve_missing_resource_ids(
+    mut conn: database::DbConnection,
+    resources: impl IntoIterator<Item = (ResourceType, i64)>,
+) -> std::result::Result<HashMap<ResourceType, HashSet<i64>>, editoast_models::Error> {
+    let mut resources = resources
+        .into_iter()
+        .into_group_map()
+        .into_iter()
+        .map(|(resource_type, ids)| (resource_type, ids.into_iter().collect()))
+        .collect::<HashMap<ResourceType, HashSet<i64>>>();
+    let infra_ids = resources.remove(&ResourceType::Infra).unwrap_or_default();
+    let rolling_stock_ids = resources
+        .remove(&ResourceType::RollingStock)
+        .unwrap_or_default();
+
+    let mut infra_conn = conn.clone();
+    let ((_, missing_infras), (_, missing_rolling_stocks)) = tokio::try_join!(
+        Infra::retrieve_batch::<_, Vec<_>>(&mut infra_conn, infra_ids),
+        RollingStock::retrieve_batch::<_, Vec<_>>(&mut conn, rolling_stock_ids),
+    )?;
+
+    Ok(HashMap::from([
+        (ResourceType::Infra, missing_infras),
+        (ResourceType::RollingStock, missing_rolling_stocks),
+    ]))
 }
 
 #[derive(Serialize, ToSchema)]
@@ -528,11 +521,22 @@ pub(in crate::views) async fn user_grants(
     let user = authn_state
         .regular_user()
         .ok_or(AuthorizationError::Unauthenticated)?;
-    let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+    let authorizer = authn_state.authorizer(regulator.openfga());
     let mut response = HashMap::<_, Vec<UserResourceGrant>>::new();
+    let missing_resources = retrieve_missing_resource_ids(
+        db_pool.get().await?,
+        body.iter().flat_map(|(resource_type, ids)| {
+            std::iter::repeat(*resource_type).zip(ids.iter().copied())
+        }),
+    )
+    .await?;
+    // Missing resources are not an error under this API: omit them before authorization.
     // TODO build all protected at once, zip them and batch send them with `authorize_all`
     for (resource_type, ids) in &body {
         for id in ids {
+            if missing_resources[resource_type].contains(id) {
+                continue;
+            }
             let grant_access = match resource_type {
                 ResourceType::Infra => {
                     authz::v2::infra_effective_grant(authz::Subject::user(user), authz::Infra(*id))
@@ -552,10 +556,6 @@ pub(in crate::views) async fn user_grants(
             let grant = match grant_access {
                 Ok(Some(grant)) => grant,
                 Ok(None) => continue,
-                Err(Check::InfraExists(infra)) => {
-                    tracing::warn!(%infra, "non-existent infra — skipping");
-                    continue;
-                }
                 Err(Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, infra)) => {
                     tracing::warn!(%infra, "user cannot read infra — skipping");
                     continue;
@@ -568,14 +568,7 @@ pub(in crate::views) async fn user_grants(
                     tracing::warn!(%rolling_stock, "user cannot read rolling stock — skipping");
                     continue;
                 }
-                Err(Check::SubjectExists(subject)) => {
-                    unreachable!("{subject} exists or race condition")
-                }
-                Err(Check::RollingStockExists(rolling_stock)) => {
-                    tracing::warn!(%rolling_stock, "non-existent rolling stock — skipping");
-                    continue;
-                }
-                Err(check) => impossible!(check),
+                Err(_) => return Err(AuthorizationError::Forbidden.into()),
             };
             response
                 .entry(*resource_type)
@@ -624,13 +617,17 @@ pub(in crate::views) async fn resource_granted_users(
     Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
     Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
 ) -> Result<Json<Vec<SubjectGrant>>> {
-    let conn = db_pool.get().await?;
+    let mut conn = db_pool.get().await?;
     let openfga = regulator.openfga();
-    let authorizer = authn_state.authorizer(openfga, conn);
+    let authorizer = authn_state.authorizer(openfga);
     // Ask OpenFGA about grants on the resource
     let ((readers, writers), owners) = match resource_type {
         ResourceType::Infra => {
             let infra = authz::Infra(resource_id);
+            Infra::exists_or_fail(&mut conn, resource_id, || AuthzError::UnknownResource {
+                resource_id,
+            })
+            .await?;
             authorizer
                 .authorize(
                     authz::v2::infra_granted_subjects(infra, InfraGrant::Reader)
@@ -640,18 +637,14 @@ pub(in crate::views) async fn resource_granted_users(
                 .await?
                 .access()
                 .await?
-                .map_err(|err| match err {
-                    Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRead, ..) => {
-                        AuthzError::Authz(AuthorizationError::Forbidden)
-                    }
-                    Check::InfraExists(_) => AuthzError::UnknownResource {
-                        resource_id: infra.0,
-                    },
-                    rejection => impossible!(rejection),
-                })?
+                .map_err(|_| AuthorizationError::Forbidden)?
         }
         ResourceType::RollingStock => {
             let rolling_stock = authz::RollingStock(resource_id);
+            RollingStock::exists_or_fail(&mut conn, resource_id, || AuthzError::UnknownResource {
+                resource_id,
+            })
+            .await?;
             authorizer
                 .authorize(
                     authz::v2::rolling_stock_granted_subjects(
@@ -670,17 +663,7 @@ pub(in crate::views) async fn resource_granted_users(
                 .await?
                 .access()
                 .await?
-                .map_err(|err| match err {
-                    Check::HasRollingStockPrivilege(
-                        Actor::Issuer,
-                        RollingStockPrivilege::CanRead,
-                        _,
-                    ) => AuthzError::Authz(AuthorizationError::Forbidden),
-                    Check::RollingStockExists(rolling_stock) => AuthzError::UnknownResource {
-                        resource_id: rolling_stock.0,
-                    },
-                    rejection => impossible!(rejection),
-                })?
+                .map_err(|_| AuthorizationError::Forbidden)?
         }
     };
 
@@ -813,6 +796,36 @@ pub(in crate::views) async fn update_grants(
     Extension(authn_state): Extension<crate::authentication::State>,
     Json(body): Json<BodyUpdateGrants>,
 ) -> Result<impl IntoResponse> {
+    {
+        let conn = db_pool.get().await?;
+        let missing_resources = match &body {
+            BodyUpdateGrants::Grant(grants) => {
+                retrieve_missing_resource_ids(
+                    conn,
+                    grants
+                        .iter()
+                        .map(|grant| (grant.resource_type, grant.resource_id)),
+                )
+                .await?
+            }
+            BodyUpdateGrants::Revoke(revokes) => {
+                retrieve_missing_resource_ids(
+                    conn,
+                    revokes
+                        .iter()
+                        .map(|revoke| (revoke.resource_type, revoke.resource_id)),
+                )
+                .await?
+            }
+        };
+        let missing_resource_id = [ResourceType::Infra, ResourceType::RollingStock]
+            .into_iter()
+            .find_map(|resource_type| missing_resources[&resource_type].iter().min().copied());
+        if let Some(resource_id) = missing_resource_id {
+            return Err(AuthzError::UnknownResource { resource_id }.into());
+        }
+    }
+
     // Fetch subjects from the database and determine whether they're a user or a group.
     let subjects = {
         let subjects_id = match &body {
@@ -844,7 +857,7 @@ pub(in crate::views) async fn update_grants(
             .collect::<HashMap<_, _>>()
     };
 
-    let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
+    let authorizer = authn_state.authorizer(regulator.openfga());
 
     match body {
         BodyUpdateGrants::Grant(grants) => {
@@ -855,39 +868,7 @@ pub(in crate::views) async fn update_grants(
 
             match prot.authorize(&authorizer).await?.access().await? {
                 Ok(_) => Ok(StatusCode::CREATED),
-                Err(Check::InfraExists(infra)) => Err(AuthzError::UnknownResource {
-                    resource_id: *infra,
-                }
-                .into()),
-                Err(Check::RollingStockExists(rolling_stock)) => Err(AuthzError::UnknownResource {
-                    resource_id: *rolling_stock,
-                }
-                .into()),
-                Err(Check::SubjectExists(subject)) => Err(AuthzError::UnknownSubject {
-                    subject_id: subject.id(),
-                }
-                .into()),
-                Err(
-                    Check::HasInfraPrivilege(
-                        Actor::Issuer,
-                        InfraPrivilege::CanShareRead
-                        | InfraPrivilege::CanShareWrite
-                        | InfraPrivilege::CanShareOwnership,
-                        _,
-                    )
-                    | Check::HasRollingStockPrivilege(
-                        Actor::Issuer,
-                        RollingStockPrivilege::CanShareRead
-                        | RollingStockPrivilege::CanShareWrite
-                        | RollingStockPrivilege::CanShareOwnership,
-                        _,
-                    )
-                    | Check::CanAlterSubjectInfraGrant(..)
-                    | Check::CanAlterSubjectRollingStockGrant(..)
-                    | Check::IsNotLastRollingStockOwner(..)
-                    | Check::IsNotLastInfraOwner(..),
-                ) => Err(AuthorizationError::Forbidden.into()),
-                Err(check) => impossible!(check),
+                Err(_) => Err(AuthorizationError::Forbidden.into()),
             }
         }
         BodyUpdateGrants::Revoke(revokes) => {
@@ -898,27 +879,7 @@ pub(in crate::views) async fn update_grants(
 
             match prot.authorize(&authorizer).await?.access().await? {
                 Ok(_) => Ok(StatusCode::NO_CONTENT),
-                Err(Check::InfraExists(infra)) => Err(AuthzError::UnknownResource {
-                    resource_id: *infra,
-                }
-                .into()),
-                Err(Check::SubjectExists(subject)) => Err(AuthzError::UnknownSubject {
-                    subject_id: subject.id(),
-                }
-                .into()),
-                Err(
-                    Check::HasInfraPrivilege(Actor::Issuer, InfraPrivilege::CanRevoke, _)
-                    | Check::SubjectEffectiveInfraGrantIsNot(..)
-                    | Check::IsNotLastInfraOwner(..)
-                    | Check::HasRollingStockPrivilege(
-                        Actor::Issuer,
-                        RollingStockPrivilege::CanRevoke,
-                        _,
-                    )
-                    | Check::SubjectEffectiveRollingStockGrantIsNot(..)
-                    | Check::IsNotLastRollingStockOwner(..),
-                ) => Err(AuthorizationError::Forbidden.into()),
-                Err(check) => impossible!(check),
+                Err(_) => Err(AuthorizationError::Forbidden.into()),
             }
         }
     }
@@ -1004,6 +965,7 @@ mod tests {
     use strum::IntoEnumIterator;
 
     use super::*;
+    use crate::error::InternalError;
     use crate::fixtures::create_empty_infra;
     use crate::fixtures::create_fast_rolling_stock;
     use crate::fixtures::create_small_infra;
@@ -1033,7 +995,7 @@ mod tests {
             .post("/authz/me/privileges")
             .by_user(toto.as_ref())
             .json(&json!({
-               "infra": [infra1, infra2, infra3, infra4]
+               "infra": [infra1, infra2, infra3, infra4, i64::MAX]
             }))
             .await
             .assert_status_ok()
@@ -1075,6 +1037,7 @@ mod tests {
         );
         assert_eq!(privileges.remove(&infra4).unwrap(), HashSet::from([]));
         assert!(!privileges.contains_key(&infra_unused));
+        assert!(!privileges.contains_key(&i64::MAX));
     }
 
     // TODO: merge with the previous test once test deadlocks are fixed
@@ -1307,6 +1270,107 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[rstest]
+    #[case(ResourceType::Infra)]
+    #[case(ResourceType::RollingStock)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn users_grants_for_missing_resource_returns_not_found(
+        #[case] resource_type: ResourceType,
+    ) {
+        let app = test_app!().build();
+        let user = app
+            .user("authz", "Authz")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(&format!("/authz/{resource_type}/{}", i64::MAX))
+            .by_user(user.as_ref())
+            .await
+            .assert_status_not_found();
+    }
+
+    #[rstest]
+    #[case(ResourceType::Infra)]
+    #[case(ResourceType::RollingStock)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_grants_for_missing_resource_returns_not_found(
+        #[case] resource_type: ResourceType,
+    ) {
+        let app = test_app!().build();
+        let owner = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+        let subject = app.user("subject", "Subject").create().await;
+
+        app.post("/authz/grants")
+            .by_user(owner.as_ref())
+            .json(&json!({
+                "grant": [{
+                    "subject_id": subject.id,
+                    "resource_type": resource_type,
+                    "resource_id": i64::MAX,
+                    "grant": StandardGrant::Reader,
+                }]
+            }))
+            .await
+            .assert_status_not_found();
+
+        app.post("/authz/grants")
+            .by_user(owner.as_ref())
+            .json(&json!({
+                "revoke": [{
+                    "subject_id": subject.id,
+                    "resource_type": resource_type,
+                    "resource_id": i64::MAX,
+                }]
+            }))
+            .await
+            .assert_status_not_found();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_grants_reports_missing_resources_deterministically() {
+        let app = test_app!().build();
+        let owner = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+        let subject = app.user("subject", "Subject").create().await;
+        let missing_infra_id = i64::MAX - 1;
+
+        let response: InternalError = app
+            .post("/authz/grants")
+            .by_user(owner.as_ref())
+            .json(&json!({
+                "grant": [
+                    {
+                        "subject_id": subject.id,
+                        "resource_type": ResourceType::RollingStock,
+                        "resource_id": i64::MAX,
+                        "grant": StandardGrant::Reader,
+                    },
+                    {
+                        "subject_id": subject.id,
+                        "resource_type": ResourceType::Infra,
+                        "resource_id": missing_infra_id,
+                        "grant": StandardGrant::Reader,
+                    },
+                ]
+            }))
+            .await
+            .assert_status_not_found()
+            .json();
+
+        assert_eq!(
+            response.context["resource_id"],
+            serde_json::Value::from(missing_infra_id)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -3113,6 +3177,12 @@ mod tests {
                 },
             ]
         );
+
+        app.post("/authz/user/info")
+            .by_user(admin.as_ref())
+            .json(&json!({ "ids": [i64::MAX] }))
+            .await
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -13,7 +13,6 @@ use authz::InfraGrant;
 use authz::InfraPrivilege;
 use authz::v2;
 use authz::v2::Authorizer as _;
-use authz::v2::Check;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -45,7 +44,6 @@ use crate::Arc;
 use crate::authentication;
 use crate::authorizers::SystemAuthorizer;
 use crate::authorizers::UserAuthorizer;
-use crate::authorizers::impossible;
 use crate::error::Result;
 use crate::generated_data::InfraGeneratedData as _;
 use crate::generated_data::operational_point::OperationalPointLayer;
@@ -198,17 +196,13 @@ pub(in crate::views) async fn list(
     let settings = match authn {
         crate::authentication::State::Skip => default_settings,
         crate::authentication::State::Authenticated { user, roles } => {
-            let authorizer =
-                UserAuthorizer::new(user, roles.clone(), regulator.openfga(), conn.clone());
+            let authorizer = UserAuthorizer::new(user, roles.clone(), regulator.openfga());
             let authorized_infras = authorizer
                 .authorize(authz::v2::infra_list(user, InfraPrivilege::CanRead))
                 .await?
                 .access()
                 .await?
-                .map_err(|err| match err {
-                    Check::SubjectExists(_) => unreachable!("checked above"),
-                    _ => AuthorizationError::Forbidden,
-                })?;
+                .map_err(|_| AuthorizationError::Forbidden)?;
             match authorized_infras {
                 authz::v2::ResourcesList::All => default_settings,
                 authz::v2::ResourcesList::Privileged(authorized_infras) => {
@@ -307,34 +301,15 @@ pub(in crate::views) async fn create(
     let infra = infra.create(&mut conn).await?;
 
     if let authentication::State::Authenticated { user, .. } = &authn_state {
-        match v2::infra_set_grant(
+        let Ok(()) = v2::infra_set_grant(
             authz::Subject::User(*user),
             authz::Infra(infra.id),
             InfraGrant::Owner,
         )
-        .authorize(&SystemAuthorizer {
-            openfga: regulator.openfga(),
-            conn: conn.clone(),
-        })
+        .authorize(&SystemAuthorizer::new_infallible(regulator.openfga()))
         .await?
         .access()
-        .await?
-        {
-            Ok(()) => {}
-            Err(v2::Check::SubjectExists(subject)) => {
-                unreachable!("authenticated user should exist: {subject:?}")
-            }
-            Err(v2::Check::InfraExists(infra)) => {
-                unreachable!("infra was just created: {infra:?}")
-            }
-            Err(
-                check @ (v2::Check::HasInfraPrivilege(..)
-                | v2::Check::CanAlterSubjectInfraGrant(..)),
-            ) => {
-                unreachable!("SystemAuthorizer should not reject infra grant checks: {check:?}")
-            }
-            Err(check) => impossible!(check),
-        }
+        .await?;
     }
 
     Ok((StatusCode::CREATED, Json(infra)))
@@ -385,34 +360,15 @@ pub(in crate::views) async fn clone(
     let cloned_infra = infra.clone(&mut conn, name).await?;
 
     if let authentication::State::Authenticated { user, .. } = &authn_state {
-        match v2::infra_set_grant(
+        let Ok(()) = v2::infra_set_grant(
             authz::Subject::User(*user),
             authz::Infra(cloned_infra.id),
             InfraGrant::Owner,
         )
-        .authorize(&SystemAuthorizer {
-            openfga: regulator.openfga(),
-            conn: conn.clone(),
-        })
+        .authorize(&SystemAuthorizer::new_infallible(regulator.openfga()))
         .await?
         .access()
-        .await?
-        {
-            Ok(()) => {}
-            Err(v2::Check::SubjectExists(subject)) => {
-                unreachable!("authenticated user should exist: {subject:?}")
-            }
-            Err(v2::Check::InfraExists(infra)) => {
-                unreachable!("infra was just cloned: {infra:?}")
-            }
-            Err(
-                check @ (v2::Check::HasInfraPrivilege(..)
-                | v2::Check::CanAlterSubjectInfraGrant(..)),
-            ) => {
-                unreachable!("SystemAuthorizer should not reject infra grant checks: {check:?}")
-            }
-            Err(check) => impossible!(check),
-        }
+        .await?;
     }
 
     Ok(Json(cloned_infra.id))

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -23,7 +23,6 @@ use utoipa::ToSchema;
 use crate::AppState;
 use crate::authentication;
 use crate::authorizers::SystemAuthorizer;
-use crate::authorizers::impossible;
 use crate::error::Result;
 use crate::generated_data::InfraGeneratedData as _;
 use crate::infra_cache::InfraCache;
@@ -207,34 +206,15 @@ pub(in crate::views) async fn post_railjson(
         .map_err(RailJsonError::from)?;
 
     if let authentication::State::Authenticated { user, .. } = &authn_state {
-        match v2::infra_set_grant(
+        let Ok(()) = v2::infra_set_grant(
             authz::Subject::user(*user),
             authz::Infra(infra.id),
             InfraGrant::Owner,
         )
-        .authorize(&SystemAuthorizer {
-            openfga: regulator.openfga(),
-            conn: conn.clone(),
-        })
+        .authorize(&SystemAuthorizer::new_infallible(regulator.openfga()))
         .await?
         .access()
-        .await?
-        {
-            Ok(()) => {}
-            Err(v2::Check::SubjectExists(subject)) => {
-                unreachable!("authenticated user should exist: {subject:?}")
-            }
-            Err(v2::Check::InfraExists(infra)) => {
-                unreachable!("infra was just imported: {infra:?}")
-            }
-            Err(
-                check @ (v2::Check::HasInfraPrivilege(..)
-                | v2::Check::CanAlterSubjectInfraGrant(..)),
-            ) => {
-                unreachable!("SystemAuthorizer should not reject infra grant checks: {check:?}")
-            }
-            Err(check) => impossible!(check),
-        }
+        .await?;
     }
 
     infra

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -542,10 +542,7 @@ impl<'a> UserBuilder<'a> {
                 .unwrap_authorized()
                 .await;
 
-            let system = SystemAuthorizer {
-                openfga: regulator.openfga(),
-                conn: app.db_pool().get().await.unwrap(),
-            };
+            let system = SystemAuthorizer::new_infallible(regulator.openfga());
             for (infra_id, grant) in infras_grant.into_iter() {
                 v2::infra_set_grant(
                     authz::Subject::User(authz::User(user.id)),
@@ -660,10 +657,7 @@ impl<'a> GroupBuilder<'a> {
             .unwrap_authorized()
             .await;
 
-            let system = SystemAuthorizer {
-                openfga: regulator.openfga(),
-                conn: app.db_pool().get().await.unwrap(),
-            };
+            let system = SystemAuthorizer::new_infallible(regulator.openfga());
             let subject = authz::Subject::Group(group_auth);
             for (infra_id, grant) in infras_grant.into_iter() {
                 v2::infra_set_grant(subject, authz::Infra(infra_id), grant)


### PR DESCRIPTION
refs https://github.com/osrd-project/osrd-confidential/issues/1168

Follows a discussion we had with @younesschrifi and @Sh099078, and feedback on the new v2 API verbosity in different places.

---

Having these checks (`InfraExists`, `ProjectExists`, etc.) are great to
guarantee that the protected operation is sound, but it results in a
bunch of issues as well:

- A DB connection is necessary to run the checks.
- There's a weird overlap between `SystemAuthorizer` and `UserAuthorizer`.
- `Authorizer::authorize` returns the first failing check. Those running
  concurrently, endpoints may return 404 or 403 depending on which one
  fails first.
- Existence checks were oftentime unnecessary as the resource is accessed
  beforehand resulting in an `unreachable!` assertion.
- It requires having authorizers in `crate editoast` instead of
  `crate authz`.
- DB queries that could have been batched were not.

This commit removes such checks. Consequently:

- We check the required resources exist before running the authorizer
  in order to keep emitting the same API errors.
- We do not match on the failing check, all ending up in 403 anyway.
  We couldn't leverage any comiler help on these matching anyway so it's
  not a huge loss, even in terms of readability. `impossible!` is
  therfore removed as well.
- `SystemAuthorizer` now never rejects but now takes the rejection type
  in generics to allow:
  - `Infallible` for direct usage and not having to deal with the `Err`;
  - `Check` in order to blend with `UserAuthorizer` when necessary.