### PR TITLE
front: show error when interval >= time window in TrainServiceForm

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -381,10 +381,12 @@
       "noTrainStep": "The increment step of the train must be greater than zero",
       "originTimeOutsideWindow": "Departure date must be between {{low}} and {{high}}",
       "pacedTrainInterval": {
+        "intervalOutsideWindow": "Cadence must be lower than repeat window",
         "tooHigh": "The cadence of the service must not be too high",
         "tooLow": "The cadence of the service has to be at least one minute"
       },
       "pacedTrainTimeWindow": {
+        "intervalOutsideWindow": "Repeat window must be greater than cadence",
         "tooHigh": "The duration of the repetition time range must not be too high",
         "tooLow": "The duration of the repetition time range has to be at least one minute"
       },

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -364,8 +364,6 @@
     "errorMessages": {
       "error": "An error has occurred",
       "hardErrorInfra": "The infrastructure contains errors and cannot be used without first being corrected.",
-      "intervalTooHigh": "The cadence of the service must not be too high",
-      "intervalTooLow": "The cadence of the service has to be at least one minute",
       "invalidInitialSpeed": "The initial speed must be rounded to the nearest tenth",
       "mandatoryField": "Required field",
       "nameLengthLimit": "The name must not exceed 128 characters",
@@ -382,9 +380,15 @@
       "noTrainCount": "The quantity of requested trains must be greater than zero",
       "noTrainStep": "The increment step of the train must be greater than zero",
       "originTimeOutsideWindow": "Departure date must be between {{low}} and {{high}}",
+      "pacedTrainInterval": {
+        "tooHigh": "The cadence of the service must not be too high",
+        "tooLow": "The cadence of the service has to be at least one minute"
+      },
+      "pacedTrainTimeWindow": {
+        "tooHigh": "The duration of the repetition time range must not be too high",
+        "tooLow": "The duration of the repetition time range has to be at least one minute"
+      },
       "requiredField": "Required field.",
-      "timeWindowTooHigh": "The duration of the repetition time range must not be too high",
-      "timeWindowTooLow": "The duration of the repetition time range has to be at least one minute",
       "tooHighInput": "Must be < 43800",
       "tooLowInput": "Must be > 0",
       "trainScheduleTitle": "An error has occurred",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -364,8 +364,6 @@
     "errorMessages": {
       "error": "Une erreur est survenue",
       "hardErrorInfra": "L'infrastructure comporte des erreurs et ne peut être utilisée sans être corrigée au préalable.",
-      "intervalTooHigh": "La cadence de la mission ne doit pas être trop grande",
-      "intervalTooLow": "La cadence de la mission doit être supérieure d'au moins une minute",
       "invalidInitialSpeed": "La vitesse initiale doit être arrondie au dixième",
       "mandatoryField": "Champ obligatoire",
       "nameLengthLimit": "Le nom ne doit pas dépasser 128 caractères",
@@ -382,9 +380,15 @@
       "noTrainCount": "La quantité de trains demandée doit être supérieure à zéro",
       "noTrainStep": "Le pas d'incrément du nom du train doit être supérieur à zéro",
       "originTimeOutsideWindow": "La date de départ doit être comprise entre le {{low}} et le {{high}}",
+      "pacedTrainInterval": {
+        "tooHigh": "La cadence de la mission ne doit pas être trop grande",
+        "tooLow": "La cadence de la mission doit être supérieure d'au moins une minute"
+      },
+      "pacedTrainTimeWindow": {
+        "tooHigh": "La durée de la plage de répétition ne doit pas être trop grande",
+        "tooLow": "La durée de la plage de répétition doit être d'au moins une minute"
+      },
       "requiredField": "Champ obligatoire.",
-      "timeWindowTooHigh": "La durée de la plage de répétition ne doit pas être trop grande",
-      "timeWindowTooLow": "La durée de la plage de répétition doit être d'au moins une minute",
       "tooHighInput": "Doit être < 43800",
       "tooLowInput": "Doit être > 0",
       "trainScheduleTitle": "Une erreur est survenue",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -381,10 +381,12 @@
       "noTrainStep": "Le pas d'incrément du nom du train doit être supérieur à zéro",
       "originTimeOutsideWindow": "La date de départ doit être comprise entre le {{low}} et le {{high}}",
       "pacedTrainInterval": {
+        "intervalOutsideWindow": "La cadence de la mission doit être inférieure à la durée de la plage de répétition",
         "tooHigh": "La cadence de la mission ne doit pas être trop grande",
         "tooLow": "La cadence de la mission doit être supérieure d'au moins une minute"
       },
       "pacedTrainTimeWindow": {
+        "intervalOutsideWindow": "La durée de la plage de répétition doit être supérieure à la cadence de la mission",
         "tooHigh": "La durée de la plage de répétition ne doit pas être trop grande",
         "tooLow": "La durée de la plage de répétition doit être d'au moins une minute"
       },

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/validateTrainSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/validateTrainSchedule.ts
@@ -12,9 +12,9 @@ export type TrainScheduleConfErrorCode =
   | 'noRollingStock'
   | 'noName'
   | 'invalidInitialSpeed'
-  | 'intervalTooLow'
-  | 'timeWindowTooLow'
-  | 'timeWindowTooHigh';
+  | 'pacedTrainInterval.tooLow'
+  | 'pacedTrainTimeWindow.tooLow'
+  | 'pacedTrainTimeWindow.tooHigh';
 
 export function validateTrainSchedule(train: TrainSchedule): TrainScheduleConfErrorCode[] {
   const errors: TrainScheduleConfErrorCode[] = [];
@@ -41,13 +41,13 @@ export function validateTrainSchedule(train: TrainSchedule): TrainScheduleConfEr
     const timeWindowDuration = Duration.parse(train.paced.time_window);
 
     if (intervalDuration.total('minute') < 1) {
-      errors.push('intervalTooLow');
+      errors.push('pacedTrainInterval.tooLow');
     }
     if (timeWindowDuration.total('minute') < 1) {
-      errors.push('timeWindowTooLow');
+      errors.push('pacedTrainTimeWindow.tooLow');
     }
     if (timeWindowDuration.total('minute') >= MAX_TIMEWINDOW_MINUTES) {
-      errors.push('timeWindowTooHigh');
+      errors.push('pacedTrainTimeWindow.tooHigh');
     }
   }
 

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -131,6 +131,14 @@ function applyFieldsToPaced(fields: TrainFieldsState, train: Train): Train['pace
     };
   }
 
+  if (
+    fields.service_interval &&
+    fields.service_window &&
+    fields.service_interval > fields.service_window
+  ) {
+    return train.paced;
+  }
+
   return train.paced
     ? {
         exceptions: train.paced.exceptions,

--- a/front/src/modules/trainHeader/TrainServiceForm.tsx
+++ b/front/src/modules/trainHeader/TrainServiceForm.tsx
@@ -69,15 +69,25 @@ export default function TrainServiceForm({
   const extraOccurrences =
     train.paced?.exceptions?.filter((exp) => exp.occurrence_index === undefined) ?? [];
 
-  const serviceIntervalError = useMemo(
-    () => (isPacedTrain ? computeServiceTimingError(fields.service_interval) : null),
-    [isPacedTrain, fields.service_interval]
-  );
+  const intervalHasChanged = fields.service_interval !== fieldsFromTrain.service_interval;
+  const windowHasChanged = fields.service_window !== fieldsFromTrain.service_window;
 
-  const serviceWindowError = useMemo(
-    () => (isPacedTrain ? computeServiceTimingError(fields.service_window) : null),
-    [isPacedTrain, fields.service_window]
-  );
+  const intervalOutsideWindowError =
+    fields.service_interval &&
+    fields.service_window &&
+    fields.service_interval > fields.service_window
+      ? ('intervalOutsideWindow' as const)
+      : null;
+
+  const serviceIntervalError = useMemo(() => {
+    if (!isPacedTrain || !intervalHasChanged) return null;
+    return computeServiceTimingError(fields.service_interval) ?? intervalOutsideWindowError;
+  }, [isPacedTrain, fields.service_interval, intervalHasChanged, intervalOutsideWindowError]);
+
+  const serviceWindowError = useMemo(() => {
+    if (!isPacedTrain || !windowHasChanged) return null;
+    return computeServiceTimingError(fields.service_window) ?? intervalOutsideWindowError;
+  }, [isPacedTrain, fields.service_window, intervalHasChanged, intervalOutsideWindowError]);
 
   const erroneousFields = useMemo(
     () =>

--- a/front/src/modules/trainHeader/TrainServiceForm.tsx
+++ b/front/src/modules/trainHeader/TrainServiceForm.tsx
@@ -19,11 +19,11 @@ import ExtraOccurrenceForm from './ExtraOccurrenceForm';
 import ExtraOccurrenceRow from './ExtraOccurrenceRow';
 import { ServiceChangeWarningDialog } from './ServiceChangeWarningDialog';
 
-export type ServiceTimingError = 'TOO_LOW' | 'TOO_HIGH' | null;
+export type ServiceTimingError = 'tooLow' | 'tooHigh' | null;
 
 export function computeServiceTimingError(serviceTiming?: number): ServiceTimingError {
-  if (!serviceTiming) return 'TOO_LOW';
-  if (serviceTiming > MAX_DURATION_MS) return 'TOO_HIGH';
+  if (!serviceTiming) return 'tooLow';
+  if (serviceTiming > MAX_DURATION_MS) return 'tooHigh';
   return null;
 }
 
@@ -155,10 +155,9 @@ export default function TrainServiceForm({
                     serviceIntervalError
                       ? {
                           status: 'error',
-                          message:
-                            serviceIntervalError === 'TOO_HIGH'
-                              ? t('manageTrainSchedule.errorMessages.intervalTooHigh')
-                              : t('manageTrainSchedule.errorMessages.intervalTooLow'),
+                          message: t(
+                            `manageTrainSchedule.errorMessages.pacedTrainInterval.${serviceIntervalError}`
+                          ),
                         }
                       : undefined
                   }
@@ -178,10 +177,9 @@ export default function TrainServiceForm({
                     serviceWindowError
                       ? {
                           status: 'error',
-                          message:
-                            serviceWindowError === 'TOO_HIGH'
-                              ? t('manageTrainSchedule.errorMessages.timeWindowTooHigh')
-                              : t('manageTrainSchedule.errorMessages.timeWindowTooLow'),
+                          message: t(
+                            `manageTrainSchedule.errorMessages.pacedTrainTimeWindow.${serviceWindowError}`
+                          ),
                         }
                       : undefined
                   }


### PR DESCRIPTION
This PR deviates a bit from ACs. ACs specify that the interval/time window must be reset to their previous value on error. Instead, this PR retains the user-provided value for consistency with the existing form error mechanism, and to leave a chance to the user to fix their mistake.

References: https://github.com/OpenRailAssociation/osrd/issues/17626