### PR TITLE
front: cleanup react testing library after each test

### DIFF
--- a/front/src/utils/hooks/__tests__/useKeyboardShortcuts.spec.ts
+++ b/front/src/utils/hooks/__tests__/useKeyboardShortcuts.spec.ts
@@ -72,13 +72,12 @@ describe('useKeyboardShortcuts', () => {
   const handlerMock1 = vi.fn();
   const handlerMock2 = vi.fn();
 
-  const { result } = renderHook(() => useKeyboardShortcuts());
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should register a shortcut', () => {
+    const { result } = renderHook(() => useKeyboardShortcuts());
     result.current.register({
       code: 'KeyS',
       optionalKeys: { ctrlKey: true },
@@ -92,6 +91,8 @@ describe('useKeyboardShortcuts', () => {
 
   it('should unregister a shortcut', () => {
     const handlerMock = vi.fn();
+
+    const { result } = renderHook(() => useKeyboardShortcuts());
 
     result.current.register({
       code: 'KeyS',
@@ -115,6 +116,8 @@ describe('useKeyboardShortcuts', () => {
   it('should not register the same shortcut twice', () => {
     const handlerMock = vi.fn();
 
+    const { result } = renderHook(() => useKeyboardShortcuts());
+
     result.current.register({
       code: 'KeyS',
       optionalKeys: { ctrlKey: true },
@@ -133,6 +136,8 @@ describe('useKeyboardShortcuts', () => {
   });
 
   it('should handle multiple shortcuts', () => {
+    const { result } = renderHook(() => useKeyboardShortcuts());
+
     result.current.register({
       code: 'KeyS',
       optionalKeys: { ctrlKey: true },

--- a/front/vitest.setup.ts
+++ b/front/vitest.setup.ts
@@ -1,6 +1,11 @@
+import { cleanup } from '@testing-library/react';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import { vi } from 'vitest';
+import { vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
 
 await i18n.use(initReactI18next).init({
   lng: 'cimode',


### PR DESCRIPTION
_See individual commits._

The [cleanup docs][1] state:

> Failing to call cleanup when you've called render could result in a
> memory leak and tests which are not "idempotent" (which can lead to
> difficult to debug errors in your tests).

See also the [setup guide for vitest][2].

[1]: https://testing-library.com/docs/react-testing-library/api#cleanup
[2]: https://testing-library.com/docs/react-testing-library/setup#auto-cleanup-in-vitest