### PR TITLE
editoast: refactor out deprecated `Authorizer::check_authorization`

### DIFF
--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -2,15 +2,12 @@ use std::collections::HashSet;
 use tracing::Level;
 use tracing::debug;
 
-use crate::Authorization;
 use crate::Error;
-use crate::Infra;
 use crate::Regulator;
 use crate::Role;
 use crate::StorageDriver;
 use crate::identity::UserIdentity;
 use crate::identity::UserInfo;
-use crate::model::InfraPrivilege;
 use crate::model::User;
 
 /// Represents how an authenticated user can interact with the authorization system
@@ -57,16 +54,6 @@ impl<S: StorageDriver> Authorizer<S> {
     #[tracing::instrument(skip_all, fields(user = %self.user, ?roles), ret(level = Level::DEBUG))]
     pub async fn check_roles(&self, roles: HashSet<Role>) -> Result<bool, Error<S::Error>> {
         self.regulator.check_roles(&User(self.user_id), roles).await
-    }
-
-    pub async fn authorize_infra(
-        &self,
-        infra: &Infra,
-        privilege: InfraPrivilege,
-    ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.regulator
-            .authorize_infra(&User(self.user_id), infra, privilege)
-            .await
     }
 }
 

--- a/editoast/authz/src/authorizer.rs
+++ b/editoast/authz/src/authorizer.rs
@@ -42,14 +42,6 @@ impl<S: StorageDriver> Authorizer<S> {
         Ok(authorizer)
     }
 
-    pub fn user_id(&self) -> i64 {
-        self.user_id
-    }
-
-    pub fn user_name(&self) -> &str {
-        &self.user.name
-    }
-
     /// Check that the user has any of the required roles
     #[tracing::instrument(skip_all, fields(user = %self.user, ?roles), ret(level = Level::DEBUG))]
     pub async fn check_roles(&self, roles: HashSet<Role>) -> Result<bool, Error<S::Error>> {

--- a/editoast/authz/src/lib.rs
+++ b/editoast/authz/src/lib.rs
@@ -98,19 +98,6 @@ impl<T: std::fmt::Debug> Authorization<T> {
     }
 }
 
-impl<T: Default> Authorization<T> {
-    #[inline]
-    fn from_privilege_check(allowed: bool) -> Self {
-        if allowed {
-            Authorization::Granted(T::default())
-        } else {
-            Authorization::Denied {
-                reason: "insufficient privileges",
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 macro_rules! authz_client {
     () => {{

--- a/editoast/authz/src/regulator.rs
+++ b/editoast/authz/src/regulator.rs
@@ -1,10 +1,8 @@
 use std::collections::HashSet;
 use std::future::Future;
 
-use fga::model::Relation as _;
 use tracing::Level;
 
-use crate::Authorization;
 use crate::Error;
 use crate::Role;
 use crate::identity::GroupInfo;
@@ -88,46 +86,10 @@ impl<S: StorageDriver> Regulator<S> {
         &self.openfga
     }
 
-    /// Returns whether a user with some id exists
-    #[tracing::instrument(skip_all, fields(user_id = %user_id), ret(level = Level::DEBUG), err)]
-    pub async fn user_exists(&self, user_id: i64) -> Result<bool, Error<S::Error>> {
-        #[expect(deprecated)]
-        self.driver
-            .get_user_info(user_id)
-            .await
-            .map(|x| x.is_some())
-            .map_err(Error::Storage)
-    }
-
-    /// Returns whether a group with some id exists
-    #[tracing::instrument(skip_all, fields(group_id = %group_id), ret(level = Level::DEBUG), err)]
-    pub async fn group_exists(&self, group_id: i64) -> Result<bool, Error<S::Error>> {
-        #[expect(deprecated)] // to be removed soon
-        self.driver
-            .get_group_info(group_id)
-            .await
-            .map(|x| x.is_some())
-            .map_err(Error::Storage)
-    }
-
-    pub async fn subject_exists(&self, subject: &Subject) -> Result<bool, Error<S::Error>> {
-        match subject {
-            Subject::User(user) => self.user_exists(user.0).await,
-            Subject::Group(group) => self.group_exists(group.0).await,
-        }
-    }
-
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn user_roles(&self, user: &User) -> Result<HashSet<Role>, Error<S::Error>> {
         // no need to check for user inexistence, an empty set will be returned in this case
         let roles = Role::list_roles(&self.openfga, model::User::role(), user).await?;
-        Ok(roles.into_iter().collect())
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn group_roles(&self, group: &Group) -> Result<HashSet<Role>, Error<S::Error>> {
-        // no need to check for group inexistence, an empty set will be returned in this case
-        let roles = Role::list_roles(&self.openfga, Group::role(), group).await?;
         Ok(roles.into_iter().collect())
     }
 
@@ -150,83 +112,5 @@ impl<S: StorageDriver> Regulator<S> {
             return Ok(true);
         }
         Ok(false)
-    }
-
-    pub async fn is_admin(&self, user: &User) -> Result<bool, Error<S::Error>> {
-        let user_roles = self.user_roles(user).await?;
-        Ok(user_roles.contains(&Role::Admin))
-    }
-
-    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn authorize_infra(
-        &self,
-        user: &User,
-        infra: &Infra,
-        privilege: InfraPrivilege,
-    ) -> Result<Authorization<()>, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra.0)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra.0));
-        }
-
-        // Check if user exists
-        if !self.user_exists(user.0).await? {
-            return Err(Error::UnknownSubject(user.0));
-        }
-
-        // Bypass if user is an admin
-        if self.is_admin(user).await? {
-            return Ok(Authorization::Bypassed);
-        }
-
-        // Calling openfga with the appropriate privilege check
-        let check = match privilege {
-            InfraPrivilege::CanRestrictedRead => {
-                self.openfga
-                    .check(model::Infra::can_restricted_read().check(user, infra))
-                    .await?
-            }
-            InfraPrivilege::CanRead => {
-                self.openfga
-                    .check(model::Infra::can_read().check(user, infra))
-                    .await?
-            }
-            InfraPrivilege::CanWrite => {
-                self.openfga
-                    .check(model::Infra::can_write().check(user, infra))
-                    .await?
-            }
-            InfraPrivilege::CanDelete => {
-                self.openfga
-                    .check(model::Infra::can_delete().check(user, infra))
-                    .await?
-            }
-            InfraPrivilege::CanShareRead => {
-                self.openfga
-                    .check(model::Infra::can_share_read().check(user, infra))
-                    .await?
-            }
-            InfraPrivilege::CanShareWrite => {
-                self.openfga
-                    .check(model::Infra::can_share_write().check(user, infra))
-                    .await?
-            }
-            InfraPrivilege::CanShareOwnership => {
-                self.openfga
-                    .check(model::Infra::can_share_ownership().check(user, infra))
-                    .await?
-            }
-            InfraPrivilege::CanRevoke => {
-                self.openfga
-                    .check(model::Infra::can_revoke().check(user, infra))
-                    .await?
-            }
-        };
-        Ok(Authorization::from_privilege_check(check))
     }
 }

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -169,6 +169,25 @@ impl<T> Protected<T> {
         authorizer.authorize(self).await
     }
 
+    /// Authorizes the protected operation and runs it if authorized, otherwise returns an error of the desired type.
+    ///
+    /// Chains [Authorizer::authorize] and [Access::access] and combines the potential errors into a single error type.
+    /// A rejection is considered an error here as well.
+    ///
+    /// Convenient to obtain one-liners and ease error handling.
+    pub async fn run<E, A>(self, authorizer: &A) -> Result<T, E>
+    where
+        E: From<A::Rejection> + From<A::Error> + From<OpenFgaError>,
+        A: Authorizer,
+    {
+        authorizer
+            .authorize(self)
+            .await?
+            .access()
+            .await?
+            .map_err(|rejection| E::from(rejection))
+    }
+
     /// Consumes the protection and produces an [Access::Authorized] without performing any check
     ///
     /// Only use this in trusted context or in an [Authorizer] implementation after performing the necessary checks.
@@ -256,6 +275,12 @@ impl<T: Send + 'static> Protected<Option<T>> {
         T: Into<E>,
     {
         self.map(async move |val| val.map(T::into))
+    }
+}
+
+impl Protected<bool> {
+    pub fn ok_or<E: Send + 'static>(self, err: E) -> Protected<Result<(), E>> {
+        self.map(async |b| b.then_some(()).ok_or(err))
     }
 }
 

