### PR TITLE
editoast: migrate macro nodes from trigram to domestic

### DIFF
--- a/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/down.sql
+++ b/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/down.sql
@@ -1,0 +1,2 @@
+DELETE FROM macro_node WHERE path_item_key LIKE 'trigram:%';
+UPDATE macro_node SET path_item_key = 'trigram:' || SUBSTRING(path_item_key, 13) WHERE path_item_key LIKE 'domestic:FR-%';

--- a/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/up.sql
+++ b/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/up.sql
@@ -1,0 +1,2 @@
+DELETE FROM macro_node WHERE path_item_key LIKE 'domestic:FR-%';
+UPDATE macro_node SET path_item_key = 'domestic:FR-' || SUBSTRING(path_item_key, 9) WHERE path_item_key LIKE 'trigram:%';

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
@@ -91,7 +91,7 @@ export const handleNodeOperation = async ({
           await updateMacroNode(state, dispatch, {
             ...indexNode,
             ...castNgeNode(node, netzgrafikDto.labels),
-            trigram: domesticReference,
+            trigram: node.betriebspunktName,
             dbId: indexNode.dbId,
             path_item_key: nodeKey,
           });

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -337,7 +337,7 @@ export const loadAndIndexNge = async (
     for (const pathKey of MacroEditorState.getPathKeys(op)) {
       state.updateNodeDataByKey(pathKey, {
         full_name: op.name,
-        trigram: MacroEditorState.encodeDomesticReference({ ...op, type: 'domestic' }),
+        trigram: op.main_code + (op.secondary_code ? `/${op.secondary_code}` : ''),
         geocoord: op.geo ? { lng: op.geo.coordinates[0], lat: op.geo.coordinates[1] } : undefined,
       });
     }

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -65,7 +65,7 @@ test.describe('Netzgrafik Editor', { tag: ['@op', '@nge'] }, () => {
   /** *************** Test 1 **************** */
   test('Verify NGE train data', async ({ ngePage }) => {
     await test.step('Verify nodes displayed on NGE graph', async () => {
-      await ngePage.expectNodes(['FR-SWS/…', 'FR-MWS/…', 'FR-MES/…']);
+      await ngePage.expectNodes(['SWS/BV', 'MWS/BV', 'MES/BV']);
     });
 
     await test.step('Verify train rows labels', async () => {


### PR DESCRIPTION
close https://github.com/OpenRailAssociation/osrd/issues/18033

1st commit: Add migration to adapt `path_item_key`.
2nd commit: Adapt frontend to avoid having a country code in trigram and always add `FR-` within the `path_item_key`. 