### PR TITLE
front: compute the possible linkings of a TOD

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/computePossibleLinkings.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/computePossibleLinkings.spec.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
+
+import computePossibleLinkings, { type LinkableOccupancy } from '../computePossibleLinkings';
+
+const MINUTE = 60_000;
+const TRACK_1 = 'V1';
+const TRACK_2 = 'V2';
+
+type OccupancyFixture = Omit<
+  LinkableOccupancy,
+  'trainId' | 'localTrackName' | 'blockType' | 'isStop' | 'active'
+> & {
+  editoastId: number;
+  /** Required, though it may be nil, so that every fixture states the occupied track. */
+  localTrackName: LinkableOccupancy['localTrackName'];
+  isStop?: boolean;
+  active?: boolean;
+};
+
+const buildOccupancy = ({
+  editoastId,
+  ...occupancy
+}: OccupancyFixture & Pick<LinkableOccupancy, 'blockType'>): LinkableOccupancy => ({
+  trainId: formatEditoastIdToTrainScheduleId(editoastId),
+  isStop: true,
+  active: true,
+  ...occupancy,
+});
+
+/** An occupancy of a train ending its path on the track. */
+const arriving = (occupancy: OccupancyFixture) =>
+  buildOccupancy({ ...occupancy, blockType: 'incoming' });
+
+/** An occupancy of a train starting its path on the track. */
+const departing = (occupancy: OccupancyFixture) =>
+  buildOccupancy({ ...occupancy, blockType: 'outgoing' });
+
+/** An occupancy of a train whose path neither starts nor ends on the track. */
+const via = (occupancy: OccupancyFixture) => buildOccupancy({ ...occupancy, blockType: 'via' });
+
+describe('computePossibleLinkings', () => {
+  it('should link a train ending its path to the next one starting from a stop on the same track', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([[formatEditoastIdToTrainScheduleId(1), formatEditoastIdToTrainScheduleId(2)]])
+    );
+  });
+
+  it('should link two trains occupying the track back to back', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 10 * MINUTE,
+        endTime: 20 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([[formatEditoastIdToTrainScheduleId(1), formatEditoastIdToTrainScheduleId(2)]])
+    );
+  });
+
+  it('should return no linking when there is no occupancy', () => {
+    expect(computePossibleLinkings([])).toEqual(new Map());
+  });
+
+  it('should not link trains occupying different tracks', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      departing({
+        localTrackName: TRACK_2,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it.each([undefined, null])(
+    'should not link trains whose track is unknown (%s)',
+    (localTrackName) => {
+      const linkings = computePossibleLinkings([
+        arriving({ localTrackName, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+        departing({
+          localTrackName,
+          editoastId: 2,
+          startTime: 30 * MINUTE,
+          endTime: 40 * MINUTE,
+        }),
+      ]);
+
+      expect(linkings).toEqual(new Map());
+    }
+  );
+
+  it('should not link a train that does not end its path on the track', () => {
+    const linkings = computePossibleLinkings([
+      via({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link a train that does not start its path on the track', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      via({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link a train that does not stop at the end of its path', () => {
+    const linkings = computePossibleLinkings([
+      arriving({
+        localTrackName: TRACK_1,
+        editoastId: 1,
+        startTime: 0,
+        endTime: 10 * MINUTE,
+        isStop: false,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link a train that does not start its path from a stop', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+        isStop: false,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link two trains whose occupancies overlap', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 40 * MINUTE }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 60 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link two trains when another one occupies the track in between', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      via({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 15 * MINUTE,
+        endTime: 20 * MINUTE,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 3,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link two trains when another one covers the whole linking', () => {
+    const linkings = computePossibleLinkings([
+      via({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 60 * MINUTE }),
+      arriving({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 5 * MINUTE,
+        endTime: 10 * MINUTE,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 3,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link two trains when another one crosses the track without stopping', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      via({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 15 * MINUTE,
+        endTime: 15 * MINUTE,
+        isStop: false,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 3,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it('should not link two trains when another one crosses the track at the handover instant', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      via({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 10 * MINUTE,
+        endTime: 10 * MINUTE,
+        isStop: false,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 3,
+        startTime: 10 * MINUTE,
+        endTime: 20 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(new Map());
+  });
+
+  it.each(['source', 'target'] as const)(
+    'should not link the %s occurrence when it is disabled',
+    (disabledSide) => {
+      const linkings = computePossibleLinkings([
+        arriving({
+          localTrackName: TRACK_1,
+          editoastId: 1,
+          startTime: 0,
+          endTime: 10 * MINUTE,
+          active: disabledSide !== 'source',
+        }),
+        departing({
+          localTrackName: TRACK_1,
+          editoastId: 2,
+          startTime: 30 * MINUTE,
+          endTime: 40 * MINUTE,
+          active: disabledSide !== 'target',
+        }),
+      ]);
+
+      expect(linkings).toEqual(new Map());
+    }
+  );
+
+  it('should ignore disabled occurrences when checking the track in between', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      via({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 15 * MINUTE,
+        endTime: 20 * MINUTE,
+        active: false,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 3,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([[formatEditoastIdToTrainScheduleId(1), formatEditoastIdToTrainScheduleId(3)]])
+    );
+  });
+
+  it('should link the trains of each track independently', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+      arriving({
+        localTrackName: TRACK_2,
+        editoastId: 3,
+        startTime: 5 * MINUTE,
+        endTime: 15 * MINUTE,
+      }),
+      departing({
+        localTrackName: TRACK_2,
+        editoastId: 4,
+        startTime: 20 * MINUTE,
+        endTime: 50 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([
+        [formatEditoastIdToTrainScheduleId(1), formatEditoastIdToTrainScheduleId(2)],
+        [formatEditoastIdToTrainScheduleId(3), formatEditoastIdToTrainScheduleId(4)],
+      ])
+    );
+  });
+
+  it('should not link two trains when another linkable occupancy stands in between', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      arriving({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 15 * MINUTE,
+        endTime: 25 * MINUTE,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 3,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 4,
+        startTime: 45 * MINUTE,
+        endTime: 55 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([[formatEditoastIdToTrainScheduleId(2), formatEditoastIdToTrainScheduleId(3)]])
+    );
+  });
+});

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/computePossibleLinkings.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/computePossibleLinkings.ts
@@ -1,0 +1,107 @@
+import { groupBy, isNil } from 'lodash';
+
+import type { TrainId } from 'reducers/osrdconf/types';
+
+export type LinkableOccupancy = {
+  trainId: TrainId;
+  /** Nil when the occupied track is unknown. */
+  localTrackName?: string | null;
+  /** Times in ms. */
+  startTime: number;
+  endTime: number;
+  /**
+   * Role of the block in the train path: `incoming` when the train ends its path here, `outgoing`
+   * when it starts it here, and `via` in between, be it a stop or a track the train only passes by.
+   */
+  blockType: 'incoming' | 'outgoing' | 'via';
+  /**
+   * Whether the train stands still on the track: it stops at the end of its path for an `incoming`
+   * block, and starts its path at a null speed for an `outgoing` one. Not read on `via` blocks.
+   */
+  isStop: boolean;
+  active: boolean;
+};
+
+/**
+ * One end of an occupancy block, as scanned along the time axis. A block of no duration — a train
+ * crossing the track without stopping — yields a single `instant` endpoint instead of a pair.
+ */
+type BlockEndpoint = {
+  time: number;
+  type: 'start' | 'end' | 'instant';
+  occupancy: LinkableOccupancy;
+};
+
+/**
+ * At equal times, ends are scanned before instants, and instants before starts, so that back to
+ * back occupancies do not read as an overlap while a train crossing the track still breaks a
+ * pending linking.
+ */
+const ENDPOINT_RANK: Record<BlockEndpoint['type'], number> = { end: 0, instant: 1, start: 2 };
+
+/**
+ * A linking is possible between two occupancies of a same track when the first train ends its path
+ * there, the second one starts its path there, both stand still, and nothing else occupies the
+ * track in between.
+ *
+ * Both ends of a linking may be a unique train as well as an occurrence of a paced train, hence the
+ * `TrainId` keys.
+ *
+ * Rather than comparing every pair of occupancies, the blocks of a track are cut into endpoints,
+ * sorted by time, then scanned once: a linking is found when the end of an incoming block is
+ * immediately followed by the start of an outgoing one, no other block being open in between.
+ *
+ * @returns the possible linkings, from the source (arriving) train to the target (departing) one.
+ * Since no other train may occupy the track in between, a train can be the source of at most one
+ * linking, and the target of at most one other.
+ */
+export default function computePossibleLinkings(
+  occupancies: LinkableOccupancy[]
+): Map<TrainId, TrainId> {
+  const linkings = new Map<TrainId, TrainId>();
+
+  const scannableOccupancies = occupancies.filter(
+    (occupancy) =>
+      occupancy.active &&
+      // Trains whose track is unknown cannot be proven to occupy the same one:
+      !isNil(occupancy.localTrackName)
+  );
+
+  for (const trackOccupancies of Object.values(groupBy(scannableOccupancies, 'localTrackName'))) {
+    const endpoints = trackOccupancies.flatMap<BlockEndpoint>((occupancy) =>
+      occupancy.startTime === occupancy.endTime
+        ? [{ time: occupancy.startTime, type: 'instant', occupancy }]
+        : [
+            { time: occupancy.startTime, type: 'start', occupancy },
+            { time: occupancy.endTime, type: 'end', occupancy },
+          ]
+    );
+    endpoints.sort((a, b) => a.time - b.time || ENDPOINT_RANK[a.type] - ENDPOINT_RANK[b.type]);
+
+    let linkingSource: LinkableOccupancy | null = null;
+    let openBlocks = 0;
+
+    for (const { type, occupancy } of endpoints) {
+      const isLinkingArrival =
+        type === 'end' && occupancy.blockType === 'incoming' && occupancy.isStop;
+      const isLinkingDeparture =
+        type === 'start' && occupancy.blockType === 'outgoing' && occupancy.isStop;
+      const isTrackFree = openBlocks === 0;
+
+      if (isLinkingArrival) {
+        linkingSource = occupancy;
+      } else if (isLinkingDeparture && linkingSource && isTrackFree) {
+        linkings.set(linkingSource.trainId, occupancy.trainId);
+        linkingSource = null;
+      } else {
+        // Any other block reaching the track discards the pending linking source:
+        linkingSource = null;
+      }
+
+      // An instant block covers no interval, so it never opens: it only discards the source above.
+      if (type !== 'instant') openBlocks += type === 'start' ? 1 : -1;
+    }
+  }
+
+  return linkings;
+}


### PR DESCRIPTION
close #17581

A linking represents the fact that a train's rolling stock leaves to run another train, occupying the track in between. This PR adds the pure function that lists, from the occupancies of a TOD, every linking that is possible, along with a unit test per rule. The acceptance criteria are listed in the issue.

The function is not plugged in yet: building its input from the API and drawing the result belongs to the linking edit mode (#17583).
