### PR TITLE
front: use Map for train schedules in TimetableContext

### DIFF
--- a/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
+++ b/front/src/applications/operationalStudies/hooks/__tests__/useSimulationResults.spec.ts
@@ -150,7 +150,7 @@ describe.skip('useSimulationResults', () => {
   };
 
   const timetableContext: TimetableContextType = {
-    trainSchedules: [],
+    trainSchedules: new Map(),
     removeTrainSchedules: () => {},
     upsertTrainSchedules: () => {},
     updateTrainScheduleDepartureTime: async () => {},

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -439,7 +439,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
   const results = useMemo(
     () => ({
       trainSchedulesWithDetails,
-      trainSchedules,
+      trainSchedulesById,
       projectionData: projectionPath
         ? {
             ...projectionPath,
@@ -461,7 +461,7 @@ const useScenarioData = (scenario: ScenarioWithDetails, infraId: number, timetab
     }),
     [
       trainSchedulesWithDetails,
-      trainSchedules,
+      trainSchedulesById,
       projectionPath,
       projectedTrains,
       allTrainsProjected,

--- a/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioTrainScheduleSet.ts
@@ -193,7 +193,7 @@ export default function useScenarioTrainScheduleSet(
       }).unwrap();
 
       // copy all the trains that were attached to the old published tss
-      const trainsToCopy: TrainSchedule[] = trainSchedules
+      const trainsToCopy: TrainSchedule[] = [...trainSchedules.values()]
         .filter((trainSchedule) => trainSchedule.train_schedule_set_id === trainScheduleSet.id)
         .map((trainSchedule) => {
           const {

--- a/front/src/applications/operationalStudies/hooks/useTimetableContext.tsx
+++ b/front/src/applications/operationalStudies/hooks/useTimetableContext.tsx
@@ -11,7 +11,7 @@ import type { TrainId } from 'reducers/osrdconf/types';
  * It does not contain any simulation-related data.
  */
 export type TimetableContextType = {
-  trainSchedules: TrainScheduleResponse[];
+  trainSchedules: Map<number, TrainScheduleResponse>;
   removeTrainSchedules: (ids: number[]) => void;
   upsertTrainSchedules: (trainSchedules: TrainScheduleResponse[]) => void;
   updateTrainScheduleDepartureTime: (

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/helpers/__tests__/parseJson.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainSchedule/helpers/__tests__/parseJson.spec.ts
@@ -31,7 +31,7 @@ describe('processJsonFile', () => {
         round_trips: [[0, 1]],
       };
       const exportPayload = buildTimetableExportPayload(
-        payloadTrains,
+        new Map(payloadTrains.map((ts) => [ts.id, ts])),
         payloadTrains.map(({ id }) => id),
         payloadRoundTrips
       );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -86,7 +86,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
 
   const {
     trainSchedulesWithDetails,
-    trainSchedules,
+    trainSchedulesById,
     projectionData,
     conflicts,
     isConflictsLoading,
@@ -105,11 +105,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
     totalConflictsCount,
     selectedTrainConflictsCount,
     displayedConflicts,
-  } = useConflictsFilter(
-    useMemo(() => trainSchedules || [], [trainSchedules]),
-    conflicts,
-    isConflictsLoading
-  );
+  } = useConflictsFilter(trainSchedulesById, conflicts, isConflictsLoading);
 
   const macroEditorState = useRef<MacroEditorState>(null);
   const lastNgeOperationPromise = useRef(Promise.resolve());
@@ -164,13 +160,13 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
 
   const timetableContext = useMemo(
     (): TimetableContextType => ({
-      trainSchedules: trainSchedules ?? [],
+      trainSchedules: trainSchedulesById,
       upsertTrainSchedules: upsertTrainSchedulesWithNge,
       removeTrainSchedules: removeTrainSchedulesWithNge,
       updateTrainScheduleDepartureTime: updateTrainScheduleDepartureTimeWithNge,
     }),
     [
-      trainSchedules,
+      trainSchedulesById,
       upsertTrainSchedulesWithNge,
       removeTrainSchedulesWithNge,
       updateTrainScheduleDepartureTimeWithNge,
@@ -217,9 +213,9 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
   const defaultStartTime = useMemo(
     () =>
       scenario.timetable_type === 'CALENDAR'
-        ? computeLatestMidnight(trainSchedules ?? [], new Date())
+        ? computeLatestMidnight([...trainSchedulesById.values()], new Date())
         : Duration.zero,
-    [scenario.timetable_type, trainSchedules]
+    [scenario.timetable_type, trainSchedulesById]
   );
 
   return (

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrenceActions.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/hooks/__tests__/useOccurrenceActions.spec.ts
@@ -42,7 +42,7 @@ const timetableContextWrapper = ({ children }: { children: ReactNode }) =>
     TimetableContext.Provider,
     {
       value: {
-        trainSchedules: [],
+        trainSchedules: new Map(),
         removeTrainSchedules: () => {},
         upsertTrainSchedules: mockUpsertTrainSchedules,
         updateTrainScheduleDepartureTime: async () => {},

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -115,8 +115,8 @@ const Timetable = ({
           },
         }).unwrap();
 
-        const trainsToUpsert = trainSchedules
-          .filter((train) => trainScheduleIdsToMove.includes(train.id))
+        const trainsToUpsert = trainScheduleIdsToMove
+          .map((id) => trainSchedules.get(id)!)
           .map((train) => ({
             ...train,
             train_schedule_set_id: trainScheduleSetId,

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -56,7 +56,7 @@ const TimetableBoardWrapper = ({
 
   const { totalPacedTrainCount, totalUniqueTrainCount } = useMemo(
     () =>
-      trainSchedules.reduce(
+      [...trainSchedules.values()].reduce(
         (acc, trainSchedule) => {
           if (!trainSchedule.paced) {
             acc.totalUniqueTrainCount += 1;
@@ -154,7 +154,7 @@ const TimetableBoardWrapper = ({
 
       removeTrainSchedules(selectedTrainScheduleIds);
 
-      if (trainSchedules.length - selectedTrainScheduleIds.length === 0) {
+      if (trainSchedules.size - selectedTrainScheduleIds.length === 0) {
         setIsSelectMode(false);
       }
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 
 import {
   Alert,
@@ -153,6 +153,8 @@ const TimetableToolbar = ({
     }
   };
 
+  const trainSchedulesList = useMemo(() => [...trainSchedules.values()], [trainSchedules]);
+
   return (
     <>
       {areInvalidTrainSchedules && (
@@ -176,7 +178,7 @@ const TimetableToolbar = ({
             data-testid="scenarios-select-options-button"
             title={t('timetable.selectOptions')}
             onClick={toggleisSelectMode}
-            disabled={trainSchedules.length === 0}
+            disabled={trainSchedules.size === 0}
             type="button"
           >
             <CheckBox />
@@ -188,7 +190,7 @@ const TimetableToolbar = ({
             data-testid="scenarios-show-train-details-button"
             title={showTrainDetails ? t('lessDetails') : t('moreDetails')}
             onClick={toggleShowTrainDetails}
-            disabled={trainSchedules.length === 0}
+            disabled={trainSchedules.size === 0}
             type="button"
           >
             <Note />
@@ -198,7 +200,7 @@ const TimetableToolbar = ({
             data-testid="scenarios-manage-round-trips-button"
             title={t('roundTripsModal.manageRoundTrips')}
             onClick={() => setRoundTripsModalIsOpen(true)}
-            disabled={trainSchedules.length === 0}
+            disabled={trainSchedules.size === 0}
             type="button"
           >
             <ArrowSwitch />
@@ -236,7 +238,7 @@ const TimetableToolbar = ({
                 resetItineraryForm({
                   startTime:
                     scenario.timetable_type === 'CALENDAR'
-                      ? computeLatestMidnight(trainSchedules, new Date())
+                      ? computeLatestMidnight(trainSchedulesList, new Date())
                       : undefined,
                 })
               );
@@ -255,7 +257,7 @@ const TimetableToolbar = ({
             data-testid="timetable-filter-button"
             title={t('timetable.toggleFilters')}
             onClick={toggleFilterPanel}
-            disabled={trainSchedules.length === 0}
+            disabled={trainSchedules.size === 0}
             type="button"
           >
             <Filter />
@@ -314,7 +316,7 @@ const TimetableToolbar = ({
           setRoundTripsModalIsOpen={setRoundTripsModalIsOpen}
           infraId={infraId}
           timetableId={timetableId}
-          trainSchedules={trainSchedules}
+          trainSchedules={trainSchedulesList}
           refreshNge={refreshNge}
         />
       )}

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/__tests__/utils.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import type { RoundTrips, TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 import { Duration } from 'utils/duration';
+import { mapBy } from 'utils/types';
 
 import { buildTimetableExportPayload, computeLatestMidnight } from '../utils';
 
@@ -13,7 +14,7 @@ const buildTrainSchedule = (id: number): TrainScheduleResponse =>
 
 describe('buildTimetableExportPayload', () => {
   it('includes forced one-way round trips for selected train schedules', () => {
-    const trainSchedules = [buildTrainSchedule(12)];
+    const trainSchedules = mapBy([buildTrainSchedule(12)], 'id');
     const roundTrips: RoundTrips = { one_ways: [12], round_trips: [] };
 
     const payload = buildTimetableExportPayload(trainSchedules, [12], roundTrips);
@@ -26,16 +27,20 @@ describe('buildTimetableExportPayload', () => {
     const trainB = buildTrainSchedule(42);
     const roundTrips: RoundTrips = { round_trips: [[21, 42]] };
 
-    const payloadWithBoth = buildTimetableExportPayload([trainA, trainB], [21, 42], roundTrips);
+    const payloadWithBoth = buildTimetableExportPayload(
+      mapBy([trainA, trainB], 'id'),
+      [21, 42],
+      roundTrips
+    );
     expect(payloadWithBoth.round_trips).toEqual([[0, 1]]);
 
-    const payloadWithSingle = buildTimetableExportPayload([trainA], [21], roundTrips);
+    const payloadWithSingle = buildTimetableExportPayload(mapBy([trainA], 'id'), [21], roundTrips);
     expect(payloadWithSingle.round_trips).toBeUndefined();
   });
 
   it('handles train schedule one-ways', () => {
-    const trainSchedule = buildTrainSchedule(7);
-    const payload = buildTimetableExportPayload([trainSchedule], [7], {
+    const trainSchedules = mapBy([buildTrainSchedule(7)], 'id');
+    const payload = buildTimetableExportPayload(trainSchedules, [7], {
       one_ways: [7],
     });
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -46,13 +46,13 @@ export const formatTrainDuration = (duration: Duration) =>
   dayjs.duration(duration.ms).format('HH[h]mm');
 
 const formatTrainSchedulesForExport = (
-  trainSchedules: TrainScheduleResponse[],
+  trainSchedules: Map<number, TrainScheduleResponse>,
   selectedTimeTableIdsFromClick: number[]
 ) => {
   const trainScheduleIndexByEditoastId = new Map<number, number>();
 
-  const formattedTrainSchedules = trainSchedules
-    .filter(({ id }) => selectedTimeTableIdsFromClick.includes(id))
+  const formattedTrainSchedules = selectedTimeTableIdsFromClick
+    .map((id) => trainSchedules.get(id)!)
     .reduce<TrainSchedule[]>((acc, trainSchedule) => {
       trainScheduleIndexByEditoastId.set(trainSchedule.id, acc.length);
       acc.push(omit(trainSchedule, ['id', 'train_schedule_set_id']));
@@ -67,7 +67,7 @@ const formatTrainSchedulesForExport = (
 
 export const copyTrainSchedulesToClipboard = async (
   selectedTimeTableIdsFromClick: number[],
-  trainSchedules: TrainScheduleResponse[]
+  trainSchedules: Map<number, TrainScheduleResponse>
 ) => {
   const { formattedTrainSchedules } = formatTrainSchedulesForExport(
     trainSchedules,
@@ -127,7 +127,7 @@ type TimetableExportPayload = {
 };
 
 export const buildTimetableExportPayload = (
-  trainSchedules: TrainScheduleResponse[],
+  trainSchedules: Map<number, TrainScheduleResponse>,
   selectedTimeTableIdsFromClick: number[],
   roundTrips?: RoundTrips
 ): TimetableExportPayload => {
@@ -149,11 +149,9 @@ export const buildTimetableExportPayload = (
 
 export const exportTrainSchedules = (
   selectedTimeTableIdsFromClick: number[],
-  trainSchedules: TrainScheduleResponse[],
+  trainSchedules: Map<number, TrainScheduleResponse>,
   roundTrips?: RoundTrips
 ) => {
-  if (!trainSchedules) return;
-
   const payload = buildTimetableExportPayload(
     trainSchedules,
     selectedTimeTableIdsFromClick,

--- a/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
@@ -156,7 +156,7 @@ export default function useOccupancyZoneDrop({
         },
       }).unwrap();
 
-      const rawTrainSchedule = trainSchedules.find((ts) => ts.id === trainSchedule.id)!;
+      const rawTrainSchedule = trainSchedules.get(trainSchedule.id)!;
       upsertTrainSchedules([
         {
           ...rawTrainSchedule,
@@ -209,7 +209,7 @@ export default function useOccupancyZoneDrop({
       if (exception) {
         await updateExceptionPath(exception, trainSchedule, newPath);
       } else {
-        const rawTrainSchedule = trainSchedules.find((ts) => ts.id === trainSchedule.id)!;
+        const rawTrainSchedule = trainSchedules.get(trainSchedule.id)!;
         const updatedTrainSchedule = {
           ...rawTrainSchedule,
           path: newPath,

--- a/front/src/modules/conflict/__tests__/utils.spec.ts
+++ b/front/src/modules/conflict/__tests__/utils.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
+import { mapBy } from 'utils/types';
 
 import type { ConflictWithTrainNames } from '../types';
 import addTrainNamesToConflicts, {
@@ -33,7 +34,7 @@ describe('addTrainNamesToConflicts', () => {
       ],
     });
 
-    const [enriched] = addTrainNamesToConflicts([conflict], trains);
+    const [enriched] = addTrainNamesToConflicts([conflict], mapBy(trains, 'id'));
     expect(enriched.trainsData.map((train) => train.name)).toEqual(['TS 1234', 'PT 4583', 'ABC']);
   });
 });

--- a/front/src/modules/conflict/hooks/useConflictsFilter.ts
+++ b/front/src/modules/conflict/hooks/useConflictsFilter.ts
@@ -26,7 +26,7 @@ import addTrainNamesToConflicts, {
 } from '../utils';
 
 const useConflictsFilter = (
-  trainSchedules: TrainScheduleResponse[],
+  trainScheduleById: Map<number, TrainScheduleResponse>,
   conflicts: Conflict[],
   isConflictsLoading: boolean
 ) => {
@@ -37,11 +37,6 @@ const useConflictsFilter = (
   const handleToggleConflictsFilter = useCallback(() => {
     setShowOnlySelectedTrain(!showOnlySelectedTrain);
   }, [showOnlySelectedTrain]);
-
-  const trainScheduleById = useMemo<Map<number, TrainScheduleResponse>>(
-    () => new Map(trainSchedules.map((trainSchedule) => [trainSchedule.id, trainSchedule])),
-    [trainSchedules]
-  );
 
   const selectedTrainName = useMemo(() => {
     if (!selectedTrainId) return null;
@@ -78,8 +73,8 @@ const useConflictsFilter = (
   useEffect(() => {
     if (isConflictsLoading) return;
     const sortedByStartTime = [...conflicts].sort((a, b) => a.start_time - b.start_time);
-    setEnrichedConflicts(addTrainNamesToConflicts(sortedByStartTime, trainSchedules));
-  }, [conflicts, isConflictsLoading, trainSchedules]);
+    setEnrichedConflicts(addTrainNamesToConflicts(sortedByStartTime, trainScheduleById));
+  }, [conflicts, isConflictsLoading, trainScheduleById]);
 
   const selectedEnrichedConflicts = useMemo(() => {
     if (!selectedTrainId) return [];

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -72,14 +72,8 @@ function getConflictTrainCategories(
 
 export default function addTrainNamesToConflicts(
   conflicts: Conflict[],
-  trainSchedules: TrainScheduleResponse[]
+  trainMap: Map<number, TrainScheduleResponse>
 ): ConflictWithTrainNames[] {
-  const trainMap: Map<number, TrainScheduleResponse> = new Map();
-
-  for (const trainSchedule of trainSchedules) {
-    trainMap.set(trainSchedule.id, trainSchedule);
-  }
-
   return conflicts.map((conflict) => {
     const names = getConflictTrainNames(conflict, trainMap);
     const categories = getConflictTrainCategories(conflict, trainMap);

--- a/front/src/modules/trainSchedule/hooks/useSelectedTrainSchedule.tsx
+++ b/front/src/modules/trainSchedule/hooks/useSelectedTrainSchedule.tsx
@@ -26,7 +26,7 @@ const useSelectedTrainSchedule = (): TrainScheduleResponse | undefined => {
   const trainScheduleId = extractTrainScheduleId(trainId);
 
   return useMemo(
-    () => trainSchedules.find((trainSchedule) => trainSchedule.id === trainScheduleId),
+    () => (trainScheduleId ? trainSchedules.get(trainScheduleId) : undefined),
     [trainSchedules, trainScheduleId]
   );
 };


### PR DESCRIPTION
Most of the time, callers need to grab a train from its ID. A Map is well suited for this purpose.

For the few cases where an iteration over all train schedules is necessary, .values() can be used.