### PR TITLE
front: hourly time axis for hourly timetables

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -87,6 +87,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
     projectionData,
     conflicts,
     isConflictsLoading,
+    hourlyTimetableDuration,
     upsertTrainSchedules,
     removeTrainSchedules,
     updateTrainScheduleDepartureTime,
@@ -248,6 +249,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
                     conflicts={conflicts}
                     trainSchedulesWithDetails={trainSchedulesWithDetails}
                     activeBoards={activeBoards}
+                    hourlyTimetableDuration={hourlyTimetableDuration}
                     isScrollingToTimeStopsTable={isScrollingToTimeStopsTable}
                     setIsScrollingToTimeStopsTable={setIsScrollingToTimeStopsTable}
                   />

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResults.tsx
@@ -30,6 +30,7 @@ import {
   getTrainIdUsedForProjection,
 } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
+import type { Duration } from 'utils/duration';
 import {
   extractEditoastIdFromTrainScheduleId,
   extractTrainScheduleIdFromOccurrenceId,
@@ -54,6 +55,10 @@ type SimulationResultsProps = {
   trainSchedulesWithDetails: TrainScheduleWithDetails[];
   conflicts?: Conflict[];
   activeBoards: Set<Board>;
+  /**
+   * Duration of the hourly timetable pattern; `undefined` for calendar scenarios.
+   */
+  hourlyTimetableDuration?: Duration;
   isScrollingToTimeStopsTable: boolean;
   setIsScrollingToTimeStopsTable: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -64,6 +69,7 @@ const SimulationResults = ({
   trainSchedulesWithDetails,
   conflicts = NO_CONFLICTS,
   activeBoards,
+  hourlyTimetableDuration,
   isScrollingToTimeStopsTable,
   setIsScrollingToTimeStopsTable,
 }: SimulationResultsProps) => {
@@ -288,6 +294,7 @@ const SimulationResults = ({
                   waypointsPanelIsOpen={waypointsPanelIsOpen}
                   setWaypointsPanelIsOpen={setWaypointsPanelIsOpen}
                   pathfindingHasFailed={projectionData?.pathfindingStatus === 'failed'}
+                  hourlyTimetableDuration={hourlyTimetableDuration}
                 />
               )}
             </div>

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartToolbar.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartToolbar.tsx
@@ -1,6 +1,5 @@
 import type { Dispatch, SetStateAction } from 'react';
 
-import { DEFAULT_ZOOM_MS_PER_PX, timeScaleToZoomValue } from '@osrd-project/ui-charts';
 import { Iterations, Linking, Sliders, ZoomIn } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useSelector } from 'react-redux';
@@ -8,22 +7,22 @@ import { useSelector } from 'react-redux';
 import { getFeatureFlag } from 'reducers/user/userSelectors';
 
 type SpaceTimeChartToolbarProps = {
-  xZoom: number;
-  handleXZoom: (newXZoom: number, xPosition?: number) => void;
+  onResetClick: () => void;
   zoomMode: boolean;
   disableZoom: boolean;
   toggleZoomMode: () => void;
   setShowSettingsPanel: Dispatch<SetStateAction<boolean>>;
   className?: string;
+  isResetButtonDisabled?: boolean;
 };
 
 const SpaceTimeChartToolbar = ({
-  xZoom,
-  handleXZoom,
+  onResetClick,
   zoomMode,
   disableZoom,
   toggleZoomMode,
   setShowSettingsPanel,
+  isResetButtonDisabled,
 }: SpaceTimeChartToolbarProps) => {
   const linkingsActivated = useSelector(getFeatureFlag('linkings'));
 
@@ -44,13 +43,10 @@ const SpaceTimeChartToolbar = ({
         data-testid="zoom-reset-button"
         type="button"
         className={cx('reset-button', {
-          'reset-button-disabled': xZoom === timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX),
+          'reset-button-disabled': isResetButtonDisabled,
         })}
-        onClick={() => {
-          if (xZoom !== timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX)) {
-            handleXZoom(timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX));
-          }
-        }}
+        onClick={onResetClick}
+        disabled={isResetButtonDisabled}
       >
         <Iterations />
       </button>

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -19,6 +19,8 @@ import {
   isInteractiveWaypoint,
   isOccupancyPickingElement,
   type Track,
+  DEFAULT_ZOOM_MS_PER_PX,
+  timeScaleToZoomValue,
 } from '@osrd-project/ui-charts';
 import { Slider } from '@osrd-project/ui-core';
 import cx from 'classnames';
@@ -130,6 +132,12 @@ type SpaceTimeChartWrapperBaseProps = {
   selectedProjectionId: TrainId;
   trainSchedulesWithDetails?: TrainScheduleWithDetails[];
   pathfindingHasFailed?: boolean;
+  /**
+   * Duration of the hourly timetable pattern; when set, the time axis renders
+   * in hourly pattern mode (signed integer hours around 0). `undefined` for
+   * calendar scenarios.
+   */
+  hourlyTimetableDuration?: Duration;
 };
 
 type SpaceTimeChartWrapperProps = SpaceTimeChartWrapperBaseProps &
@@ -206,6 +214,7 @@ const SpaceTimeChartWrapper = ({
   waypointsPanelIsOpen,
   setWaypointsPanelIsOpen,
   pathfindingHasFailed = false,
+  hourlyTimetableDuration,
 }: SpaceTimeChartWrapperProps) => {
   const { t } = useTranslation('operational-studies');
   const dispatch = useAppDispatch();
@@ -472,6 +481,35 @@ const SpaceTimeChartWrapper = ({
   }, [selectedProjectionId, trainScheduleProjections.length]);
 
   const occupancyBlocks = getOccupancyBlocks(cutProjectedTrains);
+
+  const isZoomAtDefault = xZoom === timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX);
+  const handleResetClick = useCallback(() => {
+    let xPosition: number | undefined;
+
+    if (hourlyTimetableDuration) {
+      if (spaceTimeChartProps.xOffset) {
+        pan({ dx: -spaceTimeChartProps.xOffset });
+      }
+      setTimeOrigin(0);
+      xPosition = 0;
+    }
+
+    if (!isZoomAtDefault) {
+      handleXZoom(timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX), xPosition);
+    }
+  }, [
+    hourlyTimetableDuration,
+    spaceTimeChartProps.xOffset,
+    pan,
+    setTimeOrigin,
+    isZoomAtDefault,
+    handleXZoom,
+  ]);
+
+  const isResetButtonDisabled =
+    isZoomAtDefault &&
+    (!hourlyTimetableDuration ||
+      (spaceTimeChartProps.timeOrigin === 0 && spaceTimeChartProps.xOffset === 0));
 
   const manchettePropsWithWaypointMenu = useMemo(
     () => ({
@@ -762,12 +800,12 @@ const SpaceTimeChartWrapper = ({
           }}
         >
           <SpaceTimeChartToolbar
-            xZoom={xZoom}
-            handleXZoom={handleXZoom}
+            onResetClick={handleResetClick}
             zoomMode={zoomMode}
             disableZoom={!!waypointsPanelData?.deployedWaypoints?.size}
             toggleZoomMode={toggleZoomMode}
             setShowSettingsPanel={setShowSettingsPanel}
+            isResetButtonDisabled={isResetButtonDisabled}
           />
           {showSettingsPanel && (
             <SettingsPanel
@@ -791,6 +829,7 @@ const SpaceTimeChartWrapper = ({
             spaceOrigin={
               (waypointsPanelData?.filteredWaypoints ?? operationalPoints).at(0)?.position || 0
             }
+            hourlyTimetableDuration={hourlyTimetableDuration?.ms}
           >
             {paths.map((path) => {
               const trainId = path.id as TrainId;

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/hourly-mode.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/hourly-mode.stories.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo, useRef } from 'react';
+
+import {
+  SpaceTimeChart,
+  Manchette,
+  useManchetteWithSpaceTimeChart,
+  PathLayer,
+  type ChartPath,
+} from '@osrd-project/ui-charts';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
+import { HOUR } from '../common/const';
+import { SAMPLE_WAYPOINTS, SAMPLE_CHART_PATHS } from './assets/sampleData';
+
+const DEFAULT_HEIGHT = 561;
+const PATTERN_DURATION = HOUR;
+
+// Shift sample paths so their earliest point sits at time 0, meant to showcase
+// the hourly-mode axis rendering starting at hour 0.
+const shiftPathsToZero = (paths: ChartPath[]): ChartPath[] => {
+  const minTime = Math.min(...paths.flatMap((p) => p.points.map((pt) => pt.time)));
+  return paths.map((p) => ({
+    ...p,
+    points: p.points.map((pt) => ({ ...pt, time: pt.time - minTime })),
+  }));
+};
+
+const HourlyModeWrapper = () => {
+  const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
+  const paths = useMemo(() => shiftPathsToZero(SAMPLE_CHART_PATHS), []);
+
+  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart({
+    waypoints: SAMPLE_WAYPOINTS,
+    manchetteWithSpaceTimeChartRef,
+  });
+
+  return (
+    <div className="ui-manchette-space-time-chart-wrapper">
+      <div
+        className="header bg-ambientB-5 w-full border-b border-grey-30"
+        style={{ height: '40px' }}
+      />
+      <div
+        ref={manchetteWithSpaceTimeChartRef}
+        className="manchette flex"
+        style={{ height: `${DEFAULT_HEIGHT}px` }}
+        onScroll={handleScroll}
+      >
+        <Manchette {...manchetteProps} />
+        <div className="space-time-chart-container w-full sticky">
+          <SpaceTimeChart
+            className="inset-0 absolute h-full"
+            {...spaceTimeChartProps}
+            hourlyTimetableDuration={PATTERN_DURATION}
+          >
+            {paths.map((path) => (
+              <PathLayer key={path.id} path={path} color={path.color} />
+            ))}
+          </SpaceTimeChart>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const meta: Meta<typeof HourlyModeWrapper> = {
+  title: 'Manchette with SpaceTimeChart/Hourly mode',
+  component: HourlyModeWrapper,
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof HourlyModeWrapper> = {};

--- a/front/ui/ui-charts/src/common/layers/TimeCaptions.tsx
+++ b/front/ui/ui-charts/src/common/layers/TimeCaptions.tsx
@@ -45,6 +45,10 @@ const HOURS_FORMATTER = (t: number, pixelsPerMinute: number) =>
     pixelsPerMinute > 1 ? HOUR_OPTIONS_LONG : HOUR_OPTIONS_SHORT
   );
 
+// Signed integer hour count relative to time origin 0, used for the hourly
+// pattern mode (e.g. hourly timetables): …, -2, -1, 0, 1, 2, …
+const HOURLY_HOURS_FORMATTER = (t: number) => `${Math.round(t / HOUR)}`;
+
 const DATES_FORMATER = (t: number) => new Date(t).toLocaleDateString(undefined, DATE_OPTIONS);
 
 const RANGES_FORMATER: ((t: number, pixelsPerMinute: number) => string)[] = [
@@ -60,6 +64,10 @@ const RANGES_FORMATER: ((t: number, pixelsPerMinute: number) => string)[] = [
   HOURS_FORMATTER,
   HOURS_FORMATTER,
 ];
+
+const HOURLY_RANGES_FORMATER = RANGES_FORMATER.map((f) =>
+  f === HOURS_FORMATTER ? HOURLY_HOURS_FORMATTER : f
+);
 
 export const TimeCaptions = () => {
   const drawingFunction = useCallback<DrawingFunction<TimeChartContextType>>(
@@ -85,6 +93,7 @@ export const TimeCaptions = () => {
         swapAxis = false,
         hideTimeCaptions = false,
         hideDates = false,
+        hourlyTimetableDuration,
         showTicks = false,
       }
     ) => {
@@ -109,6 +118,8 @@ export const TimeCaptions = () => {
         return false;
       });
 
+      const rangesFormatter = hourlyTimetableDuration ? HOURLY_RANGES_FORMATER : RANGES_FORMATER;
+
       let labelMarks = computeVisibleTimeMarkers(
         minT,
         maxT,
@@ -117,7 +128,7 @@ export const TimeCaptions = () => {
         (level: number, i: number) => ({
           level,
           styles: timeCaptionsStyles[level],
-          formatter: RANGES_FORMATER[i],
+          formatter: rangesFormatter[i],
         })
       );
       if (!hideDates)

--- a/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
+++ b/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
@@ -1,11 +1,20 @@
 import { useCallback, useContext } from 'react';
 
-import { MINUTE } from '../../common/consts';
+import { HOUR, MINUTE } from '../../common/consts';
 import { MouseContext, TimeChartCanvasContext } from '../../common/context';
 import { computeVisibleTimeMarkers, getCrispLineCoordinate } from '../../common/helpers/time';
 import type { TimeChartContextType, DrawingFunction } from '../../common/types';
 import { BLACK_ALPHA_25, GREY_50 } from '../helpers/colors';
 import { useDraw } from '../hooks/useCanvas';
+
+// Signed `Xh MM` string for hourly pattern mode (e.g. -1h30, 0h05, 2h15).
+function formatHourlyTime(t: number): string {
+  const sign = t < 0 ? '-' : '';
+  const abs = Math.abs(t);
+  const h = Math.floor(abs / HOUR);
+  const m = Math.floor((abs % HOUR) / MINUTE);
+  return `${sign}${h}h${m.toString().padStart(2, '0')}`;
+}
 
 const TimeGraduations = () => {
   const mouseContext = useContext(MouseContext);
@@ -24,6 +33,7 @@ const TimeGraduations = () => {
         swapAxis,
         width,
         height,
+        hourlyTimetableDuration,
         theme: { breakpoints, timeRanges, timeGraduationsStyles, timeGraduationsPriorities },
       }
     ) => {
@@ -72,41 +82,45 @@ const TimeGraduations = () => {
       if (!swapAxis && isHover && !isNaN(mouseX)) {
         const crispX = getCrispLineCoordinate(mouseX, 1);
         const timeValue = getTime(crispX);
-        const timeLabel = new Date(timeValue).toLocaleTimeString();
+        if (Number.isFinite(timeValue)) {
+          const timeLabel = hourlyTimetableDuration
+            ? formatHourlyTime(timeValue)
+            : new Date(timeValue).toLocaleTimeString();
 
-        ctx.globalAlpha = 1;
+          ctx.globalAlpha = 1;
 
-        // Vertical line:
-        ctx.strokeStyle = BLACK_ALPHA_25;
-        ctx.lineWidth = 1;
-        ctx.setLineDash([]);
-        ctx.beginPath();
-        ctx.moveTo(crispX, 0);
-        ctx.lineTo(crispX, spaceAxisSize);
-        ctx.stroke();
+          // Vertical line:
+          ctx.strokeStyle = BLACK_ALPHA_25;
+          ctx.lineWidth = 1;
+          ctx.setLineDash([]);
+          ctx.beginPath();
+          ctx.moveTo(crispX, 0);
+          ctx.lineTo(crispX, spaceAxisSize);
+          ctx.stroke();
 
-        // Label
-        const padding = 4;
-        const fontSize = 12;
-        const fontWeight = '400';
-        const fontFamily = 'IBM Plex Sans, sans-regular';
-        ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
-        const textWidth = ctx.measureText(timeLabel).width;
+          // Label
+          const padding = 4;
+          const fontSize = 12;
+          const fontWeight = '400';
+          const fontFamily = 'IBM Plex Sans, sans-regular';
+          ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+          const textWidth = ctx.measureText(timeLabel).width;
 
-        const labelX = Math.min(
-          Math.max(crispX - textWidth / 2 - padding, 0),
-          width - textWidth - padding * 2
-        );
+          const labelX = Math.min(
+            Math.max(crispX - textWidth / 2 - padding, 0),
+            width - textWidth - padding * 2
+          );
 
-        const labelY = spaceAxisSize - 50;
+          const labelY = spaceAxisSize - 50;
 
-        // Label background
-        ctx.fillStyle = '#FFFFFF';
-        ctx.fillRect(labelX, labelY - fontSize - 2, textWidth + padding * 2, fontSize + 4);
+          // Label background
+          ctx.fillStyle = '#FFFFFF';
+          ctx.fillRect(labelX, labelY - fontSize - 2, textWidth + padding * 2, fontSize + 4);
 
-        // Text
-        ctx.fillStyle = GREY_50;
-        ctx.fillText(timeLabel, labelX + padding, labelY);
+          // Text
+          ctx.fillStyle = GREY_50;
+          ctx.fillText(timeLabel, labelX + padding, labelY);
+        }
       }
 
       // Reset

--- a/front/ui/ui-charts/src/common/types.ts
+++ b/front/ui/ui-charts/src/common/types.ts
@@ -129,6 +129,14 @@ export type ChartOptions = {
   hideTimeCaptions?: boolean;
   showTicks?: boolean;
   swapAxis?: boolean;
+  /**
+   * When set, the time axis renders hours as signed integers relative to time
+   * origin 0 (…, -2, -1, 0, 1, 2, …) instead of localized clock times, and
+   * date captions are hidden. The value is the length (in ms) of one hourly
+   * timetable pattern iteration, so downstream layers (markers, pattern bars)
+   * can reuse it. Meant for repeating patterns (e.g. hourly timetables).
+   */
+  hourlyTimetableDuration?: number;
 };
 
 export type TimeChartContextType = BaseTimeChartContextType & ChartOptions;

--- a/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
@@ -45,6 +45,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
     hidePathsLabels,
     showTicks,
     hideDates,
+    hourlyTimetableDuration,
     theme,
     onPan,
     onZoom,
@@ -76,6 +77,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
         hidePathsLabels,
         showTicks,
         hideDates,
+        hourlyTimetableDuration,
       }),
     [
       operationalPoints,
@@ -93,6 +95,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
       hidePathsLabels,
       showTicks,
       hideDates,
+      hourlyTimetableDuration,
     ]
   );
 
@@ -147,11 +150,13 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
       hideGrid: !!hideGrid,
       hidePathsLabels: !!hidePathsLabels,
       showTicks: !!showTicks,
-      hideDates: !!hideDates,
+      hideDates: !!hideDates || !!hourlyTimetableDuration,
+      hourlyTimetableDuration,
       theme: fullTheme,
-      captionSize: hideDates
-        ? fullTheme.timeCaptionsSize
-        : fullTheme.dateCaptionsSize + fullTheme.timeCaptionsSize,
+      captionSize:
+        hideDates || hourlyTimetableDuration
+          ? fullTheme.timeCaptionsSize
+          : fullTheme.dateCaptionsSize + fullTheme.timeCaptionsSize,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fingerprint]);

--- a/front/ui/ui-charts/src/spaceTimeChart/lib/types.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/lib/types.ts
@@ -120,6 +120,14 @@ export type SpaceTimeChartProps = {
   hidePathsLabels?: boolean;
   hideDates?: boolean;
   showTicks?: boolean;
+  /**
+   * When set, the time axis renders hours as signed integers relative to time
+   * origin 0 (…, -2, -1, 0, 1, 2, …) instead of localized clock times, and
+   * date captions are hidden. The value is the length (in ms) of one hourly
+   * timetable pattern iteration, so downstream layers (markers, pattern bars)
+   * can reuse it. Meant for repeating patterns (e.g. hourly timetables).
+   */
+  hourlyTimetableDuration?: number;
 
   // Custom styles:
   theme?: Partial<SpaceTimeChartTheme>;


### PR DESCRIPTION
Adds a `hourlyTimetableDuration` prop to the space time chart. When active, the
time axis renders hours as signed integers relative to time origin 0
(…, -2, -1, 0, 1, 2, …) instead of localized clock times, hides date
captions, and switches the hover label to a signed `Xh MM` format.

In hourly timetables, the Fit button also resets the horizontal view
to hour 0.

To test, open a hourly timetable and pan/zoom the space time chart,
then click Fit.

Prepares #17617 