### PR TITLE
editoast: add bbox endpoint for infra

### DIFF
--- a/editoast/editoast_models/src/infra.rs
+++ b/editoast/editoast_models/src/infra.rs
@@ -11,12 +11,15 @@ use chrono::DateTime;
 use chrono::Utc;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
+use diesel::QueryableByName;
 use diesel::delete;
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
+use diesel::sql_types::Nullable;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
 use educe::Educe;
+use schemas::primitives::BoundingBox;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::IntoEnumIterator;
@@ -114,6 +117,39 @@ impl Infra {
             .await?;
 
         Ok(())
+    }
+
+    pub async fn bbox(&self, conn: &mut DbConnection) -> Result<Option<BoundingBox>, crate::Error> {
+        use diesel::sql_types::Float8;
+
+        #[derive(Debug, QueryableByName)]
+        struct Bbox {
+            #[diesel(sql_type = Nullable<Float8>)]
+            min_lon: Option<f64>,
+            #[diesel(sql_type = Nullable<Float8>)]
+            min_lat: Option<f64>,
+            #[diesel(sql_type = Nullable<Float8>)]
+            max_lon: Option<f64>,
+            #[diesel(sql_type = Nullable<Float8>)]
+            max_lat: Option<f64>,
+        }
+
+        // Retrieving min/max X/Y is required to handle flat infra along x or y axis. ST_Extent returns a LineString instead of Polygon in this case.
+        let res = sql_query("SELECT ST_XMin(env) as min_lon, ST_YMin(env) as min_lat, ST_XMax(env) as max_lon, ST_YMax(env) as max_lat FROM (SELECT ST_Transform(ST_SetSRID(ST_Extent(geographic), 3857), 4326) as env FROM infra_layer_track_section WHERE infra_id = $1) AS bbox_query")
+            .bind::<BigInt, _>(self.id)
+            .get_result::<Bbox>(conn.write().await.deref_mut())
+            .await
+            ?;
+
+        Ok(match (res.min_lon, res.min_lat, res.max_lon, res.max_lat) {
+            (Some(min_lon), Some(min_lat), Some(max_lon), Some(max_lat)) => Some(BoundingBox {
+                min_lon,
+                min_lat,
+                max_lon,
+                max_lat,
+            }),
+            _ => None,
+        })
     }
 
     pub async fn clone(

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -971,6 +971,30 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Operation'
+  /infra/{infra_id}/bbox:
+    get:
+      tags:
+      - infra
+      summary: Retrieve the bounding box of an infra.
+      parameters:
+      - name: infra_id
+        in: path
+        description: An existing infra ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: The bbox of the infra if it contains tracks
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - type: 'null'
+                - $ref: '#/components/schemas/BoundingBox'
+        '404':
+          description: Infra ID not found
   /infra/{infra_id}/clone:
     post:
       tags:

--- a/editoast/src/views.rs
+++ b/editoast/src/views.rs
@@ -133,6 +133,7 @@ fn service_router() -> server::router::DocumentedRouter {
                             .route("/", post!(infra::edition::edit))
                             .route("/", delete!(infra::delete))
                             .route("/", put!(infra::put))
+                            .route("/bbox", get!(infra::bbox))
                             .route("/auto_fixes", get!(infra::auto_fixes::list_auto_fixes))
                             .route("/clone", post!(infra::clone))
                             .route(

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -28,6 +28,7 @@ use editoast_models::prelude::*;
 use geos::Geom;
 use itertools::Itertools;
 use schemas::infra::SwitchType;
+use schemas::primitives::BoundingBox;
 use schemas::primitives::Identifier;
 use schemas::primitives::NonBlankString;
 use serde::Deserialize;
@@ -453,6 +454,41 @@ pub(in crate::views) async fn put(
         })
         .await?;
     Ok(Json(infra))
+}
+
+/// Retrieve the bounding box of an infra.
+#[editoast_derive::route]
+#[utoipa::path(
+    get, path = "/",
+    tag = "infra",
+    params(InfraIdParam),
+    responses(
+        (status = 200, description = "The bbox of the infra if it contains tracks", body = Option<BoundingBox>),
+        (status = 404, description = "Infra ID not found"),
+    ),
+)]
+pub(in crate::views) async fn bbox(
+    Extension(authn_state): Extension<authentication::State>,
+    State(AppState {
+        db_pool, openfga, ..
+    }): State<AppState>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
+) -> Result<Json<Option<BoundingBox>>> {
+    let infra = Infra::retrieve_or_fail(db_pool.get().await?, infra_id, || {
+        InfraApiError::NotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    if let authentication::State::Authenticated { user, .. } = &authn_state {
+        v2::infra_privileges(*user, authz::Infra(infra_id))
+            .map(async |privileges| privileges.contains(&authz::InfraPrivilege::CanRestrictedRead))
+            .ok_or(AuthorizationError::Forbidden)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
+            .await??;
+    }
+
+    Ok(Json(infra.bbox(&mut db_pool.get().await?).await?))
 }
 
 /// Return the railjson list of switch types
@@ -1383,6 +1419,63 @@ pub mod tests {
                 .by_user(user_reader.as_ref())
                 .await
                 .assert_status_ok();
+        }
+    }
+
+    mod bbox {
+        use super::*;
+        use approx::assert_relative_eq;
+        use pretty_assertions::assert_eq;
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn get_bbox() {
+            let app = test_app!().build();
+            let db_pool = app.db_pool();
+            let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+            let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+            let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
+                .await
+                .unwrap();
+            generated_data::refresh_all(db_pool.clone(), small_infra.id, &infra_cache)
+                .await
+                .unwrap();
+
+            let user = app
+                .user("user", "User")
+                .with_infra_grant(empty_infra.id, InfraGrant::RestrictedReader)
+                .with_infra_grant(small_infra.id, InfraGrant::RestrictedReader)
+                .create()
+                .await;
+
+            let res: Option<BoundingBox> = app
+                .get(format!("/infra/{}/bbox", empty_infra.id).as_str())
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            assert_eq!(res, None);
+
+            let res: Option<BoundingBox> = app
+                .get(format!("/infra/{}/bbox", small_infra.id).as_str())
+                .by_user(user.as_ref())
+                .await
+                .assert_status_ok()
+                .json();
+            let bbox = res.expect("Expected a bounding box for small_infra");
+
+            let bbox_ref: BoundingBox = infra_cache.track_sections().values().fold(
+                BoundingBox::default(),
+                |mut bbox, ts| {
+                    bbox.union(&ts.unwrap_track_section().bbox_geo);
+                    bbox
+                },
+            );
+
+            assert_relative_eq!(bbox.min_lat, bbox_ref.min_lat);
+            assert_relative_eq!(bbox.min_lon, bbox_ref.min_lon);
+            assert_relative_eq!(bbox.max_lat, bbox_ref.max_lat);
+            assert_relative_eq!(bbox.max_lon, bbox_ref.max_lon);
         }
     }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -328,6 +328,13 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/infra/${queryArg.infraId}/auto_fixes` }),
         providesTags: ['infra'],
       }),
+      getInfraByInfraIdBbox: build.query<
+        GetInfraByInfraIdBboxApiResponse,
+        GetInfraByInfraIdBboxApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}/bbox` }),
+        providesTags: ['infra'],
+      }),
       postInfraByInfraIdClone: build.mutation<
         PostInfraByInfraIdCloneApiResponse,
         PostInfraByInfraIdCloneApiArg
