### PR TITLE
front : fix technical text shows on icons hover 

### DIFF
--- a/front/public/locales/de/translation.json
+++ b/front/public/locales/de/translation.json
@@ -820,6 +820,7 @@
     "calculatedArrivalTime": "berechnete Ankunft",
     "calculatedDepartureTime": "berechnete Abfahrt",
     "calculatedDepartureTimeFull": "berechnete Abfahrtszeit",
+    "clearCellTitle": "zelle löschen",
     "computedTheoreticalMargin": "berechnete theoretische Marge",
     "dayCounter": "T+{{count}}",
     "departureTime": "angeforderte Abfahrt",

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -845,6 +845,7 @@
     "calculatedArrivalTime": "calculated arrival time",
     "calculatedDepartureTime": "calculated depart. time",
     "calculatedDepartureTimeFull": "calculated departure time",
+    "clearCellTitle": "clear the cell",
     "computedTheoreticalMargin": "computed theoretical margin",
     "dayCounter": "D+{{count}}",
     "departureTime": "requested depart. time",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -845,6 +845,7 @@
     "calculatedArrivalTime": "arrivée calculée",
     "calculatedDepartureTime": "départ calculé",
     "calculatedDepartureTimeFull": "départ calculé",
+    "clearCellTitle": "effacer la cellule",
     "computedTheoreticalMargin": "marge théorique calculée",
     "dayCounter": "J+{{count}}",
     "departureTime": "départ demandé",

--- a/front/src/modules/timesStops/ClearButton.tsx
+++ b/front/src/modules/timesStops/ClearButton.tsx
@@ -6,10 +6,11 @@ import { createPortal } from 'react-dom';
 type ClearButtonProps = {
   isVisible: boolean;
   containerRef: React.RefObject<HTMLElement | null>;
+  title?: string;
   onClear: () => void;
 };
 
