### PR TITLE
editoast: openapi: add default values where applicable

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -16608,25 +16608,43 @@ components:
             oneOf:
             - type: 'null'
             - $ref: '#/components/schemas/TrainCategory'
+            default: null
           comfort:
-            $ref: '#/components/schemas/Comfort'
+            oneOf:
+            - $ref: '#/components/schemas/Comfort'
+            default: STANDARD
           constraint_distribution:
-            $ref: '#/components/schemas/Distribution'
+            oneOf:
+            - $ref: '#/components/schemas/Distribution'
+            default: STANDARD
           initial_speed:
             type: number
             format: double
+            default: 0.0
           labels:
             type: array
             items:
               type: string
+            default: []
           margins:
-            $ref: '#/components/schemas/Margins'
+            oneOf:
+            - $ref: '#/components/schemas/Margins'
+            default:
+              boundaries: []
+              values:
+              - 0%
           options:
-            $ref: '#/components/schemas/TrainScheduleOptions'
+            oneOf:
+            - $ref: '#/components/schemas/TrainScheduleOptions'
+            default:
+              stops_at_end_of_block: false
+              use_electrical_profiles: true
+              use_speed_limits_for_simulation: true
           path:
             type: array
             items:
               $ref: '#/components/schemas/PathItem'
+            default: []
           power_restrictions:
             type: array
             items:
@@ -16645,24 +16663,30 @@ components:
                 value:
                   type: string
               additionalProperties: false
+            default: []
           rolling_stock_name:
             type: string
+            default: ''
           schedule:
             type: array
             items:
               $ref: '#/components/schemas/ScheduleItem'
+            default: []
           speed_limit_tag:
             oneOf:
             - type: 'null'
             - $ref: '#/components/schemas/NonBlankString'
+            default: null
           start_time:
             type: integer
             format: int64
             description: |-
               For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.
               For hourly timetables: elapsed ms since the timetable start.
+            default: 0
           train_name:
             type: string
+            default: ''
       - type: object
         properties:
           paced:

