### PR TITLE
front: include can_backtrack to stdcm pathfinding calls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,6 @@ services:
       S3_SECRET_ACCESS_KEY: secret_key
       S3_ENDPOINT_URL: http://s3:9900
       S3_BUCKET_NAME: osrd
-      ENABLE_BACKTRACK: ${ENABLE_BACKTRACK-false}
     command: >
       /bin/sh -c "
         fga_migrations apply &&

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -431,11 +431,7 @@ fn build_pathfinding_request(
             .enumerate()
             .map(|(index, offsets)| core_client::pathfinding::PathItem {
                 locations: offsets,
-                can_backtrack: pathfinding_input
-                    .path_items
-                    .get(index)
-                    .map(|item| item.can_backtrack)
-                    .unwrap_or(false),
+                can_backtrack: pathfinding_input.path_items[index].can_backtrack,
             })
             .collect(),
         rolling_stock_loading_gauge: pathfinding_input.rolling_stock_loading_gauge,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -479,10 +479,6 @@ impl VirtualTrainRun {
         infra: &Infra,
         consists_parameters: &[PhysicsConsistParameters],
     ) -> Result<Vec<Self>> {
-        // TODO : Remove this env var when the backtracking feature is done
-        let enable_backtrack =
-            std::env::var("ENABLE_BACKTRACK").unwrap_or_else(|_| "false".to_string()) == "true";
-
         // Doesn't matter for now, but eventually it will affect tmp speed limits
         let approx_start_time = stdcm_request.get_earliest_step_time();
         let train_schedules_with_consists = itertools::chain!(
@@ -517,11 +513,7 @@ impl VirtualTrainRun {
                                 .unwrap()
                         }),
                         reception_signal: ReceptionSignal::Stop,
-                        can_backtrack: if enable_backtrack {
-                            stdcm_step.duration.is_some()
-                        } else {
-                            false
-                        },
+                        can_backtrack: stdcm_step.pathfinding_item.can_backtrack,
                         ..Default::default()
                     })
                     .collect::<Vec<ScheduleItem>>(),

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -268,10 +268,6 @@ impl Request {
                 _ => panic!("Unexpected pathfinding result"),
             })?;
 
