### PR TITLE
editoast: authz: add `Protected::map`

### DIFF
--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -197,7 +197,7 @@ impl<T: Send + 'static> Protected<T> {
         Self::new(move |_| async move { Ok(t) }.boxed())
     }
 
-    pub fn map<U: Send + 'static>(
+    pub fn then<U: Send + 'static>(
         self,
         f: impl for<'c> FnOnce(&'c fga::Client, T) -> BoxFuture<'c, Result<U, OpenFgaError>>
         + Send
@@ -214,6 +214,21 @@ impl<T: Send + 'static> Protected<T> {
             }),
             checks,
         }
+    }
+
+    pub fn map<U, F, Fut>(self, f: F) -> Protected<U>
+    where
+        U: Send + 'static,
+        F: FnOnce(T) -> Fut + Send + 'static,
+        Fut: Future<Output = U> + Send + 'static,
+    {
+        self.then(move |_, t| {
+            async move {
+                let u = f(t).await;
+                Ok(u)
+            }
+            .boxed()
+        })
     }
 
     pub fn zip<U: Send + 'static>(
@@ -240,7 +255,7 @@ impl<T: Send + 'static> Protected<Option<T>> {
         E: Send + 'static,
         T: Into<E>,
     {
-        self.map(move |_, val| async move { Ok(val.map(T::into)) }.boxed())
+        self.map(async move |val| val.map(T::into))
     }
 }
 
