### PR TITLE
editoast, front: rename PathfindingResultSuccess to PathfindingResult

### DIFF
--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -91,7 +91,7 @@ pub struct InvalidPathItem {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum PathfindingCoreResult {
-    Success(PathfindingResultSuccess),
+    Success(PathfindingResult),
     NotFoundInBlocks {
         track_section_ranges: Vec<TrackRange>,
         length: u64,
@@ -102,7 +102,7 @@ pub enum PathfindingCoreResult {
     },
     NotFoundInTracks,
     IncompatibleConstraints {
-        relaxed_constraints_path: Box<PathfindingResultSuccess>,
+        relaxed_constraints_path: Box<PathfindingResult>,
         incompatible_constraints: Box<IncompatibleConstraints>,
     },
     InvalidPathItems {
@@ -114,11 +114,11 @@ pub enum PathfindingCoreResult {
     },
 }
 
-/// A successful pathfinding result. This is also used for STDCM response.
+/// A pathfinding result. This is also used for STDCM response.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
-#[schema(as = CorePathfindingResultSuccess)]
+#[schema(as = CorePathfindingResult)]
 #[derive(Default)]
-pub struct PathfindingResultSuccess {
+pub struct PathfindingResult {
     /// Full description of the path data
     pub path: TrainPath,
     /// Length of the path in mm
@@ -166,7 +166,7 @@ pub enum PathfindingNotFound {
     #[default]
     NotFoundInTracks,
     IncompatibleConstraints {
-        relaxed_constraints_path: Box<PathfindingResultSuccess>,
+        relaxed_constraints_path: Box<PathfindingResult>,
         incompatible_constraints: Box<IncompatibleConstraints>,
     },
 }

--- a/editoast/core_client/src/stdcm.rs
+++ b/editoast/core_client/src/stdcm.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use super::pathfinding::PathItem;
-use super::pathfinding::PathfindingResultSuccess;
+use super::pathfinding::PathfindingResult;
 use super::pathfinding::TrackRange;
 use super::simulation::PhysicsConsist;
 use super::simulation::SimulationSuccess;
@@ -186,13 +186,13 @@ pub struct ProgressCoordinates {
 pub enum Response {
     Success {
         simulation: SimulationSuccess,
-        path: PathfindingResultSuccess,
+        path: PathfindingResult,
         departure_time: DateTime<Utc>,
     },
     PathNotFound {
         most_blocking_work_schedules: Vec<ConflictingWorkSchedule>,
         nearest_to_destination_work_schedules: Vec<ConflictingWorkSchedule>,
-        partial_path: Option<PathfindingResultSuccess>,
+        partial_path: Option<PathfindingResult>,
         last_reached_operational_point: Option<LastReachedOperationalPoint>,
     },
 }

--- a/editoast/core_task/src/envs/simulation.rs
+++ b/editoast/core_task/src/envs/simulation.rs
@@ -334,7 +334,7 @@ pub(crate) mod test_data {
     /// We use the length field to identify it since the content doesn't matter
     pub(crate) fn path(id: usize, positions_count: u64) -> serde_json::Value {
         let response = core_client::pathfinding::PathfindingCoreResult::Success(
-            core_client::pathfinding::PathfindingResultSuccess {
+            core_client::pathfinding::PathfindingResult {
                 path: core_client::pathfinding::TrainPath {
                     blocks: Vec::new(),
                     routes: Vec::new(),

--- a/editoast/core_task/src/envs/simulation/request.rs
+++ b/editoast/core_task/src/envs/simulation/request.rs
@@ -16,12 +16,12 @@ pub(super) fn build_request(
     core_env: &CoreEnv,
     electrical_profile_set_id: Option<u64>,
     SimulationKey(sim_consist, params, pathfinding::PathfindingKey(pf_consist, constraints)): &SimulationKey,
-    core_client::pathfinding::PathfindingResultSuccess {
+    core_client::pathfinding::PathfindingResult {
         path,
         path_item_positions,
         backtrack_path_items,
         ..
-    }: core_client::pathfinding::PathfindingResultSuccess,
+    }: core_client::pathfinding::PathfindingResult,
 ) -> Result<core_client::simulation::Request, ()> {
     if constraints.path_items.len() != path_item_positions.len() {
         tracing::error!(
@@ -178,7 +178,7 @@ mod tests {
             routes: Vec::new(),
             track_section_ranges: Vec::new(),
         };
-        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+        let path_success = core_client::pathfinding::PathfindingResult {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
@@ -279,7 +279,7 @@ mod tests {
             routes: Vec::new(),
             track_section_ranges: Vec::new(),
         };
-        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+        let path_success = core_client::pathfinding::PathfindingResult {
             path: path.clone(),
             length: 100,
             path_item_positions: path_item_positions.clone(),
@@ -440,7 +440,7 @@ mod tests {
             routes: Vec::new(),
             track_section_ranges: Vec::new(),
         };
-        let path_success = core_client::pathfinding::PathfindingResultSuccess {
+        let path_success = core_client::pathfinding::PathfindingResult {
             path,
             length: 100,
             path_item_positions: path_positions,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5900,10 +5900,10 @@ components:
           incompatible_constraints:
             $ref: '#/components/schemas/CoreIncompatibleConstraints'
           relaxed_constraints_path:
-            $ref: '#/components/schemas/CorePathfindingResultSuccess'
-    CorePathfindingResultSuccess:
+            $ref: '#/components/schemas/CorePathfindingResult'
+    CorePathfindingResult:
       type: object
-      description: A successful pathfinding result. This is also used for STDCM response.
+      description: A pathfinding result. This is also used for STDCM response.
       required:
       - path
       - length
@@ -13193,7 +13193,7 @@ components:
     PathfindingResult:
       oneOf:
       - allOf:
-        - $ref: '#/components/schemas/CorePathfindingResultSuccess'
+        - $ref: '#/components/schemas/CorePathfindingResult'
         - type: object
           required:
           - status
@@ -15653,7 +15653,7 @@ components:
             type: string
             format: date-time
           pathfinding_result:
-            $ref: '#/components/schemas/CorePathfindingResultSuccess'
+            $ref: '#/components/schemas/CorePathfindingResult'
           simulation:
             $ref: '#/components/schemas/SimulationResponseSuccess'
           status:
@@ -15682,7 +15682,7 @@ components:
           partial_pathfinding_result:
             oneOf:
             - type: 'null'
-            - $ref: '#/components/schemas/CorePathfindingResultSuccess'
+            - $ref: '#/components/schemas/CorePathfindingResult'
           status:
             type: string
             enum:

--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -383,7 +383,6 @@ mod tests {
     use authz::RollingStockGrant;
     use chrono::TimeDelta;
     use core_client::mocking::MockingClient;
-    use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::pathfinding::TrainPath;
     use reqwest::StatusCode;
     use schemas::infra::LevelCrossingPart;
@@ -446,8 +445,8 @@ mod tests {
         assert!(result.is_none());
     }
 
-    fn pathfinding_result_success() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
+    fn pathfinding_result_success() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -19,7 +19,6 @@ use core_client::pathfinding::PathfindingCoreResult;
 use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingNotFound;
 use core_client::pathfinding::PathfindingRequest;
-use core_client::pathfinding::PathfindingResultSuccess;
 use database::DbConnection;
 use educe::Educe;
 use itertools::Itertools;
@@ -170,7 +169,7 @@ impl From<PathfindingInput> for core_task::PathfindingConsist {
 #[serde(tag = "status", rename_all = "snake_case")]
 #[schema(title_variants)]
 pub enum PathfindingResult {
-    Success(PathfindingResultSuccess),
+    Success(core_client::pathfinding::PathfindingResult),
     Failure(PathfindingFailure),
 }
 
@@ -505,7 +504,6 @@ pub mod tests {
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::InvalidPathItem;
     use core_client::pathfinding::PathfindingInputError;
-    use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::pathfinding::TrainPath;
     use pretty_assertions::assert_eq;
     use schemas::rolling_stock::LoadingGaugeType;
@@ -539,7 +537,7 @@ pub mod tests {
     }
 
     fn pathfinding_result(length: u64) -> PathfindingResult {
-        PathfindingResult::Success(PathfindingResultSuccess {
+        PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -1,6 +1,5 @@
 use crate::error::Result;
 use core_client::CoreClient;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::pathfinding::TrackRange;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::ReportTrain;
@@ -528,7 +527,7 @@ impl TrainToProjectOnOperationalPoint {
     fn new_from_invalid<T: TrainScheduleLike>(
         ts: &T,
         sim: SimulationResponseSuccess,
-        path: PathfindingResultSuccess,
+        path: core_client::pathfinding::PathfindingResult,
     ) -> Self {
         // Reuse the space-time curve from the track projection, so that scheduled
         // `PathItemLocation::TrackOffset`s are visible on the STD even for invalid trains.
@@ -859,7 +858,7 @@ pub fn compute_projected_train_path_op_without_simulation<T: TrainScheduleLike>(
 fn extract_curve_for_invalid_train_with_sim<T: TrainScheduleLike>(
     train_schedule: &T,
     sim: &SimulationResponseSuccess,
-    path: &PathfindingResultSuccess,
+    path: &core_client::pathfinding::PathfindingResult,
 ) -> SpaceTimeCurve {
     let mut positions = vec![0];
     let mut times = vec![0];

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -786,10 +786,11 @@ mod tests {
     use crate::views::timetable::simulation::SimulationResponseSuccess;
 
     use super::*;
+    use crate::views::path::pathfinding;
     use authz::InfraGrant;
     use authz::RollingStockGrant;
     use common::units;
-    use core_client::pathfinding::PathfindingResultSuccess;
+    use core_client::pathfinding::PathfindingResult;
     use core_client::pathfinding::TrackRange;
     use core_client::pathfinding::TrainPath;
     use core_client::simulation::CompleteReportTrain;
@@ -1228,7 +1229,7 @@ mod tests {
         let target_simulation = Response::Success(fake_occurrence_simulation_success());
 
         // Create mock pathfinding results with track section ranges
-        let source_pathfinding = PathfindingResult::Success(PathfindingResultSuccess {
+        let source_pathfinding = pathfinding::PathfindingResult::Success(PathfindingResult {
             path: TrainPath {
                 track_section_ranges: vec![
                     TrackRange {
@@ -1249,7 +1250,7 @@ mod tests {
             ..Default::default()
         });
 
-        let target_pathfinding = PathfindingResult::Success(PathfindingResultSuccess {
+        let target_pathfinding = pathfinding::PathfindingResult::Success(PathfindingResult {
             path: TrainPath {
                 track_section_ranges: vec![
                     TrackRange {

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -2,7 +2,6 @@ use chrono::Duration;
 use core_client::AsCoreRequest;
 use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingNotFound;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::pathfinding::TrainPath;
 use core_client::simulation::CompleteReportTrain;
 use core_client::simulation::ElectricalProfiles;
@@ -519,7 +518,7 @@ pub async fn consist_train_simulation_batch<T: TrainScheduleLike>(
             consist,
         } = train_schedule_with_consist;
         let (path, path_item_positions, backtrack_path_items) = match pathfinding.as_ref() {
-            PathfindingResult::Success(PathfindingResultSuccess {
+            PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
                 path,
                 path_item_positions,
                 backtrack_path_items,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -35,7 +35,6 @@ use core_client::AsCoreStreaming;
 use core_client::CoreClient;
 use core_client::Progress;
 use core_client::pathfinding::InvalidPathItem;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::stdcm::ConflictingWorkSchedule;
 use core_client::stdcm::ConsistConfiguration;
 use core_client::stdcm::ConsistSchedule;
@@ -101,13 +100,13 @@ pub struct StdcmConflictingWorkSchedule {
 pub(in crate::views) enum StdcmResponse {
     Success {
         simulation: SimulationResponseSuccess,
-        pathfinding_result: PathfindingResultSuccess,
+        pathfinding_result: core_client::pathfinding::PathfindingResult,
         departure_time: DateTime<Utc>,
     },
     PathNotFound {
         most_blocking_work_schedules: Vec<StdcmConflictingWorkSchedule>,
         nearest_to_destination_work_schedules: Vec<StdcmConflictingWorkSchedule>,
-        partial_pathfinding_result: Option<PathfindingResultSuccess>,
+        partial_pathfinding_result: Option<core_client::pathfinding::PathfindingResult>,
         last_reached_operational_point: Option<StdcmLastReachedOperationalPoint>,
     },
     PreprocessingSimulationError {
@@ -895,8 +894,8 @@ mod tests {
         }
     }
 
-    fn pathfinding_result_success() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
+    fn pathfinding_result_success() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],
@@ -908,8 +907,8 @@ mod tests {
         }
     }
 
-    fn pathfinding_result_partial() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
+    fn pathfinding_result_partial() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/timetable/track_occupancy.rs
+++ b/editoast/src/views/timetable/track_occupancy.rs
@@ -1,5 +1,4 @@
 use common::units::millisecond;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::simulation::ReportTrain;
 use schemas::infra::TrackOffset;
 use schemas::primitives::NonBlankString;
@@ -28,7 +27,7 @@ pub(super) struct TrackOccupancy {
 struct OccupancyContext<'a> {
     op_id: &'a str,
     report_train: Option<&'a ReportTrain>,
-    pathfinding_success: Option<&'a PathfindingResultSuccess>,
+    pathfinding_success: Option<&'a core_client::pathfinding::PathfindingResult>,
     matching_index: Option<usize>,
     schedule_item: Option<&'a ScheduleItem>,
 }
@@ -368,7 +367,7 @@ pub mod tests {
         track_section: Identifier,
         path_item_positions: Vec<u64>,
     ) -> PathfindingResult {
-        PathfindingResult::Success(PathfindingResultSuccess {
+        PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
             path: core_client::pathfinding::TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -21,7 +21,6 @@ use core_client::AsCoreRequest;
 use core_client::CoreClient;
 use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingInputError::UnauthorizedRollingStock;
-use core_client::pathfinding::PathfindingResultSuccess;
 use core_client::signal_projection::SignalUpdate;
 use core_client::simulation::PhysicsConsist;
 use core_task::Correlated;
@@ -1039,12 +1038,13 @@ pub(in crate::views) async fn etcs_braking_curves(
     .unwrap();
 
     // Extract simulation path
-    let pathfinding_response: PathfindingResultSuccess = match pathfinding_result.as_ref() {
-        PathfindingResult::Success(path) => path.clone(),
-        _ => {
-            return Err(TrainScheduleError::PathfindingFailed { train_schedule_id }.into());
-        }
-    };
+    let pathfinding_response: core_client::pathfinding::PathfindingResult =
+        match pathfinding_result.as_ref() {
+            PathfindingResult::Success(path) => path.clone(),
+            _ => {
+                return Err(TrainScheduleError::PathfindingFailed { train_schedule_id }.into());
+            }
+        };
 
     // Extract mrsp
     let mrsp = match simulation_result.as_ref() {
@@ -2265,7 +2265,6 @@ mod tests {
     use core_client::mocking::MockingClient;
     use core_client::pathfinding::InvalidPathItem;
     use core_client::pathfinding::PathfindingInputError;
-    use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::pathfinding::TrackRange;
     use core_client::pathfinding::TrainPath;
     use core_client::simulation::CompleteReportTrain;
@@ -3782,7 +3781,7 @@ mod tests {
 
         assert_eq!(
             response,
-            PathfindingResult::Success(PathfindingResultSuccess {
+            PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
                 path: TrainPath {
                     blocks: vec![],
                     routes: vec![],
@@ -4100,7 +4099,7 @@ mod tests {
 
         assert_eq!(
             response,
-            PathfindingResult::Success(PathfindingResultSuccess {
+            PathfindingResult::Success(core_client::pathfinding::PathfindingResult {
                 path: TrainPath {
                     blocks: vec![],
                     routes: vec![],
@@ -4621,8 +4620,8 @@ mod tests {
         assert!(response_unauthorized.is_empty());
     }
 
-    fn pathfinding_result_success() -> PathfindingResultSuccess {
-        PathfindingResultSuccess {
+    fn pathfinding_result_success() -> core_client::pathfinding::PathfindingResult {
+        core_client::pathfinding::PathfindingResult {
             path: TrainPath {
                 blocks: vec![],
                 routes: vec![],

--- a/front/src/applications/operationalStudies/helpers/upsertTrackOffsetPathItemsInWaypoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertTrackOffsetPathItemsInWaypoints.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next';
 
-import type { CorePathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResult, TrainSchedule } from 'common/api/osrdEditoastApi';
 import type { PathWaypoint, ProjectionWaypoint } from 'modules/simulationResult/types';
 
 /**
@@ -9,21 +9,21 @@ import type { PathWaypoint, ProjectionWaypoint } from 'modules/simulationResult/
 export function upsertTrackOffsetPathItemsInWaypoints(
   type: 'projection',
   path: TrainSchedule['path'],
-  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResult['path_item_positions'],
   operationalPoints: ProjectionWaypoint[],
   t: TFunction<'operational-studies'>
 ): ProjectionWaypoint[];
 export function upsertTrackOffsetPathItemsInWaypoints(
   type: 'path',
   path: TrainSchedule['path'],
-  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResult['path_item_positions'],
   operationalPoints: PathWaypoint[],
   t: TFunction<'operational-studies'>
 ): PathWaypoint[];
 export function upsertTrackOffsetPathItemsInWaypoints(
   type: 'projection' | 'path',
   path: TrainSchedule['path'],
-  pathItemsPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemsPositions: CorePathfindingResult['path_item_positions'],
   operationalPoints: (ProjectionWaypoint | PathWaypoint)[],
   t: TFunction<'operational-studies'>
 ): (ProjectionWaypoint | PathWaypoint)[] {

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -4,7 +4,7 @@ import type {
   CoreIncompatibleConstraints,
   TrainSchedule,
   PathProperties,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   SimulationResponse,
   SimulationResponseSuccess,
   MacroNodeForm,
@@ -65,7 +65,7 @@ export type ManageTrainSchedulePathProperties = {
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];
   length: number;
-  trackSectionRanges: NonNullable<CorePathfindingResultSuccess['path']['track_section_ranges']>;
+  trackSectionRanges: NonNullable<CorePathfindingResult['path']['track_section_ranges']>;
   incompatibleConstraints?: CoreIncompatibleConstraints;
 };
 
@@ -138,7 +138,7 @@ export type SimulationResults =
       train: Train;
       rollingStock: RollingStockWithLiveries;
       simulation: SimulationResponseSuccess;
-      path: CorePathfindingResultSuccess;
+      path: CorePathfindingResult;
       pathProperties: PathPropertiesFormatted;
       powerRestrictions: LayerData<PowerRestrictionValues>[];
     };
@@ -189,7 +189,7 @@ export type PathProjectionResult = {
 } & (
   | {
       pathfindingStatus: 'succeeded';
-      pathfinding: CorePathfindingResultSuccess;
+      pathfinding: CorePathfindingResult;
       geometry: PathProperties['geometry'];
       projectingOnSimulatedPathException: boolean | undefined;
     }

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -3,7 +3,7 @@ import { type Dictionary, isEqual, omit } from 'lodash';
 
 import type {
   OperationalPointReference,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   PathItemLocation,
   PathProperties,
   RelatedOperationalPoint,
@@ -280,7 +280,7 @@ export const sortPathOperationalPoints = (ops: PathWaypoint[], path: PathItem[])
 export const preparePathPropertiesData = (
   electricalProfiles: SimulationResponseSuccess['electrical_profiles'] | undefined,
   { slopes, curves, electrifications, operational_points, geometry }: PathProperties,
-  { path_item_positions, length }: CorePathfindingResultSuccess,
+  { path_item_positions, length }: CorePathfindingResult,
   trainSchedulePath: TrainSchedule['path'],
   t: TFunction<'operational-studies'>
 ): PathPropertiesFormatted => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsExport/SimulationResultsExport.tsx
@@ -9,7 +9,7 @@ import type {
   PathPropertiesFormatted,
 } from 'applications/operationalStudies/types';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   RollingStockWithLiveries,
   SimulationResponseSuccess,
 } from 'common/api/osrdEditoastApi';
@@ -20,7 +20,7 @@ import exportTrainCSV from './exportTrainCSV';
 import useFormattedOperationalPoints from './useFormattedOperationalPoints';
 
 const exportTrainPDF = async (
-  path: CorePathfindingResultSuccess,
+  path: CorePathfindingResult,
   scenarioData: { name: string; infraName: string },
   train: Train,
   simulation: SimulationResponseSuccess,
@@ -63,7 +63,7 @@ const exportTrainPDF = async (
 };
 
 type SimulationResultsExportProps = {
-  path: CorePathfindingResultSuccess;
+  path: CorePathfindingResult;
   scenarioData: { name: string; infraName: string };
   train: Train;
   simulation: SimulationResponseSuccess;

--- a/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/SimulationResults/SimulationResultsMap.tsx
@@ -11,7 +11,7 @@ import usePathOps from 'applications/operationalStudies/hooks/usePathOps';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   RelatedOperationalPoint,
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
@@ -35,7 +35,7 @@ const MAP_ID = 'simulation-result-map';
 type SimulationResultMapProps = {
   pathSteps?: TrainSchedule['path'];
   pathProperties?: PathPropertiesFormatted;
-  pathfindingResults?: CorePathfindingResultSuccess;
+  pathfindingResults?: CorePathfindingResult;
   setMapCanvas?: (mapCanvas: string) => void;
 };
 
@@ -86,7 +86,7 @@ const SimulationResultMap = ({
       steps: TrainSchedule['path'],
       matchedOps: Map<string, RelatedOperationalPoint | null>,
       pathPropertiesOps?: PathPropertiesFormatted['operationalPoints'],
-      simulatedPath?: CorePathfindingResultSuccess
+      simulatedPath?: CorePathfindingResult
     ) => {
       // 1. Get path steps track ids to fetch their track metadata
       const allTrackIds = steps.reduce<string[]>((acc, step) => {

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -5,7 +5,7 @@ import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/
 import type { StdcmPathProperties } from 'applications/stdcm/types';
 import type {
   PostInfraByInfraIdPathPropertiesApiArg,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
@@ -17,7 +17,7 @@ import type { AppDispatch } from 'store';
  *  Function to fetch and format path properties
  */
 const fetchPathProperties = async (
-  pathfinding_result: CorePathfindingResultSuccess,
+  pathfinding_result: CorePathfindingResult,
   infraId: number,
   dispatch: AppDispatch
 ): Promise<StdcmPathProperties> => {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3766,7 +3766,7 @@ export type CoreTrainPath = {
   /** Track section ranges, in order. */
   track_section_ranges: CoreTrackRange[];
 };
-export type CorePathfindingResultSuccess = {
+export type CorePathfindingResult = {
   /** The indexes of the path items where the train backtracks */
   backtrack_path_items?: number[] | null;
   /** Length of the path in mm */
@@ -3849,7 +3849,7 @@ export type CorePathfindingNotFound =
   | {
       error_type: 'incompatible_constraints';
       incompatible_constraints: CoreIncompatibleConstraints;
-      relaxed_constraints_path: CorePathfindingResultSuccess;
+      relaxed_constraints_path: CorePathfindingResult;
     };
 export type PathfindingFailure =
   | (CorePathfindingInputError & {
@@ -3859,7 +3859,7 @@ export type PathfindingFailure =
       failed_status: 'pathfinding_not_found';
     });
 export type PathfindingResult =
-  | (CorePathfindingResultSuccess & {
+  | (CorePathfindingResult & {
       status: 'success';
     })
   | (PathfindingFailure & {
@@ -4955,7 +4955,7 @@ export type SimulationResponse =
 export type StdcmResponse =
   | {
       departure_time: string;
-      pathfinding_result: CorePathfindingResultSuccess;
+      pathfinding_result: CorePathfindingResult;
       simulation: SimulationResponseSuccess;
       status: 'success';
     }
@@ -4963,7 +4963,7 @@ export type StdcmResponse =
       last_reached_operational_point?: null | StdcmLastReachedOperationalPoint;
       most_blocking_work_schedules: StdcmConflictingWorkSchedule[];
       nearest_to_destination_work_schedules: StdcmConflictingWorkSchedule[];
-      partial_pathfinding_result?: null | CorePathfindingResultSuccess;
+      partial_pathfinding_result?: null | CorePathfindingResult;
       status: 'path_not_found';
     }
   | {

--- a/front/src/modules/SimulationReportSheet/SimulationReportSheet.tsx
+++ b/front/src/modules/SimulationReportSheet/SimulationReportSheet.tsx
@@ -4,7 +4,7 @@ import { Page, Text, Image, Document, View } from '@react-pdf/renderer';
 import type { TFunction } from 'i18next';
 
 import type { OperationalPointWithTimeAndSpeed } from 'applications/operationalStudies/types';
-import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResult } from 'common/api/osrdEditoastApi';
 import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
 import { msToKmh, kgToT } from 'utils/physics';
 
@@ -16,7 +16,7 @@ import type { RouteTableRow, SimulationSheetData } from './types';
 import { formatOperationalStudiesDataForSimulationTable } from './utils/formatSimulationTable';
 
 type SimulationReportSheetProps = {
-  path: CorePathfindingResultSuccess;
+  path: CorePathfindingResult;
   scenarioData: { name: string; infraName: string };
   trainData: SimulationSheetData;
   mapCanvas?: string;

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationTable.ts
@@ -1,7 +1,7 @@
 import type { Style } from '@react-pdf/types';
 
 import type { OperationalPointWithTimeAndSpeed } from 'applications/operationalStudies/types';
-import type { CorePathfindingResultSuccess } from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResult } from 'common/api/osrdEditoastApi';
 import { timeToLocaleStringRounded } from 'utils/date';
 import { addDurationToDate, Duration } from 'utils/duration';
 import { kgToT } from 'utils/physics';
@@ -58,7 +58,7 @@ export const getRowStyle = (
 
 export const formatOperationalStudiesDataForSimulationTable = (
   operationalPointsList: OperationalPointWithTimeAndSpeed[],
-  pathItemPositions: CorePathfindingResultSuccess['path_item_positions'],
+  pathItemPositions: CorePathfindingResult['path_item_positions'],
   rollingStock: { mass: number; name: string },
   dateTimeLocale: Intl.Locale
 ) =>

--- a/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
+++ b/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
@@ -3,7 +3,7 @@ import { compact } from 'lodash';
 
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   RollingStock,
   TrainSchedule,
   TrainScheduleResponse,
@@ -18,7 +18,7 @@ import { mmToKm, mToMm } from 'utils/physics';
 export const formatPowerRestrictionRanges = (
   powerRestrictions: NonNullable<TrainSchedule['power_restrictions']>,
   path: TrainSchedule['path'],
-  stepsPathPositions: CorePathfindingResultSuccess['path_item_positions']
+  stepsPathPositions: CorePathfindingResult['path_item_positions']
 ): LayerData<Omit<PowerRestrictionValues, 'handled'>>[] =>
   compact(
     powerRestrictions.map((powerRestriction) => {
@@ -81,7 +81,7 @@ const formatPowerRestrictionRangesWithHandled = ({
 }: {
   selectedTrainSchedule: Pick<TrainScheduleResponse, 'path' | 'power_restrictions'>;
   selectedTrainRollingStock?: RollingStock;
-  pathfindingResult: CorePathfindingResultSuccess;
+  pathfindingResult: CorePathfindingResult;
   pathProperties: PathPropertiesFormatted;
 }) => {
   if (powerRestrictions && selectedTrainRollingStock) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useGetProjectedTrainOperationalPoints.ts
@@ -5,10 +5,7 @@ import { useSelector } from 'react-redux';
 
 import { applyPathStepWeight } from 'applications/operationalStudies/helpers/applyPathStepWeight';
 import { upsertTrackOffsetPathItemsInWaypoints } from 'applications/operationalStudies/helpers/upsertTrackOffsetPathItemsInWaypoints';
-import type {
-  CorePathfindingResultSuccess,
-  TrainScheduleResponse,
-} from 'common/api/osrdEditoastApi';
+import type { CorePathfindingResult, TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 import type { ProjectionWaypoint, ProjectionData } from 'modules/simulationResult/types';
 import { getProjectionType } from 'reducers/simulationResults/selectors';
 
@@ -23,7 +20,7 @@ const useGetProjectedTrainOperationalPoints = ({
   infraId: number;
   timetableId: number | undefined;
   path?: TrainScheduleResponse['path'];
-  pathfinding?: CorePathfindingResultSuccess;
+  pathfinding?: CorePathfindingResult;
   projectedOperationalPoints?: ProjectionData['operationalPoints'];
 }) => {
   const { t } = useTranslation('operational-studies');

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/useProjectedConflicts.ts
@@ -4,14 +4,14 @@ import type {
   Conflict,
   CoreConflictRequirement,
   PathProperties,
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 
 const useProjectedConflicts = (
   infraId: number,
   conflicts: Conflict[],
-  path: CorePathfindingResultSuccess | undefined
+  path: CorePathfindingResult | undefined
 ) => {
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useLazyQuery();
@@ -20,7 +20,7 @@ const useProjectedConflicts = (
   useEffect(() => {
     const fetchProjectedZones = async ({
       path: { track_section_ranges },
-    }: CorePathfindingResultSuccess) => {
+    }: CorePathfindingResult) => {
       const { zones } = await postPathProperties({
         infraId,
         pathPropertiesInput: {

--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathPropertiesFormatted } from 'applications/operationalStudies/types';
 import type {
-  CorePathfindingResultSuccess,
+  CorePathfindingResult,
   ReceptionSignal,
   RollingStock,
   SimulationResponseSuccess,
@@ -40,7 +40,7 @@ type TimeStopsTableWrapperProps = {
   selectedTrain: Train;
   trainSchedulesWithDetails: TrainScheduleWithDetails[];
   simulatedTrain?: SimulationResponseSuccess['final_output'];
-  simulatedPath?: CorePathfindingResultSuccess;
+  simulatedPath?: CorePathfindingResult;
   simulatedPathItemTimes?: Extract<SimulationSummary, { isValid: true }>['pathItemTimes'];
   simulatedPathItemRespect?: Extract<SimulationSummary, { isValid: true }>['pathItemRespect'];
   operationalPointsOnPath?: PathPropertiesFormatted['operationalPoints'];

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -6357,9 +6357,9 @@ class CorePathfindingInputError(
     )
 
 
-class CorePathfindingResultSuccess(BaseModel):
+class CorePathfindingResult(BaseModel):
     """
-    A successful pathfinding result. This is also used for STDCM response.
+    A pathfinding result. This is also used for STDCM response.
     """
 
     backtrack_path_items: list[BacktrackPathItem] | None = None
@@ -6712,7 +6712,7 @@ class PathItem(BaseModel):
 class PathfindingNotFoundIncompatibleConstraints(BaseModel):
     error_type: Literal["incompatible_constraints"] = "incompatible_constraints"
     incompatible_constraints: CoreIncompatibleConstraints
-    relaxed_constraints_path: CorePathfindingResultSuccess
+    relaxed_constraints_path: CorePathfindingResult
 
 
 class PathfindingFailurePathfindingNotFound5(
@@ -6771,7 +6771,7 @@ class PathfindingInput(BaseModel):
     """
 
 
-class PathfindingResultSuccess(CorePathfindingResultSuccess):
+class PathfindingResultSuccess(CorePathfindingResult):
     status: Literal["success"] = "success"
 
 
@@ -7075,7 +7075,7 @@ class SpeedSection(BaseModel):
 
 class StdcmResponseSuccess(BaseModel):
     departure_time: AwareDatetime
-    pathfinding_result: CorePathfindingResultSuccess
+    pathfinding_result: CorePathfindingResult
     simulation: SimulationResponseSuccess
     status: Literal["success"] = "success"
 
@@ -7500,7 +7500,7 @@ class StdcmResponsePathNotFound(BaseModel):
     last_reached_operational_point: StdcmLastReachedOperationalPoint | None = None
     most_blocking_work_schedules: list[StdcmConflictingWorkSchedule]
     nearest_to_destination_work_schedules: list[StdcmConflictingWorkSchedule]
-    partial_pathfinding_result: CorePathfindingResultSuccess | None = None
+    partial_pathfinding_result: CorePathfindingResult | None = None
     status: Literal["path_not_found"] = "path_not_found"
 
 


### PR DESCRIPTION
The current name suggests that the struct is reserved for successful case only. Since we want to use it for partial pathfinding in ``PathNotFound``, we rename it to make it neutral.

The original commit is located here: https://github.com/OpenRailAssociation/osrd/pull/17938/changes/a2ae44720e52f496685df30855a6d92afe4589ae

This is @elise-chin commit. I just extracted it in a separate PR.