-const ClearButton = ({ isVisible, containerRef, onClear }: ClearButtonProps) => {
+const ClearButton = ({ isVisible, containerRef, title, onClear }: ClearButtonProps) => {
   const [btnPos, setBtnPos] = useState<{ top: number; left: number } | null>(null);
 
   useLayoutEffect(() => {
@@ -51,7 +52,7 @@ const ClearButton = ({ isVisible, containerRef, onClear }: ClearButtonProps) => 
         onClear();
       }}
     >
-      <Clear size="sm" />
+      <Clear size="sm" title={title} />
     </button>,
     document.body
   );

--- a/front/src/modules/timesStops/DurationCell.tsx
+++ b/front/src/modules/timesStops/DurationCell.tsx
@@ -397,12 +397,14 @@ export type DurationCellHandle = {
 
 const DurationCell = ({
   disabled,
+  clearButtonTitle,
   ref,
   ...props
 }: CellContext<TimesStopsRowNew, Duration | null> &
   Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> & {
     onCommit?: (seconds: number | null, propagationMode: StopPropagationMode) => void;
     disabled?: boolean;
+    clearButtonTitle?: string;
     ref?: React.Ref<DurationCellHandle>;
   }) => {
   const { onCommit, getValue, row, table } = props || {};
@@ -567,7 +569,12 @@ const DurationCell = ({
           disableToDestination={isLastRow}
         />
       </div>
-      <ClearButton isVisible={state.isEditing} containerRef={containerRef} onClear={handleClear} />
+      <ClearButton
+        isVisible={state.isEditing}
+        title={clearButtonTitle}
+        containerRef={containerRef}
+        onClear={handleClear}
+      />
     </>
   );
 };

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -481,6 +481,8 @@ type TimeCellProps = CellContext<TimesStopsRowNew, Date | null> &
     referenceDate?: Date;
     /** When the cell is empty, pre-fill the input with this value when the user focuses to edit. */
     prefillValue?: Date | null;
+    /** Title for the clear button. */
+    clearButtonTitle?: string;
     /** Called after Enter validates the input. Use to move focus (e.g. to the cell below). */
     onEnterKeyDown?: () => void;
     /** Called on Tab key to move focus to the next/previous editable time cell. */
@@ -494,6 +496,7 @@ const TimeCell = ({
   getValue,
   referenceDate,
   prefillValue,
+  clearButtonTitle,
   onEnterKeyDown,
   onTabKeyDown,
   onCommit,
@@ -734,6 +737,7 @@ const TimeCell = ({
       <ClearButton
         isVisible={state.focusedSection !== null && !state.empty && !disableClear}
         containerRef={inputRef}
+        title={clearButtonTitle}
         onClear={handleClear}
       />
     </>

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -339,6 +339,7 @@ const TimesStopsTable = ({
         {...info}
         referenceDate={getDepartureReferenceDate(row, startTime)}
         prefillValue={row.computedDeparture}
+        clearButtonTitle={t('clearCellTitle')}
         onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedDeparture')}
         onTabKeyDown={(direction) =>
           focusRequestedCellOnTab(info.row.index, 'requestedDeparture', direction)
@@ -381,6 +382,7 @@ const TimesStopsTable = ({
   const returnStopDurationCell = (info: CellContext<TimesStopsRowNew, Duration | null>) => (
     <DurationCell
       ref={registerTimeCellRef(info.row.index, 'stopDuration')}
+      clearButtonTitle={t('clearCellTitle')}
       {...info}
       onCommit={(seconds, propagationMode) =>
         info.table.options.meta!.onStopDurationChange(info.row.original, seconds, propagationMode)
@@ -464,6 +466,7 @@ const TimesStopsTable = ({
         {...info}
         referenceDate={getArrivalReferenceDate(row, allRows, startTime)}
         prefillValue={row.computedArrival}
+        clearButtonTitle={t('clearCellTitle')}
         onEnterKeyDown={() => focusCellBelow(info.row.index, 'requestedArrival')}
         onTabKeyDown={(direction) =>
           focusRequestedCellOnTab(info.row.index, 'requestedArrival', direction)

--- a/front/ui/ui-icons/scripts/build.js
+++ b/front/ui/ui-icons/scripts/build.js
@@ -59,6 +59,7 @@ const extractMetadataFromFilename = (fileName) => {
 const validateSvgAndExtractPath = (svgFilePath, height) => {
   const svg = readFileSync(svgFilePath, 'utf8');
   const svgElement = load(svg)('svg');
+  svgElement.find('title').remove();
   const svgWidth = parseInt(svgElement.attr('width'));
   const svgHeight = parseInt(svgElement.attr('height'));
   const svgViewBox = svgElement.attr('viewBox');


### PR DESCRIPTION
**What**
Fixes :Hover on icons shows technical text  #17190 & #17299

It has translation files changes for de/en/fr
and then carries a translation from parent to children


<img width="579" height="284" alt="image" src="https://github.com/user-attachments/assets/cf8c1e68-03c9-4dec-8b5c-e52d67c291d1" />

<img width="277" height="402" alt="image" src="https://github.com/user-attachments/assets/2f4f9161-125e-48c7-bd75-a7b59d26f3d8" />

**Why**

I did my analysis on this .[ Created a demo ](https://plnkr.co/edit/w5trSVxTwgtPPGxC?preview)to show that the in the ui-icons there are svg with <title>icon/16/clear-1</title> property , and to show these title as tool tip is their default behavior .

and the /ui-icons is full of these svg with title

<img width="1215" height="778" alt="image" src="https://github.com/user-attachments/assets/999f6bb4-128f-418c-89ba-7819665d492c" />

I also was able to override the svg title of the particular x as follows:

<img width="1213" height="665" alt="image" src="https://github.com/user-attachments/assets/21780c43-a658-4989-aebb-56f03f710ff9" />

 and removed  all the title's from SVG using svgElement.find('title').remove();

And then in the title  I display some useful tooltip (<title> {t('clearCellTitle')} </title>):
French: "effacer la cellule"
English: "clear the cell"
German: "zelle löschen"