@@ -256,14 +271,10 @@ where
         C: FromIterator<<C as IntoIterator>::Item>,
         <T as IntoIterator>::Item: Into<<C as IntoIterator>::Item>,
     {
-        self.map(move |_, val| {
-            async move {
-                Ok(val
-                    .into_iter()
-                    .map(<T as IntoIterator>::Item::into)
-                    .collect::<C>())
-            }
-            .boxed()
+        self.map(async move |val| {
+            val.into_iter()
+                .map(<T as IntoIterator>::Item::into)
+                .collect::<C>()
         })
     }
 }

--- a/editoast/authz/src/v2/group.rs
+++ b/editoast/authz/src/v2/group.rs
@@ -52,7 +52,7 @@ pub fn user_groups(user: User) -> Protected<Vec<Group>> {
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
     group_members(group)
-        .map(move |openfga, existing_members| {
+        .then(move |openfga, existing_members| {
             async move {
                 let existing_members = HashSet::from_iter(existing_members);
                 let new_members = members.difference(&existing_members);
@@ -74,7 +74,7 @@ pub fn add_members(group: Group, members: HashSet<User>) -> Protected<()> {
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn remove_members(group: Group, members: HashSet<User>) -> Protected<()> {
     group_members(group)
-        .map(move |openfga, existing_members| {
+        .then(move |openfga, existing_members| {
             async move {
                 let existing_members = HashSet::from_iter(existing_members);
                 let expelled = members.intersection(&existing_members);

--- a/editoast/authz/src/v2/infra.rs
+++ b/editoast/authz/src/v2/infra.rs
@@ -126,7 +126,7 @@ pub fn infra_effective_grant(subject: Subject, infra: Infra) -> Protected<Option
 ///
 /// No transaction is setup as OpenFGA does not support them.
 pub fn infra_set_grant(subject: Subject, infra: Infra, new_grant: InfraGrant) -> Protected<()> {
-    let prot = infra_revoke_grant(subject, infra).map(move |openfga, _has_revoked| {
+    let prot = infra_revoke_grant(subject, infra).then(move |openfga, _has_revoked| {
         async move {
             let mut writes = openfga.prepare_writes();
             match (subject, new_grant) {
@@ -206,7 +206,7 @@ pub fn infra_set_grant(subject: Subject, infra: Infra, new_grant: InfraGrant) ->
 /// Returns `true` if a grant was revoked, `false` otherwise, making the operation idempotent.
 /// No transaction is setup as OpenFGA does not support them.
 pub fn infra_revoke_grant(subject: Subject, infra: Infra) -> Protected<bool> {
-    let prot = infra_direct_grant(subject, infra).map(move |openfga, grant| {
+    let prot = infra_direct_grant(subject, infra).then(move |openfga, grant| {
         async move {
             let Some(grant) = grant else {
                 return Ok(false);
@@ -375,15 +375,12 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
     }
     get_granted_users(infra, grant)
         .zip(get_granted_groups(infra, grant))
-        .map(move |_, (users, groups)| {
-            async move {
-                Ok(users
-                    .into_iter()
-                    .map(Subject::User)
-                    .chain(groups.into_iter().map(Subject::Group))
-                    .collect_vec())
-            }
-            .boxed()
+        .map(async move |(users, groups)| {
+            users
+                .into_iter()
+                .map(Subject::User)
+                .chain(groups.into_iter().map(Subject::Group))
+                .collect_vec()
         })
         .with_check(Check::HasInfraPrivilege(
             Actor::Issuer,
@@ -393,7 +390,7 @@ pub fn infra_granted_subjects(infra: Infra, grant: InfraGrant) -> Protected<Vec<
 }
 
 pub fn infra_list(user: User, privilege: InfraPrivilege) -> Protected<ResourcesList<Infra>> {
-    subject_roles(Subject::user(user)).map(move |openfga, roles| {
+    subject_roles(Subject::user(user)).then(move |openfga, roles| {
         async move {
             if roles.contains(&Role::Admin) {
                 return Ok(ResourcesList::All);

--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -71,7 +71,7 @@ pub fn project_effective_grant(
 
 pub fn project_set_grant(subject: Subject, project: Project) -> Protected<()> {
     project_direct_grant(subject, project)
-        .map(move |openfga, grant| {
+        .then(move |openfga, grant| {
             async move {
                 // Projects only have one grant level, the subject either has it or doesn't
                 let update = match grant {
@@ -113,7 +113,7 @@ pub fn project_revoke_grant(subject: Subject, project: Project) -> Protected<boo
     // Revoking rules:
     // Only admins can fully revoke grants
     project_direct_grant(subject, project)
-        .map(move |openfga, grant| {
+        .then(move |openfga, grant| {
             async move {
                 let Some(grant) = grant else {
                     return Ok(false);
@@ -163,7 +163,7 @@ pub fn project_privileges(user: User, project: Project) -> Protected<HashSet<Pro
 
 /// Lists all the projects a user has access to
 pub fn project_list(user: User) -> Protected<ResourcesList<Project>> {
-    subject_roles(Subject::user(user)).map(move |openfga, roles| {
+    subject_roles(Subject::user(user)).then(move |openfga, roles| {
         async move {
             if roles.contains(&Role::Admin) {
                 return Ok(ResourcesList::All);
@@ -203,15 +203,12 @@ pub fn project_granted_subjects(project: Project) -> Protected<Vec<Subject>> {
     }
     get_granted_users(project)
         .zip(get_granted_groups(project))
-        .map(move |_, (users, groups)| {
-            async move {
-                Ok(users
-                    .into_iter()
-                    .map(Subject::User)
-                    .chain(groups.into_iter().map(Subject::Group))
-                    .collect())
-            }
-            .boxed()
+        .map(async move |(users, groups)| {
+            users
+                .into_iter()
+                .map(Subject::User)
+                .chain(groups.into_iter().map(Subject::Group))
+                .collect()
         })
         .with_check(Check::HasProjectPrivilege(
             Actor::Issuer,

--- a/editoast/authz/src/v2/roles.rs
+++ b/editoast/authz/src/v2/roles.rs
@@ -28,7 +28,7 @@ pub fn subject_roles(subject: Subject) -> Protected<Vec<Role>> {
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
     subject_roles(subject)
-        .map(move |openfga, existing_roles| {
+        .then(move |openfga, existing_roles| {
             async move {
                 let existing_roles = HashSet::from_iter(existing_roles);
                 let new_roles = roles.difference(&existing_roles);
@@ -58,7 +58,7 @@ pub fn add_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
 /// Idempotent but not atomic due to the lack of transactions in OpenFGA.
 pub fn remove_roles(subject: Subject, roles: HashSet<Role>) -> Protected<()> {
     subject_roles(subject)
-        .map(move |openfga, existing_roles| {
+        .then(move |openfga, existing_roles| {
             async move {
                 let existing_roles = HashSet::from_iter(existing_roles);
                 let removed_roles = roles.intersection(&existing_roles);

--- a/editoast/authz/src/v2/rolling_stock.rs
+++ b/editoast/authz/src/v2/rolling_stock.rs
@@ -145,7 +145,7 @@ pub fn rolling_stock_set_grant(
     new_grant: RollingStockGrant,
 ) -> Protected<()> {
     let prot =
-        rolling_stock_revoke_grant(subject, rolling_stock).map(move |openfga, _has_revoked| {
+        rolling_stock_revoke_grant(subject, rolling_stock).then(move |openfga, _has_revoked| {
             async move {
                 let mut writes = openfga.prepare_writes();
                 match (subject, new_grant) {
@@ -315,15 +315,12 @@ pub fn rolling_stock_granted_subjects(
     }
     get_granted_users(rolling_stock, grant)
         .zip(get_granted_groups(rolling_stock, grant))
-        .map(move |_, (users, groups)| {
-            async move {
-                Ok(users
-                    .into_iter()
-                    .map(Subject::User)
-                    .chain(groups.into_iter().map(Subject::Group))
-                    .collect_vec())
-            }
-            .boxed()
+        .map(async move |(users, groups)| {
+            users
+                .into_iter()
+                .map(Subject::User)
+                .chain(groups.into_iter().map(Subject::Group))
+                .collect_vec()
         })
         .with_check(Check::HasRollingStockPrivilege(
             Actor::Issuer,
@@ -382,7 +379,7 @@ pub fn rolling_stock_revoke_grant(
     subject: Subject,
     rolling_stock: RollingStock,
 ) -> Protected<bool> {
-    let prot = rolling_stock_direct_grant(subject, rolling_stock).map(move |openfga, grant| {
+    let prot = rolling_stock_direct_grant(subject, rolling_stock).then(move |openfga, grant| {
         async move {
             let Some(grant) = grant else {
                 return Ok(false);

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -31,7 +31,6 @@ use editoast_models::RollingStock;
 use editoast_models::User;
 use editoast_models::authn::user::UserWithIdentities;
 use editoast_models::prelude::*;
-use futures::FutureExt as _;
 use futures::TryStreamExt;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -304,21 +303,18 @@ pub(in crate::views) async fn users_info(
             groups,
         )| {
             let group_by_id = group_by_id.clone();
-            v2::subject_roles(authz::Subject::user(id)).map(move |_, roles| {
-                async move {
-                    Ok(UserInfo {
-                        id,
-                        name,
-                        identities,
-                        roles: HashSet::from_iter(roles),
-                        groups: groups
-                            .into_iter()
-                            // Skip group if it does not exist
-                            .filter_map(|g| group_by_id.get(&*g).cloned())
-                            .collect(),
-                    })
+            v2::subject_roles(authz::Subject::user(id)).map(async move |roles| {
+                UserInfo {
+                    id,
+                    name,
+                    identities,
+                    roles: HashSet::from_iter(roles),
+                    groups: groups
+                        .into_iter()
+                        // Skip group if it does not exist
+                        .filter_map(|g| group_by_id.get(&*g).cloned())
+                        .collect(),
                 }
-                .boxed()
             })
         },
     ))


### PR DESCRIPTION
* Adds a simpler version of `Protected::map` that does not need explicit future boxing but does not provide the OpenFGA client reference in argument.
* Rename the existing `Protected::map` to `Protected::then`.
* Use `Protected::map` where the former client argument was ignored.