@@ -1869,6 +1876,12 @@ export type GetInfraByInfraIdAttachedAndTrackIdApiArg = {
 export type GetInfraByInfraIdAutoFixesApiResponse =
   /** status 200 The list of suggested operations */ Operation[];
 export type GetInfraByInfraIdAutoFixesApiArg = {
+  /** An existing infra ID */
+  infraId: number;
+};
+export type GetInfraByInfraIdBboxApiResponse =
+  /** status 200 The bbox of the infra if it contains tracks */ null | BoundingBox;
+export type GetInfraByInfraIdBboxApiArg = {
   /** An existing infra ID */
   infraId: number;
 };
@@ -3496,6 +3509,12 @@ export type Operation =
     } & {
       operation_type: 'DELETE';
     });
+export type BoundingBox = {
+  max_lat: number;
+  max_lon: number;
+  min_lat: number;
+  min_lon: number;
+};
 export type ObjectRef = {
   obj_id: string;
   type: ObjectType;
@@ -3572,12 +3591,6 @@ export type InfraError = {
   obj_id: string;
   obj_type: ObjectType;
   sub_type: InfraErrorType;
-};
-export type BoundingBox = {
-  max_lat: number;
-  max_lon: number;
-  min_lat: number;
-  min_lon: number;
 };
 export type GeoJsonPoint = {
   coordinates: GeoJsonPointValue;


### PR DESCRIPTION
The idea of this PR is to add an endpoint that retrieves the bounding box of an infra.

For example small infra will returns this:

```yaml
min_lat: 49.466
min_lon: -0.4
max_lat: 49.51299999999999
max_lon: -0.09
```


<img width="1178" height="648" alt="image" src="https://github.com/user-attachments/assets/6c4b7abe-cbd2-4e57-916d-b26c88b6f89f" />
