### PR TITLE
editoast: filter out unauthorized trains in `GET:/timetable/id/conflicts`

### DIFF
--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use authz::RollingStockPrivilege;
 use axum::Extension;
 use axum::Json;
 use axum::extract::Path;
@@ -11,12 +12,14 @@ use common::units::quantities::Offset;
 use editoast_models::prelude::*;
 use itertools::Itertools as _;
 use itertools::izip;
+use schemas::paced_train::RollingStockChangeGroup;
 use schemas::timetable_type::TimetableType;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authorizers::SystemAuthorizer;
 use crate::error::Result;
 use crate::views::AuthenticationExt;
 use crate::views::infra::InfraIdQueryParam;
@@ -299,12 +302,14 @@ fn split_routing(period: u64, requirements: &[RoutingRequirement]) -> Vec<Routin
 pub(in crate::views) async fn conflicts(
     State(AppState {
         config,
+        regulator,
         db_pool,
         valkey_client,
         core_client,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<crate::authentication::State>,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
     Query(ElectricalProfileSetIdQueryParam {
@@ -368,6 +373,14 @@ pub(in crate::views) async fn conflicts(
             (ts, ts_exceptions)
         })
         .collect();
+
+    let train_schedules_with_exceptions = filter_unauthorized_train_schedules_and_exceptions(
+        regulator.openfga(),
+        conn.clone(),
+        authn_state,
+        train_schedules_with_exceptions,
+    )
+    .await?;
 
     // Flatten paced trains occurrences
     let (occurrence_ids, occurrence_trains): (Vec<_>, Vec<_>) = train_schedules_with_exceptions
@@ -449,22 +462,103 @@ pub(in crate::views) async fn conflicts(
     Ok(Json(conflicts_response?))
 }
 
+/// Take a collection of train schedules and their associated exceptions and filter out those with
+/// an unauthorized rolling stock. When a train schedule is filtered out all its exceptions are
+/// skipped aswell, but when an exception is filtered its associated train schedule is kept if its
+/// rolling stock is authorized given the provided authentication state.
+pub async fn filter_unauthorized_train_schedules_and_exceptions(
+    openfga: &fga::Client,
+    conn: DbConnection,
+    authn_state: crate::authentication::State,
+    train_schedules_with_exceptions: Vec<(
+        editoast_models::TrainSchedule,
+        Vec<schemas::TrainScheduleException>,
+    )>,
+) -> crate::error::Result<
+    Vec<(
+        editoast_models::TrainSchedule,
+        Vec<schemas::TrainScheduleException>,
+    )>,
+> {
+    let Some(user) = authn_state.regular_user() else {
+        return Ok(train_schedules_with_exceptions);
+    };
+    let system_authorizer = SystemAuthorizer::new_infallible(openfga);
+    let Ok(authorized_train_schedules) =
+        authz::v2::rolling_stock_list(user, RollingStockPrivilege::CanRead)
+            .authorize(&system_authorizer)
+            .await?
+            .access()
+            .await?;
+    match authorized_train_schedules {
+        authz::v2::ResourcesList::All => Ok(train_schedules_with_exceptions),
+        authz::v2::ResourcesList::Privileged(authorized_rs_list) => {
+            let authorized_rolling_stocks: Vec<editoast_models::RollingStock> =
+                editoast_models::RollingStock::retrieve_batch_unchecked(
+                    &mut conn.clone(),
+                    authorized_rs_list.iter().map(|rs| rs.0),
+                )
+                .await?;
+            let authorized_rolling_stock_names: Vec<String> = authorized_rolling_stocks
+                .into_iter()
+                .map(|rolling_stock| rolling_stock.name)
+                .collect();
+
+            Ok(train_schedules_with_exceptions
+                .into_iter()
+                .filter(|(train_schedule, _)| {
+                    authorized_rolling_stock_names.contains(&train_schedule.rolling_stock_name)
+                })
+                .map(|(train_schedule, exceptions)| {
+                    (
+                        train_schedule,
+                        exceptions
+                            .into_iter()
+                            .filter(|exception| {
+                                if let Some(RollingStockChangeGroup {
+                                    rolling_stock_name, ..
+                                }) = &exception.change_groups.rolling_stock
+                                {
+                                    authorized_rolling_stock_names.contains(rolling_stock_name)
+                                } else {
+                                    true
+                                }
+                            })
+                            .collect(),
+                    )
+                })
+                .collect_vec())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::InternalError;
+    use crate::fixtures::create_fast_rolling_stock;
     use crate::fixtures::create_hourly_timetable_with_train_schedule_set;
     use crate::fixtures::create_small_infra;
+    use crate::fixtures::create_timetable_with_train_schedule_set;
+    use crate::fixtures::create_train_schedule_exception;
     use crate::fixtures::simple_paced_train_base;
+    use crate::fixtures::simple_paced_train_changeset;
+    use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::test_app;
 
     use super::*;
+    use authz::InfraGrant;
+    use authz::RollingStockGrant;
     use common::units;
     use core_client::simulation::RoutingRequirement;
     use core_client::simulation::RoutingZoneRequirement;
     use core_client::simulation::SpacingRequirement;
     use editoast_models::train_schedule::TrainScheduleChangeset;
+    use pretty_assertions::assert_eq;
     use reqwest::StatusCode;
     use rstest::rstest;
+    use schemas::TrainScheduleExceptionChangeGroups;
+    use schemas::paced_train::RollingStockChangeGroup;
+    use schemas::train_schedule::Comfort;
 
     fn spacing(zone: &str, begin_time: u64, end_time: u64) -> SpacingRequirement {
         SpacingRequirement {
@@ -663,12 +757,17 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn conflicts_hourly_rejects_period_over_24h() {
-        let app = test_app!().skip_authz().build();
+        let app = test_app!().build();
         let pool = app.db_pool();
 
         let infra = create_small_infra(&mut pool.get_ok()).await;
         let (timetable, train_schedule_set) =
             create_hourly_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
+        let user = app
+            .user("user", "User")
+            .with_infra_grant(infra.id, InfraGrant::Reader)
+            .create()
+            .await;
 
         // Period = 5 * 7 = 35h.
         for time_window in [5, 7] {
@@ -692,9 +791,111 @@ mod tests {
                 )
                 .as_str(),
             )
+            .by_user(user.as_ref())
             .await
             .assert_status(StatusCode::UNPROCESSABLE_ENTITY)
             .json();
         assert_eq!(response.error_type, "editoast:timetable:InvalidPeriod");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn filter_unauthorized_train_schedules() {
+        let app = test_app!().build();
+        let pool = app.db_pool();
+        let rs_authorized = create_fast_rolling_stock(&mut pool.get_ok(), "authorized_rs").await;
+        let rs_no_grant = create_fast_rolling_stock(&mut pool.get_ok(), "forbidden_rs").await;
+        let (timetable, train_schedule_set) =
+            create_timetable_with_train_schedule_set(&mut pool.get_ok()).await;
+        let train_schedule_authorized = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("train_schedule_authorized".into())
+            .rolling_stock_name(rs_authorized.name.clone())
+            .create(&mut pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+        let train_schedule_unauthorized_exception =
+            simple_paced_train_changeset(train_schedule_set.id)
+                .train_name("train_schedule_forbidden_exception".into())
+                .rolling_stock_name(rs_authorized.name.clone())
+                .create(&mut pool.get_ok())
+                .await
+                .expect("failed to create train schedule");
+        let train_schedule_unauthorized = simple_paced_train_changeset(train_schedule_set.id)
+            .train_name("train_schedule_no_grant".into())
+            .rolling_stock_name(rs_no_grant.name.clone())
+            .create(&mut pool.get_ok())
+            .await
+            .expect("failed to create train schedule");
+        let change_group_authorized = TrainScheduleExceptionChangeGroups {
+            rolling_stock: Some(RollingStockChangeGroup {
+                rolling_stock_name: rs_authorized.name.clone(),
+                comfort: Comfort::AirConditioning,
+            }),
+            ..Default::default()
+        };
+        let change_group_no_grant = TrainScheduleExceptionChangeGroups {
+            rolling_stock: Some(RollingStockChangeGroup {
+                rolling_stock_name: rs_no_grant.name.clone(),
+                comfort: Comfort::AirConditioning,
+            }),
+            ..Default::default()
+        };
+        let exception_authorized: schemas::TrainScheduleException =
+            create_train_schedule_exception(
+                &mut pool.get_ok(),
+                timetable.id,
+                train_schedule_authorized.id,
+                None,
+                None,
+                Some(change_group_authorized),
+            )
+            .await
+            .into();
+        let exception_unauthorized: schemas::TrainScheduleException =
+            create_train_schedule_exception(
+                &mut pool.get_ok(),
+                timetable.id,
+                train_schedule_authorized.id,
+                None,
+                None,
+                Some(change_group_no_grant),
+            )
+            .await
+            .into();
+
+        let openfga = app.openfga();
+
+        let user = app
+            .user("user", "User")
+            .with_rolling_stock_grant(rs_authorized.id, RollingStockGrant::Reader)
+            .create()
+            .await;
+        let authn_state = crate::authentication::State::Authenticated {
+            user: authz::User(user.id),
+            roles: vec![],
+        };
+        let train_schedules_with_exceptions = vec![
+            (
+                train_schedule_authorized.clone(),
+                vec![exception_authorized.clone()],
+            ),
+            (
+                train_schedule_unauthorized_exception.clone(),
+                vec![exception_unauthorized],
+            ),
+            (train_schedule_unauthorized, vec![]),
+        ];
+        let authorized_train_schedules = filter_unauthorized_train_schedules_and_exceptions(
+            openfga,
+            pool.get_ok(),
+            authn_state,
+            train_schedules_with_exceptions,
+        )
+        .await
+        .expect("the authorization filter method should succeed");
+        let expected_response = vec![
+            (train_schedule_authorized, vec![exception_authorized]),
+            (train_schedule_unauthorized_exception, vec![]),
+        ];
+        assert_eq!(expected_response, authorized_train_schedules);
     }
 }


### PR DESCRIPTION
Context: https://github.com/osrd-project/osrd-confidential/issues/1064

I'm not sure of the expected behavior for train schedules which contain an exception with an
unauthorized rolling stock:
- Filter out the exception, keep the train schedule and its other
   exceptions ? => That's the current choice
 - Filter out the whole train schedule ?
 - Check if the exception is an extra occurrence or if it changes an
   existing one, and:
    - Exception on an existing occurrence:
       - Revert the rolling stock change but keep the exception if it makes
       other changes ?
       - Filter out the exception if its only change is compared to the
       normal occurrence is a change of rolling stock ?
     - New occurrence:
       - Delete the exception ?
       - Change its rolling stock to match its train schedule (already
       authorized) rolling stock ?