### PR TITLE
front: check PathItemLocation.type instead of using the "in" operator

### DIFF
--- a/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Vias.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/DisplayItinerary/Vias.tsx
@@ -43,7 +43,7 @@ const Vias = ({ zoomToFeaturePoint }: ViasProps) => {
               <small data-testid="via-dropped-name" className="mr-1 text-nowrap">
                 {`${
                   via.name ||
-                  ('operational_point' in via.location &&
+                  (via.location.type === 'operational_point_part_reference' &&
                     via.location.operational_point.type === 'domestic' &&
                     via.location.operational_point.main_code) ||
                   (via.positionOnPath &&

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -251,7 +251,7 @@ const useTimesStopsTableData = (
 
         const matchingOp =
           pathStepOp ??
-          ('operational_point' in pathStep.location && stableOPs
+          (pathStep.location.type === 'operational_point_part_reference' && stableOPs
             ? stableOPs.find((op) => op.pathItemId === pathStep.id)
             : undefined);
 


### PR DESCRIPTION
The "in" operator is error prone: TypeScript allows objects to have
extra fields for type aliases. Check the "type" field instead.

~~Depends on #17983~~  
Spotted by @SharglutDev in https://github.com/OpenRailAssociation/osrd/pull/17983#discussion_r3721367202