--- a/editoast/schemas/src/train_schedule.rs
+++ b/editoast/schemas/src/train_schedule.rs
@@ -51,6 +51,7 @@ use crate::rolling_stock::TrainCategory;
 
 #[serde_as]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(default)]
 #[serde(remote = "Self")]
 pub struct TrainOccurrence {
     pub train_name: String,
@@ -62,6 +63,7 @@ pub struct TrainOccurrence {
     /// For hourly timetables: elapsed ms since the timetable start.
     #[serde(with = "common::units::millisecond::i64")]
     #[schema(value_type = i64)]
+    #[schema(default = 0)]
     pub start_time: Offset,
     pub path: Vec<PathItem>,
     #[serde(default)]

--- a/osrd_schemas/generate-types.sh
+++ b/osrd_schemas/generate-types.sh
@@ -17,6 +17,7 @@ uv run datamodel-codegen \
     --collapse-root-models \
     --output-model-type pydantic_v2.BaseModel \
     --use-default \
+    --strict-nullable \
     --set-default-enum-member \
     --enum-field-as-literal one \
     --use-annotated \

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -3897,7 +3897,7 @@ class StdcmResponseInternalError(BaseModel):
 
 
 class StdcmSearchEnvironment(BaseModel):
-    allowed_tracks: dict[str, list[str]] | None
+    allowed_tracks: dict[str, list[str]]
     """
     Map of a key (ex. loading gauge) with their allowed track section ids.
     """
@@ -3951,7 +3951,7 @@ class StdcmSearchEnvironmentCreateForm(BaseModel):
 
 
 class StdcmSearchEnvironmentResponse(BaseModel):
-    allowed_tracks: dict[str, list[str]] | None
+    allowed_tracks: dict[str, list[str]]
     """
     Map of a gauge with their authorized track section ids.
     None means no zones restrictions.
@@ -4117,7 +4117,7 @@ class TowedRollingStockForm(BaseModel):
     Velocity in m·s⁻¹
     """
     name: str
-    railjson_version: str | None = "3.4"
+    railjson_version: str = "3.4"
     rolling_resistance: RollingResistancePerWeight
     startup_acceleration: float
     """
@@ -6612,7 +6612,7 @@ class RollingStockForm(BaseModel):
     Mapping of power restriction code to power class
     """
     primary_category: TrainMainCategory
-    railjson_version: str | None = "3.4"
+    railjson_version: str = "3.4"
     raise_pantograph_time: Annotated[float | None, Field(examples=[15.0])] = None
     """
      The time it takes to raise this train's pantograph in seconds.
@@ -7347,25 +7347,25 @@ class Paced(BaseModel):
 
 class TrainSchedule(BaseModel):
     category: TrainCategoryMain | TrainCategorySub | None = None
-    comfort: Comfort | None = Comfort.STANDARD
+    comfort: Comfort = Comfort.STANDARD
     constraint_distribution: Distribution = Distribution.STANDARD
-    initial_speed: float | None = 0.0
-    labels: list[str] | None = []
-    margins: Annotated[Margins | None, Field(validate_default=True)] = {
+    initial_speed: float = 0.0
+    labels: list[str] = []
+    margins: Annotated[Margins, Field(validate_default=True)] = {
         "boundaries": [],
         "values": ["0%"],
     }
-    options: Annotated[TrainScheduleOptions | None, Field(validate_default=True)] = {
+    options: Annotated[TrainScheduleOptions, Field(validate_default=True)] = {
         "stops_at_end_of_block": False,
         "use_electrical_profiles": True,
         "use_speed_limits_for_simulation": True,
     }
     path: Annotated[list[PathItem], Field(validate_default=True)] = []
     power_restrictions: Annotated[
-        list[PowerRestriction] | None, Field(validate_default=True)
+        list[PowerRestriction], Field(validate_default=True)
     ] = []
     rolling_stock_name: str = ""
-    schedule: Annotated[list[ScheduleItem] | None, Field(validate_default=True)] = []
+    schedule: Annotated[list[ScheduleItem], Field(validate_default=True)] = []
     speed_limit_tag: NonBlankString | None = None
     start_time: OffsetInMs = 0
     """

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -7347,23 +7347,32 @@ class Paced(BaseModel):
 
 class TrainSchedule(BaseModel):
     category: TrainCategoryMain | TrainCategorySub | None = None
-    comfort: Comfort | None = None
-    constraint_distribution: Distribution
-    initial_speed: float | None = None
-    labels: list[str] | None = None
-    margins: Margins | None = None
-    options: TrainScheduleOptions | None = None
-    path: list[PathItem]
-    power_restrictions: list[PowerRestriction] | None = None
-    rolling_stock_name: str
-    schedule: list[ScheduleItem] | None = None
+    comfort: Comfort | None = Comfort.STANDARD
+    constraint_distribution: Distribution = Distribution.STANDARD
+    initial_speed: float | None = 0.0
+    labels: list[str] | None = []
+    margins: Annotated[Margins | None, Field(validate_default=True)] = {
+        "boundaries": [],
+        "values": ["0%"],
+    }
+    options: Annotated[TrainScheduleOptions | None, Field(validate_default=True)] = {
+        "stops_at_end_of_block": False,
+        "use_electrical_profiles": True,
+        "use_speed_limits_for_simulation": True,
+    }
+    path: Annotated[list[PathItem], Field(validate_default=True)] = []
+    power_restrictions: Annotated[
+        list[PowerRestriction] | None, Field(validate_default=True)
+    ] = []
+    rolling_stock_name: str = ""
+    schedule: Annotated[list[ScheduleItem] | None, Field(validate_default=True)] = []
     speed_limit_tag: NonBlankString | None = None
-    start_time: OffsetInMs
+    start_time: OffsetInMs = 0
     """
     For calendar timetables: elapsed ms since 1970-01-01T00:00:00Z.
     For hourly timetables: elapsed ms since the timetable start.
     """
-    train_name: str
+    train_name: str = ""
     paced: Paced | None = None
 
 

--- a/osrd_schemas/pyproject.toml
+++ b/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.2.0"
+version = "0.2.1"
 description = "Auto-generated OSRD pydantic schemas (editoast + railway manager interface openapi)"
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/osrd_schemas/pyproject.toml
+++ b/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.2.1"
+version = "0.3.0"
 description = "Auto-generated OSRD pydantic schemas (editoast + railway manager interface openapi)"
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/osrd_schemas/uv.lock
+++ b/osrd_schemas/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },

--- a/osrd_schemas/uv.lock
+++ b/osrd_schemas/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "osrd-schemas"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
Current issues with this PR:

* For some reason, `--strict-nullable` makes `dict` fields non `None` even though they don't have a default
* `datamodel-codegen` uses a formalism supported by `pydantic: [`validate_default=True`](https://pydantic.dev/docs/validation/latest/concepts/fields/#validate-default-values), which puts dict literals as defaults
  * `ty` doesn't like it since it detects a mismatch bewteen the field type (a `BaseModel`) and the default value (a `dict`)
  * I don't like it either because even though it works, it looks broken. Especially the mutability of the default value (but again, [it works](https://pydantic.dev/docs/validation/latest/concepts/fields/#mutable-default-values))