### PR TITLE
process-compose: use `./gradlew` instead of gradle

### DIFF
--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -11,7 +11,7 @@ environment:
 processes:
   core:
     working_dir: "${OSRD_PATH}/core/"
-    command: "gradle run --args='worker'"
+    command: "./gradlew run --args='worker'"
     environment:
       - "ALL_INFRA=true"
       - "CORE_EDITOAST_URL=http://localhost:8090"


### PR DESCRIPTION
We use `./gradlew` everywhere so it didn’t make sense to use `gradle` here