### PR TITLE
editoast: add missing migration for path step with new op model

### DIFF
--- a/editoast/migrations/2026-08-06-073437-0000_adapt_path_steps_op_inter/down.sql
+++ b/editoast/migrations/2026-08-06-073437-0000_adapt_path_steps_op_inter/down.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION revert_path_step_trigram (path jsonb)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+SELECT
+    jsonb_agg(
+        CASE
+            WHEN elem @? '$.location.operational_point.main_code' 
+                THEN jsonb_set(
+                    elem,
+                    '{location,operational_point}',
+                    jsonb_build_object(
+                        'type', 'trigram',
+                        'trigram', elem->'location'->'operational_point'->'main_code',
+                        'secondary_code', elem->'location'->'operational_point'->'secondary_code'
+                    )
+                )
+            ELSE elem
+        END
+    )
+FROM jsonb_array_elements(path) AS elem;
+$$;
+
+UPDATE train_schedule SET path = revert_path_step_trigram(path);
+
+UPDATE train_schedule_exception
+SET change_groups = jsonb_set(
+    change_groups,
+    '{path_and_schedule,path}',
+    revert_path_step_trigram(change_groups#>'{path_and_schedule,path}')
+)
+WHERE change_groups ? 'path_and_schedule';
+
+
+DROP FUNCTION IF EXISTS revert_path_step_trigram(jsonb);

--- a/editoast/migrations/2026-08-06-073437-0000_adapt_path_steps_op_inter/up.sql
+++ b/editoast/migrations/2026-08-06-073437-0000_adapt_path_steps_op_inter/up.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE FUNCTION adapt_path_step_trigram (path jsonb)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+SELECT
+    jsonb_agg(
+        CASE
+            WHEN elem @? '$.location.operational_point.trigram' 
+                THEN jsonb_set(
+                    elem,
+                    '{location,operational_point}',
+                    jsonb_build_object(
+                        'type', 'domestic',
+                        'country_code', 'FR',
+                        'main_code', elem->'location'->'operational_point'->'trigram',
+                        'secondary_code', elem->'location'->'operational_point'->'secondary_code'
+                    )
+                )
+            ELSE elem
+        END
+    )
+FROM jsonb_array_elements(path) AS elem;
+$$;
+
+UPDATE train_schedule SET path = adapt_path_step_trigram(path);
+
+UPDATE train_schedule_exception
+SET change_groups = jsonb_set(
+    change_groups,
+    '{path_and_schedule,path}',
+    adapt_path_step_trigram(change_groups#>'{path_and_schedule,path}')
+)
+WHERE change_groups ? 'path_and_schedule';
+
+
+DROP FUNCTION IF EXISTS adapt_path_step_trigram(jsonb);


### PR DESCRIPTION
This fixes train schedules using trigrams as path steps. The idea is to migrate their path to the new domestic variant.

Linked to this PR: https://github.com/OpenRailAssociation/osrd/pull/17195