### PR TITLE
editoast: adapt connection scan algo

### DIFF
--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -119,11 +119,23 @@ struct Profile {
     arrival_ms: TimeOfDayMs,
 }
 
+/// A function ordering two criteria, main criterion first.
+type OrderCriterion = fn(arrival_ms: TimeOfDayMs, leg_count: u32) -> (u32, u32);
+
+fn order_by_time(arrival_ms: TimeOfDayMs, leg_count: u32) -> (u32, u32) {
+    (arrival_ms, leg_count)
+}
+
+fn order_by_legs(arrival_ms: TimeOfDayMs, leg_count: u32) -> (u32, u32) {
+    (leg_count, arrival_ms)
+}
+
 impl Profile {
-    /// Whether [self] is superior to [other] both departure time and in arrival time, the number of legs breaking ties.
-    fn dominates(&self, other: &Self) -> bool {
+    /// Whether [self] is superior to [other] both in departure time and in criterion.
+    fn dominates(&self, other: &Self, order_criterion: OrderCriterion) -> bool {
         self.departure_ms >= other.departure_ms
-            && (self.arrival_ms, self.leg_count) <= (other.arrival_ms, other.leg_count)
+            && order_criterion(self.arrival_ms, self.leg_count)
+                <= order_criterion(other.arrival_ms, other.leg_count)
     }
 }
 
@@ -138,7 +150,12 @@ pub struct JourneyListParams {
     pub transfer_ms: u32,
 }
 
-/// This returns up to 3 journeys, each journey being the list of [Leg] to take.
+/// This returns 3 journeys if they exist, each journey being the list of [Leg] to take:
+/// - the one departing closest to [`JourneyListParams::start_ms`] on the earliest arrival front
+/// - the fastest one
+/// - the one taking the fewest legs, whatever its duration
+///
+/// A journey satisfying several criteria is returned several times.
 ///
 /// Some pre-conditions are required:
 ///
@@ -155,27 +172,78 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Leg>> {
         return Vec::new();
     }
 
-    let profiles = scan_connections(&p);
+    let profiles_by_time = scan_connections(&p, order_by_time);
+    let profiles_by_legs = scan_connections(&p, order_by_legs);
 
-    let mut start_profiles: Vec<&Profile> = profiles[p.start].iter().collect();
+    let closest_departure_journey = profiles_by_time[p.start]
+        .iter()
+        .min_by_key(|profile| {
+            (
+                u32::abs_diff(profile.departure_ms, p.start_ms),
+                profile.arrival_ms,
+            )
+        })
+        .map(|profile| {
+            extract_journey(
+                &profiles_by_time,
+                &p.connections,
+                p.transfer_ms,
+                p.end,
+                profile,
+            )
+        });
 
-    // TODO: In this first version we try the departures closest to the requested time first.
-    // We should use more specific criteria to select the best 3 journeys.
-    start_profiles.sort_unstable_by_key(|profile| u32::abs_diff(profile.departure_ms, p.start_ms));
+    let fastest_journey = profiles_by_time[p.start]
+        .iter()
+        .min_by_key(|profile| {
+            (
+                profile.arrival_ms - profile.departure_ms,
+                u32::abs_diff(profile.departure_ms, p.start_ms),
+                profile.arrival_ms,
+            )
+        })
+        .map(|profile| {
+            extract_journey(
+                &profiles_by_time,
+                &p.connections,
+                p.transfer_ms,
+                p.end,
+                profile,
+            )
+        });
 
-    // Explore the profile graph to create up to 3 journeys that a traveler can take to go from start to end.
-    start_profiles
+    let fewest_legs_journey = profiles_by_legs[p.start]
+        .iter()
+        .min_by_key(|profile| {
+            (
+                profile.leg_count,
+                u32::abs_diff(profile.departure_ms, p.start_ms),
+                profile.arrival_ms,
+            )
+        })
+        .map(|profile| {
+            extract_journey(
+                &profiles_by_legs,
+                &p.connections,
+                p.transfer_ms,
+                p.end,
+                profile,
+            )
+        });
+
+    closest_departure_journey
         .into_iter()
-        .map(|profile| extract_journey(&profiles, &p.connections, p.transfer_ms, p.end, profile))
-        .take(3)
+        .chain(fastest_journey)
+        .chain(fewest_legs_journey)
         .collect()
 }
 
 /// Scans every connection and returns the profiles of each stop, indexed by stop id.
 ///
 /// Profiles are ordered by decreasing `departure_ms`.
