### PR TITLE
front: upgrade maplibre-gl to v6

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -73,7 +73,7 @@
         "js-file-download": "^0.4.12",
         "json-schema": "^0.4.0",
         "lodash": "^4.18.1",
-        "maplibre-gl": "^5.24.0",
+        "maplibre-gl": "^6.7.0",
         "party-js": "^2.2.0",
         "pmtiles": "^4.5.0",
         "rc-slider": "^11.1.9",
@@ -2910,9 +2910,12 @@
       "license": "MIT"
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -2922,9 +2925,9 @@
       "license": "ISC"
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
-      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
@@ -2932,30 +2935,23 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.1"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
+        "pbf": "^5.0.0"
       }
     },
     "node_modules/@maplibre/geojson-vt": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
-      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
       "license": "ISC",
       "dependencies": {
-        "kdbush": "^4.0.2"
+        "kdbush": "^4.1.0"
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
@@ -2978,34 +2974,24 @@
       }
     },
     "node_modules/@maplibre/mlt": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.8.tgz",
-      "integrity": "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.1.tgz",
+      "integrity": "sha512-5n5dgolE2EYxwCKgx8vlwURCB8A+kyfJJyThlYimjlGgOcOe2Bhw9VxxnnHC91OC9PgHg+nVdgVPTYPkIo62vg==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0"
       }
     },
     "node_modules/@maplibre/vt-pbf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
-      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@maplibre/geojson-vt": "^5.0.4",
         "@types/geojson": "^7946.0.16",
-        "@types/supercluster": "^7.1.3",
-        "pbf": "^4.0.1",
-        "supercluster": "^8.0.1"
+        "pbf": "^5.1.0"
       }
-    },
-    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
-      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
-      "license": "ISC"
     },
     "node_modules/@math.gl/web-mercator": {
       "version": "3.6.3",
@@ -7837,15 +7823,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/tether": {
       "version": "1.4.9",
       "license": "MIT"
@@ -10377,7 +10354,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "3.0.2",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
@@ -12604,9 +12583,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "license": "ISC"
     },
     "node_modules/keyv": {
@@ -13065,27 +13044,25 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
-      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.7.0.tgz",
+      "integrity": "sha512-Y1Q1+UP9WXou0DUrnaFdDsoMqiMCWy6aS968IBUaQ2eZi6H1/kPCfpfZOWXFJZbeKMkX9Wo6OFzY/k48qqPf3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.1.0",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/geojson-vt": "^6.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
-        "@maplibre/mlt": "^1.1.8",
-        "@maplibre/vt-pbf": "^4.3.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.4.1",
+        "@maplibre/mlt": "^1.2.0",
+        "@maplibre/vt-pbf": "^4.3.2",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.0.2",
+        "earcut": "^3.2.3",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.0.2",
+        "kdbush": "^4.1.0",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
+        "pbf": "^5.1.2",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -13098,18 +13075,23 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
+    "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/maplibre-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.8.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
-      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz",
+      "integrity": "sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "quickselect": "^3.0.0",
-        "rw": "^1.3.3",
         "tinyqueue": "^3.0.0"
       },
       "bin": {
@@ -14881,9 +14863,9 @@
       }
     },
     "node_modules/pbf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -18268,15 +18250,6 @@
       "version": "4.2.0",
       "license": "MIT"
     },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -20508,7 +20481,7 @@
         "classnames": "^2.5.1",
         "file-saver": "^2.0.5",
         "lodash": "^4.18.1",
