### PR TITLE
editoast: replace PowerRestriction with PowerRestrictionItem

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -13204,6 +13204,7 @@ components:
       - PT2H
     PowerRestrictionItem:
       type: object
+      title: PowerRestrictionItem
       required:
       - from
       - to
@@ -16623,6 +16624,7 @@ components:
             type: array
             items:
               type: object
+              title: PowerRestrictionItem
               required:
               - from
               - to

--- a/editoast/schemas/src/train_schedule/power_restriction_item.rs
+++ b/editoast/schemas/src/train_schedule/power_restriction_item.rs
@@ -5,6 +5,7 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
+#[schema(title = "PowerRestrictionItem")]
 pub struct PowerRestrictionItem {
     #[schema(inline)]
     pub from: NonBlankString,

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -13,7 +13,7 @@ from typing_extensions import TypeAliasType
 from .overrides import OffsetInMs
 
 
-class PowerRestriction(BaseModel):
+class PowerRestrictionItem(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3208,15 +3208,6 @@ class PathfindingTrackLocationInput(BaseModel):
     )
     position: float
     track: Annotated[str, Field(max_length=255, min_length=1)]
-
-
-class PowerRestrictionItem(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    from_: Annotated[str, Field(alias="from", min_length=1)]
-    to: Annotated[str, Field(min_length=1)]
-    value: str
 
 
 class TrackSectionRange(BaseModel):
@@ -7352,7 +7343,7 @@ class TrainSchedule(BaseModel):
     margins: Margins | None = None
     options: TrainScheduleOptions | None = None
     path: list[PathItem]
-    power_restrictions: list[PowerRestriction] | None = None
+    power_restrictions: list[PowerRestrictionItem] | None = None
     rolling_stock_name: str
     schedule: list[ScheduleItem] | None = None
     speed_limit_tag: NonBlankString | None = None


### PR DESCRIPTION
Currently, utoipa generates a new `PowerRestriction` class for `TrainSchedule.power_restrictions`, which is a duplicate of `PowerRestrictionItem`. This PR removes the duplicate class.