### PR TITLE
front: fix timestop departure update

### DIFF
--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -214,18 +214,20 @@ export const propagateTime = (
 
   if (isOriginUpdate || update.propagationMode === 'shiftAllWaypoints') {
     if (!isOriginUpdate) return propagateShiftAll(delta, selectedTrain);
+    let result: PropagationResult | undefined;
     if (isShiftAllPropagation || update.propagationMode === 'toDestination')
-      return propagateShiftAll(delta, selectedTrain);
+      result = propagateShiftAll(delta, selectedTrain);
     // atThisWaypoint at origin = only move start_time. Following offsets are compensated so
     // their absolute times stay the same — which is exactly what fromDeparture does.
-    if (update.propagationMode === 'atThisWaypoint')
-      return propagateFromEditedPoint(
+    else if (update.propagationMode === 'atThisWaypoint')
+      result = propagateFromEditedPoint(
         delta,
         update.row.pathStepId!,
         selectedTrain,
         'fromDeparture'
       );
-    return undefined;
+    // Use the exact typed value as updatedStartTime (avoids inheriting sub-second ms from current start_time)
+    return result && newValue ? { ...result, updatedStartTime: newValue } : result;
   }
 
   if (update.propagationMode === 'atThisWaypoint' || !update.row.pathStepId) return undefined;

--- a/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
+++ b/front/src/modules/timesStops/hooks/useTimesStopsTableData.ts
@@ -83,8 +83,11 @@ const buildTableRow = ({
   closedSignal,
   margins,
 }: BuildTableRowParams): TimesStopsRowNew => {
+  // Truncate sub-second part: schedule.arrival is stored in whole seconds
+  // (via Math.floor in diffSeconds in scheduleStateToApiFields())
+  const startDateMs = Math.floor(startDate.getTime() / 1000) * 1000;
   const requestedArrival = schedule?.arrival
-    ? new Date(startDate.getTime() + Duration.parse(schedule.arrival).ms)
+    ? new Date(startDateMs + Duration.parse(schedule.arrival).ms)
     : null;
 
   // computedArrival is offset from startDate

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -17,7 +17,7 @@ import trainSettingsReducer from './trainSettingsReducer';
 export const operationalStudiesInitialConf: OperationalStudiesConfState = {
   ...defaultCommonConf,
   name: '',
-  startTime: new Date(),
+  startTime: new Date(Math.floor(Date.now() / 1000) * 1000),
   initialSpeed: 0,
   labels: [],
   rollingStockName: '',


### PR DESCRIPTION
fix #18026 

### Context
Since the start time migration from Date to milliseconds to support hourly timetables, the front now carries a start time value that might be accurate to the millisecond. 
The origin of these milliseconds comes from the legacy manage train schedule interface which, if it doesn't find an already existing start time, takes the one from the store which is initiated with `new Date()` (accurate to the ms) when opening the app.

After some discussions with @maelysLeratRosso, we decided to fix this in 3 different spots corresponding to the 3 commits (read the descriptions for more details).

> [!NOTE]
> This issue and its cause might lead to another change of our model to use ISO8601 format for at least the start time which was requested by some devs of the project.
> @flomonster will be taking care of this refacto in the near future.

