### PR TITLE
front: enable project grants

### DIFF
--- a/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
+++ b/front/src/applications/operationalStudies/views/Project/ProjectView.tsx
@@ -22,6 +22,7 @@ import {
   osrdEditoastApi,
 } from 'common/api/osrdEditoastApi';
 import GrantsManager from 'common/authorization/components/GrantsManager';
+import useAuthz from 'common/authorization/hooks/useAuthz';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import OptionsSNCF from 'common/BootstrapSNCF/OptionsSNCF';
 import { Loader, Spinner } from 'common/Loaders';
@@ -32,6 +33,7 @@ import { cleanScenarioLocalStorage } from 'modules/scenario/helpers/utils';
 import { getFeatureFlag } from 'reducers/user/userSelectors';
 import { useProjectImage } from 'utils/hooks/useProjectImage';
 import { budgetFormat } from 'utils/numbers';
+import { useAsyncMemo } from 'utils/useAsyncMemo';
 
 import StudyCard from './StudyCard';
 
@@ -74,6 +76,13 @@ const ProjectView = () => {
   } = osrdEditoastApi.endpoints.getProjectsByProjectId.useQuery(
     projectId ? { projectId: +projectId } : skipToken
   );
+
+  const { getUserPrivileges } = useAuthz();
+  // Get the user privileges for the project
+  const userPrivileges = useAsyncMemo(async () => {
+    const data = projectGrantsActivated ? await getUserPrivileges({ project: [projectId!] }) : {};
+    return data.project || {};
+  }, [getUserPrivileges, projectId, projectGrantsActivated]);
 
   const imageUrl = useProjectImage(project?.image);
 
@@ -241,7 +250,15 @@ const ProjectView = () => {
                     </div>
                     {/* TODO: adapt with the good resourceType when back is ready */}
                     {projectGrantsActivated && (
-                      <GrantsManager resourceId={project.id} resourceType="infra" />
+                      <GrantsManager
+                        resourceId={project.id}
+                        resourceType="project"
+                        userPrivileges={
+                          userPrivileges.type === 'ready'
+                            ? userPrivileges.data[project.id]
+                            : undefined
+                        }
+                      />
                     )}
                   </div>
                   <div className={'pl-md-2 col-lg-8 col-md-8'}>

--- a/front/src/applications/operationalStudies/views/Project/styles/_project.scss
+++ b/front/src/applications/operationalStudies/views/Project/styles/_project.scss
@@ -61,6 +61,10 @@
           height: 160px;
         }
       }