-        // TODO : Remove this env var when the backtracking feature is done
-        let enable_backtrack =
-            std::env::var("ENABLE_BACKTRACK").unwrap_or_else(|_| "false".to_string()) == "true";
-
         Ok(track_offsets
             .iter()
             .zip(&self.steps)
@@ -280,11 +276,7 @@ impl Request {
                     stop_duration: path_item.duration,
                     path_item: core_client::pathfinding::PathItem {
                         locations: track_offset.clone(),
-                        can_backtrack: if enable_backtrack {
-                            path_item.duration.is_some()
-                        } else {
-                            false
-                        },
+                        can_backtrack: path_item.pathfinding_item.can_backtrack,
                     },
                     step_timing_data: path_item.timing_data.as_ref().map(|timing_data| {
                         core_client::stdcm::StepTimingData {

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -674,7 +674,8 @@
     "featureFlags": {
       "hourlyTimetables": "Enable hourly timetables",
       "linkings": "Enable linkings",
-      "projectGrants": "Enable project grants management"
+      "projectGrants": "Enable project grants management",
+      "stdcmBacktrack": "Enable STDCM backtracking"
     },
     "help": "Help",
     "impersonation": "Impersonate user",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -674,7 +674,8 @@
     "featureFlags": {
       "hourlyTimetables": "Activer les trames 2h",
       "linkings": "Activer les enchaînements",
-      "projectGrants": "Activer la gestion des permissions projets"
+      "projectGrants": "Activer la gestion des permissions projets",
+      "stdcmBacktrack": "Activer le rebroussement STDCM"
     },
     "help": "Aide",
     "impersonation": "Se faire passer pour un utilisateur",

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -4,7 +4,7 @@ import { compact, isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import { stdcmPathStepToPathItemLocation } from 'applications/stdcm/utils';
+import { canPathStepBacktrack, stdcmPathStepToPathItemLocation } from 'applications/stdcm/utils';
 import {
   osrdEditoastApi,
   type PathfindingResult,
@@ -18,6 +18,7 @@ import {
   getTrackSectionIdsByLoadingGauge,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
+import { getFeatureFlag } from 'reducers/user/userSelectors';
 
 import {
   getConsistChanges,
@@ -29,16 +30,29 @@ import useStdcmLightRollingStock from './useStdcmLightRollingStock';
 /**
  * Compute the path items locations from the path steps
  */
-function pathStepsToLocations(
-  pathSteps: StdcmPathStep[]
-): Array<NonNullable<StdcmPathStep['operationalPoint']>> {
-  return compact(pathSteps.map((s) => s.operationalPoint));
+function pathStepsToLocations(pathSteps: StdcmPathStep[]): Array<
+  NonNullable<StdcmPathStep['operationalPoint']> & {
+    canBacktrack: boolean;
+  }
+> {
+  return compact(
+    pathSteps.map((step) => {
+      if (!step.operationalPoint) {
+        return null;
+      }
+      return {
+        ...step.operationalPoint,
+        canBacktrack: canPathStepBacktrack(step),
+      };
+    })
+  );
 }
 
 const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefined) => {
   const pathSteps = useSelector(getStdcmPathSteps);
   const [pathStepsLocations, setPathStepsLocations] = useState(pathStepsToLocations(pathSteps));
 
+  const backtrackEnabled = useSelector(getFeatureFlag('stdcmBacktrack'));
   const speedLimitByTag = useSelector(getStdcmSpeedLimitByTag);
   const rollingStock = useStdcmLightRollingStock();
   const loadingGauge = useSelector(getLoadingGauge);
@@ -87,9 +101,10 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
         return;
       }
 
-      const stdcmPathSteps = pathStepsLocations.map((step) =>
-        stdcmPathStepToPathItemLocation(step)
-      );
+      const stdcmPathSteps = pathStepsLocations.map((step) => ({
+        location: stdcmPathStepToPathItemLocation(step),
+        can_backtrack: backtrackEnabled && step.canBacktrack,
+      }));
 
       const pathSegmentsIndexes = getPathSegmentsIndexes(consistChanges, pathStepsLocations.length);
 
@@ -123,6 +138,7 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
     launchPathfinding();
   }, [
     pathStepsLocations,
+    backtrackEnabled,
     rollingStock,
     speedLimitByTag,
     loadingGauge,

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -28,6 +28,7 @@ import { setFailure } from 'reducers/main';
 import { addStdcmSimulations } from 'reducers/osrdconf/stdcmConf';
 import { getStdcmConf, getStdcmInfraID } from 'reducers/osrdconf/stdcmConf/selectors';
 import { updateSelectedTrain } from 'reducers/simulationResults';
+import { getFeatureFlag } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
 import { useDateTimeLocale } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
@@ -53,6 +54,7 @@ const useStdcm = ({
   const dateTimeLocale = useDateTimeLocale();
   const osrdconf = useSelector(getStdcmConf);
   const infraId = useSelector(getStdcmInfraID);
+  const backtrackEnabled = useSelector(getFeatureFlag('stdcmBacktrack'));
   const abortRequests = useRef<Array<() => void>>(null);
   const isCancelledRef = useRef(false);
   const progressPoints = useRef<StdcmProgressPoints>([]);
@@ -247,7 +249,7 @@ const useStdcm = ({
     isCancelledRef.current = false;
     progressPoints.current = [];
 
-    const validConfig = checkStdcmConf(dispatch, t, dateTimeLocale, osrdconf);
+    const validConfig = checkStdcmConf(dispatch, t, dateTimeLocale, osrdconf, backtrackEnabled);
     if (!validConfig) return;
 
     setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.pending);

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -12,7 +12,7 @@ import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/ty
 import type { Duration } from 'utils/duration';
 import { kmhToMs, tToKg } from 'utils/physics';
 
-import { stdcmPathStepToPathItemLocation } from '.';
+import { canPathStepBacktrack, stdcmPathStepToPathItemLocation } from '.';
 import { StdcmStopTypes } from '../types';
 import createMargin from './createMargin';
 
@@ -34,7 +34,8 @@ export const checkStdcmConf = (
   dispatch: Dispatch,
   t: TFunction,
   dateTimeLocale: Intl.Locale,
-  osrdconf: OsrdStdcmConfState
+  osrdconf: OsrdStdcmConfState,
+  backtrackEnabled: boolean
 ): ValidStdcmConfig | null => {
   const {
     stdcmPathSteps: pathSteps,
@@ -181,7 +182,10 @@ export const checkStdcmConf = (
 
     return {
       duration,
-      pathfinding_item: { location: formattedLocation, can_backtrack: false },
+      pathfinding_item: {
+        location: formattedLocation,
+        can_backtrack: backtrackEnabled && canPathStepBacktrack(step),
+      },
       timing_data: timingData,
     };
   });

--- a/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
+++ b/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
@@ -2,8 +2,8 @@ import type {
   LightRollingStock,
   LoadingGaugeType,
   osrdEditoastApi,
+  PathfindingItem,
   PathfindingResult,
-  PathItemLocation,
 } from 'common/api/osrdEditoastApi';
 import { getPathfindingQuery } from 'modules/pathfinding/utils';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
@@ -32,7 +32,7 @@ type getSegmentConstraintsOptions = {
 
 type LaunchSegmentedPathfindingOptions = {
   pathSegmentsIndexes: number[];
-  stdcmPathSteps: PathItemLocation[];
+  stdcmPathSteps: PathfindingItem[];
   consistChanges: ConsistChange[];
   getLightRollingStockById: GetLightRollingStockById;
   postPathfindingBlocks: PostPathfindingBlocks;

--- a/front/src/applications/stdcm/utils/index.ts
+++ b/front/src/applications/stdcm/utils/index.ts
@@ -2,6 +2,8 @@ import type { PathItemLocation, PostSimilarTrainsApiResponse } from 'common/api/
 import { type MarkerInformation, MARKER_TYPE } from 'common/Map/components/ItineraryMarkers';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 
+import { StdcmStopTypes } from '../types';
+
 export const getTimesInfoFromDate = (date?: Date | null) =>
   date
     ? {
@@ -118,3 +120,8 @@ export const stdcmPathStepToPathItemLocation = (
     },
   };
 };
+
+export const canPathStepBacktrack = (pathStep: StdcmPathStep): boolean =>
+  pathStep.isVia &&
+  (pathStep.stopType === StdcmStopTypes.SERVICE_STOP ||
+    pathStep.stopType === StdcmStopTypes.DRIVER_SWITCH);

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -279,7 +279,9 @@ const usePathfinding = ({
       const pathfindingInput = getPathfindingQuery({
         infraId,
         rollingStock,
-        pathSteps: steps.filter((step) => !step.isInvalid).map((step) => step?.location),
+        pathSteps: steps
+          .filter((step) => !step.isInvalid)
+          .map((step) => ({ location: step.location, can_backtrack: false })),
         speedLimitByTag:
           options.speedLimitTag !== undefined ? options.speedLimitTag : speedLimitByTag,
       });

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -8,6 +8,7 @@ import type {
   PathItemLocation,
   PathProperties,
   PathfindingInput,
+  PathfindingItem,
   PostInfraByInfraIdPathfindingBlocksApiArg,
 } from 'common/api/osrdEditoastApi';
 import { getSupportedElectrification, isThermal } from 'modules/rollingStock/helpers/electric';
@@ -83,7 +84,7 @@ export const getPathfindingQuery = ({
     LightRollingStock,
     'effort_curves' | 'loading_gauge' | 'max_speed' | 'length' | 'supported_signaling_systems'
   >;
-  pathSteps: (PathItemLocation | null)[];
+  pathSteps: (PathfindingItem | null)[];
   loadingGauge?: LoadingGaugeType;
   speedLimitByTag?: string | null;
   allowedTrackSections?: string[];
@@ -92,10 +93,7 @@ export const getPathfindingQuery = ({
   const destination = pathSteps.at(-1);
   if (infraId && rollingStock && origin && destination) {
     // Only origin and destination can be null so we can compact and we want to remove any via that would be null
-    const pathItems: PathfindingInput['path_items'] = compact(pathSteps).map((location) => ({
-      location,
-      can_backtrack: false,
-    }));
+    const pathItems: PathfindingInput['path_items'] = compact(pathSteps);
 
     return {
       infraId,

--- a/front/src/reducers/user/index.ts
+++ b/front/src/reducers/user/index.ts
@@ -3,7 +3,12 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { ApiError } from 'common/api/baseGeneratedApis';
 import type { Role } from 'common/api/osrdEditoastApi';
 
-export const FEATURE_FLAGS = ['linkings', 'hourlyTimetables', 'projectGrants'] as const;
+export const FEATURE_FLAGS = [
+  'linkings',
+  'hourlyTimetables',
+  'projectGrants',
+  'stdcmBacktrack',
+] as const;
 export type FeatureFlag = (typeof FEATURE_FLAGS)[number];
 
 export type UserPreferences = Record<FeatureFlag, boolean> & {
@@ -14,6 +19,7 @@ const defaultFeatureFlags: Record<FeatureFlag, boolean> = {
   linkings: false,
   hourlyTimetables: false,
   projectGrants: false,
+  stdcmBacktrack: false,
 };
 
 export type UserState = {


### PR DESCRIPTION
closes #18028 
closes #18029

only [front: add backtrack feature flag, forward can_backtrack to stdcm calls](https://github.com/OpenRailAssociation/osrd/pull/18114/changes/758a1f3262fb4a88804c92b773b80fb35b971b6e) and this [editoast: forward can_backtrack from front to editoast](https://github.com/OpenRailAssociation/osrd/pull/18114/changes/00cfef3a0d2ee737b0b9bd33199ddf897e0ff3c0)

this PR will be rebased once [this PR ](https://github.com/OpenRailAssociation/osrd/pull/18107)will be merged

To test the backtracking you should `Enable STDCM Backtracking` flag in the users settings
You can test the backtracking in LMR with this example :
St-Louis-les-Aygalades -> Miramas -> Fos
With the via being a stop (service stop or driver switch)