-        "maplibre-gl": "^5.24.0",
+        "maplibre-gl": "^6.2.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-map-gl": "^8.1.2"
@@ -20916,7 +20889,7 @@
         "lodash": "^4.18.1"
       },
       "peerDependencies": {
-        "maplibre-gl": "^5.6.1",
+        "maplibre-gl": "^6.2.0",
         "react": "^18.0.0 || ^19.1.0",
         "react-dom": "^18.0.0 || ^19.1.0",
         "react-map-gl": "^8.0.4"

--- a/front/package.json
+++ b/front/package.json
@@ -73,7 +73,7 @@
     "js-file-download": "^0.4.12",
     "json-schema": "^0.4.0",
     "lodash": "^4.18.1",
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.7.0",
     "party-js": "^2.2.0",
     "pmtiles": "^4.5.0",
     "rc-slider": "^11.1.9",

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -3,8 +3,6 @@ import { useContext, useMemo, useState, type PropsWithChildren } from 'react';
 import type { Geometry } from 'geojson';
 import type { TFunction } from 'i18next';
 import { isEmpty, isNil } from 'lodash';
-import maplibregl from 'maplibre-gl';
-import { Protocol } from 'pmtiles';
 import { withTranslation } from 'react-i18next';
 import ReactMapGL, { AttributionControl, ScaleControl, type MapRef } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
@@ -49,9 +47,6 @@ type MapProps<S extends CommonToolState = CommonToolState> = {
   mapRef: React.RefObject<MapRef | null>;
   infraID: number | undefined;
 };
-
-const protocol = new Protocol();
-maplibregl.addProtocol('pmtiles', protocol.tile);
 
 const MapUnplugged = ({
   mapRef,

--- a/front/src/common/Map/init.ts
+++ b/front/src/common/Map/init.ts
@@ -1,5 +1,8 @@
-import maplibregl from 'maplibre-gl';
+import { addProtocol, setWorkerUrl } from 'maplibre-gl';
+import workerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url';
 import { Protocol } from 'pmtiles';
 
+setWorkerUrl(workerUrl);
+
 const protocol = new Protocol();
-maplibregl.addProtocol('pmtiles', protocol.tile);
+addProtocol('pmtiles', protocol.tile);

--- a/front/src/common/Map/init.ts
+++ b/front/src/common/Map/init.ts
@@ -1,0 +1,5 @@
+import maplibregl from 'maplibre-gl';
+import { Protocol } from 'pmtiles';
+
+const protocol = new Protocol();
+maplibregl.addProtocol('pmtiles', protocol.tile);

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -6,6 +6,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import 'styles/scss/vendor/bootstrap-sncf/site-intern.scss';
 
 import { Loader } from 'common/Loaders';
+import 'common/Map/init';
 import App from 'main/app';
 import { persistor, store } from 'store';
 

--- a/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
+++ b/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
@@ -98,7 +98,7 @@ const IncompatibleConstraints = ({
           layersId: ['pathfinding-incompatible-constraints'],
         });
         if (nearestResult?.feature && nearestResult?.feature.properties.ids) {
-          setHoveredConstraint(new Set(JSON.parse(nearestResult.feature.properties.ids)));
+          setHoveredConstraint(new Set(nearestResult.feature.properties.ids));
         } else {
           setHoveredConstraint(new Set([]));
         }
@@ -113,7 +113,7 @@ const IncompatibleConstraints = ({
         });
         if (nearestResult?.feature && nearestResult?.feature.properties.ids) {
           setSelectedConstraint((prev) => {
-            const nextSelected = JSON.parse(nearestResult.feature.properties.ids);
+            const nextSelected = nearestResult.feature.properties.ids;
             if (isArray(nextSelected)) {
               // if we click on the same selected value
               // => we clear the selection

--- a/front/ui/storybook/package.json
+++ b/front/ui/storybook/package.json
@@ -29,7 +29,7 @@
     "classnames": "^2.5.1",
     "file-saver": "^2.0.5",
     "lodash": "^4.18.1",
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.2.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-map-gl": "^8.1.2"

--- a/front/ui/storybook/stories/ui-charts/spaceTimeChart/config.ts
+++ b/front/ui/storybook/stories/ui-charts/spaceTimeChart/config.ts
@@ -1,4 +1,0 @@
-declare module '*.svg' {
-  const content: string;
-  export default content;
-}

--- a/front/ui/storybook/stories/ui-warped-map/Algorithms.tsx
+++ b/front/ui/storybook/stories/ui-warped-map/Algorithms.tsx
@@ -14,6 +14,7 @@ import { Layer, type LineLayerSpecification, Source } from 'react-map-gl/maplibr
 
 import { OSM_BASE_MAP_STYLE, OSM_SOURCE } from './helpers';
 import { useAsyncMemo } from './useAsyncMemo';
+import './init';
 
 const SOURCES: SourceDefinition[] = [OSM_SOURCE];
 

--- a/front/ui/storybook/stories/ui-warped-map/SampleMap.tsx
+++ b/front/ui/storybook/stories/ui-warped-map/SampleMap.tsx
@@ -5,10 +5,9 @@ import { featureCollection } from '@turf/helpers';
 import type { Feature, LineString } from 'geojson';
 import { Layer, type LineLayerSpecification, Source } from 'react-map-gl/maplibre';
 
-import 'maplibre-gl/dist/maplibre-gl.css';
-
 import { OSM_BASE_MAP_STYLE, OSM_SOURCE } from './helpers';
 import { useAsyncMemo } from './useAsyncMemo';
+import './init';
 
 const SOURCES: SourceDefinition[] = [OSM_SOURCE];
 

--- a/front/ui/storybook/stories/ui-warped-map/init.ts
+++ b/front/ui/storybook/stories/ui-warped-map/init.ts
@@ -1,0 +1,1 @@
+import 'maplibre-gl/dist/maplibre-gl.css';

--- a/front/ui/storybook/stories/ui-warped-map/init.ts
+++ b/front/ui/storybook/stories/ui-warped-map/init.ts
@@ -1,1 +1,6 @@
+import { setWorkerUrl } from 'maplibre-gl';
+import workerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url';
+
 import 'maplibre-gl/dist/maplibre-gl.css';
+
+setWorkerUrl(workerUrl);

--- a/front/ui/storybook/tsconfig.json
+++ b/front/ui/storybook/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "rootDir": "../",
     "outDir": "./dist",
-    "declarationDir": "./dist"
+    "declarationDir": "./dist",
+    "types": ["vite/client"]
   }
 }

--- a/front/ui/ui-warped-map/package.json
+++ b/front/ui/ui-warped-map/package.json
@@ -59,7 +59,7 @@
     "lodash": "^4.18.1"
   },
   "peerDependencies": {
-    "maplibre-gl": "^5.6.1",
+    "maplibre-gl": "^6.2.0",
     "react": "^18.0.0 || ^19.1.0",
     "react-dom": "^18.0.0 || ^19.1.0",
     "react-map-gl": "^8.0.4"


### PR DESCRIPTION
_See individual commits._

Migration guide:
https://github.com/maplibre/maplibre-gl-js/blob/HEAD/docs/guides/v5-to-v6-migration-guide.md

Vite setup guide:
https://github.com/maplibre/maplibre-gl-js/blob/1275d68a557f6c9f81a169707a2ce219bcc6dc90/docs/index.md#installation