+      .grant-manager-body {
+        margin-block: 8px;
+        padding: 8px;
+      }
       .project-details-title-content {
         .project-details-title-name {
           display: flex;

--- a/front/src/applications/operationalStudies/views/ProjectList/ProjectListView.tsx
+++ b/front/src/applications/operationalStudies/views/ProjectList/ProjectListView.tsx
@@ -13,13 +13,14 @@ import {
   type ProjectWithStudies,
   type SearchResultItemProject,
 } from 'common/api/osrdEditoastApi';
+import useAuthz from 'common/authorization/hooks/useAuthz';
 import OptionsSNCF from 'common/BootstrapSNCF/OptionsSNCF';
 import { Spinner } from 'common/Loaders';
 import NavBar from 'common/NavBar';
 import SelectionToolbar from 'common/SelectionToolbar';
 import AddOrEditProjectModal from 'modules/project/components/AddOrEditProjectModal';
 import cleanLocalStorageByProject from 'modules/project/helpers/cleanLocalStorageByProject';
-import { getUserSafeWord } from 'reducers/user/userSelectors';
+import { getFeatureFlag, getUserSafeWord } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
 
 import ProjectCard from './ProjectCard';
@@ -36,6 +37,7 @@ const ProjectListView = () => {
   const { t } = useTranslation('operational-studies');
   const dispatch = useAppDispatch();
   const safeWord = useSelector(getUserSafeWord);
+  const projectGrantsActivated = useSelector(getFeatureFlag('projectGrants'));
   const [sortOption, setSortOption] = useState<SortOptions>('LastModifiedDesc');
   const [filter, setFilter] = useState('');
   const [filterChips, setFilterChips] = useState('');
@@ -71,6 +73,8 @@ const ProjectListView = () => {
     ordering: sortOption,
     pageSize: 1000,
   });
+  const { getUserPrivileges } = useAuthz();
+
   const [isLoading, setIsLoading] = useState(true);
 
   const sortOptions = [
@@ -85,6 +89,18 @@ const ProjectListView = () => {
   ];
 
   const getProjectList = async () => {
+    if (!allProjects || allProjects.results.length === 0) return setProjectsList([]);
+    const privileges = projectGrantsActivated
+      ? await getUserPrivileges({
+          project: allProjects.results.map((project) => project.id),
+        })
+      : {};
+    // The project resource only exposes NONE/OWNER grants, so 'has_access' tells if the user can see it
+    const accessibleProjectIds = new Set(
+      Object.entries(privileges.project ?? {})
+        .filter(([, userPrivileges]) => userPrivileges.has('has_access'))
+        .map(([id]) => Number(id))
+    );
     setIsLoading(true);
     if (filter || safeWord !== '') {
       const payload: PostSearchApiArg = {
@@ -105,6 +121,9 @@ const ProjectListView = () => {
       };
       try {
         let filteredData = (await postSearch(payload).unwrap()) as SearchResultItemProject[];
+        filteredData = projectGrantsActivated
+          ? filteredData.filter((project) => accessibleProjectIds.has(project.id))
+          : filteredData;
         if (sortOption === 'LastModifiedDesc') {
           filteredData = [...filteredData].sort((a, b) =>
             b.last_modification.localeCompare(a.last_modification)
@@ -117,7 +136,11 @@ const ProjectListView = () => {
         console.error('filter projetcs error : ', error);
       }
     } else {
-      setProjectsList(allProjects?.results || []);
+      setProjectsList(
+        projectGrantsActivated
+          ? allProjects.results.filter((project) => accessibleProjectIds.has(project.id))
+          : allProjects.results
+      );
     }
     setIsLoading(false);
   };
@@ -164,7 +187,7 @@ const ProjectListView = () => {
 
   useEffect(() => {
     getProjectList();
-  }, [sortOption, filter, safeWord, allProjects]);
+  }, [sortOption, filter, safeWord, allProjects, projectGrantsActivated]);
 
   return (
     <>

--- a/front/src/common/authorization/components/GrantsManager.tsx
+++ b/front/src/common/authorization/components/GrantsManager.tsx
@@ -10,6 +10,7 @@ import GrantsManagerSubjects from './GrantsManagerSubjects';
 
 function getGrantLabel(userPrivileges: Set<Privilege>): keyof typeof GRANTS_LABEL {
   if (userPrivileges.has('can_delete')) return 'OWNER';
+  if (userPrivileges.has('has_access')) return 'OWNER'; // custom privilege for project access
   if (userPrivileges.has('can_write')) return 'WRITER';
   if (userPrivileges.has('can_read')) return 'READER';
   if (userPrivileges.has('can_restricted_read')) return 'RESTRICTED_READER';
@@ -35,7 +36,7 @@ const GrantsManager = ({
   const [displayGrantSection, setDisplayGrantSection] = useState(false);
 
   const grantLabel = getGrantLabel(userPrivileges);
-  const canRead = userPrivileges.has('can_read');
+  const canRead = userPrivileges.has('can_read') || userPrivileges.has('has_access');
 
   return (
     <div className="grant-manager">

--- a/front/src/common/authorization/components/GrantsManagerSubject.tsx
+++ b/front/src/common/authorization/components/GrantsManagerSubject.tsx
@@ -9,7 +9,7 @@ import { ThreeDots } from 'common/Loaders';
 import type { AsyncStatus } from 'common/types';
 import { getErrorMessage } from 'utils/error';
 
-import type { Grant, Privilege, Subject } from '../types';
+import type { Grant, Privilege, ResourceType, Subject } from '../types';
 import generateGrantSelectProps from '../utils/generateGrantSelectProps';
 
 type GrantsManagerSubjectProps = {
@@ -17,6 +17,7 @@ type GrantsManagerSubjectProps = {
   subjectGrant?: Grant;
   userId: number;
   userPrivileges: Set<Privilege>;
+  resourceType: ResourceType;
   onChange: (grant?: Grant) => Promise<void>;
 };
 
@@ -25,6 +26,7 @@ const GrantsManagerSubject = ({
   subjectGrant,
   userId,
   userPrivileges,
+  resourceType,
   onChange,
 }: GrantsManagerSubjectProps) => {
   const { t } = useTranslation();
@@ -49,9 +51,10 @@ const GrantsManagerSubject = ({
       generateGrantSelectProps({
         subjectGrant,
         userPrivileges,
+        resourceType,
         t,
       }),
-    [userPrivileges, subjectGrant, t]
+    [userPrivileges, subjectGrant, resourceType, t]
   );
 
   useEffect(() => {

--- a/front/src/common/authorization/components/GrantsManagerSubjects.tsx
+++ b/front/src/common/authorization/components/GrantsManagerSubjects.tsx
@@ -36,6 +36,7 @@ const GrantsManagerSubjects = ({
     generateGrantSelectProps({
       subjectGrant: selectedUserGrant,
       userPrivileges,
+      resourceType,
       t,
     });
 
@@ -75,6 +76,7 @@ const GrantsManagerSubjects = ({
             subjectGrant={grant}
             userId={userId}
             userPrivileges={userPrivileges}
+            resourceType={resourceType}
             onChange={async (value?: Grant) => {
               await updateGrant(resourceType, resourceId, subject.id, value);
               onChangeSuccess?.(subject.id, value);

--- a/front/src/common/authorization/components/GrantsManagerSubjects.tsx
+++ b/front/src/common/authorization/components/GrantsManagerSubjects.tsx
@@ -79,6 +79,7 @@ const GrantsManagerSubjects = ({
             resourceType={resourceType}
             onChange={async (value?: Grant) => {
               await updateGrant(resourceType, resourceId, subject.id, value);
+              await refetch();
               onChangeSuccess?.(subject.id, value);
             }}
           />

--- a/front/src/common/authorization/consts.ts
+++ b/front/src/common/authorization/consts.ts
@@ -1,3 +1,5 @@
+import type { ResourceType } from './types';
+
 // The order is important here, as it is used to determine the order of the grants
 export enum GRANTS_LABEL {
   NONE = 'none',
@@ -11,3 +13,10 @@ export enum SUBJECT_TYPES {
   USER = 'User',
   GROUP = 'Group',
 }
+
+// Resource types which don't expose the whole set of grants
+export const RESOURCE_TYPE_ALLOWED_GRANTS: Partial<
+  Record<ResourceType, Array<keyof typeof GRANTS_LABEL>>
+> = {
+  project: ['NONE', 'OWNER'],
+};

--- a/front/src/common/authorization/hooks/useAuthz.tsx
+++ b/front/src/common/authorization/hooks/useAuthz.tsx
@@ -65,7 +65,7 @@ export default function useAuthz() {
           );
           return accByType;
         },
-        {} as Record<ResourceType, { [id: number]: Grant }>
+        {} as Partial<Record<ResourceType, { [id: number]: Grant }>>
       );
     },
     [retrieveUserGrants]
@@ -88,7 +88,7 @@ export default function useAuthz() {
           );
           return accByType;
         },
-        {} as Record<ResourceType, { [id: number]: Set<Privilege> }>
+        {} as Partial<Record<ResourceType, { [id: number]: Set<Privilege> }>>
       );
     },
     [retrieveUserPrivileges]
@@ -99,32 +99,8 @@ export default function useAuthz() {
    */
   const checkUserPrivileges = useCallback(
     async (resourceType: ResourceType, resourceId: number, privileges: Privilege[]) => {
-      let infras: number[];
-      let rolling_stocks: number[];
-      let projects: number[];
-      switch (resourceType) {
-        case 'rolling_stock':
-          infras = [];
-          rolling_stocks = [resourceId];
-          projects = [];
-          break;
-        case 'infra':
-          infras = [resourceId];
-          rolling_stocks = [];
-          projects = [];
-          break;
-        case 'project':
-          infras = [];
-          rolling_stocks = [];
-          projects = [resourceId];
-          break;
-      }
-      const result = await getUserPrivileges({
-        infra: infras,
-        rolling_stock: rolling_stocks,
-        project: projects,
-      });
-      const userPrivileges = result[resourceType] ? result[resourceType][resourceId] : new Set();
+      const result = await getUserPrivileges({ [resourceType]: [resourceId] });
+      const userPrivileges = result[resourceType]?.[resourceId] ?? new Set();
       return privileges.every((privilege) => userPrivileges.has(privilege));
     },
     [getUserPrivileges]

--- a/front/src/common/authorization/utils/generateGrantSelectProps.ts
+++ b/front/src/common/authorization/utils/generateGrantSelectProps.ts
@@ -1,8 +1,8 @@
 import type { TFunction } from 'i18next';
 
-import type { Grant, Privilege } from 'common/authorization/types';
+import type { Grant, Privilege, ResourceType } from 'common/authorization/types';
 
-import { GRANTS_LABEL } from '../consts';
+import { GRANTS_LABEL, RESOURCE_TYPE_ALLOWED_GRANTS } from '../consts';
 
 function getRequiredPrivilegesToAddGrant(grant: keyof typeof GRANTS_LABEL): Privilege[] {
   switch (grant) {
@@ -25,16 +25,23 @@ function getRequiredPrivilegesToAddGrant(grant: keyof typeof GRANTS_LABEL): Priv
 const generateGrantSelectProps = ({
   subjectGrant,
   userPrivileges,
+  resourceType,
   t,
 }: {
   subjectGrant?: Grant;
   userPrivileges: Set<Privilege>;
+  resourceType: ResourceType;
   t: TFunction;
 }) => {
+  // Some resource types (eg. project) only expose a subset of the grants
+  const grantsForResource = RESOURCE_TYPE_ALLOWED_GRANTS[resourceType];
+
   // List of options that the user is allowed to assign
   const allowedOptions = Object.keys(GRANTS_LABEL).reduce(
     (acc, grantKey) => {
       const grant = grantKey as keyof typeof GRANTS_LABEL;
+
+      if (grantsForResource && !grantsForResource.includes(grant)) return acc;
 
       const requiredPrivileges = getRequiredPrivilegesToAddGrant(grant);
       const isOptionShown = requiredPrivileges.every((privilege) => userPrivileges.has(privilege));

--- a/front/src/common/authorization/utils/generateGrantSelectProps.ts
+++ b/front/src/common/authorization/utils/generateGrantSelectProps.ts
@@ -49,10 +49,11 @@ const generateGrantSelectProps = ({
     [] as Array<{ label: string; value?: Grant }>
   );
 
-  // If the subject has no grant, we are in the case to add a new  user on the resource
+  // If the subject has no grant, we are in the case to add a new user on the resource
+  // Revoking access makes no sense here since the subject already has none
   if (subjectGrant === undefined) {
     return {
-      options: allowedOptions,
+      options: allowedOptions.filter((option) => option.value !== undefined),
       readOnly: false,
     };
   }

--- a/front/src/common/authorization/utils/generateGrantSelectProps.ts
+++ b/front/src/common/authorization/utils/generateGrantSelectProps.ts
@@ -4,7 +4,15 @@ import type { Grant, Privilege, ResourceType } from 'common/authorization/types'
 
 import { GRANTS_LABEL, RESOURCE_TYPE_ALLOWED_GRANTS } from '../consts';
 
-function getRequiredPrivilegesToAddGrant(grant: keyof typeof GRANTS_LABEL): Privilege[] {
+// Privilege that grants ownership over the resource, used to add/revoke the OWNER/NONE grants
+function getOwnerPrivilege(resourceType: ResourceType): Privilege {
+  return resourceType === 'project' ? 'has_access' : 'can_share_ownership';
+}
+
+function getRequiredPrivilegesToAddGrant(
+  grant: keyof typeof GRANTS_LABEL,
+  resourceType: ResourceType
+): Privilege[] {
   switch (grant) {
     case 'RESTRICTED_READER':
       return ['can_share_read'];
@@ -13,10 +21,10 @@ function getRequiredPrivilegesToAddGrant(grant: keyof typeof GRANTS_LABEL): Priv
     case 'WRITER':
       return ['can_share_write'];
     case 'OWNER':
-      return ['can_share_ownership'];
+      return [getOwnerPrivilege(resourceType)];
     // NONE means revoke, and only a owner can do that
     case 'NONE':
-      return ['can_share_ownership'];
+      return [getOwnerPrivilege(resourceType)];
     default:
       return [];
   }
@@ -43,7 +51,7 @@ const generateGrantSelectProps = ({
 
       if (grantsForResource && !grantsForResource.includes(grant)) return acc;
 
-      const requiredPrivileges = getRequiredPrivilegesToAddGrant(grant);
+      const requiredPrivileges = getRequiredPrivilegesToAddGrant(grant, resourceType);
       const isOptionShown = requiredPrivileges.every((privilege) => userPrivileges.has(privilege));
       if (isOptionShown) {
         acc.push({
@@ -65,7 +73,7 @@ const generateGrantSelectProps = ({
     };
   }
 
-  // Search for the subject 's option in the allowed list
+  // Search for the subject's option in the allowed list
   // if the subject's option is not found, we return only its grant and in readonly mode
   const subjectValueIndex = allowedOptions.findIndex((option) => option.value === subjectGrant);
   if (subjectValueIndex < 0) {
@@ -84,7 +92,7 @@ const generateGrantSelectProps = ({
 
   // In case of not owner of the resource, we need to remove all options below the subject one.
   // A user can't revoke a grant if he is not owner
-  if (!userPrivileges.has('can_share_ownership')) {
+  if (!userPrivileges.has(getOwnerPrivilege(resourceType))) {
     const filteredOptions = allowedOptions.filter((_, index) => index >= subjectValueIndex);
     return {
       value: allowedOptions[subjectValueIndex],

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
@@ -37,7 +37,6 @@ const InfraSelectorModalBodyEdition = ({
   const { getUserPrivileges } = useAuthz();
   const userPrivilegesByInfraId = useAsyncMemo(async () => {
     const data = await getUserPrivileges({
-      rolling_stock: [],
       infra: infrasList.map((infra) => infra.id),
     });
     return data.infra || {};

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
@@ -54,7 +54,7 @@ const InfraSelectorModalBodyStandard = ({
 
   // Get the user privileges for infras
   const userPrivilegesByInfraId = useAsyncMemo(async () => {
-    const data = await getUserPrivileges({ rolling_stock: [], infra: infraIdsList });
+    const data = await getUserPrivileges({ infra: infraIdsList });
     return data.infra || {};
     // redraw is in the deps to force the reload of the privileges when the user changes his own grant
   }, [getUserPrivileges, infraIdsList, redraw]);

--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
@@ -196,7 +196,6 @@ const useFilterRollingStock = ({
     // call editoast
     const data = await getUserPrivileges({
       rolling_stock: allRollingStocks.map((rs) => rs.id),
-      infra: [],
     });
     return data.rolling_stock || {};
   }, [

--- a/front/src/reducers/infra/generateGrantSelectProps.spec.ts
+++ b/front/src/reducers/infra/generateGrantSelectProps.spec.ts
@@ -26,6 +26,7 @@ describe('generateSelectPropsForGrant', () => {
     const result = generateGrantSelectProps({
       subjectGrant: 'READER',
       userPrivileges: new Set(GRANTS.OWNER),
+      resourceType: 'infra',
       t,
     });
 
@@ -49,6 +50,7 @@ describe('generateSelectPropsForGrant', () => {
     const result = generateGrantSelectProps({
       subjectGrant: 'READER',
       userPrivileges: new Set(GRANTS.WRITER),
+      resourceType: 'infra',
       t,
     });
 
@@ -66,6 +68,7 @@ describe('generateSelectPropsForGrant', () => {
     const result = generateGrantSelectProps({
       subjectGrant: 'WRITER',
       userPrivileges: new Set(GRANTS.READER),
+      resourceType: 'infra',
       t,
     });
 


### PR DESCRIPTION
close #17988 

### Test the PR:

<details>
<summary>
Setup to test the PR
</summary>

#### To have more users
- Add user:
`docker exec osrd-editoast editoast user add --skip-if-exists 'Jane Doe' 'jane.doe@example.com'`
- Pass it operational studies role:
`docker exec osrd-editoast editoast roles add 'jane.doe@example.com' OperationalStudies`

#### To activate the editoast feature flag : 
Add `ENABLE_PROJECT_PERMISSIONS: 'true'` in the editoast environment in `docker-compose.yml`
</details>

#### Test guide : 
- Activate the project grants feature flag
- Open a project, the grants manager should be present under the project image
- Impersonate Jane Doe, we should get a 403 and be redirected to the 403 error page
- Go back to home page and logout from Jane Doe and open a scenario
- Impersonate Jane Doe, we should get a 403 and be redirected to the 403 error page (Jane doesn't have access to the project yet)
- Logout from Jane and repeat when on a study and logout from Jane
- Go back to a project, open the grant manager and try to add grant to Jane Doe
- The only possible option in the select should be "full access"
- Give full access to Jane Doe and go back to the home page
- Impersonate Jane
- Open the project list, we should only see the project we just gave grants to
- Open the project, we should have access to it, its studies and scenarios and be able to edit them (if Jane has access to the infra used by the scenario otherwise we will get a 403 as well)
- Go back to home page, remove the feature flag for project grants; we should see every projects available
- Logout from Jane and go back on the project grants manager
- You should be able to revoke Jane right on the project by passing "no access". Do it
- Log on Jane, you should not see any project in the project list