### PR TITLE
front, ui-core: translate the "Add" option of the track combo box

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -418,6 +418,7 @@
     "inverseOD": "Route umkehren",
     "itineraryModal": {
       "addLocationOnMap": "Betriebsstelle auf der Karte hinzufügen",
+      "addTrack": "Hinzufügen",
       "alertInvalidOP": "Mindestens ein Wegepunkt konnte nicht erkannt werden",
       "cancel": "Abbrechen",
       "focusLocationOnMap": "Karte auf diese Betriebsstelle zentrieren",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -420,6 +420,7 @@
       "addLocationOnMap": "Add a location on the map",
       "addPoint": "Add point",
       "addPointOnMap": "Add this waypoint using the map",
+      "addTrack": "Add",
       "alertInvalidOP": "At least one of the waypoints could not be recognized",
       "alertMissingDestination": "Destination is not defined",
       "alertMissingOrigin": "Origin is not defined",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -420,6 +420,7 @@
       "addLocationOnMap": "Ajouter un point remarquable sur la carte",
       "addPoint": "Ajouter",
       "addPointOnMap": "Ajoutez ce point en utilisant la carte",
+      "addTrack": "Ajouter",
       "alertInvalidOP": "Au moins un des points de passage n'a pas été reconnu",
       "alertMissingDestination": "La destination n'est pas définie",
       "alertMissingOrigin": "L'origine n'est pas définie",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
@@ -515,6 +515,7 @@ const PathStepItem = ({
                     onTrackNameChange(value);
                     onAddCustomTrack({ trackId: value, trackName: value });
                   }}
+                  addCustomValueLabel={t('addTrack')}
                   small
                   narrow
                   data-testid="track-name"

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -35,6 +35,7 @@ export type ComboBoxProps<T> = Omit<InputProps, 'value' | 'onChange'> & {
 
   allowCustomValue?: boolean;
   onAddCustomValue?: (value: string) => void;
+  /** Defaults to `Add` */
   addCustomValueLabel?: string;
 };
 
@@ -63,7 +64,7 @@ const ComboBox = <T,>({
   renderFooterItem,
   allowCustomValue = false,
   onAddCustomValue,
-  addCustomValueLabel,
+  addCustomValueLabel = 'Add',
   ...inputProps
 }: ComboBoxProps<T>) => {
   const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
@@ -346,7 +347,7 @@ const ComboBox = <T,>({
               onMouseEnter={() => setActiveSuggestionIndex(customValueIndex)}
               data-testid={testIdPrefix ? `${testIdPrefix}-add-custom` : undefined}
             >
-              {addCustomValueLabel ?? `Add "${inputValue.trim()}"`}
+              {`${addCustomValueLabel} "${inputValue.trim()}"`}
             </li>
           )}
 


### PR DESCRIPTION
Fixes #17532

## Problem

In the itinerary modal, typing a value in the track (`Voie`) input shows a custom-value option at the bottom of the dropdown. That option always rendered in English **and** echoed the typed value back — `Add "V1"` — regardless of the UI language.

The cause is in `PathStepItem.tsx`: the track `ComboBox` is rendered with `allowCustomValue` but without `addCustomValueLabel`, so `ui-core`'s `ComboBox` falls back to its hardcoded default:

```ts
{addCustomValueLabel ?? `Add "${inputValue.trim()}"`}
```

## Fix

Pass an explicit label from the existing i18n namespace and add the corresponding key:

- `addCustomValueLabel={t('addTrack')}` on the track combo box.
- New key `manageTrainSchedule.itineraryModal.addTrack` in `en` (`Add`), `fr` (`Ajouter`) and `de` (`Hinzufügen`), matching the wordings requested in the issue.

This also drops the interpolated track name, as asked in the issue (the expected text is just `Add` / `Ajouter` / `Hinzufügen`).

`es`, `it` and the other locales do not currently carry the surrounding `itineraryModal` keys either, so they are left untouched and keep falling back to English, per the "en and fr must exist, others are WIP" rule in `front/README.md`.

## Validation

Run from `front/`:

- `bash scripts/i18n-order-checker.sh` → `✅ All translation files are sorted.`
- `npx oxfmt --check` on the touched files → clean
- `npx oxlint` on `PathStepItem.tsx` → same 13 pre-existing errors as on `dev`, no new ones
- `npm run build-ui && npx tsc --noEmit` → clean (confirms `addCustomValueLabel` is a valid `ComboBox` prop)
- `npx vitest run` → **98 test files passed, 923 tests passed**, 16 skipped