### PR TITLE
editoast: authz: edit behavior of `project_revoke_grant`

### DIFF
--- a/editoast/authz/src/model.rs
+++ b/editoast/authz/src/model.rs
@@ -230,8 +230,7 @@ pub enum ProjectPrivilege {
     HasAccess,
 }
 
-#[derive(EnumString, Serialize)]
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Copy, Clone, Debug, EnumString, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum ProjectGrant {

--- a/editoast/authz/src/v2.rs
+++ b/editoast/authz/src/v2.rs
@@ -21,6 +21,7 @@ use crate::Infra;
 use crate::InfraGrant;
 use crate::InfraPrivilege;
 use crate::Project;
+use crate::ProjectGrant;
 use crate::ProjectPrivilege;
 use crate::Role;
 use crate::RollingStock;
@@ -79,12 +80,6 @@ pub enum Check {
     /// IMPORTANT: it is *NOT* a replacement for [`Self::HasInfraPrivilege`] with sharing privileges (forbids illegal promotions)
     /// NOTE: groups grants are managed by admins exclusively so this check always rejects group subjects as admin checks are bypassed
     CanAlterSubjectInfraGrant(Subject, Infra, InfraGrant),
-    /// The issuer must be allowed to change the subject's infra grant
-    ///
-    /// No-op grant changes are allowed.
-    /// As [ProjectGrant] has only one grant level so anoyone with this grant has sharing privileges.
-    /// NOTE: groups grants are managed by admins exclusively so this check always rejects group subjects as admin checks are bypassed
-    CanGiveSubjectProjectGrant(Subject, Project),
     /// The subject must not have the specified effective infra grant
     SubjectEffectiveInfraGrantIsNot(InfraGrant, Subject, Infra),
     /// The subject must not be the last direct owner of the infra
@@ -100,6 +95,16 @@ pub enum Check {
     SubjectEffectiveRollingStockGrantIsNot(RollingStockGrant, Subject, RollingStock),
     /// The subject must not be the last direct owner of the rolling stock
     IsNotLastRollingStockOwner(Subject, RollingStock),
+    /// The issuer must be allowed to change the subject's infra grant
+    ///
+    /// No-op grant changes are allowed.
+    /// As [ProjectGrant] has only one grant level so anoyone with this grant has sharing privileges.
+    /// NOTE: groups grants are managed by admins exclusively so this check always rejects group subjects as admin checks are bypassed
+    CanGiveSubjectProjectGrant(Subject, Project),
+    /// The subject must not have the specified effective project grant
+    SubjectEffectiveProjectGrantIsNot(ProjectGrant, Subject, Project),
+    /// The subject must not be the last direct owner of the project
+    IsNotLastProjectOwner(Subject, Project),
 }
 
 /// The result of authorizing a [Protected] operation via [Authorizer::authorize]

--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -132,7 +132,11 @@ pub fn project_revoke_grant(subject: Subject, project: Project) -> Protected<boo
             }
             .boxed()
         })
-        .with_check(Check::HasRole(Actor::Issuer, Role::Admin))
+        .with_check_iter([
+            Check::HasProjectPrivilege(Actor::Issuer, ProjectPrivilege::HasAccess, project),
+            Check::SubjectEffectiveProjectGrantIsNot(ProjectGrant::Owner, subject, project),
+            Check::IsNotLastProjectOwner(subject, project),
+        ])
 }
 
 pub fn project_privileges(user: User, project: Project) -> Protected<HashSet<ProjectPrivilege>> {
@@ -731,7 +735,9 @@ mod tests {
     #[case::project_revoke_grant(
         project_revoke_grant(Subject::user(1), Project(1)).checks,
         &[
-            Check::HasRole(Actor::Issuer, Role::Admin),
+            Check::HasProjectPrivilege(Actor::Issuer, ProjectPrivilege::HasAccess, Project(1)),
+            Check::SubjectEffectiveProjectGrantIsNot(ProjectGrant::Owner, Subject::user(1), Project(1)),
+            Check::IsNotLastProjectOwner(Subject::user(1), Project(1)),
         ]
     )]
     #[case::project_privileges(

--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -155,27 +155,6 @@ impl<'c> UserAuthorizer<'c> {
                 // verification function.
                 Some(check)
             }
-
-            Check::CanGiveSubjectProjectGrant(authz::Subject::User(_), project) => {
-                // There is only one level of grant. The issuer must own a grant on the project to
-                // share it to other users.
-                let Ok(grant) = authz::v2::project_effective_grant(self.issuer(), *project)
-                    .access_authorized::<Infallible>(self.openfga)
-                    .access()
-                    .await?;
-
-                match grant {
-                    Some(ProjectGrant::Owner) => None,
-                    None => Some(check),
-                }
-            }
-            Check::CanGiveSubjectProjectGrant(authz::Subject::Group(_), _) => {
-                // The only users to allowed to alter group grants are admins who bypass this entire
-                // verification function: trying to give a grant to a group in the UserAuthorizer should
-                // always be rejected
-                Some(check)
-            }
-
             Check::SubjectEffectiveInfraGrantIsNot(grant, subject, infra) => {
                 let Ok(subject_grant) = authz::v2::infra_effective_grant(*subject, *infra)
                     .access_authorized::<Infallible>(self.openfga)
@@ -183,6 +162,7 @@ impl<'c> UserAuthorizer<'c> {
                     .await?;
                 (subject_grant == Some(*grant)).then_some(check)
             }
+
             Check::CanAlterSubjectRollingStockGrant(
                 subject @ authz::Subject::User(_),
                 rolling_stock,
@@ -242,6 +222,40 @@ impl<'c> UserAuthorizer<'c> {
                 .access_authorized::<Infallible>(self.openfga)
                 .access()
                 .await?;
+                (owners.len() == 1 && owners.contains(subject)).then_some(check)
+            }
+
+            Check::CanGiveSubjectProjectGrant(authz::Subject::User(_), project) => {
+                // There is only one level of grant. The issuer must own a grant on the project to
+                // share it to other users.
+                let Ok(grant) = authz::v2::project_effective_grant(self.issuer(), *project)
+                    .access_authorized::<Infallible>(self.openfga)
+                    .access()
+                    .await?;
+                match grant {
+                    Some(ProjectGrant::Owner) => None,
+                    None => Some(check),
+                }
+            }
+            Check::CanGiveSubjectProjectGrant(authz::Subject::Group(_), _) => {
+                // The only users to allowed to alter group grants are admins who bypass this entire
+                // verification function: trying to give a grant to a group in the UserAuthorizer should
+                // always be rejected
+                Some(check)
+            }
+            Check::SubjectEffectiveProjectGrantIsNot(grant, subject, project) => {
+                let Ok(subject_grant) = authz::v2::project_effective_grant(*subject, *project)
+                    .access_authorized::<Infallible>(self.openfga)
+                    .access()
+                    .await?;
+                (subject_grant == Some(*grant)).then_some(check)
+            }
+            Check::IsNotLastProjectOwner(subject, project) => {
+                let Ok(owners) = authz::v2::project_granted_subjects(*project)
+                    .access_authorized::<Infallible>(self.openfga)
+                    .access()
+                    .await?;
+
                 (owners.len() == 1 && owners.contains(subject)).then_some(check)
             }
         })


### PR DESCRIPTION
Modification of the checks of `project_revoke_grant` for a better fit of the behavior with others objects with permissions (`infra`, `rolling_stock`)