### PR TITLE
Fix speed limits list blinking in editor

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/utils.ts
+++ b/front/src/applications/editor/tools/rangeEdition/utils.ts
@@ -413,4 +413,4 @@ export const makeRouteElements = (
   }, {});
 
 export const trackRangeKey = (trackRange: ApplicableTrackRange, index: number) =>
-  `track-range-${trackRange.track}-${trackRange.begin}-${trackRange.end}-${trackRange.applicable_directions}-${index}`;
+  `track-range-${trackRange.track}-${trackRange.applicable_directions}-${index}`;


### PR DESCRIPTION
closes #8188 

This is a followup completing https://github.com/OpenRailAssociation/osrd/pull/17971

This change prevents making a new id out of the new start and end of the line, thus not rerendering the list when dragging the extremities on the map.