-/// They are also ordered by decreasing `arrival_ms` since they all lie on the Pareto front.
-fn scan_connections(p: &JourneyListParams) -> Vec<Vec<Profile>> {
+/// They are also ordered by decreasing first criterion (`arrival_ms` or `leg_count`),
+/// since they all lie on the Pareto front.
+fn scan_connections(p: &JourneyListParams, order_criterion: OrderCriterion) -> Vec<Vec<Profile>> {
     let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); p.stop_count];
 
     // This maps trips to the best TripArrival found over the connections scanned so far
@@ -208,7 +276,7 @@ fn scan_connections(p: &JourneyListParams) -> Vec<Vec<Profile>> {
         let Some(arrival) = [direct, seated, transfer]
             .into_iter()
             .flatten()
-            .min_by_key(|arrival| (arrival.arrival_ms, arrival.leg_count))
+            .min_by_key(|arrival| order_criterion(arrival.arrival_ms, arrival.leg_count))
         else {
             continue;
         };
@@ -230,7 +298,7 @@ fn scan_connections(p: &JourneyListParams) -> Vec<Vec<Profile>> {
         // inserted at the end and we only need to compare it with the last profile.
         match stop_profiles.last_mut() {
             Some(last) => {
-                if !last.dominates(&candidate) {
+                if !last.dominates(&candidate, order_criterion) {
                     if last.departure_ms == candidate.departure_ms {
                         *last = candidate
                     } else {

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -149,7 +149,7 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
 
         let t2 = profiles[connection.arrival]
             .iter()
-            .rfind(|profile| profile.departure_ms > connection.arrival_ms + transfer_ms)
+            .rfind(|profile| profile.departure_ms >= connection.arrival_ms + transfer_ms)
             .map_or(u32::MAX, |profile| {
                 if profile.out_connection.is_some() {
                     profile.arrival_ms

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -158,43 +158,38 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
                 }
             });
 
-        let t = u32::min(t1, t2);
+        let t_min = u32::min(t1, t2);
 
-        if t == u32::MAX {
+        if t_min == u32::MAX {
             continue;
         }
 
         let candidate = Profile {
             out_connection: Some(connection_id),
             departure_ms: connection.departure_ms,
-            arrival_ms: t,
+            arrival_ms: t_min,
         };
 
-        let profiles = &mut profiles[connection.departure];
+        let stop_profiles = &mut profiles[connection.departure];
 
-        let pivot = profiles
-            .iter()
-            .rposition(|profile| profile.departure_ms >= candidate.departure_ms);
-
-        let mut earlier_profiles = match pivot {
-            Some(position) => profiles
-                .drain(position + 1..)
-                .filter(|profile| candidate.dominates(profile))
-                .collect(),
-            None => Vec::new(),
-        };
-
-        let insert_candidate = match profiles.last() {
-            Some(profile) => !profile.dominates(&candidate),
-            None => true,
-        };
-
-        if insert_candidate {
-            profiles.push(candidate);
-            trip_min_arrival_ms[connection.trip] = t;
+        // A candidate departs at his connection's departure_ms (no footpath variation).
+        // Since connections are scanned by decreasing departure_ms, the candidate can only be
+        // inserted at the end and we only need to compare it with the last profile.
+        match stop_profiles.last_mut() {
+            Some(last) => {
+                if !last.dominates(&candidate) {
+                    if last.departure_ms == candidate.departure_ms {
+                        *last = candidate
+                    } else {
+                        stop_profiles.push(candidate);
+                    }
+                }
+            }
+            None => {
+                stop_profiles.push(candidate);
+            }
         }
-
-        profiles.append(&mut earlier_profiles);
+        trip_min_arrival_ms[connection.trip] = t_min;
     }
 
     let mut start_profiles: Vec<&Profile> = profiles[start]

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -148,39 +148,25 @@ pub struct JourneyListParams {
 ///
 /// See asserts below for more pre-conditions.
 pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Leg>> {
-    let JourneyListParams {
-        stop_count,
-        trip_count,
-        connections,
-        start_ms,
-        start_tolerance,
-        start,
-        end,
-        transfer_ms,
-    } = p;
+    assert!(p.start < p.stop_count);
+    assert!(p.end < p.stop_count);
 
-    assert!(start < stop_count);
-    assert!(end < stop_count);
-
-    if start == end {
+    if p.start == p.end {
         return Vec::new();
     }
 
-    let profiles = scan_connections(stop_count, trip_count, &connections, end, transfer_ms);
+    let profiles = scan_connections(&p);
 
-    let mut start_profiles: Vec<&Profile> = profiles[start]
-        .iter()
-        .filter(|profile| u32::abs_diff(profile.departure_ms, start_ms) <= start_tolerance)
-        .collect();
+    let mut start_profiles: Vec<&Profile> = profiles[p.start].iter().collect();
 
     // TODO: In this first version we try the departures closest to the requested time first.
     // We should use more specific criteria to select the best 3 journeys.
-    start_profiles.sort_unstable_by_key(|profile| u32::abs_diff(profile.departure_ms, start_ms));
+    start_profiles.sort_unstable_by_key(|profile| u32::abs_diff(profile.departure_ms, p.start_ms));
 
     // Explore the profile graph to create up to 3 journeys that a traveler can take to go from start to end.
     start_profiles
         .into_iter()
-        .map(|profile| extract_journey(&profiles, &connections, transfer_ms, end, profile))
+        .map(|profile| extract_journey(&profiles, &p.connections, p.transfer_ms, p.end, profile))
         .take(3)
         .collect()
 }
@@ -189,20 +175,20 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Leg>> {
 ///
 /// Profiles are ordered by decreasing `departure_ms`.
 /// They are also ordered by decreasing `arrival_ms` since they all lie on the Pareto front.
-fn scan_connections(
-    stop_count: usize,
-    trip_count: usize,
-    connections: &[Connection],
-    end: StopId,
-    transfer_ms: u32,
-) -> Vec<Vec<Profile>> {
-    let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); stop_count];
+fn scan_connections(p: &JourneyListParams) -> Vec<Vec<Profile>> {
+    let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); p.stop_count];
 
     // This maps trips to the best TripArrival found over the connections scanned so far
-    let mut trip_arrivals = vec![None; trip_count];
+    let mut trip_arrivals = vec![None; p.trip_count];
 
-    for (connection_id, connection) in connections.iter().enumerate() {
-        let direct = (connection.arrival == end).then_some(TripArrival {
+    for (connection_id, connection) in p.connections.iter().enumerate() {
+        if connection.departure == p.start
+            && u32::abs_diff(connection.departure_ms, p.start_ms) > p.start_tolerance
+        {
+            continue;
+        }
+
+        let direct = (connection.arrival == p.end).then_some(TripArrival {
             arrival_ms: connection.arrival_ms,
             leg_count: 1,
             exit_connection_id: connection_id,
@@ -212,7 +198,7 @@ fn scan_connections(
 
         let transfer = profiles[connection.arrival]
             .iter()
-            .rfind(|profile| profile.departure_ms >= connection.arrival_ms + transfer_ms)
+            .rfind(|profile| profile.departure_ms >= connection.arrival_ms + p.transfer_ms)
             .map(|profile| TripArrival {
                 arrival_ms: profile.arrival_ms,
                 leg_count: profile.leg_count + 1,

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -81,6 +81,9 @@ struct TripArrival {
     /// The arrival time at the target
     arrival_ms: TimeOfDayMs,
 
+    /// The number of legs between entering the trip and reaching the target
+    leg_count: u32,
+
     /// The connection the traveler exits the trip to reach the target at `arrival_ms`
     exit_connection_id: ConnectionId,
 }
@@ -100,11 +103,14 @@ pub struct Leg {
 /// A Profile documents part of a route travelers can take to reach the destination.
 ///
 /// More specifically, at `departure_ms`, a traveler can take the leg
-/// `leg` to reach the destination at `arrival_ms`.
+/// `leg` to reach the destination at `arrival_ms` in `leg_count` legs.
 #[derive(Clone, Debug)]
 struct Profile {
     /// The leg taken at the departure stop
     leg: Leg,
+
+    /// The number of legs between the departure stop and the target
+    leg_count: u32,
 
     /// The departure time at a given stop.
     departure_ms: TimeOfDayMs,
@@ -114,9 +120,10 @@ struct Profile {
 }
 
 impl Profile {
-    /// Whether [self] is superior to [other] both in arrival time and departure time.
+    /// Whether [self] is superior to [other] both departure time and in arrival time, the number of legs breaking ties.
     fn dominates(&self, other: &Self) -> bool {
-        self.departure_ms >= other.departure_ms && self.arrival_ms <= other.arrival_ms
+        self.departure_ms >= other.departure_ms
+            && (self.arrival_ms, self.leg_count) <= (other.arrival_ms, other.leg_count)
     }
 }
 
@@ -197,6 +204,7 @@ fn scan_connections(
     for (connection_id, connection) in connections.iter().enumerate() {
         let direct = (connection.arrival == end).then_some(TripArrival {
             arrival_ms: connection.arrival_ms,
+            leg_count: 1,
             exit_connection_id: connection_id,
         });
 
@@ -207,13 +215,14 @@ fn scan_connections(
             .rfind(|profile| profile.departure_ms >= connection.arrival_ms + transfer_ms)
             .map(|profile| TripArrival {
                 arrival_ms: profile.arrival_ms,
+                leg_count: profile.leg_count + 1,
                 exit_connection_id: connection_id,
             });
 
         let Some(arrival) = [direct, seated, transfer]
             .into_iter()
             .flatten()
-            .min_by_key(|arrival| arrival.arrival_ms)
+            .min_by_key(|arrival| (arrival.arrival_ms, arrival.leg_count))
         else {
             continue;
         };
@@ -223,6 +232,7 @@ fn scan_connections(
                 enter_connection_id: connection_id,
                 exit_connection_id: arrival.exit_connection_id,
             },
+            leg_count: arrival.leg_count,
             departure_ms: connection.departure_ms,
             arrival_ms: arrival.arrival_ms,
         };

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -80,7 +80,7 @@ pub struct Connection {
 #[derive(Clone, Debug)]
 struct Profile {
     /// The connection taken at the departure stop
-    out_connection: Option<ConnectionId>,
+    out_connection: ConnectionId,
 
     /// The departure time at a given stop.
     departure_ms: TimeOfDayMs,
@@ -131,43 +131,44 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
     assert!(start < stop_count);
     assert!(end < stop_count);
 
+    if start == end {
+        return Vec::new();
+    }
+
     // stop index -> profiles
     // profiles are ordered by decreasing departure_ms
     // they are also ordered by decreasing arrival_ms since they all lie on the Pareto front
     let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); stop_count];
-    profiles[end].push(Profile {
-        out_connection: None,
-        departure_ms: u32::MAX,
-        arrival_ms: 0,
-    });
 
     // This maps trips to the earliest arrival time possible when taking this trip.
     let mut trip_min_arrival_ms = vec![u32::MAX; trip_count];
 
     for (connection_id, connection) in connections.iter().enumerate() {
-        let t1 = trip_min_arrival_ms[connection.trip];
+        let direct_arrival_ms = if connection.arrival == end {
+            connection.arrival_ms
+        } else {
+            u32::MAX
+        };
 
-        let t2 = profiles[connection.arrival]
+        let seated_arrival_ms = trip_min_arrival_ms[connection.trip];
+
+        let transfer_arrival_ms = profiles[connection.arrival]
             .iter()
             .rfind(|profile| profile.departure_ms >= connection.arrival_ms + transfer_ms)
-            .map_or(u32::MAX, |profile| {
-                if profile.out_connection.is_some() {
-                    profile.arrival_ms
-                } else {
-                    connection.arrival_ms
-                }
-            });
+            .map_or(u32::MAX, |profile| profile.arrival_ms);
 
-        let t_min = u32::min(t1, t2);
+        let arrival_ms = direct_arrival_ms
+            .min(seated_arrival_ms)
+            .min(transfer_arrival_ms);
 
-        if t_min == u32::MAX {
+        if arrival_ms == u32::MAX {
             continue;
         }
 
         let candidate = Profile {
-            out_connection: Some(connection_id),
+            out_connection: connection_id,
             departure_ms: connection.departure_ms,
-            arrival_ms: t_min,
+            arrival_ms,
         };
 
         let stop_profiles = &mut profiles[connection.departure];
@@ -189,7 +190,7 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
                 stop_profiles.push(candidate);
             }
         }
-        trip_min_arrival_ms[connection.trip] = t_min;
+        trip_min_arrival_ms[connection.trip] = arrival_ms;
     }
 
     let mut start_profiles: Vec<&Profile> = profiles[start]
@@ -205,13 +206,12 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
     start_profiles
         .into_iter()
         .filter_map(|profile| {
-            let out_connection = profile.out_connection?;
             to_journey_list_rec(
                 &profiles,
                 &connections,
                 transfer_ms,
                 end,
-                vec![out_connection],
+                vec![profile.out_connection],
             )
         })
         .take(3)
@@ -240,9 +240,7 @@ fn to_journey_list_rec(
 
     // Try profiles from the one reaching the target earliest (see profiles construction) and stop at the first solution found
     profiles[start].iter().rev().find_map(|profile| {
-        let out_conn_id = profile
-            .out_connection
-            .expect("expected start != end to imply out_connection is Some");
+        let out_conn_id = profile.out_connection;
 
         let out_conn = connections[out_conn_id];
 

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -73,14 +73,38 @@ pub struct Connection {
     pub arrival_ms: TimeOfDayMs,
 }
 
+/// Pairs a connection to exit a trip from with the resulting target arrival time.
+///
+/// A traveler on the trip should exit it at `exit_connection` to arrive to the target at `arrival_ms`
+#[derive(Clone, Copy, Debug)]
+struct TripArrival {
+    /// The arrival time at the target
+    arrival_ms: TimeOfDayMs,
+
+    /// The connection the traveler exits the trip to reach the target at `arrival_ms`
+    exit_connection_id: ConnectionId,
+}
+
+/// A Leg represents a part of a journey taken on a specific trip.
+///
+/// The traveler enters the trip at `enter_connection` and exits it after `exit_connection`.
+#[derive(Clone, Copy, Debug)]
+pub struct Leg {
+    /// The id of the connection taken to enter a trip
+    pub enter_connection_id: ConnectionId,
+
+    /// The id of the last connection taken before exiting the trip
+    pub exit_connection_id: ConnectionId,
+}
+
 /// A Profile documents part of a route travelers can take to reach the destination.
 ///
-/// More specifically, at `departure_ms`, a traveler can take the train
-/// connection `out_connection` to reach the destination at `arrival_ms`.
+/// More specifically, at `departure_ms`, a traveler can take the leg
+/// `leg` to reach the destination at `arrival_ms`.
 #[derive(Clone, Debug)]
 struct Profile {
-    /// The connection taken at the departure stop
-    out_connection: ConnectionId,
+    /// The leg taken at the departure stop
+    leg: Leg,
 
     /// The departure time at a given stop.
     departure_ms: TimeOfDayMs,
@@ -107,7 +131,7 @@ pub struct JourneyListParams {
     pub transfer_ms: u32,
 }
 
-/// This returns up to 3 journeys, each journey being the list of connections to take given as their [ConnectionId].
+/// This returns up to 3 journeys, each journey being the list of [Leg] to take.
 ///
 /// Some pre-conditions are required:
 ///
@@ -116,7 +140,7 @@ pub struct JourneyListParams {
 /// - All connections' `departure`s and `arrival`s must be strictly lower than [`JourneyListParams::stop_count`]
 ///
 /// See asserts below for more pre-conditions.
-pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
+pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Leg>> {
     let JourneyListParams {
         stop_count,
         trip_count,
@@ -140,35 +164,40 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
     // they are also ordered by decreasing arrival_ms since they all lie on the Pareto front
     let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); stop_count];
 
-    // This maps trips to the earliest arrival time possible when taking this trip.
-    let mut trip_min_arrival_ms = vec![u32::MAX; trip_count];
+    // This maps trips to the best TripArrival found over the connections scanned so far
+    let mut trip_arrivals = vec![None; trip_count];
 
     for (connection_id, connection) in connections.iter().enumerate() {
-        let direct_arrival_ms = if connection.arrival == end {
-            connection.arrival_ms
-        } else {
-            u32::MAX
-        };
+        let direct = (connection.arrival == end).then_some(TripArrival {
+            arrival_ms: connection.arrival_ms,
+            exit_connection_id: connection_id,
+        });
 
-        let seated_arrival_ms = trip_min_arrival_ms[connection.trip];
+        let seated = trip_arrivals[connection.trip];
 
-        let transfer_arrival_ms = profiles[connection.arrival]
+        let transfer = profiles[connection.arrival]
             .iter()
             .rfind(|profile| profile.departure_ms >= connection.arrival_ms + transfer_ms)
-            .map_or(u32::MAX, |profile| profile.arrival_ms);
+            .map(|profile| TripArrival {
+                arrival_ms: profile.arrival_ms,
+                exit_connection_id: connection_id,
+            });
 
-        let arrival_ms = direct_arrival_ms
-            .min(seated_arrival_ms)
-            .min(transfer_arrival_ms);
-
-        if arrival_ms == u32::MAX {
+        let Some(arrival) = [direct, seated, transfer]
+            .into_iter()
+            .flatten()
+            .min_by_key(|arrival| arrival.arrival_ms)
+        else {
             continue;
-        }
+        };
 
         let candidate = Profile {
-            out_connection: connection_id,
+            leg: Leg {
+                enter_connection_id: connection_id,
+                exit_connection_id: arrival.exit_connection_id,
+            },
             departure_ms: connection.departure_ms,
-            arrival_ms,
+            arrival_ms: arrival.arrival_ms,
         };
 
         let stop_profiles = &mut profiles[connection.departure];
@@ -190,7 +219,8 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
                 stop_profiles.push(candidate);
             }
         }
-        trip_min_arrival_ms[connection.trip] = arrival_ms;
+
+        trip_arrivals[connection.trip] = Some(arrival);
     }
 
     let mut start_profiles: Vec<&Profile> = profiles[start]
@@ -205,65 +235,34 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<ConnectionId>> {
     // Explore the profile graph to create up to 3 journeys that a traveler can take to go from start to end.
     start_profiles
         .into_iter()
-        .filter_map(|profile| {
-            to_journey_list_rec(
-                &profiles,
-                &connections,
-                transfer_ms,
-                end,
-                vec![profile.out_connection],
-            )
-        })
+        .map(|profile| extract_journey(&profiles, &connections, transfer_ms, end, profile))
         .take(3)
         .collect()
 }
 
-/// Recursively extends `path`, connection by connection, into a complete journey to `end`.
-///
-/// `path` is the non-empty list of connection taken so far.
-/// At each stop, the profiles are explored starting with the one reaching `end` earliest.
-/// A candidate connection is discarded when the transfer time cannot be met or when it would make the path loop.
-/// Returns `None` if no journey extends `path`.
-fn to_journey_list_rec(
+/// Rebuilds the journey starting at `starting_profile`, leg by leg, until it reaches `end`.
+fn extract_journey(
     profiles: &[Vec<Profile>],
     connections: &[Connection],
     transfer_ms: u32,
     end: StopId,
-    path: Vec<ConnectionId>,
-) -> Option<Vec<ConnectionId>> {
-    let last_connection = connections[*path.last().unwrap()];
-    let start: StopId = last_connection.arrival;
+    starting_profile: &Profile,
+) -> Vec<Leg> {
+    let mut journey = Vec::new();
+    let mut stop_profile = starting_profile;
 
-    if start == end {
-        return Some(path);
-    }
+    loop {
+        journey.push(stop_profile.leg);
+        let exit_connection = connections[stop_profile.leg.exit_connection_id];
 
-    // Try profiles from the one reaching the target earliest (see profiles construction) and stop at the first solution found
-    profiles[start].iter().rev().find_map(|profile| {
-        let out_conn_id = profile.out_connection;
-
-        let out_conn = connections[out_conn_id];
-
-        let next_stop = out_conn.arrival;
-        // The traveler only needs `transfer_ms` when changing trains
-        let earliest_next_departure_ms = if out_conn.trip == last_connection.trip {
-            last_connection.arrival_ms
-        } else {
-            last_connection.arrival_ms + transfer_ms
-        };
-
-        if path
-            .iter()
-            .any(|connection_id| connections[*connection_id].departure == next_stop)
-            || start == next_stop
-            || out_conn.departure_ms < earliest_next_departure_ms
-        {
-            return None;
+        if exit_connection.arrival == end {
+            return journey;
         }
 
-        let mut new_path = path.clone();
-        new_path.push(out_conn_id);
+        let next = profiles[exit_connection.arrival]
+            .iter()
+            .rfind(|profile| profile.departure_ms >= exit_connection.arrival_ms + transfer_ms);
 
-        to_journey_list_rec(profiles, connections, transfer_ms, end, new_path)
-    })
+        stop_profile = next.expect("next existence is guaranteed by the scan");
+    }
 }

--- a/editoast/profile_connection_scan/src/lib.rs
+++ b/editoast/profile_connection_scan/src/lib.rs
@@ -159,9 +159,36 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Leg>> {
         return Vec::new();
     }
 
-    // stop index -> profiles
-    // profiles are ordered by decreasing departure_ms
-    // they are also ordered by decreasing arrival_ms since they all lie on the Pareto front
+    let profiles = scan_connections(stop_count, trip_count, &connections, end, transfer_ms);
+
+    let mut start_profiles: Vec<&Profile> = profiles[start]
+        .iter()
+        .filter(|profile| u32::abs_diff(profile.departure_ms, start_ms) <= start_tolerance)
+        .collect();
+
+    // TODO: In this first version we try the departures closest to the requested time first.
+    // We should use more specific criteria to select the best 3 journeys.
+    start_profiles.sort_unstable_by_key(|profile| u32::abs_diff(profile.departure_ms, start_ms));
+
+    // Explore the profile graph to create up to 3 journeys that a traveler can take to go from start to end.
+    start_profiles
+        .into_iter()
+        .map(|profile| extract_journey(&profiles, &connections, transfer_ms, end, profile))
+        .take(3)
+        .collect()
+}
+
+/// Scans every connection and returns the profiles of each stop, indexed by stop id.
+///
+/// Profiles are ordered by decreasing `departure_ms`.
+/// They are also ordered by decreasing `arrival_ms` since they all lie on the Pareto front.
+fn scan_connections(
+    stop_count: usize,
+    trip_count: usize,
+    connections: &[Connection],
+    end: StopId,
+    transfer_ms: u32,
+) -> Vec<Vec<Profile>> {
     let mut profiles: Vec<Vec<Profile>> = vec![Vec::new(); stop_count];
 
     // This maps trips to the best TripArrival found over the connections scanned so far
@@ -223,21 +250,7 @@ pub fn journey_list(p: JourneyListParams) -> Vec<Vec<Leg>> {
         trip_arrivals[connection.trip] = Some(arrival);
     }
 
-    let mut start_profiles: Vec<&Profile> = profiles[start]
-        .iter()
-        .filter(|profile| u32::abs_diff(profile.departure_ms, start_ms) <= start_tolerance)
-        .collect();
-
-    // TODO: In this first version we try the departures closest to the requested time first.
-    // We should use more specific criteria to select the best 3 journeys.
-    start_profiles.sort_unstable_by_key(|profile| u32::abs_diff(profile.departure_ms, start_ms));
-
-    // Explore the profile graph to create up to 3 journeys that a traveler can take to go from start to end.
-    start_profiles
-        .into_iter()
-        .map(|profile| extract_journey(&profiles, &connections, transfer_ms, end, profile))
-        .take(3)
-        .collect()
+    profiles
 }
 
 /// Rebuilds the journey starting at `starting_profile`, leg by leg, until it reaches `end`.

--- a/editoast/src/views/search_journeys.rs
+++ b/editoast/src/views/search_journeys.rs
@@ -368,24 +368,25 @@ pub(in crate::views) async fn search_journeys(
         journeys
             .into_iter()
             .map(|journey| {
-                let path_indexed_connections = journey
+                journey
                     .into_iter()
-                    .map(|connection_id| path_indexed_connections[connection_id]);
+                    .map(|leg| {
+                        let enter = path_indexed_connections[leg.enter_connection_id];
+                        let exit = path_indexed_connections[leg.exit_connection_id];
 
-                merge_connections(path_indexed_connections)
-                    .map(|path_indexed_connection| TrainSchedulePart {
-                        train_schedule_id: train_schedule_ids
-                            [path_indexed_connection.connection.trip],
-                        from: TrainSchedulePartBound {
-                            path_step_index: path_indexed_connection.departure_path_index,
-                            op_id: op_ids[path_indexed_connection.connection.departure].clone(),
-                            time_ms: path_indexed_connection.connection.departure_ms,
-                        },
-                        to: TrainSchedulePartBound {
-                            path_step_index: path_indexed_connection.arrival_path_index,
-                            op_id: op_ids[path_indexed_connection.connection.arrival].clone(),
-                            time_ms: path_indexed_connection.connection.arrival_ms,
-                        },
+                        TrainSchedulePart {
+                            train_schedule_id: train_schedule_ids[enter.connection.trip],
+                            from: TrainSchedulePartBound {
+                                path_step_index: enter.departure_path_index,
+                                op_id: op_ids[enter.connection.departure].clone(),
+                                time_ms: enter.connection.departure_ms,
+                            },
+                            to: TrainSchedulePartBound {
+                                path_step_index: exit.arrival_path_index,
+                                op_id: op_ids[exit.connection.arrival].clone(),
+                                time_ms: exit.connection.arrival_ms,
+                            },
+                        }
                     })
                     .collect()
             })
@@ -405,34 +406,4 @@ fn find_op_index(
 ) -> Option<usize> {
     let op_ref_id = op_cache.get_op_ref_id(op_ref)?;
     op_index_by_id.get(&op_ref_id).copied()
-}
-
-/// Merge connections of a same trip taken in a row into a single one.
-fn merge_connections<'a, I>(mut iter: I) -> impl Iterator<Item = PathIndexedConnection> + 'a
-where
-    I: Iterator<Item = PathIndexedConnection> + 'a,
-{
-    let mut prev_connection: Option<PathIndexedConnection> = None;
-
-    std::iter::from_fn(move || {
-        loop {
-            let next_connection = match iter.next() {
-                Some(conn) => conn,
-                None => return prev_connection.take(),
-            };
-
-            match &mut prev_connection {
-                Some(prev_conn) => {
-                    if prev_conn.connection.trip == next_connection.connection.trip {
-                        prev_conn.connection.arrival = next_connection.connection.arrival;
-                        prev_conn.connection.arrival_ms = next_connection.connection.arrival_ms;
-                        prev_conn.arrival_path_index = next_connection.arrival_path_index;
-                    } else {
-                        return prev_connection.replace(next_connection);
-                    }
-                }
-                None => prev_connection = Some(next_connection),
-            }
-        }
-    })
 }


### PR DESCRIPTION
Aligns the profile CSA implementation with the paper it is ported from [Connection Scan Algorithm](https://arxiv.org/pdf/1703.05997), §4 and replaces the three arbitrary journeys returned with three meaningful ones.

Please review commit by commit.

1. Accept transfers with exactly `transfer_ms`
2. Simplify profile insertion: remove unused pivot and drain block, connections being scanned by decreasing departure. Make the trip arrival update unconditional, like in the paper (§4.2)
3. Name each case of the profile scan explicitly: walking to the target, remaining seated, transferring (§4.2)
4. Use journey pointers to extract journeys: profiles carry the leg they start, so rebuilding follows what the scan decided instead of searching for it again (§4.6.1) and we don't need to merge connection afterward anymore
5. Extract profile scan into a helper: prepares the introduction of a second scan in the last commit
6. Add a secondary criterion on leg count: takes the leg count (§4.5) as a secondary criterion for Pareto front, preparing the introduction of the second scan specifically on leg count in the last commit
7. Filter out connections from start departing out of start window: filtering the start profiles after the scan was too late because a profile departing after the window could dominate the valid ones
8. Select the best journeys according to 3 criteria: the closest departure to the requested `start_ms`, the fastest, and the fewest legs whatever the duration. The first two are searched on the earliest arrival Pareto front but the last needs its own front because a simpler journey arriving a few seconds later would otherwise be dominated. It also means that the closest departure is only the closest among the dominant profiles (but not necessarily the absolute closest departure)

Test will be added once the endpoint behaviour is settled.
