### PR TITLE
editoast: fix duplicate class names in generated code

### DIFF
--- a/editoast/core_client/src/path_properties.rs
+++ b/editoast/core_client/src/path_properties.rs
@@ -114,7 +114,6 @@ pub struct OperationalPointOnPath {
     pub country_code: NonBlankString,
     #[schema(inline)]
     pub main_code: NonBlankString,
-    #[schema(inline)]
     pub secondary_code: Option<NonBlankString>,
     pub is_passenger_station: bool,
     #[schema(inline)]

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -288,7 +288,6 @@ pub struct SpeedLimitProperties {
     /// A boundary is a distance from the beginning of the path in mm.
     pub boundaries: Vec<u64>,
     /// List of `n+1` values associated to the ranges
-    #[schema(inline)]
     pub values: Vec<SpeedLimitProperty>,
 }
 #[derive(Debug, Serialize, Educe)]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5648,8 +5648,7 @@ components:
         secondary_code:
           oneOf:
           - type: 'null'
-          - type: string
-            minLength: 1
+          - $ref: '#/components/schemas/NonBlankString'
         secondary_name:
           oneOf:
           - type: 'null'
@@ -6056,6 +6055,74 @@ components:
           minimum: 0
         zone:
           type: string
+    CoreSpeedLimitProperties:
+      type: object
+      description: A MRSP computation result (Most Restrictive Speed Profile)
+      required:
+      - boundaries
+      - values
+      properties:
+        boundaries:
+          type: array
+          items:
+            type: integer
+            format: int64
+            minimum: 0
+          description: |-
+            List of `n` boundaries of the ranges (block path).
+            A boundary is a distance from the beginning of the path in mm.
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/CoreSpeedLimitProperty'
+          description: List of `n+1` values associated to the ranges
+    CoreSpeedLimitProperty:
+      type: object
+      required:
+      - speed
+      properties:
+        source:
+          oneOf:
+          - type: 'null'
+          - oneOf:
+            - type: object
+              title: SpeedLimitSourceGivenTrainTag
+              required:
+              - tag
+              - speed_limit_source_type
+              properties:
+                speed_limit_source_type:
+                  type: string
+                  enum:
+                  - given_train_tag
+                tag:
+                  type: string
+            - type: object
+              title: SpeedLimitSourceFallbackTag
+              required:
+              - tag
+              - speed_limit_source_type
+              properties:
+                speed_limit_source_type:
+                  type: string
+                  enum:
+                  - fallback_tag
+                tag:
+                  type: string
+            - type: object
+              title: SpeedLimitSourceUnknownTag
+              required:
+              - speed_limit_source_type
+              properties:
+                speed_limit_source_type:
+                  type: string
+                  enum:
+                  - unknown_tag
+          description: source of the speed-limit if relevant (tag used)
+        speed:
+          type: number
+          format: double
+          description: in meters per second
     CoreTrackRange:
       type: object
       description: |-
@@ -12144,8 +12211,7 @@ components:
         secondary_code:
           oneOf:
           - type: 'null'
-          - type: string
-            minLength: 1
+          - $ref: '#/components/schemas/NonBlankString'
         secondary_name:
           oneOf:
           - type: 'null'
@@ -12510,6 +12576,7 @@ components:
             $ref: '#/components/schemas/ScheduleItem'
     PathItem:
       type: object
+      title: PathItem
       description: A location on the path of a train
       required:
       - id
@@ -13262,8 +13329,7 @@ components:
         secondary_code:
           oneOf:
           - type: 'null'
-          - type: string
-            minLength: 1
+          - $ref: '#/components/schemas/NonBlankString'
         secondary_name:
           oneOf:
           - type: 'null'
@@ -13981,6 +14047,7 @@ components:
             format: int64
     ScheduleItem:
       type: object
+      title: ScheduleItem
       required:
       - at
       properties:
@@ -14893,71 +14960,7 @@ components:
                     $ref: '#/components/schemas/CoreZoneUpdate'
           description: Simulation that takes into account the regularity margins and the schedule item times
         mrsp:
-          type: object
-          description: A MRSP computation result (Most Restrictive Speed Profile)
-          required:
-          - boundaries
-          - values
-          properties:
-            boundaries:
-              type: array
-              items:
-                type: integer
-                format: int64
-                minimum: 0
-              description: |-
-                List of `n` boundaries of the ranges (block path).
-                A boundary is a distance from the beginning of the path in mm.
-            values:
-              type: array
-              items:
-                type: object
-                required:
-                - speed
-                properties:
-                  source:
-                    oneOf:
-                    - type: 'null'
-                    - oneOf:
-                      - type: object
-                        title: SpeedLimitSourceGivenTrainTag
-                        required:
-                        - tag
-                        - speed_limit_source_type
-                        properties:
-                          speed_limit_source_type:
-                            type: string
-                            enum:
-                            - given_train_tag
-                          tag:
-                            type: string
-                      - type: object
-                        title: SpeedLimitSourceFallbackTag
-                        required:
-                        - tag
-                        - speed_limit_source_type
-                        properties:
-                          speed_limit_source_type:
-                            type: string
-                            enum:
-                            - fallback_tag
-                          tag:
-                            type: string
-                      - type: object
-                        title: SpeedLimitSourceUnknownTag
-                        required:
-                        - speed_limit_source_type
-                        properties:
-                          speed_limit_source_type:
-                            type: string
-                            enum:
-                            - unknown_tag
-                    description: source of the speed-limit if relevant (tag used)
-                  speed:
-                    type: number
-                    format: double
-                    description: in meters per second
-              description: List of `n+1` values associated to the ranges
+          $ref: '#/components/schemas/CoreSpeedLimitProperties'
         provisional:
           $ref: '#/components/schemas/CoreReportTrain'
           description: Simulation that takes into account the regularity margins
@@ -15177,8 +15180,7 @@ components:
         value:
           oneOf:
           - type: 'null'
-          - type: string
-            minLength: 1
+          - $ref: '#/components/schemas/NonBlankString'
     SpeedLimits:
       type: object
       required:
@@ -16386,8 +16388,7 @@ components:
           speed_limit_tag:
             oneOf:
             - type: 'null'
-            - type: string
-              minLength: 1
+            - $ref: '#/components/schemas/NonBlankString'
           start_time:
             type: integer
             format: int64

--- a/editoast/schemas/src/infra/operational_point.rs
+++ b/editoast/schemas/src/infra/operational_point.rs
@@ -28,7 +28,6 @@ pub struct OperationalPoint {
     pub country_code: NonBlankString,
     #[schema(inline)]
     pub main_code: NonBlankString,
-    #[schema(inline)]
     pub secondary_code: Option<NonBlankString>,
     pub is_passenger_station: bool,
     #[schema(inline)]

--- a/editoast/schemas/src/paced_train.rs
+++ b/editoast/schemas/src/paced_train.rs
@@ -169,7 +169,6 @@ pub struct LabelsChangeGroup {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct SpeedLimitTagChangeGroup {
-    #[schema(inline)]
     pub value: Option<NonBlankString>,
 }
 

--- a/editoast/schemas/src/train_schedule.rs
+++ b/editoast/schemas/src/train_schedule.rs
@@ -77,7 +77,6 @@ pub struct TrainOccurrence {
     #[serde_as(as = "DefaultOnNull")]
     pub comfort: Comfort,
     pub constraint_distribution: Distribution,
-    #[schema(inline)]
     #[serde(default)]
     pub speed_limit_tag: Option<NonBlankString>,
     #[schema(inline)]

--- a/editoast/schemas/src/train_schedule/path_item.rs
+++ b/editoast/schemas/src/train_schedule/path_item.rs
@@ -8,6 +8,7 @@ use crate::infra::TrackOffset;
 
 /// A location on the path of a train
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(title = "PathItem")]
 pub struct PathItem {
     /// The unique identifier of the path item.
     /// This is used to reference path items in the train schedule.

--- a/editoast/schemas/src/train_schedule/schedule_item.rs
+++ b/editoast/schemas/src/train_schedule/schedule_item.rs
@@ -22,6 +22,7 @@ pub enum ReceptionSignal {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(remote = "Self")]
+#[schema(title = "ScheduleItem")]
 pub struct ScheduleItem {
     /// Position on the path of the schedule item.
     #[schema(inline)]

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -749,7 +749,6 @@ struct RelatedOperationalPoint {
     pub country_code: NonBlankString,
     #[schema(inline)]
     pub main_code: NonBlankString,
-    #[schema(inline)]
     pub secondary_code: Option<NonBlankString>,
     pub is_passenger_station: bool,
     #[schema(inline)]

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -76,7 +76,6 @@ pub struct SimulationResponseSuccess {
     /// Simulation that takes into account the regularity margins and the schedule item times
     #[schema(inline)]
     pub final_output: CompleteReportTrain,
-    #[schema(inline)]
     pub mrsp: SpeedLimitProperties,
     #[schema(inline)]
     pub electrical_profiles: ElectricalProfiles,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3134,7 +3134,7 @@ export type OperationalPoint = {
   parts: OperationalPointPart[];
   /** Primary Location Code : https://rne.eu/it/products/ccs/crd/ */
   plc?: null | string;
-  secondary_code?: null | string;
+  secondary_code?: null | NonBlankString;
   secondary_name?: null | string;
   uic?: number | null;
   weight?: number | null;
@@ -3549,7 +3549,7 @@ export type RelatedOperationalPoint = {
   name: string;
   parts: RelatedOperationalPointPart[];
   plc?: null | string;
-  secondary_code?: null | string;
+  secondary_code?: null | NonBlankString;
   secondary_name?: null | string;
   uic?: number | null;
   weight?: number | null;
@@ -3620,7 +3620,7 @@ export type CoreOperationalPointOnPath = {
   plc?: null | string;
   /** Distance from the beginning of the path in mm */
   position: number;
-  secondary_code?: null | string;
+  secondary_code?: null | NonBlankString;
   secondary_name?: null | string;
   uic?: number | null;
   /** Importance of the operational point */
@@ -4599,6 +4599,33 @@ export type CoreZoneUpdate = {
   time: number;
   zone: string;
 };
+export type CoreSpeedLimitProperty = {
+  /** source of the speed-limit if relevant (tag used) */
+  source?:
+    | null
+    | (
+        | {
+            speed_limit_source_type: 'given_train_tag';
+            tag: string;
+          }
+        | {
+            speed_limit_source_type: 'fallback_tag';
+            tag: string;
+          }
+        | {
+            speed_limit_source_type: 'unknown_tag';
+          }
+      );
+  /** in meters per second */
+  speed: number;
+};
+export type CoreSpeedLimitProperties = {
+  /** List of `n` boundaries of the ranges (block path).
+    A boundary is a distance from the beginning of the path in mm. */
+  boundaries: number[];
+  /** List of `n+1` values associated to the ranges */
+  values: CoreSpeedLimitProperty[];
+};
 export type SimulationResponseSuccess = {
   /** Simulation without any regularity margins */
   base: CoreReportTrain;
@@ -4625,33 +4652,7 @@ export type SimulationResponseSuccess = {
     spacing_requirements: CoreSpacingRequirement[];
     zone_updates: CoreZoneUpdate[];
   };
-  /** A MRSP computation result (Most Restrictive Speed Profile) */
-  mrsp: {
-    /** List of `n` boundaries of the ranges (block path).
-        A boundary is a distance from the beginning of the path in mm. */
-    boundaries: number[];
-    /** List of `n+1` values associated to the ranges */
-    values: {
-      /** source of the speed-limit if relevant (tag used) */
-      source?:
-        | null
-        | (
-            | {
-                speed_limit_source_type: 'given_train_tag';
-                tag: string;
-              }
-            | {
-                speed_limit_source_type: 'fallback_tag';
-                tag: string;
-              }
-            | {
-                speed_limit_source_type: 'unknown_tag';
-              }
-          );
-      /** in meters per second */
-      speed: number;
-    }[];
-  };
+  mrsp: CoreSpeedLimitProperties;
   /** Simulation that takes into account the regularity margins */
   provisional: CoreReportTrain;
 };
@@ -4977,7 +4978,7 @@ export type RollingStockCategoryChangeGroup = {
   value?: null | TrainCategory;
 };
 export type SpeedLimitTagChangeGroup = {
-  value?: null | string;
+  value?: null | NonBlankString;
 };
 export type StartTimeChangeGroup = {
   /** For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.
@@ -5045,7 +5046,7 @@ export type TrainSchedule = {
   }[];
   rolling_stock_name: string;
   schedule?: ScheduleItem[];
-  speed_limit_tag?: null | string;
+  speed_limit_tag?: null | NonBlankString;
   /** For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.
     For hourly timetables: elapsed ms since the timetable start. */
   start_time: number;

--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -77,6 +77,8 @@ export type PostSendLastMinuteRequestApiArg = {
     simulation_report_sheet: Blob;
   };
 };
+export type ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesSpeedLimitTagOneOf1 =
+  string;
 export type ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesScheduleItemsPropertiesReferenceBaseArrivalOneOf1 =
   string;
 export type ConstraintDistribution = 'STANDARD' | 'MARECO';
@@ -86,12 +88,12 @@ export type Options = {
   use_speed_limits_for_simulation?: boolean;
 };
 export type Margins = {
-  boundaries: string[];
+  boundaries: ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesSpeedLimitTagOneOf1[];
   /** The values of the margins. Must contains one more element than the boundaries
     Can be a percentage `X%` or a time in minutes per 100 kilometer `Xmin/100km` */
   values: string[];
 };
-export type Items = {
+export type PathItem = {
   /** The unique identifier of the path item.
     This is used to reference path items in the train schedule. */
   id: string;
@@ -132,7 +134,7 @@ export type Items = {
         type: 'operational_point_part_reference';
       });
 };
-export type Items2 = {
+export type ScheduleItem = {
   arrival?: null | ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesScheduleItemsPropertiesReferenceBaseArrivalOneOf1;
   /** Position on the path of the schedule item. */
   at: string;
@@ -189,7 +191,7 @@ export type TransformTimetableResponse = {
     initial_speed?: number;
     labels?: string[];
     margins?: {
-      boundaries: string[];
+      boundaries: ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesSpeedLimitTagOneOf1[];
       /** The values of the margins. Must contains one more element than the boundaries
             Can be a percentage `X%` or a time in minutes per 100 kilometer `Xmin/100km` */
       values: string[];
@@ -281,13 +283,13 @@ export type TransformTimetableResponse = {
         };
         path_and_schedule?: {
           margins: Margins;
-          path: Items[];
+          path: PathItem[];
           power_restrictions: {
             from: string;
             to: string;
             value: string;
           }[];
-          schedule: Items2[];
+          schedule: ScheduleItem[];
         };
         rolling_stock?: {
           comfort: Comfort;
@@ -297,7 +299,7 @@ export type TransformTimetableResponse = {
           value?: null | ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesCategoryOneOf1;
         };
         speed_limit_tag?: {
-          value?: null | string;
+          value?: null | ComponentsSchemasTransformTimetableResponsePropertiesPacedTrainsItemsAllOf0PropertiesSpeedLimitTagOneOf1;
         };
         start_time?: {
           /** For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -22,10 +22,6 @@ class PowerRestriction(BaseModel):
     value: str
 
 
-class SpeedLimitTag(RootModel[str]):
-    root: Annotated[str, Field(min_length=1)]
-
-
 class AddOperation(BaseModel):
     """
     JSON Patch 'add' operation representation
@@ -204,10 +200,6 @@ class Plc(RootModel[str]):
     """
 
 
-class SecondaryCode(RootModel[str]):
-    root: Annotated[str, Field(min_length=1)]
-
-
 class SecondaryName(RootModel[str]):
     root: Annotated[str, Field(min_length=1)]
 
@@ -382,6 +374,48 @@ class CoreSpacingRequirement(BaseModel):
     Time in ms: see begin_time
     """
     zone: str
+
+
+class SpeedLimitSourceGivenTrainTag(BaseModel):
+    """
+    source of the speed-limit if relevant (tag used)
+    """
+
+    speed_limit_source_type: Literal["given_train_tag"]
+    tag: str
+
+
+class SpeedLimitSourceFallbackTag(BaseModel):
+    """
+    source of the speed-limit if relevant (tag used)
+    """
+
+    speed_limit_source_type: Literal["fallback_tag"]
+    tag: str
+
+
+class SpeedLimitSourceUnknownTag(BaseModel):
+    """
+    source of the speed-limit if relevant (tag used)
+    """
+
+    speed_limit_source_type: Literal["unknown_tag"]
+
+
+class CoreSpeedLimitProperty(BaseModel):
+    source: (
+        SpeedLimitSourceGivenTrainTag
+        | SpeedLimitSourceFallbackTag
+        | SpeedLimitSourceUnknownTag
+        | None
+    ) = None
+    """
+    source of the speed-limit if relevant (tag used)
+    """
+    speed: float
+    """
+    in meters per second
+    """
 
 
 class CoreZoneUpdate(BaseModel):
@@ -2831,7 +2865,7 @@ class OperationalPointReferenceId(BaseModel):
     type: Literal["id"]
 
 
-class SecondaryCode2(RootModel[str]):
+class SecondaryCode(RootModel[str]):
     root: Annotated[str, Field(min_length=1)]
     """
     An optional secondary code to identify a more specific location
@@ -2844,7 +2878,7 @@ class OperationalPointReferenceDomestic(BaseModel):
     """
     The operational point main code
     """
-    secondary_code: SecondaryCode2 | None = None
+    secondary_code: SecondaryCode | None = None
     """
     An optional secondary code to identify a more specific location
     """
@@ -2852,7 +2886,7 @@ class OperationalPointReferenceDomestic(BaseModel):
 
 
 class OperationalPointReferenceUic(BaseModel):
-    secondary_code: SecondaryCode2 | None = None
+    secondary_code: SecondaryCode | None = None
     """
     An optional secondary code to identify a more specific location
     """
@@ -3187,10 +3221,6 @@ class RefillLaw(BaseModel):
 
 
 class Plc2(RootModel[str]):
-    root: Annotated[str, Field(min_length=1)]
-
-
-class SecondaryCode4(RootModel[str]):
     root: Annotated[str, Field(min_length=1)]
 
 
@@ -3582,64 +3612,6 @@ class ElectricalProfiles(BaseModel):
     """
 
 
-class SpeedLimitSourceGivenTrainTag(BaseModel):
-    """
-    source of the speed-limit if relevant (tag used)
-    """
-
-    speed_limit_source_type: Literal["given_train_tag"]
-    tag: str
-
-
-class SpeedLimitSourceFallbackTag(BaseModel):
-    """
-    source of the speed-limit if relevant (tag used)
-    """
-
-    speed_limit_source_type: Literal["fallback_tag"]
-    tag: str
-
-
-class SpeedLimitSourceUnknownTag(BaseModel):
-    """
-    source of the speed-limit if relevant (tag used)
-    """
-
-    speed_limit_source_type: Literal["unknown_tag"]
-
-
-class Value(BaseModel):
-    source: (
-        SpeedLimitSourceGivenTrainTag
-        | SpeedLimitSourceFallbackTag
-        | SpeedLimitSourceUnknownTag
-        | None
-    ) = None
-    """
-    source of the speed-limit if relevant (tag used)
-    """
-    speed: float
-    """
-    in meters per second
-    """
-
-
-class Mrsp(BaseModel):
-    """
-    A MRSP computation result (Most Restrictive Speed Profile)
-    """
-
-    boundaries: list[Boundary]
-    """
-    List of `n` boundaries of the ranges (block path).
-    A boundary is a distance from the beginning of the path in mm.
-    """
-    values: list[Value]
-    """
-    List of `n+1` values associated to the ranges
-    """
-
-
 class PathItemTimesBaseItem(RootModel[int]):
     root: Annotated[int, Field(ge=0)]
 
@@ -3792,7 +3764,7 @@ class SpeedDependantPower(BaseModel):
     speeds: list[float]
 
 
-class Value1(RootModel[float]):
+class Value(RootModel[float]):
     root: Annotated[float, Field(ge=0.0)]
 
 
@@ -3805,19 +3777,15 @@ class SpeedIntervalValueCurve(BaseModel):
     Speed in m/s (sorted ascending)
     External bounds are implicit to [0, rolling_stock.max_speed]
     """
-    values: Annotated[list[Value1], Field(examples=[[0.5, 0.6, 0.5]], min_length=1)]
+    values: Annotated[list[Value], Field(examples=[[0.5, 0.6, 0.5]], min_length=1)]
     """
     Interval values, must be >= 0 (unit to be made explicit at use)
     There must be one more value than boundaries
     """
 
 
-class Value2(RootModel[str]):
-    root: Annotated[str, Field(min_length=1)]
-
-
 class SpeedLimitTagChangeGroup(BaseModel):
-    value: Value2 | None = None
+    value: NonBlankString | None = None
 
 
 class SpeedLimits(BaseModel):
@@ -4537,6 +4505,22 @@ class CoreRoutingRequirement(BaseModel):
     """
     route: str
     zones: list[CoreRoutingZoneRequirement]
+
+
+class CoreSpeedLimitProperties(BaseModel):
+    """
+    A MRSP computation result (Most Restrictive Speed Profile)
+    """
+
+    boundaries: list[Boundary]
+    """
+    List of `n` boundaries of the ranges (block path).
+    A boundary is a distance from the beginning of the path in mm.
+    """
+    values: list[CoreSpeedLimitProperty]
+    """
+    List of `n+1` values associated to the ranges
+    """
 
 
 class CoreTrackRange(BaseModel):
@@ -5728,10 +5712,7 @@ class SimulationResponseSuccess(BaseModel):
     """
     Simulation that takes into account the regularity margins and the schedule item times
     """
-    mrsp: Mrsp
-    """
-    A MRSP computation result (Most Restrictive Speed Profile)
-    """
+    mrsp: CoreSpeedLimitProperties
     provisional: CoreReportTrain
     """
     Simulation that takes into account the regularity margins
@@ -6812,7 +6793,7 @@ class CoreOperationalPointOnPath(BaseModel):
     """
     Distance from the beginning of the path in mm
     """
-    secondary_code: SecondaryCode | None = None
+    secondary_code: NonBlankString | None = None
     secondary_name: SecondaryName | None = None
     uic: Annotated[int | None, Field(ge=0)] = None
     weight: Annotated[int | None, Field(ge=0, le=100)]
@@ -6950,7 +6931,7 @@ class OperationalPoint(BaseModel):
     """
     Primary Location Code : https://rne.eu/it/products/ccs/crd/
     """
-    secondary_code: SecondaryCode | None = None
+    secondary_code: NonBlankString | None = None
     secondary_name: SecondaryName | None = None
     uic: Annotated[int | None, Field(ge=0)] = None
     weight: Annotated[int | None, Field(ge=0)] = None
@@ -7065,7 +7046,7 @@ class RelatedOperationalPoint(BaseModel):
     name: Annotated[str, Field(min_length=1)]
     parts: list[RelatedOperationalPointPart]
     plc: Plc2 | None = None
-    secondary_code: SecondaryCode4 | None = None
+    secondary_code: NonBlankString | None = None
     secondary_name: SecondaryName | None = None
     uic: Annotated[int | None, Field(ge=0)] = None
     weight: Annotated[int | None, Field(ge=0)] = None
@@ -7297,7 +7278,7 @@ class TrainSchedule(BaseModel):
     power_restrictions: list[PowerRestriction] | None = None
     rolling_stock_name: str
     schedule: list[ScheduleItem] | None = None
-    speed_limit_tag: SpeedLimitTag | None = None
+    speed_limit_tag: NonBlankString | None = None
     start_time: OffsetInMs
     """
     For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.

--- a/python/railjson_generator/railjson_generator/schema/infra/infra.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/infra.py
@@ -96,7 +96,7 @@ class Infra:
                 plc=models.Plc(op.plc) if op.plc is not None else None,
                 country_code=op.country_code,
                 main_code=op.main_code,
-                secondary_code=models.SecondaryCode(op.secondary_code)
+                secondary_code=models.NonBlankString(op.secondary_code)
                 if op.secondary_code is not None
                 else None,
                 is_passenger_station=op.is_passenger_station,


### PR DESCRIPTION
Some fields hid their type name from the OpenAPI spec, so the code generators guessed names and picked clashing ones, like `Value2` and `SecondaryCode2`. Using the real type name fixes this and updates the generated files.