### PR TITLE
front: reset projected trains when path changes

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/__tests__/useLazyProjectTrains.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/__tests__/useLazyProjectTrains.spec.ts
@@ -45,6 +45,7 @@ vi.mock('applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader'
   default: vi.fn(
     class {
       projectTrainSchedules = mockProjectTrainSchedules;
+      cancel = vi.fn();
     }
   ),
 }));
@@ -207,12 +208,9 @@ describe('useLazyProjectTrains', () => {
 
   describe('loader selection', () => {
     it('should use TrainTrackProjectionLazyLoader when projectionType is trackProjection', () => {
+      const path = { track_section_ranges: [], blocks: [], routes: [] };
       renderHookWithStore(
-        () =>
-          useLazyProjectTrains({
-            ...base,
-            path: { track_section_ranges: [], blocks: [], routes: [] },
-          }),
+        () => useLazyProjectTrains({ ...base, path }),
         {},
         {
           simulation: {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useLazyProjectTrains.ts
@@ -94,6 +94,7 @@ const useLazyProjectTrains = ({
       );
     }
 
+    setProjectedTrainsById(new Map());
     loader.projectTrainSchedules([...trainSchedulesByIdRef.current.keys()]);
 
     loaderRef.current = loader;


### PR DESCRIPTION
Without this, when the path changes, we're displaying old train projections on a different path while new projections are loading, which is non-sensical.

To fix this, reset projected trains when we're re-creating a new train projection loader, right before launching projection.

As a side effect, this results in cancel() being called in TrainTrackProjectionLazyLoader tests. This method as missing, add it. Also use a constant path instead of passing a new object each time the hook is rendered.

Reported by @flomonster 