--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -721,15 +721,11 @@ mod tests {
     )]
     #[case::project_set_grant(
         project_set_grant(Subject::user(1), Project(1)).checks,
-        &[
-            Check::CanGiveSubjectProjectGrant(Subject::user(1), Project(1))
-        ]
+        &[Check::CanGiveSubjectProjectGrant(Subject::user(1), Project(1))]
     )]
     #[case::project_revoke_grant(
         project_revoke_grant(Subject::user(1), Project(1)).checks,
-        &[
-            Check::HasRole(Actor::Issuer, Role::Admin),
-        ]
+        &[Check::HasRole(Actor::Issuer, Role::Admin)]
     )]
     #[case::project_privileges(
         project_privileges(User(1), Project(1)).checks,

--- a/editoast/src/authentication.rs
+++ b/editoast/src/authentication.rs
@@ -84,7 +84,7 @@ impl State {
     ///
     /// If this function returns a user, then it is subject to permissions,
     /// otherwise they likely can be bypassed.
-    pub fn regular_user(&self) -> Option<authz::User> {
+    pub fn user(&self) -> Option<authz::User> {
         match self {
             State::Skip => None,
             State::Authenticated { user, .. } => Some(*user),

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -37,7 +37,6 @@ mod test_app;
 
 use ::core::str;
 
-use ::authz::Authorization;
 use ::authz::Authorizer;
 use core_client::CoreClient;
 use editoast_derive::EditoastError;
@@ -45,8 +44,6 @@ use editoast_models::PgAuthDriver;
 use thiserror::Error;
 
 pub use server::OpenApiRoot;
-
-use crate::error::Result;
 
 #[cfg(test)]
 use test_app::test_app;
@@ -464,7 +461,7 @@ pub enum Authentication {
     /// The issuer of the request did not provide any authentication information.
     Unauthenticated,
     /// The issuer of the request provided the 'x-remote-user-identity' header.
-    Authenticated(Authorizer<PgAuthDriver>),
+    Authenticated(#[expect(dead_code)] Authorizer<PgAuthDriver>),
     /// The requests comes from a trusted service (like core). All requests are considered safe.
     SkipAuthorization {
         #[expect(unused)]
@@ -473,30 +470,6 @@ pub enum Authentication {
         name: Option<String>,
     },
 }
-
-impl Authentication {
-    /// Function wrapper that allows you to check if the issuer of the request has the good privilege, grant, role....
-    /// If the request is unauthenticated, it will return an Unauthorized error, and for the SkipAuthorization.
-    /// The provided function will be called with the authorizer and its result will be checked by the allowed() method.
-    /// In case of error, a Forbidden error will be returned.
-    /// How to use it: `auth.check_authorization(async |authorizer| authorizer.authorize_infra_delete(infra_id).await).await?;`
-    async fn check_authorization<E: Into<AuthorizationError>>(
-        self,
-        f: impl AsyncFnOnce(Authorizer<PgAuthDriver>) -> Result<Authorization<()>, E>,
-    ) -> Result<(), AuthorizationError> {
-        match self {
-            Authentication::SkipAuthorization { .. } => Ok(()),
-            Authentication::Unauthenticated => Err(AuthorizationError::Unauthenticated),
-            Authentication::Authenticated(authorizer) => f(authorizer)
-                .await
-                .map_err(Into::into)?
-                .allowed()
-                .map_err(|_| AuthorizationError::Forbidden),
-        }
-    }
-}
-
-pub use server::middlewares::AuthenticationExt;
 
 pub type AuthorizerError = ::authz::Error<<PgAuthDriver as ::authz::StorageDriver>::Error>;
 
@@ -508,6 +481,7 @@ pub enum AuthorizationError {
     Unauthenticated,
     #[error("Forbidden (403) — user has insufficient privileges")]
     #[editoast_error(status = 403)]
+    #[from(::authz::v2::Check)]
     Forbidden,
     #[error("Forbidden (403) — user must be an admin to impersonate")]
     #[editoast_error(status = 403)]
@@ -522,6 +496,12 @@ pub enum AuthorizationError {
     #[error(transparent)]
     #[editoast_error(status = 500)]
     DbError(#[from] database::db_connection_pool::DatabasePoolError),
+}
+
+impl From<crate::authorizers::Error> for AuthorizationError {
+    fn from(crate::authorizers::Error(fga_error): crate::authorizers::Error) -> Self {
+        Self::from(fga_error)
+    }
 }
 
 #[cfg(test)]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -160,7 +160,7 @@ pub(in crate::views) async fn user_groups(
     }): State<AppState>,
 ) -> Result<Json<Vec<Group>>> {
     let user = authn_state
-        .regular_user()
+        .user()
         .ok_or(AuthorizationError::Unauthenticated)?;
     let authorizer = authn_state.authorizer(regulator.openfga());
     let user_groups = authz::v2::user_groups(user)
@@ -516,7 +516,7 @@ pub(in crate::views) async fn user_grants(
     Json(body): Json<HashMap<ResourceType, Vec<i64>>>,
 ) -> Result<Json<HashMap<ResourceType, Vec<UserResourceGrant>>>> {
     let user = authn_state
-        .regular_user()
+        .user()
         .ok_or(AuthorizationError::Unauthenticated)?;
     let authorizer = authn_state.authorizer(regulator.openfga());
     let mut response = HashMap::<_, Vec<UserResourceGrant>>::new();

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -10,9 +11,10 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
 use crate::infra_cache::InfraCache;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
@@ -67,9 +69,10 @@ pub(in crate::views) async fn attached(
         db_pool,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
 ) -> Result<Json<HashMap<ObjectType, Vec<String>>>> {
     // Check that infra exists
     let mut conn = db_pool.get().await?;
@@ -79,16 +82,13 @@ pub(in crate::views) async fn attached(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     // Check track existence
     let infra_cache = InfraCache::get_or_load(

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::hash_map::HashMap;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -14,6 +15,7 @@ use tracing::debug;
 use tracing::error;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
 use crate::generated_data::generate_infra_errors;
 use crate::generated_data::infra_error::InfraError;
@@ -24,7 +26,7 @@ use crate::infra_cache::operation::DeleteOperation;
 use crate::infra_cache::operation::Operation;
 use crate::infra_cache::operation::UpdateOperation;
 use crate::infra_cache::operation::patch_infra_object;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use editoast_models::Infra;
@@ -94,9 +96,10 @@ pub(in crate::views) async fn list_auto_fixes(
         db_pool,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
 ) -> Result<Json<Vec<Operation>>> {
     let mut conn = db_pool.get().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), infra_id, || InfraApiError::NotFound {
@@ -104,16 +107,13 @@ pub(in crate::views) async fn list_auto_fixes(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     // accepting the early release of ReadGuard as it's anyway released when sending the suggestions (so before edit)
     let mut infra_cache_clone = InfraCache::get_or_load(

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -1,11 +1,13 @@
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::Json;
 use axum::extract::Path;
@@ -127,10 +129,11 @@ pub(in crate::views) async fn delimited_area(
         db_pool,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(DelimitedAreaForm { entries, exits }): Json<DelimitedAreaForm>,
 ) -> Result<Json<DelimitedAreaResponse>> {
     // TODO in case of a missing exit, return an empty list of track ranges instead of returning all
@@ -142,16 +145,13 @@ pub(in crate::views) async fn delimited_area(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let infra_cache = InfraCache::get_or_load(
         &mut conn,

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1,4 +1,5 @@
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -29,6 +30,7 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
 use crate::generated_data;
 use crate::infra_cache::InfraCache;
@@ -38,7 +40,7 @@ use crate::infra_cache::operation::DeleteOperation;
 use crate::infra_cache::operation::Operation;
 use crate::infra_cache::operation::UpdateOperation;
 use crate::map;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use database::DbConnection;
@@ -73,9 +75,10 @@ pub(in crate::views) async fn edit(
         infra_caches,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(operations): Json<Vec<Operation>>,
 ) -> Result<Json<Vec<InfraObject>>> {
     // TODO: lock for update
@@ -84,13 +87,13 @@ pub(in crate::views) async fn edit(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanWrite)
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanWrite))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let mut infra_cache = InfraCache::get_or_load_mut(
         &mut db_pool.get().await?,
@@ -133,9 +136,10 @@ pub(in crate::views) async fn split_track_section(
         infra_caches,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(payload): Json<TrackOffset>,
 ) -> Result<Json<Vec<String>>> {
     info!(
@@ -150,13 +154,13 @@ pub(in crate::views) async fn split_track_section(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanWrite)
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanWrite))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let mut infra_cache = InfraCache::get_or_load_mut(
         &mut db_pool.get().await?,

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
-use std::sync::Arc;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -13,16 +13,17 @@ use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 
+use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
 use crate::generated_data::InfraErrorLevel;
 use crate::generated_data::InfraGeneratedData as _;
 use crate::generated_data::infra_error::InfraError;
 use crate::generated_data::infra_error::InfraErrorTypeLabel;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdParam;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
-use database::DbConnectionPoolV2;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
 
@@ -69,7 +70,9 @@ pub(in crate::views) struct InfraErrorResponse {
      ),
  )]
 pub(in crate::views) async fn list_errors(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<100>>,
     Query(ErrorListQueryParams {
@@ -77,7 +80,7 @@ pub(in crate::views) async fn list_errors(
         error_type,
         object_id,
     }): Query<ErrorListQueryParams>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
 ) -> Result<Json<ErrorListResponse>> {
     let error_type = match error_type.map(|et| InfraErrorTypeLabel::from_str(&et).ok()) {
         Some(None) => return Err(ListErrorsErrors::WrongErrorTypeProvided.into()),
@@ -91,16 +94,13 @@ pub(in crate::views) async fn list_errors(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let (results, total_count) = infra
         .get_paginated_errors(&mut conn, level, error_type, object_id, page, page_size)

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -1,17 +1,18 @@
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use schemas::infra::TrackSection;
 use schemas::primitives::BoundingBox;
-use std::sync::Arc;
 use thiserror::Error;
 
+use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use editoast_models::Infra;
@@ -40,8 +41,10 @@ enum LinesErrors {
 )]
 pub(in crate::views) async fn get_line_bbox(
     Path((infra_id, line_code)): Path<(i64, i64)>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
 ) -> Result<Json<BoundingBox>> {
     let line_code: i32 = line_code.try_into().unwrap();
 
@@ -51,16 +54,13 @@ pub(in crate::views) async fn get_line_bbox(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let mut bbox = BoundingBox::default();
     let selection_settings =

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -37,7 +37,6 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::AuthenticationExt;
 use super::pagination::PaginationStats;
 use crate::AppState;
 use crate::Arc;
@@ -188,7 +187,7 @@ pub(in crate::views) async fn list(
     State(AppState {
         db_pool, regulator, ..
     }): State<AppState>,
-    Extension(authn): Extension<crate::authentication::State>,
+    Extension(authn): Extension<authentication::State>,
     Query(pagination): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<InfraListResponse>> {
     let conn = &mut db_pool.get().await?;
@@ -244,8 +243,10 @@ pub(in crate::views) struct InfraIdParam {
     ),
 )]
 pub(in crate::views) async fn get(
-    State(AppState { db_pool, .. }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(infra): Path<InfraIdParam>,
 ) -> Result<Json<Infra>> {
     let infra_id = infra.infra_id;
@@ -254,16 +255,13 @@ pub(in crate::views) async fn get(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     Ok(Json(infra))
 }
@@ -340,7 +338,6 @@ pub(in crate::views) struct CloneQuery {
     ),
 )]
 pub(in crate::views) async fn clone(
-    Extension(auth): AuthenticationExt,
     Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(AppState {
@@ -354,14 +351,13 @@ pub(in crate::views) async fn clone(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.clone()
-        .check_authorization(async |authorizer| {
-            authorizer
-                .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
-                .await
-        })
-        .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let cloned_infra = infra.clone(&mut conn, name).await?;
 
@@ -400,17 +396,19 @@ pub(in crate::views) async fn clone(
     ),
 )]
 pub(in crate::views) async fn delete(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<impl IntoResponse> {
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanDelete)
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanDelete))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     if Infra::fast_delete_static(db_pool.get().await?, infra_id).await? {
         Ok(StatusCode::NO_CONTENT)
@@ -469,8 +467,10 @@ pub(in crate::views) async fn put(
     )
 )]
 pub(in crate::views) async fn get_switch_types(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<Json<Vec<SwitchType>>> {
     let mut conn = db_pool.get().await?;
@@ -480,16 +480,13 @@ pub(in crate::views) async fn get_switch_types(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let selection_settings =
         SelectionSettings::new().filter(move || SwitchTypeModel::INFRA_ID.eq(infra.id));
@@ -522,9 +519,11 @@ pub(in crate::views) async fn get_switch_types(
     )
 )]
 pub(in crate::views) async fn get_speed_limit_tags(
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
     State(builtin_tags): State<Arc<SpeedLimitTagIds>>,
 ) -> Result<Json<HashSet<String>>> {
     let mut conn = db_pool.get().await?;
@@ -534,16 +533,13 @@ pub(in crate::views) async fn get_speed_limit_tags(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let infra_tags = infra.get_speed_limit_tags(&mut conn).await?;
     let union_tags: HashSet<String> = infra_tags
@@ -574,10 +570,12 @@ pub(in crate::views) struct GetVoltagesQueryParams {
     )
 )]
 pub(in crate::views) async fn get_voltages(
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Query(param): Query<GetVoltagesQueryParams>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
 ) -> Result<Json<Vec<String>>> {
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
@@ -585,16 +583,13 @@ pub(in crate::views) async fn get_voltages(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let voltages = infra
         .get_voltages(&mut db_pool.get().await?, include_rolling_stock_modes)
@@ -642,17 +637,19 @@ async fn set_locked(mut conn: DbConnection, infra_id: i64, locked: bool) -> Resu
     )
 )]
 pub(in crate::views) async fn lock(
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
 ) -> Result<impl IntoResponse> {
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanWrite)
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanWrite))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     set_locked(db_pool.get().await?, infra_id, true).await?;
     Ok(StatusCode::NO_CONTENT)
@@ -670,17 +667,19 @@ pub(in crate::views) async fn lock(
     )
 )]
 pub(in crate::views) async fn unlock(
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
 ) -> Result<impl IntoResponse> {
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanWrite)
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanWrite))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     set_locked(db_pool.get().await?, infra_id, false).await?;
     Ok(StatusCode::NO_CONTENT)
@@ -746,22 +745,22 @@ operational point that it matches on a given infrastructure.
     ),
 )]
 pub(in crate::views) async fn match_operational_points(
-    State(AppState { db_pool, .. }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Json(MatchOperationalPointsForm {
         operational_point_references,
     }): Json<MatchOperationalPointsForm>,
 ) -> Result<Json<MatchOperationalPointsResponse>> {
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
     let mut conn = db_pool.get().await?;
     let op_cache = OperationalPointCache::load_from_operational_points(
         conn.clone(),

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -1,21 +1,22 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
 use schemas::primitives::ObjectType;
 use thiserror::Error;
 
 use super::InfraApiError;
 use super::InfraIdParam;
+use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use editoast_models::Infra;
 use editoast_models::infra::ObjectQueryable;
 use editoast_models::prelude::*;
@@ -55,8 +56,10 @@ pub(in crate::views) struct ObjectTypeParam {
 pub(in crate::views) async fn get_objects(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Path(object_type_param): Path<ObjectTypeParam>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Json(obj_ids): Json<Vec<String>>,
 ) -> Result<Json<Vec<ObjectQueryable>>> {
     if !has_unique_ids(&obj_ids) {
@@ -68,16 +71,13 @@ pub(in crate::views) async fn get_objects(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let objects = infra
         .get_objects(
@@ -131,24 +131,23 @@ pub(in crate::views) struct ListObjectsResponse {
 pub(in crate::views) async fn list_objects_ids(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Path(ObjectTypeParam { object_type }): Path<ObjectTypeParam>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
 ) -> Result<Json<ListObjectsResponse>> {
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let objects = infra
         .list_objects(&mut db_pool.get().await?, object_type)

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -16,10 +17,11 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use editoast_models::Infra;
@@ -90,9 +92,10 @@ pub(in crate::views) async fn pathfinding_view(
         infra_caches,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Query(params): Query<QueryParam>,
     Json(input): Json<InfraPathfindingInput>,
@@ -113,16 +116,13 @@ pub(in crate::views) async fn pathfinding_view(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let infra_cache = InfraCache::get_or_load(
         &mut db_pool.get().await?,

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use authz::InfraGrant;
 use authz::v2;
 use axum::Extension;
@@ -26,10 +24,9 @@ use crate::authorizers::SystemAuthorizer;
 use crate::error::Result;
 use crate::generated_data::InfraGeneratedData as _;
 use crate::infra_cache::InfraCache;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
-use database::DbConnectionPoolV2;
 use editoast_models::Infra;
 use editoast_models::prelude::*;
 use schemas::primitives::ObjectType;
@@ -47,8 +44,10 @@ use schemas::primitives::ObjectType;
 )]
 pub(in crate::views) async fn get_railjson(
     Path(infra): Path<InfraIdParam>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
 ) -> Result<impl IntoResponse> {
     let infra_id = infra.infra_id;
     let infra_meta = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
@@ -56,13 +55,13 @@ pub(in crate::views) async fn get_railjson(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(&authz::Infra(infra_id), authz::InfraPrivilege::CanRead)
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let futures: Vec<_> = ObjectType::iter()
         .map(|object_type| (object_type, db_pool.get()))

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -1,24 +1,24 @@
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
-use database::DbConnectionPoolV2;
 use schemas::infra::RoutePath;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 use strum::Display;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
 use crate::infra_cache::Graph;
 use crate::infra_cache::InfraCache;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use crate::views::params::List;
@@ -60,8 +60,10 @@ pub(in crate::views) struct RoutesResponse {
 )]
 pub(in crate::views) async fn get_routes_from_waypoint(
     Path(path): Path<RoutesFromWaypointParams>,
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
 ) -> Result<Json<RoutesResponse>> {
     let mut conn = db_pool.get().await?;
     let infra = Infra::retrieve_or_fail(conn.clone(), path.infra_id, || InfraApiError::NotFound {
@@ -69,16 +71,13 @@ pub(in crate::views) async fn get_routes_from_waypoint(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(path.infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(path.infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let routes = infra
         .get_routes_from_waypoint(&mut conn, &path.waypoint_id, path.waypoint_type.to_string())
@@ -146,9 +145,10 @@ pub(in crate::views) async fn get_routes_track_ranges(
         infra_caches,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(infra): Path<i64>,
     Query(params): Query<RouteTrackRangesParams>,
 ) -> Result<Json<Vec<RouteTrackRangesResult>>> {
@@ -160,16 +160,13 @@ pub(in crate::views) async fn get_routes_track_ranges(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let infra_cache = InfraCache::get_or_load(
         &mut db_pool.get().await?,
@@ -219,9 +216,10 @@ pub(in crate::views) async fn get_routes_nodes(
         infra_caches,
         valkey_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Json(node_states): Json<HashMap<String, Option<String>>>,
 ) -> Result<Json<RoutesFromNodesPositions>> {
@@ -230,16 +228,13 @@ pub(in crate::views) async fn get_routes_nodes(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     if node_states.is_empty() {
         return Ok(Json(RoutesFromNodesPositions::default()));

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -1,6 +1,7 @@
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
 use crate::views::projection::interpolate_arrival_time;
@@ -8,6 +9,7 @@ use crate::views::rolling_stock::RollingStockError;
 use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use crate::views::timetable::simulation::train_simulation_ordered_batch;
+use authz::v2;
 use editoast_models::Infra;
 use editoast_models::LevelCrossingModel;
 use editoast_models::Timetable;
@@ -100,9 +102,10 @@ pub(in crate::views) async fn occupancy(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(LevelCrossingOccupancyForm {
         train_ids,
         level_crossing_ids,
@@ -111,15 +114,13 @@ pub(in crate::views) async fn occupancy(
         electrical_profile_set_id,
     }): Json<LevelCrossingOccupancyForm>,
 ) -> Result<Json<HashMap<Identifier, Vec<LevelCrossingOccupancy>>>> {
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let conn = &mut db_pool.get().await?;
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -6,6 +6,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -32,8 +33,9 @@ use tracing::info;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::PathfindingError;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::timetable::PhysicsConsistParameters;
@@ -244,9 +246,10 @@ pub(in crate::views) async fn post(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(infra_id): Path<i64>,
     Json(path_input): Json<PathfindingInput>,
 ) -> Result<Json<PathfindingResult>> {
@@ -256,16 +259,13 @@ pub(in crate::views) async fn post(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let op_cache =
         OperationalPointCache::load_path_items(conn, infra.id, &path_input.path_items).await?;

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -6,6 +6,7 @@
 //! - Then if the user requests the curves and slopes, editoast will retrieve the slopes from the cache and ask the core to compute the curves.
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -24,8 +25,9 @@ use std::hash::Hash;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::retrieve_infra_version;
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Hash)]
@@ -87,9 +89,10 @@ pub(in crate::views) async fn post(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(infra_id): Path<i64>,
     Json(path_properties_input): Json<PathPropertiesInput>,
 ) -> Result<Json<PathProperties>> {
@@ -97,16 +100,13 @@ pub(in crate::views) async fn post(
     let conn = &mut db_pool.get().await?;
     let infra_version = retrieve_infra_version(conn, infra_id).await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     use core_task::Task as _;
     let path_properties = PathPropertiesRequest {

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -1,3 +1,4 @@
+use authz::v2;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -22,9 +23,10 @@ use tracing::Instrument as _;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::timetable::conflicts::retrieve_trains;
 
@@ -147,8 +149,10 @@ struct PathIndexedConnection {
     ),
 )]
 pub(in crate::views) async fn search_journeys(
-    State(AppState { db_pool, .. }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Json(JourneySearchQuery {
         infra_id,
         timetable_ids,
@@ -187,15 +191,13 @@ pub(in crate::views) async fn search_journeys(
 
     Infra::exists_or_fail(&mut conn, infra_id, || Error::InfraNotFound { infra_id }).await?;
 
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let train_schedules: Vec<_> = JoinSetStream::new(train_schedule_futs)
         // Converts `Result<Result<_, InternalError>, JoinError>` into `Result<_, InternalError>`

--- a/editoast/src/views/server/middlewares.rs
+++ b/editoast/src/views/server/middlewares.rs
@@ -243,8 +243,6 @@ pub(in crate::views) async fn authentication_validation_middleware(
     Ok(next.run(req).await)
 }
 
-pub type AuthenticationExt = axum::extract::Extension<Authentication>;
-
 async fn authenticate(
     headers: &axum::http::HeaderMap,
     regulator: Regulator,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -14,6 +14,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -65,8 +66,9 @@ use super::pagination::PaginationQueryParams;
 use super::pagination::PaginationStats;
 use super::path::pathfinding::PathfindingResult;
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::timetable::simulation::SimulationResponseSuccess;
 use editoast_models::Infra;
@@ -286,9 +288,10 @@ pub(in crate::views) async fn requirements(
         valkey_client,
         core_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Query(page_settings): Query<PaginationQueryParams<200>>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
@@ -296,16 +299,13 @@ pub(in crate::views) async fn requirements(
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
 ) -> Result<Json<TrainRequirementsPage>> {
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let conn = &mut db_pool.get().await?;
 
@@ -475,24 +475,23 @@ pub(in crate::views) struct LocalTrackNamesForm {
     ),
 )]
 pub(in crate::views) async fn get_local_track_names(
-    State(AppState { db_pool, .. }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Json(LocalTrackNamesForm {
         operational_point_references,
         infra_id,
     }): Json<LocalTrackNamesForm>,
 ) -> Result<Json<HashMap<NonBlankString, HashSet<NonBlankString>>>> {
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     timeout(std::time::Duration::from_secs(240), async move {
         let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -1,3 +1,4 @@
+use authz::v2;
 use std::collections::HashMap;
 
 use axum::Extension;
@@ -17,8 +18,9 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
 use crate::views::timetable::ElectricalProfileSetIdQueryParam;
 use crate::views::timetable::TimetableError;
@@ -302,9 +304,10 @@ pub(in crate::views) async fn conflicts(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
     Query(ElectricalProfileSetIdQueryParam {
@@ -318,16 +321,13 @@ pub(in crate::views) async fn conflicts(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let (timetable_type, trains) = retrieve_trains(conn.clone(), timetable_id).await?;
 

--- a/editoast/src/views/timetable/linkings.rs
+++ b/editoast/src/views/timetable/linkings.rs
@@ -346,7 +346,8 @@ mod tests {
     use std::collections::HashSet;
 
     use authz::Role;
-    use editoast_models::prelude::{Create, Model};
+    use editoast_models::prelude::Create;
+    use editoast_models::prelude::Model;
     use reqwest::StatusCode;
     use serde_json::json;
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -1,6 +1,7 @@
 pub(crate) mod request;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -53,9 +54,10 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
+use crate::authentication;
 use crate::error::InternalError;
 use crate::error::Result;
-use crate::views::AuthenticationExt;
+use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::TrainScheduleWithConsist;
 use crate::views::timetable::PhysicsConsistParameters;
 use crate::views::timetable::simulation;
@@ -191,9 +193,10 @@ pub(in crate::views) async fn stdcm(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(id): Path<i64>,
     Query(query): Query<StdcmQueryParams>,
     Json(request): Json<Request>,
@@ -211,17 +214,13 @@ pub(in crate::views) async fn stdcm(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.clone()
-        .check_authorization(async |authorizer| {
-            authorizer
-                .authorize_infra(
-                    &authz::Infra(infra_id),
-                    authz::InfraPrivilege::CanRestrictedRead,
-                )
-                .await
-        })
-        .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     // 2. Get Timetable / Work schedules
     Timetable::exists_or_fail(&mut conn, timetable_id, || StdcmError::TimetableNotFound {

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -5,6 +5,7 @@ use std::iter::Extend as _;
 use std::sync::Arc;
 
 use authz;
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -49,9 +50,10 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use super::AppState;
-use super::AuthenticationExt;
+use crate::authentication;
 use crate::error::EditoastError as _;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::operational_point_cache::OperationalPointCache;
 use crate::views::path::pathfinding::PathfindingFailure;
@@ -325,9 +327,10 @@ pub(in crate::views) async fn simulation_summary(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(SimulationBatchForm {
         infra_id,
         timetable_id,
@@ -342,16 +345,13 @@ pub(in crate::views) async fn simulation_summary(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     /////
     // Init the simulation environment
@@ -598,9 +598,10 @@ pub(in crate::views) async fn get_path(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(TrainScheduleIdParam {
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
@@ -618,16 +619,13 @@ pub(in crate::views) async fn get_path(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let train_schedule =
         editoast_models::TrainSchedule::retrieve_or_fail(conn.clone(), train_schedule_id, || {
@@ -750,9 +748,10 @@ pub(in crate::views) async fn simulation(
         valkey_client,
         core_client,
         db_pool,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(TrainScheduleIdParam {
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
@@ -768,16 +767,13 @@ pub(in crate::views) async fn simulation(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     // Retrieve train_schedule or fail
     let train_schedule = editoast_models::TrainSchedule::retrieve_or_fail(
@@ -887,9 +883,10 @@ pub(in crate::views) async fn etcs_braking_curves(
         valkey_client,
         core_client,
         db_pool,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Path(TrainScheduleIdParam {
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
@@ -905,16 +902,13 @@ pub(in crate::views) async fn etcs_braking_curves(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     // Retrieve train schedule or fail
     let train_schedule = editoast_models::TrainSchedule::retrieve_or_fail(
@@ -1055,9 +1049,10 @@ pub(in crate::views) async fn project_path(
         valkey_client,
         core_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(ProjectPathForm {
         infra_id,
         timetable_id,
@@ -1071,15 +1066,13 @@ pub(in crate::views) async fn project_path(
     })
     .await?;
 
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let conn = &mut db_pool.get().await?;
 
@@ -1184,9 +1177,10 @@ pub(in crate::views) async fn project_path_op(
         valkey_client,
         core_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(ProjectPathOperationalPointForm {
         infra_id,
         train_ids,
@@ -1202,15 +1196,13 @@ pub(in crate::views) async fn project_path_op(
     })
     .await?;
 
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let conn = &mut db_pool.get().await?;
 
@@ -1372,9 +1364,10 @@ pub(in crate::views) async fn occupancy_blocks(
         valkey_client,
         core_client,
         config,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(OccupancyBlockForm {
         infra_id,
         timetable_id,
@@ -1383,15 +1376,13 @@ pub(in crate::views) async fn occupancy_blocks(
         electrical_profile_set_id,
     }): Json<OccupancyBlockForm>,
 ) -> Result<Json<HashMap<i64, OccupancyBlocksTrainScheduleResult>>> {
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     let infra = &Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
@@ -1538,9 +1529,10 @@ pub(in crate::views) async fn track_occupancy(
         db_pool,
         valkey_client,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(TrackOccupancyForm {
         train_schedule_ids,
         operational_point_reference,
@@ -1550,15 +1542,13 @@ pub(in crate::views) async fn track_occupancy(
         use_simulation,
     }): Json<TrackOccupancyForm>,
 ) -> Result<Json<Vec<TrackSectionOccupancy>>> {
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     // Load infrastructure and paced trains
     let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {

--- a/editoast/src/views/worker_load.rs
+++ b/editoast/src/views/worker_load.rs
@@ -1,3 +1,4 @@
+use authz::v2;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::State;
@@ -13,9 +14,10 @@ use serde::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
 
-use super::AuthenticationExt;
 use crate::AppState;
+use crate::authentication;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use editoast_models::Infra;
 use editoast_models::timetable::Timetable;
 
@@ -76,9 +78,10 @@ pub(in crate::views) async fn worker_load(
     State(AppState {
         db_pool,
         core_client,
+        regulator,
         ..
     }): State<AppState>,
-    Extension(auth): AuthenticationExt,
+    Extension(authn_state): Extension<authentication::State>,
     Json(WorkerLoadForm {
         infra_id,
         timetable_id,
@@ -89,16 +92,13 @@ pub(in crate::views) async fn worker_load(
     })
     .await?;
 
-    // Check user privilege on infra
-    auth.check_authorization(async |authorizer| {
-        authorizer
-            .authorize_infra(
-                &authz::Infra(infra_id),
-                authz::InfraPrivilege::CanRestrictedRead,
-            )
-            .await
-    })
-    .await?;
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
+            .await??;
+    }
 
     // Check timetable exists
     if let Some(timetable_id) = timetable_id {


### PR DESCRIPTION
refs https://github.com/osrd-project/osrd-confidential/issues/1168

Removes the last `authz::Authorizer` (V1) usage by changing the way we check for infra privileges before attempting an operation.

> [!NOTE]
> Thanks @Sh099078 for adding authorization unit tests on infra endpoints.

After this PR, we can completely remove everything from `authz` V1! https://github.com/OpenRailAssociation/osrd/pull/18037

## VS `authorizers::require`

@younesschrifi @Sh099078 
Used in https://github.com/OpenRailAssociation/osrd/pull/17364.

The main advantage is that it does not require a separate util function serving this sole purpose, all while keeping things explicit with one less indirection and having the same length or shorter.

#### before

```rust
if let Some(user) = authn_state.regular_user() {
    let authorizer = authn_state.authorizer(regulator.openfga(), db_pool.get().await?);
    crate::authorizers::require(
        &authorizer,
        rolling_stock_privileges(user, authz::RollingStock(light_rolling_stock_id)),
        &RollingStockPrivilege::CanRead,
    )
    .await?;
}
```

#### after

```rust
if let authentication::State::Authenticated { user, .. } = &authn_state {
    v2::infra_privileges(*user, authz::Infra(infra_id))
        .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRead))
        .ok_or(AuthorizationError::Forbidden)
        .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
        .await??;
}
```

## VS my first proposition

@Sh099078 @flomonster @woshilapin 

Well... it did not work. The default set of privileges was empty when authorization was skip thus forbidding every time. We do need the `if let` if we don't want to overly rely on `State`.

#### pros

* shorter
* still explicit
* processing the set while still wrapped in `Protected` allows us to define `ok_or_else` on `Protected<bool>` because [it's still unstable on `bool`](https://doc.rust-lang.org/core/primitive.bool.html#method.ok_or)

#### cons

The only one I can see is the double result coming from `Protected::<Result<(), AuthorizationError>::run`.

I wanted 3. You wanted only one. How about two?
<img width="220" height="117" alt="image" src="https://github.com/user-attachments/assets/edef80e0-bbe0-4834-abb4-b9a326b779a1" />

#### before

```rust
authn_state
    .user()
    .map_or_default(|user| v2::infra_privileges(user, authz::Infra(infra_id)))
    .run_or_forbid::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
    .await?
    .contains(&authz::InfraPrivilege::CanRead)
    .then_some(())
    .ok_or(AuthorizationError::Forbidden)?;
```

#### after

```rust
if let authentication::State::Authenticated { user, .. } = &authn_state {
    v2::infra_privileges(*user, authz::Infra(infra_id)) // Protected<HashSet<_>>
        .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRead)) // Protected<bool>
        .ok_or(AuthorizationError::Forbidden) // Protected<Result<(), AuthorizationError>>
        .run::<AuthorizationError, _>(&authn_state.authorizer(regulator.openfga()))
        .await??;
}
```