### PR TITLE
editoast: rename osrdyne into core config

### DIFF
--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -111,14 +111,12 @@ pub async fn runserver(
         health_check_timeout: Duration::milliseconds(health_check_timeout_ms as i64),
         map_layers_max_zoom: map_layers_config.max_zoom as u8,
         postgres_config: postgres.into(),
-        osrdyne_config: views::OsrdyneConfig {
+        core_config: views::CoreConfig {
             mq_url,
-            core: views::CoreConfig {
-                timeout: Duration::seconds(core_timeout as i64),
-                single_worker: core_single_worker,
-                num_channels: core_client_channels_size,
-                worker_pool_id,
-            },
+            timeout: Duration::seconds(core_timeout as i64),
+            single_worker: core_single_worker,
+            num_channels: core_client_channels_size,
+            worker_pool_id,
         },
         valkey_config: valkey_config.into_cache_config(),
         openfga_config: openfga.into(),

--- a/editoast/src/views/server.rs
+++ b/editoast/src/views/server.rs
@@ -45,15 +45,11 @@ use crate::views::timetable;
 
 #[derive(Clone)]
 pub struct CoreConfig {
+    pub mq_url: Url,
     pub timeout: Duration,
     pub single_worker: bool,
     pub num_channels: usize,
     pub worker_pool_id: String,
-}
-
-pub struct OsrdyneConfig {
-    pub mq_url: Url,
-    pub core: CoreConfig,
 }
 
 #[derive(Clone)]
@@ -84,7 +80,7 @@ pub struct ServerConfig {
     pub health_check_timeout: Duration,
     pub map_layers_max_zoom: u8,
     pub postgres_config: PostgresConfig,
-    pub osrdyne_config: OsrdyneConfig,
+    pub core_config: CoreConfig,
     pub valkey_config: cache::Config,
     pub openfga_config: OpenfgaConfig,
     pub root_url: Url,
@@ -159,8 +155,8 @@ impl AppState {
                 single_worker,
                 num_channels,
                 worker_pool_id,
+                mq_url,
             }: CoreConfig,
-            mq_url: Url,
         ) -> anyhow::Result<Arc<CoreClient>> {
             let options = mq_client::Options {
                 uri: mq_url,
@@ -172,13 +168,8 @@ impl AppState {
             let client = CoreClient::new_mq(options).await?;
             Ok(Arc::new(client))
         }
-        let core_client_fut = tokio::spawn(
-            connect_core_client(
-                config.osrdyne_config.core.clone(),
-                config.osrdyne_config.mq_url.clone(),
-            )
-            .in_current_span(),
-        );
+        let core_client_fut =
+            tokio::spawn(connect_core_client(config.core_config.clone()).in_current_span());
 
         #[tracing::instrument(skip_all, level = "info", err, name = "OpenFGA connection")]
         async fn connect_openfga(openfga_config: OpenfgaConfig) -> anyhow::Result<fga::Client> {

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -54,7 +54,6 @@ use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
 
 use super::CoreConfig;
 use super::OpenfgaConfig;
-use super::OsrdyneConfig;
 use super::PostgresConfig;
 use super::Regulator;
 use super::ServerConfig;
@@ -152,14 +151,12 @@ impl TestAppBuilder {
                 database_url: Url::parse("postgres://osrd:password@localhost:5432/osrd").unwrap(),
                 pool_size: 32,
             },
-            osrdyne_config: OsrdyneConfig {
+            core_config: CoreConfig {
                 mq_url: Url::parse("amqp://osrd:password@127.0.0.1:5672/%2f").unwrap(),
-                core: CoreConfig {
-                    timeout: chrono::Duration::seconds(180),
-                    single_worker: false,
-                    num_channels: 8,
-                    worker_pool_id: "core".into(),
-                },
+                timeout: chrono::Duration::seconds(180),
+                single_worker: false,
+                num_channels: 8,
+                worker_pool_id: "core".into(),
             },
             valkey_config: cache::Config::NoCache,
             root_url: self


### PR DESCRIPTION
Editoast does not depend on osrdyne anymore.
This re-arrange legacy structs.