### PR TITLE
front : fix added missing translation keys to sdd DetailsBox

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -539,7 +539,11 @@
     "simulationSheet": "Simulationsblatt",
     "speedDistanceDiagram": "GSD",
     "speedDistanceSettings": {
+      "accelerating": "Beschleunigung",
+      "coasting": "Ausrollen",
       "context": "Kontext",
+      "decelerating": "Verzögerung",
+      "electric": "Elektrisch",
       "electricalProfiles": "Bahnstromprofile",
       "energySource": "Energiequelle",
       "etcs": {
@@ -554,6 +558,7 @@
         "title": "ETCS",
         "transition": "Überg."
       },
+      "incompatible": "Unvereinbar",
       "powerRestrictions": "Leistungsbeschränkungen",
       "reticleInfos": "Fadenkreuz-Infos",
       "slopes": "Längsneigungen",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -631,7 +631,11 @@
     "simulationSheet": "Train path sheet",
     "speedDistanceDiagram": "SDD",
     "speedDistanceSettings": {
+      "accelerating": "Accelerating",
+      "coasting": "Coasting",
       "context": "Context",
+      "decelerating": "Decelerating",
+      "electric": "Electric",
       "electricalProfiles": "Electrical profiles",
       "energySource": "Energy source",
       "etcs": {
@@ -646,6 +650,7 @@
         "title": "ETCS",
         "transition": "Trans."
       },
+      "incompatible": "Incompatible",
       "invalidSimulation": "The selected train can't be simulated",
       "noData": "Data is displayed when a train is selected",
       "powerRestrictions": "Power restrictions",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -631,7 +631,11 @@
     "simulationSheet": "Fiche de tracé",
     "speedDistanceDiagram": "GEV",
     "speedDistanceSettings": {
+      "accelerating": "En accélération",
+      "coasting": "En roue libre",
       "context": "Contexte",
+      "decelerating": "En décélération",
+      "electric": "Électrique",
       "electricalProfiles": "Profils électrique",
       "energySource": "Source d'énergie",
       "etcs": {
@@ -646,6 +650,7 @@
         "title": "ETCS",
         "transition": "Trans."
       },
+      "incompatible": "Incompatible",
       "invalidSimulation": "Le train sélectionné ne peut pas être simulé",
       "noData": "La donnée est affichée lorsqu'un train est sélectionné",
       "powerRestrictions": "Restrictions de puissance",

--- a/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpeedDistanceDiagram/SpeedDistanceDiagramWrapper.tsx
@@ -68,6 +68,13 @@ const SpeedDistanceDiagramWrapper = ({
       etcs: t('speedDistanceSettings.etcs.title'),
       electricalProfiles: t('speedDistanceSettings.electricalProfiles'),
       powerRestrictions: t('speedDistanceSettings.powerRestrictions'),
+      reticleValues: {
+        incompatible: t('speedDistanceSettings.incompatible'),
+        electric: t('speedDistanceSettings.electric'),
+        accelerating: t('speedDistanceSettings.accelerating'),
+        decelerating: t('speedDistanceSettings.decelerating'),
+        coasting: t('speedDistanceSettings.coasting'),
+      },
     },
     layersDisplay: {
       context: t('speedDistanceSettings.context'),

--- a/front/ui/storybook/stories/ui-charts/speedSpaceChart/consts.ts
+++ b/front/ui/storybook/stories/ui-charts/speedSpaceChart/consts.ts
@@ -7,6 +7,13 @@ export const defaultTranslations = {
     etcs: 'ETCS',
     electricalProfiles: 'Electrical Profiles',
     powerRestrictions: 'Power Restrictions',
+    reticleValues: {
+      incompatible: 'Incompatible',
+      electric: 'Electric',
+      accelerating: 'Accelerating',
+      decelerating: 'Decelerating',
+      coasting: 'Coasting',
+    },
   },
   layersDisplay: {
     context: 'Context',

--- a/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
@@ -41,6 +41,13 @@ export type SpeedSpaceChartProps = {
       etcs: string;
       electricalProfiles: string;
       powerRestrictions: string;
+      reticleValues: {
+        incompatible: string;
+        electric: string;
+        accelerating: string;
+        decelerating: string;
+        coasting: string;
+      };
     };
     layersDisplay: {
       context: string;

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
@@ -69,6 +69,18 @@ const DetailsBox = ({
   const speedDifference = Number(speedText) - Number(ecoSpeedText);
   const speedDifferenceText = speedDifference !== 0 ? `-${speedDifference.toFixed(1)}` : null;
 
+  const reticleValues = translations?.detailsBoxDisplay.reticleValues;
+  const translatedModeText =
+    modeText === '--'
+      ? modeText
+      : (reticleValues?.[modeText as keyof typeof reticleValues] ?? modeText);
+  const translatedEffortText =
+    reticleValues?.[effortText as keyof typeof reticleValues] ?? effortText;
+  const translatedElectricalProfileText =
+    electricalProfileText === 'incompatible'
+      ? (reticleValues?.incompatible ?? electricalProfileText)
+      : electricalProfileText;
+
   const activeEtcsBrakingTypes = getActiveEtcsBrakingTypes(store.etcsLayersDisplay);
   const activeEtcsBrakingCurveTypes = getActiveEtcsBrakingCurveTypes(store.etcsLayersDisplay);
   const etcsEndOfCurves = etcsSpeedValues
@@ -102,12 +114,14 @@ const DetailsBox = ({
           {speedDifferenceText && <span id="speed-difference-text">{speedDifferenceText}</span>}
         </div>
         {(energySource || tractionStatus || modeText || effortText) && <hr />}
-        {energySource && <span id="mode-text">{modeText || '--'}</span>}
-        {tractionStatus && <span id="effort-text">{effortText || '--'}</span>}
+        {energySource && <span id="mode-text">{translatedModeText || '--'}</span>}
+        {tractionStatus && <span id="effort-text">{translatedEffortText || '--'}</span>}
         {electricalModeText && (
           <div id="electrical-mode-text">
             <span>{electricalModeText || '--'}</span>
-            {electricalProfiles && <span className="ml-2">{electricalProfileText || '--'}</span>}
+            {electricalProfiles && (
+              <span className="ml-2">{translatedElectricalProfileText || '--'}</span>
+            )}
           </div>
         )}
         {powerRestrictions && (


### PR DESCRIPTION
**WHAT**
 Fixes #14931


**How**
Keys were added to _speedDistanceSettings_  .json for the Details Box in SDD

So now the translation Appears 

**Reulst** 
<img width="893" height="713" alt="image" src="https://github.com/user-attachments/assets/87bc76f1-9fba-4b8b-a3a4-af0ae2e0e485" />

Formatted 

Caution :

There already exists a  key `simulationResults.electricalProfiles.incompatible`  . I added a `simulationResults.speedDistanceSettings.incompatible`   . So does this makes  `simulationResults.electricalProfiles.incompatible` redundant . Was this key intentionally added ?  