### PR TITLE
editoast: filter readable train schedule in track occupancy

### DIFF
--- a/editoast/src/authorizers.rs
+++ b/editoast/src/authorizers.rs
@@ -11,7 +11,6 @@ use authz::v2::Check;
 use authz::v2::Protected;
 use futures::StreamExt as _;
 use futures::stream::FuturesUnordered;
-use models::prelude::RetrieveBatchUnchecked as _;
 use tracing::Instrument as _;
 
 /// An authorizer that represents editoast's authorization decisions
@@ -311,40 +310,6 @@ where
     } else {
         Err(AuthorizationError::Forbidden)
     }
-}
-
-/// Ensures the issuer can read every rolling stock of `rolling_stock_names`, and fails with a
-/// [`AuthorizationError::Forbidden`] as soon as one of them isn't readable.
-pub async fn require_readable_rolling_stocks(
-    rolling_stock_names: impl IntoIterator<Item = String>,
-    conn: &mut database::DbConnection,
-    authn_state: &crate::authentication::State,
-    openfga: &fga::Client,
-) -> crate::error::Result<()> {
-    let Some(user) = authn_state.user() else {
-        return Ok(());
-    };
-
-    // Rolling stocks are referenced by name, the authorization by id
-    let rolling_stock_names = rolling_stock_names
-        .into_iter()
-        .collect::<std::collections::HashSet<_>>();
-    let rolling_stocks: Vec<models::RollingStock> =
-        models::RollingStock::retrieve_batch_unchecked(conn, rolling_stock_names)
-            .await
-            .map_err(crate::views::rolling_stock::RollingStockError::from)?;
-
-    // Not using rolling_stock_list: we bail out as soon as one rolling stock isn't readable
-    let authorizer = authn_state.authorizer(openfga);
-    for rolling_stock in rolling_stocks {
-        require(
-            &authorizer,
-            authz::v2::rolling_stock_privileges(user, authz::RollingStock(rolling_stock.id)),
-            &authz::RollingStockPrivilege::CanRead,
-        )
-        .await?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1909,17 +1909,33 @@ pub(in crate::views) async fn track_occupancy(
 
     // Check user privilege on the rolling stocks of the occurrences.
     // Without a simulation, no rolling stock is involved: the check is skipped.
-    if use_simulation {
-        crate::authorizers::require_readable_rolling_stocks(
-            trains
-                .iter()
-                .map(|occurrence| occurrence.rolling_stock_name.clone()),
-            conn,
+    let readable_occurrence_ids = if use_simulation {
+        let occurrences_by_rolling_stock = train_ids
+            .iter()
+            .cloned()
+            .zip(trains.iter().cloned())
+            .map(|(id, occurrence)| (occurrence.rolling_stock_name.clone(), (id, occurrence)))
+            .into_group_map();
+
+        let rolling_stock_names = occurrences_by_rolling_stock.keys().cloned().collect_vec();
+        let rolling_stocks: Vec<RollingStock> =
+            RollingStock::retrieve_batch_unchecked(&mut conn.clone(), rolling_stock_names)
+                .await
+                .map_err(RollingStockError::from)?;
+
+        filter_readable_occurrences(
+            occurrences_by_rolling_stock,
+            &rolling_stocks,
             &authn_state,
             &openfga,
         )
-        .await?;
-    }
+        .await?
+        .into_iter()
+        .map(|(occurrence_id, _)| occurrence_id)
+        .collect::<HashSet<_>>()
+    } else {
+        train_ids.iter().cloned().collect()
+    };
 
     let op_location =
         PathItemLocation::OperationalPointPartReference(OperationalPointPartReference {
@@ -1942,6 +1958,15 @@ pub(in crate::views) async fn track_occupancy(
     let occupancies = match operational_point {
         Some(operational_point) => {
             if use_simulation {
+                // Occurrences whose rolling stock the user cannot read are not simulated: like
+                // invalid trains, their occupancy is computed from their schedule only
+                let (readable, unreadable): (Vec<_>, Vec<_>) = izip!(train_ids, trains)
+                    .partition(|(train_id, _)| readable_occurrence_ids.contains(train_id));
+                let (readable_ids, readable_trains): (Vec<_>, Vec<_>) =
+                    readable.into_iter().unzip();
+                let (unreadable_ids, unreadable_trains): (Vec<_>, Vec<_>) =
+                    unreadable.into_iter().unzip();
+
                 let simulation_params = TrackOccupancySimulationParams {
                     conn,
                     valkey_client,
@@ -1950,14 +1975,24 @@ pub(in crate::views) async fn track_occupancy(
                     electrical_profile_set_id,
                     app_version: config.app_version.as_deref(),
                 };
-                find_track_occupancy_for_known_operational_point_with_simulation(
-                    train_ids,
-                    trains,
-                    &op_cache,
-                    operational_point,
-                    simulation_params,
-                )
-                .await?
+                let mut occupancies =
+                    find_track_occupancy_for_known_operational_point_with_simulation(
+                        readable_ids,
+                        readable_trains,
+                        &op_cache,
+                        operational_point,
+                        simulation_params,
+                    )
+                    .await?;
+                occupancies.extend(
+                    find_track_occupancy_for_known_operational_point_without_simulation(
+                        unreadable_ids,
+                        unreadable_trains,
+                        &op_cache,
+                        operational_point,
+                    ),
+                );
+                occupancies
             } else {
                 find_track_occupancy_for_known_operational_point_without_simulation(
                     train_ids,
@@ -4683,12 +4718,19 @@ mod tests {
         .await
     }
 
-    /// With a simulation, a train whose rolling stock the user cannot read is forbidden
+    /// Even with a simulation, a train whose rolling stock the user cannot read is reported: like
+    /// an invalid train, its occupancy is computed without simulation
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn track_occupancy_without_rolling_stock_permission() {
-        init_track_occupancy_test_without_rolling_stock_permission(true)
-            .await
-            .assert_status_forbidden();
+        let track_occupancies: Vec<TrackSectionOccupancy> =
+            init_track_occupancy_test_without_rolling_stock_permission(true)
+                .await
+                .assert_status_ok()
+                .json();
+
+        // The very same result as without a simulation
+        assert_eq!(track_occupancies.len(), 1);
+        assert_eq!(track_occupancies[0].trains.len(), 4);
     }
 
     /// Without a simulation, no rolling stock is involved: the train is reported even though the


### PR DESCRIPTION
Context: https://github.com/osrd-project/osrd-confidential/issues/1064

When calling `POST:/train_schedules/track_occupancy`  with `use_simulation`, only simulate the trains that the request issuer is authorized to read and find the track occupancy of the trains with unauthorized rolling stocks without simulating them instead of returning a `403 Forbidden` when any of the rolling stocks is unauthorized.