### PR TITLE
front: drop timeToMsSinceMidnight()

### DIFF
--- a/front/src/applications/searchJourney/hooks/useSearchJourney.ts
+++ b/front/src/applications/searchJourney/hooks/useSearchJourney.ts
@@ -10,7 +10,7 @@ import {
   getSearchJourneyStartTime,
   getSearchJourneyTimetableIds,
 } from 'reducers/searchJourney/selectors';
-import { timeToMsSinceMidnight } from 'utils/date';
+import { Duration } from 'utils/duration';
 
 export const SEARCH_JOURNEY_REQUEST_STATUS = Object.freeze({
   idle: 'IDLE',
@@ -70,7 +70,7 @@ export default function useSearchJourney() {
             secondary_code: destination.secondaryCode,
           },
         },
-        start_ms: timeToMsSinceMidnight(startTime),
+        start_ms: new Duration(startTime).ms,
         start_tolerance: START_TOLERANCE_MS,
         transfer_ms: TRANSFER_MS,
       },

--- a/front/src/utils/__tests__/date.spec.ts
+++ b/front/src/utils/__tests__/date.spec.ts
@@ -5,7 +5,6 @@ import {
   isArrivalDateInSearchTimeWindow,
   timeToLocaleString,
   timeToLocaleStringRounded,
-  timeToMsSinceMidnight,
 } from 'utils/date';
 import { Duration } from 'utils/duration';
 
@@ -114,17 +113,5 @@ describe('timeToLocaleStringRounded', () => {
     expect(timeToLocaleStringRounded(new Duration({ hours: 25, minutes: 7 }), locale)).toEqual(
       '25:07'
     );
-  });
-});
-
-describe('timeToMsSinceMidnight', () => {
-  it('should convert hours and minutes to milliseconds since midnight', () => {
-    const result = timeToMsSinceMidnight({ hours: 8, minutes: 30 });
-    expect(result).toBe((8 * 60 + 30) * 60 * 1000);
-  });
-
-  it('should return 0 for midnight', () => {
-    const result = timeToMsSinceMidnight({ hours: 0, minutes: 0 });
-    expect(result).toBe(0);
   });
 });

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -58,21 +58,6 @@ export const timeToLocaleString = (time: StartTime, locale: Intl.Locale): string
   time instanceof Duration ? durationToElapsedString(time, true) : time.toLocaleTimeString(locale);
 
 /**
- * Converts a time-of-day (hours/minutes, no date) into the equivalent offset in
- * milliseconds since midnight.
- * @param hours - The hour (0-23).
- * @param minutes - The minute (0-59).
- * @returns The equivalent time in milliseconds since midnight.
- */
-export const timeToMsSinceMidnight = ({
-  hours,
-  minutes,
-}: {
-  hours: number;
-  minutes: number;
-}): number => (hours * 60 + minutes) * 60 * 1000;
-
-/**
  * Format a start time to a string rounded to the nearest minute: a locale-aware clock
  * time for a Date (calendar timetable), or an "H:mm" elapsed time for a Duration
  * (offset from the start of an hourly timetable, which has no locale/calendar meaning).


### PR DESCRIPTION
The existing Duration class already provides this functionality. No need to introduce a separate function.