### PR TITLE
front: adapt train header for hourly timetables

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -34,7 +34,7 @@ import {
 } from 'reducers/simulationResults';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch, type AppDispatch } from 'store';
-import { Duration } from 'utils/duration';
+import { Duration, type StartTime, startTimeToMs } from 'utils/duration';
 import { formatEditoastIdToTrainScheduleId, isOccurrenceId } from 'utils/trainId';
 
 import {
@@ -54,7 +54,7 @@ type UpdateTrainScheduleParams = {
   originalTrainSchedule: TrainScheduleWithDetails;
   updatedTrainSchedule: TrainSchedule;
   occurrenceId?: OccurrenceId;
-  addedExceptions: { startTime: Date }[];
+  addedExceptions: { startTime: StartTime }[];
   deletedAddedExceptionId?: number;
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
   dispatch: AppDispatch;
@@ -138,7 +138,7 @@ export async function updateTrainSchedule({
   const newAddedExceptions: PacedTrainException[] = addedExceptions.map(
     ({ startTime: exStartTime }) => ({
       key: '', // TODO : remove this when the key will be removed from the model
-      start_time: { value: exStartTime.getTime() },
+      start_time: { value: startTimeToMs(exStartTime) },
     })
   );
 

--- a/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
+++ b/front/src/modules/trainHeader/CollapsedTrainOverview.tsx
@@ -2,6 +2,7 @@ import { Button } from '@osrd-project/ui-core';
 import { ChevronDown } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
+import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PacedTrain } from 'applications/operationalStudies/types';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
 import type { Train } from 'reducers/osrdconf/types';
@@ -31,6 +32,7 @@ const CollapsedTrainOverview = ({
   onItineraryOpened,
 }: CollapsedTrainOverviewProps) => {
   const { t } = useTranslation(['operational-studies', 'translation']);
+  const { scenario } = useScenarioContext();
   const dateTimeLocale = useDateTimeLocale();
 
   const pacedTrain = train.paced ? (train as PacedTrain) : null;
@@ -57,9 +59,11 @@ const CollapsedTrainOverview = ({
             {getServiceInterval(pacedTrain)}’ — {getServiceWindow(pacedTrain)}’
           </div>
         )}
-        <div className="train-departure-date" data-testid="train-departure-date">
-          {getShortDepartureDate(train, dateTimeLocale)}
-        </div>
+        {scenario.timetable_type === 'CALENDAR' && (
+          <div className="train-departure-date" data-testid="train-departure-date">
+            {getShortDepartureDate(train, dateTimeLocale)}
+          </div>
+        )}
         <div className="train-category" data-testid="train-category">
           {getShortCategoryName(train, t, subCategories)}
         </div>

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -70,7 +70,7 @@ export type TrainFieldsState = {
   service_window?: number;
   use_electrical_profiles: boolean | null;
   labels: string[];
-  added_exception_date: Date;
+  added_exception_date: StartTime;
   rolling_stock: LightRollingStockWithLiveries | string;
   departure_date: StartTime;
   initial_speed: string | null;
@@ -115,7 +115,7 @@ function getFieldsFromTrain(
     service_window: train.paced ? Duration.parse(train.paced.time_window).valueOf() : undefined,
     use_electrical_profiles: train?.options?.use_electrical_profiles ?? null,
     labels: train.labels ?? [],
-    added_exception_date: new Date(train.start_time),
+    added_exception_date: startTime,
     rolling_stock: rollingStock ?? train.rolling_stock_name,
     departure_date: startTime,
     initial_speed:

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -9,13 +9,16 @@ import {
   TokenInput,
   type CalendarSlot,
 } from '@osrd-project/ui-core';
+import cx from 'classnames';
 import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
+import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type {
   LightRollingStockWithLiveries,
   PathfindingResult,
   TrainCategory,
+  TimetableType,
 } from 'common/api/osrdEditoastApi';
 import type { Comfort, ConstraintDistribution } from 'common/api/osrdRailwayManagerApi';
 import Banner from 'common/Banner';
@@ -27,8 +30,9 @@ import useCategoryOptions, {
   categoryOptionId,
 } from 'modules/rollingStock/hooks/useCategoryOptions';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
+import { parseStartTime } from 'modules/trainSchedule/helpers/formatTrainScheduleWithDetails';
 import type { Train } from 'reducers/osrdconf/types';
-import { Duration } from 'utils/duration';
+import { Duration, type StartTime } from 'utils/duration';
 import { usePrevious } from 'utils/hooks/state';
 import { kmhToMs } from 'utils/physics';
 import { isOccurrenceId } from 'utils/trainId';
@@ -68,7 +72,7 @@ export type TrainFieldsState = {
   labels: string[];
   added_exception_date: Date;
   rolling_stock: LightRollingStockWithLiveries | string;
-  departure_date: Date;
+  departure_date: StartTime;
   initial_speed: string | null;
   service_changed_confirmed: boolean;
 };
@@ -94,9 +98,11 @@ function computeInitialSpeedError(
 
 function getFieldsFromTrain(
   train: Train,
-  rollingStocks: LightRollingStockWithLiveries[]
+  rollingStocks: LightRollingStockWithLiveries[],
+  timetableType: TimetableType
 ): TrainFieldsState {
   const rollingStock = rollingStocks.find((rs) => rs.name === train.rolling_stock_name);
+  const startTime = parseStartTime(train.start_time, timetableType);
 
   return {
     train_name: train.train_name,
@@ -111,7 +117,7 @@ function getFieldsFromTrain(
     labels: train.labels ?? [],
     added_exception_date: new Date(train.start_time),
     rolling_stock: rollingStock ?? train.rolling_stock_name,
-    departure_date: new Date(train.start_time),
+    departure_date: startTime,
     initial_speed:
       train.initial_speed === undefined ? null : String(Math.round(train.initial_speed * 36) / 10),
     service_changed_confirmed: !train.paced || train.paced.exceptions.length === 0,
@@ -232,14 +238,15 @@ const ExpandedTrainForm = ({
 }: ExpandedTrainFormProps) => {
   const { t } = useTranslation(['operational-studies', 'translation']);
   const infraID = useInfraID();
+  const { scenario } = useScenarioContext();
   const speedLimitTags = useSpeedLimitTags(infraID);
   const categoryOptions = useCategoryOptions(false);
 
   const { filteredRollingStockList: rollingStocks } = useFilterRollingStock();
 
   const fieldsFromTrain = useMemo(
-    () => getFieldsFromTrain(train, rollingStocks),
-    [train, rollingStocks]
+    () => getFieldsFromTrain(train, rollingStocks, scenario.timetable_type),
+    [train, rollingStocks, scenario.timetable_type]
   );
   const [fields, setFields] = useState<TrainFieldsState>(fieldsFromTrain);
 
@@ -393,7 +400,11 @@ const ExpandedTrainForm = ({
         onPersistTrain={onPersistTrain}
         revertServiceChange={revertServiceChange}
       />
-      <div className="train-form">
+      <div
+        className={cx('train-form', {
+          'calendar-timetable': scenario.timetable_type === 'CALENDAR',
+        })}
+      >
         <div className="train-name" data-testid="train-name">
           <Input
             id="train-header-name-input"
@@ -413,29 +424,31 @@ const ExpandedTrainForm = ({
             }
           />
         </div>
-        <div className="train-departure-date">
-          <DatePicker
-            testIdPrefix="train-header-departure-date"
-            value={fields.departure_date}
-            isRangeMode={false}
-            inputProps={{
-              id: 'train-header-departure-date-input',
-              label: t('manageTrainSchedule.trainHeader.form.departureDate'),
-              small: true,
-            }}
-            onDateChange={(departureDate) => {
-              if (!departureDate) return;
-              const startTimeDate = new Date(train.start_time);
-              departureDate?.setHours(
-                startTimeDate.getHours(),
-                startTimeDate.getMinutes(),
-                startTimeDate.getSeconds()
-              );
-              onFieldImmediateChange('departure_date', departureDate);
-            }}
-            selectableSlot={ANY_DATE_SLOT}
-          />
-        </div>
+        {fields.departure_date instanceof Date && (
+          <div className="train-departure-date">
+            <DatePicker
+              testIdPrefix="train-header-departure-date"
+              value={fields.departure_date}
+              isRangeMode={false}
+              inputProps={{
+                id: 'train-header-departure-date-input',
+                label: t('manageTrainSchedule.trainHeader.form.departureDate'),
+                small: true,
+              }}
+              onDateChange={(departureDate) => {
+                if (!departureDate) return;
+                const startTimeDate = new Date(train.start_time);
+                departureDate?.setHours(
+                  startTimeDate.getHours(),
+                  startTimeDate.getMinutes(),
+                  startTimeDate.getSeconds()
+                );
+                onFieldImmediateChange('departure_date', departureDate);
+              }}
+              selectableSlot={ANY_DATE_SLOT}
+            />
+          </div>
+        )}
         <div className="train-initial-velocity" data-testid="train-header-initial-velocity-field">
           <Input
             id="train-header-initial-velocity-input"

--- a/front/src/modules/trainHeader/ExtraOccurrenceForm.tsx
+++ b/front/src/modules/trainHeader/ExtraOccurrenceForm.tsx
@@ -1,11 +1,13 @@
-import { Button, DatePicker, TimePicker } from '@osrd-project/ui-core';
+import { Button, DatePicker, TimePicker, DurationInput } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
+
+import { Duration, type StartTime } from 'utils/duration';
 
 import { ANY_DATE_SLOT } from './ExpandedTrainForm';
 
 type ExtraOccurrenceFormProps = {
-  addedExceptionDate: Date;
-  setAddedExceptionDate: (newDate: Date) => void;
+  addedExceptionDate: StartTime;
+  setAddedExceptionDate: (newDate: StartTime) => void;
   onCreateAddedException: () => void;
 };
 
@@ -18,45 +20,64 @@ const ExtraOccurrenceForm = ({
 
   return (
     <div className="train-add-extra-occurrence-form">
-      <DatePicker
-        testIdPrefix="train-header-extra-occurrence-date"
-        value={addedExceptionDate}
-        onDateChange={(newDate) => {
-          if (newDate) {
-            const dateWithTime = new Date(newDate.getTime());
-            dateWithTime.setHours(
-              addedExceptionDate.getHours(),
-              addedExceptionDate.getMinutes(),
-              addedExceptionDate.getSeconds()
-            );
-            setAddedExceptionDate(dateWithTime);
-          }
-        }}
-        selectableSlot={ANY_DATE_SLOT}
-        inputProps={{
-          id: 'train-add-extra-occurrence-date',
-          label: t('manageTrainSchedule.trainHeader.form.departureDate'),
-          small: true,
-        }}
-      />
-      <TimePicker
-        id={'train-add-extra-occurrence-time'}
-        testIdPrefix="train-header-extra-occurrence-time"
-        label={t('manageTrainSchedule.trainHeader.form.departureTime')}
-        hours={addedExceptionDate.getHours()}
-        minutes={addedExceptionDate.getMinutes()}
-        seconds={addedExceptionDate.getSeconds()}
-        displaySeconds={true}
-        onTimeChange={({ hours, minutes, seconds }) => {
-          const newDate = new Date(addedExceptionDate.getTime());
-          newDate.setHours(hours);
-          newDate.setMinutes(minutes);
-          newDate.setSeconds(seconds ?? 0);
-
-          setAddedExceptionDate(newDate);
-        }}
-        small
-      />
+      {addedExceptionDate instanceof Date ? (
+        <>
+          <DatePicker
+            testIdPrefix="train-header-extra-occurrence-date"
+            value={addedExceptionDate}
+            onDateChange={(newDate) => {
+              if (newDate) {
+                const dateWithTime = new Date(newDate.getTime());
+                dateWithTime.setHours(
+                  addedExceptionDate.getHours(),
+                  addedExceptionDate.getMinutes(),
+                  addedExceptionDate.getSeconds()
+                );
+                setAddedExceptionDate(dateWithTime);
+              }
+            }}
+            selectableSlot={ANY_DATE_SLOT}
+            inputProps={{
+              id: 'train-add-extra-occurrence-date',
+              label: t('manageTrainSchedule.trainHeader.form.departureDate'),
+              small: true,
+            }}
+          />
+          <TimePicker
+            id={'train-add-extra-occurrence-time'}
+            testIdPrefix="train-header-extra-occurrence-time"
+            label={t('manageTrainSchedule.trainHeader.form.departureTime')}
+            hours={addedExceptionDate.getHours()}
+            minutes={addedExceptionDate.getMinutes()}
+            seconds={addedExceptionDate.getSeconds()}
+            displaySeconds={true}
+            onTimeChange={({ hours, minutes, seconds }) => {
+              const newDate = new Date(addedExceptionDate.getTime());
+              newDate.setHours(hours);
+              newDate.setMinutes(minutes);
+              newDate.setSeconds(seconds ?? 0);
+              setAddedExceptionDate(newDate);
+            }}
+            small
+          />
+        </>
+      ) : (
+        <DurationInput
+          id={'train-add-extra-occurrence-time'}
+          label={t('manageTrainSchedule.trainHeader.form.departureTime')}
+          value={addedExceptionDate.ms}
+          units={[
+            { key: 'h', label: ':' },
+            { key: 'm', label: ':' },
+            { key: 's', label: '' },
+          ]}
+          padChar="0"
+          onChange={(milliseconds) => {
+            setAddedExceptionDate(new Duration({ milliseconds }));
+          }}
+          small
+        />
+      )}
       <div className="actions">
         <Button
           id={'train-add-extra-occurrence-time-add'}

--- a/front/src/modules/trainHeader/ExtraOccurrenceRow.tsx
+++ b/front/src/modules/trainHeader/ExtraOccurrenceRow.tsx
@@ -1,9 +1,10 @@
 import { Trash } from '@osrd-project/ui-icons';
 
-import { useDateTimeLocale } from 'utils/date';
+import { useDateTimeLocale, timeToLocaleString } from 'utils/date';
+import type { StartTime } from 'utils/duration';
 
 type ExtraOccurrenceRowProps = {
-  startTime: Date;
+  startTime: StartTime;
   onDelete: () => void;
 };
 
@@ -19,17 +20,19 @@ const ExtraOccurrenceRow = ({ startTime, onDelete }: ExtraOccurrenceRowProps) =>
       >
         <Trash />
       </button>
-      <div
-        className="train-extra-occurrence-date"
-        data-testid="train-header-extra-occurrence-date-value"
-      >
-        {startTime.toLocaleDateString(dateTimeLocale)}
-      </div>
+      {startTime instanceof Date && (
+        <div
+          className="train-extra-occurrence-date"
+          data-testid="train-header-extra-occurrence-date-value"
+        >
+          {startTime.toLocaleDateString(dateTimeLocale)}
+        </div>
+      )}
       <div
         className="train-extra-occurrence-time"
         data-testid="train-header-extra-occurrence-time-value"
       >
-        {startTime.toLocaleTimeString(dateTimeLocale)}
+        {timeToLocaleString(startTime, dateTimeLocale)}
       </div>
     </div>
   );

--- a/front/src/modules/trainHeader/ExtraOccurrenceRow.tsx
+++ b/front/src/modules/trainHeader/ExtraOccurrenceRow.tsx
@@ -1,46 +1,38 @@
 import { Trash } from '@osrd-project/ui-icons';
 
+import { useDateTimeLocale } from 'utils/date';
+
 type ExtraOccurrenceRowProps = {
   startTime: Date;
   onDelete: () => void;
 };
 
-function formatDateString(date: Date) {
-  const day = String(date.getDate()).padStart(2, '0');
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const year = String(date.getFullYear()).slice(-2);
-  return `${day}/${month}/${year}`;
-}
+const ExtraOccurrenceRow = ({ startTime, onDelete }: ExtraOccurrenceRowProps) => {
+  const dateTimeLocale = useDateTimeLocale();
 
-function formatTimeString(date: Date) {
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
-  return `${hours}:${minutes}:${seconds}`;
-}
-
-const ExtraOccurrenceRow = ({ startTime, onDelete }: ExtraOccurrenceRowProps) => (
-  <div className="train-extra-occurrence" data-testid="train-header-extra-occurrence-row">
-    <button
-      className="train-extra-occurrence-delete"
-      onClick={onDelete}
-      data-testid="train-header-extra-occurrence-delete-button"
-    >
-      <Trash />
-    </button>
-    <div
-      className="train-extra-occurrence-date"
-      data-testid="train-header-extra-occurrence-date-value"
-    >
-      {formatDateString(startTime)}
+  return (
+    <div className="train-extra-occurrence" data-testid="train-header-extra-occurrence-row">
+      <button
+        className="train-extra-occurrence-delete"
+        onClick={onDelete}
+        data-testid="train-header-extra-occurrence-delete-button"
+      >
+        <Trash />
+      </button>
+      <div
+        className="train-extra-occurrence-date"
+        data-testid="train-header-extra-occurrence-date-value"
+      >
+        {startTime.toLocaleDateString(dateTimeLocale)}
+      </div>
+      <div
+        className="train-extra-occurrence-time"
+        data-testid="train-header-extra-occurrence-time-value"
+      >
+        {startTime.toLocaleTimeString(dateTimeLocale)}
+      </div>
     </div>
-    <div
-      className="train-extra-occurrence-time"
-      data-testid="train-header-extra-occurrence-time-value"
-    >
-      {formatTimeString(startTime)}
-    </div>
-  </div>
-);
+  );
+};
 
 export default ExtraOccurrenceRow;

--- a/front/src/modules/trainHeader/TrainHeader.tsx
+++ b/front/src/modules/trainHeader/TrainHeader.tsx
@@ -13,6 +13,7 @@ import { setFailure } from 'reducers/main';
 import { selectTrainToEdit } from 'reducers/osrdconf/operationalStudiesConf';
 import type { Train } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
+import type { StartTime } from 'utils/duration';
 import { extractEditoastIdFromTrainId, isOccurrenceId } from 'utils/trainId';
 
 import CollapsedTrainOverview from './CollapsedTrainOverview';
@@ -26,7 +27,7 @@ export type TrainHeaderProps = {
 };
 
 export type ExtraOccurrencesChanges = {
-  addedExceptions?: { startTime: Date }[];
+  addedExceptions?: { startTime: StartTime }[];
   deletedAddedExceptionId?: number;
 };
 

--- a/front/src/modules/trainHeader/TrainServiceForm.tsx
+++ b/front/src/modules/trainHeader/TrainServiceForm.tsx
@@ -4,7 +4,9 @@ import { Button, DurationInput, Switch } from '@osrd-project/ui-core';
 import { ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
+import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PacedTrain } from 'applications/operationalStudies/types';
+import { parseStartTime } from 'modules/trainSchedule/helpers/formatTrainScheduleWithDetails';
 import type { Train } from 'reducers/osrdconf/types';
 import { MAX_DURATION_MS } from 'utils/duration';
 import { findExceptionInPacedTrainByOccurrenceId } from 'utils/trainExceptions';
@@ -57,6 +59,8 @@ export default function TrainServiceForm({
   revertServiceChange,
 }: TrainServiceFormProps) {
   const { t } = useTranslation(['operational-studies', 'translation']);
+  const { scenario } = useScenarioContext();
+
   const [extraOccurrencesVisible, setExtraOccurrencesVisible] = useState(false);
 
   const pacedTrain = train.paced ? (train as PacedTrain) : null;
@@ -226,7 +230,7 @@ export default function TrainServiceForm({
               .map((occurrence) => (
                 <ExtraOccurrenceRow
                   key={`${occurrence.id}-${occurrence.key}`}
-                  startTime={new Date(occurrence.start_time!.value)}
+                  startTime={parseStartTime(occurrence.start_time!.value, scenario.timetable_type)}
                   onDelete={() => {
                     // TODO_EXCEPTION: remove this when the exception migration will be done
                     if (occurrence.id !== null && occurrence.id !== undefined) {

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -157,6 +157,10 @@
       place-self: center start;
       padding: var(--non-field-spacing);
     }
+
+    #train-add-extra-occurrence-time.ui-duration-input {
+      width: 100%;
+    }
   }
 
   .train-extra-occurrences-list {

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -177,7 +177,6 @@
     .train-extra-occurrence-date {
       background-color: var(--white100);
       padding: 6px 7px;
-      margin-left: 16px;
     }
 
     .train-extra-occurrence-time {
@@ -213,6 +212,10 @@
       span {
         display: contents;
       }
+    }
+
+    .train-extra-occurrence-delete + div {
+      margin-left: 16px;
     }
   }
 

--- a/front/src/modules/trainHeader/styles/expanded.scss
+++ b/front/src/modules/trainHeader/styles/expanded.scss
@@ -40,6 +40,10 @@
       margin-top: -8px;
     }
 
+    &:not(.calendar-timetable) .train-initial-velocity {
+      grid-row: span 2;
+    }
+
     label {
       margin-bottom: unset;
     }

--- a/front/ui/ui-core/src/components/DurationInput/DurationInput.tsx
+++ b/front/ui/ui-core/src/components/DurationInput/DurationInput.tsx
@@ -323,6 +323,7 @@ export const DurationInput = ({
     >
       <div
         ref={containerRef}
+        id={id}
         className={cx('ui-duration-input', { small })}
         role="group"
         aria-label="Duration Input"


### PR DESCRIPTION
_See individual commits._

~~Note, the first commit has been cherry-picked from #18076.~~

References: https://github.com/OpenRailAssociation/osrd/issues/17626