### PR TITLE
editoast: front: adapt nge node path item key

### DIFF
--- a/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/down.sql
+++ b/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/down.sql
@@ -1,2 +1,3 @@
 DELETE FROM macro_node WHERE path_item_key LIKE 'trigram:%';
-UPDATE macro_node SET path_item_key = 'trigram:' || SUBSTRING(path_item_key, 13) WHERE path_item_key LIKE 'domestic:FR-%';
+UPDATE macro_node SET path_item_key = 'trigram:' || SUBSTRING(path_item_key, 10, LENGTH(path_item_key) - 12) WHERE path_item_key LIKE 'domestic:%#__';
+UPDATE macro_node SET trigram = SUBSTRING(trigram, 1, LENGTH(trigram) - 3) WHERE trigram LIKE '%#__';

--- a/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/up.sql
+++ b/editoast/migrations/2026-08-06-164808-0000_adapt_node_path_item_key/up.sql
@@ -1,2 +1,2 @@
-DELETE FROM macro_node WHERE path_item_key LIKE 'domestic:FR-%';
-UPDATE macro_node SET path_item_key = 'domestic:FR-' || SUBSTRING(path_item_key, 9) WHERE path_item_key LIKE 'trigram:%';
+DELETE FROM macro_node WHERE path_item_key LIKE 'domestic:%#FR';
+UPDATE macro_node SET path_item_key = 'domestic:' || SUBSTRING(path_item_key, 9) || '#FR', trigram = trigram || '#FR' WHERE path_item_key LIKE 'trigram:%';

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/MacroEditorState.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/MacroEditorState.ts
@@ -257,14 +257,14 @@ export default class MacroEditorState {
 
   /**
    * Encode a domestic operational point reference in the form:
-   * ${country_code}-${main_code}/${secondary_code}
+   * ${main_code}/${secondary_code}#${country_code}
    */
   static encodeDomesticReference(
     opRef: Extract<OperationalPointReference, { type: 'domestic' }>
   ): string {
     const secondaryCode = opRef.secondary_code ? `/${opRef.secondary_code}` : '';
-    const countryCode = opRef.country_code === '??' ? '' : `${opRef.country_code}-`;
-    return `${countryCode}${opRef.main_code}${secondaryCode}`;
+    const countryCode = opRef.country_code === '??' ? '' : `#${opRef.country_code}`;
+    return `${opRef.main_code}${secondaryCode}${countryCode}`;
   }
 
   /**
@@ -325,21 +325,15 @@ export default class MacroEditorState {
 
   /**
    * Decode a domestic operational point reference in the form:
-   * ${country_code}-${main_code}/${secondary_code}
+   * ${main_code}/${secondary_code}#${country_code}
    */
   static decodeDomesticReference(
     pathKey: string
   ): Extract<OperationalPointReference, { type: 'domestic' }> {
-    const [country_code_main_code, secondary_code] = pathKey.split('/');
-    const country_code_main_code_split = country_code_main_code.split('-');
+    const [main_code_secondary_code, splitted_country_code] = pathKey.split('#');
+    const [main_code, secondary_code] = main_code_secondary_code.split('/');
 
-    let country_code, main_code;
-    if (country_code_main_code_split.length === 2) {
-      [country_code, main_code] = country_code_main_code_split;
-    } else {
-      main_code = country_code_main_code;
-      country_code = '??';
-    }
+    const country_code = splitted_country_code ? splitted_country_code : '??';
 
     return { main_code, secondary_code, country_code, type: 'domestic' };
   }

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/MacroEditorState.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/__tests__/MacroEditorState.spec.ts
@@ -4,7 +4,7 @@ import MacroEditorState from '../MacroEditorState';
 
 describe('MacroEditorState.parsePathKey', () => {
   test('parses a domestic path key with a country code and secondary code', () => {
-    expect(MacroEditorState.parsePathKey('domestic:FR-ORL/BV')).toEqual({
+    expect(MacroEditorState.parsePathKey('domestic:ORL/BV#FR')).toEqual({
       type: 'operational_point_part_reference',
       operational_point: {
         type: 'domestic',
@@ -28,7 +28,7 @@ describe('MacroEditorState.parsePathKey', () => {
   });
 
   test('parses a domestic path key without a secondary code', () => {
-    expect(MacroEditorState.parsePathKey('domestic:FR-ORL')).toEqual({
+    expect(MacroEditorState.parsePathKey('domestic:ORL#FR')).toEqual({
       type: 'operational_point_part_reference',
       operational_point: {
         type: 'domestic',

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
@@ -91,7 +91,7 @@ export const handleNodeOperation = async ({
           await updateMacroNode(state, dispatch, {
             ...indexNode,
             ...castNgeNode(node, netzgrafikDto.labels),
-            trigram: node.betriebspunktName,
+            trigram: domesticReference,
             dbId: indexNode.dbId,
             path_item_key: nodeKey,
           });
@@ -118,7 +118,7 @@ export const handleNodeOperation = async ({
         }
       } else {
         // It's an unknown node, we need to create it in the db
-        // We assume that `betriebspunktName` follows the `${country_code}-${main_code}/${secondary_code}` format
+        // We assume that `betriebspunktName` follows the `${main_code}/${secondary_code}#${country_code}` format
         const key = MacroEditorState.getPathKey({
           type: 'operational_point_part_reference',
           operational_point: MacroEditorState.decodeDomesticReference(node.betriebspunktName),

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -337,7 +337,7 @@ export const loadAndIndexNge = async (
     for (const pathKey of MacroEditorState.getPathKeys(op)) {
       state.updateNodeDataByKey(pathKey, {
         full_name: op.name,
-        trigram: op.main_code + (op.secondary_code ? `/${op.secondary_code}` : ''),
+        trigram: MacroEditorState.encodeDomesticReference({ ...op, type: 'domestic' }),
         geocoord: op.geo ? { lng: op.geo.coordinates[0], lat: op.geo.coordinates[1] } : undefined,
       });
     }

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -65,7 +65,7 @@ test.describe('Netzgrafik Editor', { tag: ['@op', '@nge'] }, () => {
   /** *************** Test 1 **************** */
   test('Verify NGE train data', async ({ ngePage }) => {
     await test.step('Verify nodes displayed on NGE graph', async () => {
-      await ngePage.expectNodes(['SWS/BV', 'MWS/BV', 'MES/BV']);
+      await ngePage.expectNodes(['SWS/BV#…', 'MWS/BV…', 'MES/BV#…']);
     });
 
     await test.step('Verify train rows labels', async () => {
@@ -89,7 +89,7 @@ test.describe('Netzgrafik Editor', { tag: ['@op', '@nge'] }, () => {
 
       await test.step('Verify one-way tab shows SWS/BV (South_West_station) → MES/BV (Mid_East_station)', async () => {
         const oneWayRegex =
-          /SWS\/BV\s*\(South_West_station\)[\s\S]*?30[\s\S]*?MES\/BV\s*\(Mid_East_station\)/i;
+          /SWS\/BV#FR\s*\(South_West_station\)[\s\S]*?30[\s\S]*?MES\/BV#FR\s*\(Mid_East_station\)/i;
         await ngePage.openOneWayTabAndExpect(oneWayRegex);
       });
 


### PR DESCRIPTION
The idea is to add the country code at the end of the path_item_key. In addition, we adapt nodes trigram so the import/export works again.

Note: I adapted an existing migration; it's normal since we are adapting a fix. It's not a big deal for people who already ran this migration.