### PR TITLE
trainsim: speed constraint fix

### DIFF
--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/Curve.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/Curve.kt
@@ -188,8 +188,8 @@ class Curve(val xs: LongArray, val ys: LongArray) {
      *
      * If the segment doesn't intersect with the curve, this function returns null.
      *
-     * If the segment intersects through several points, this function returns the point with the
-     * lowest X coordinate.
+     * If the segment intersects through several points, this function returns the point where the
+     * segment and the curve first stop intersecting.
      */
     fun intersectsAt(x1: Long, y1: Long, x2: Long, y2: Long): Vec2? {
         require(x1 < x2)
@@ -234,10 +234,23 @@ class Curve(val xs: LongArray, val ys: LongArray) {
                 val yAhi = if (vAy == vBy) vAy else vAy + (vBy - vAy) * (xhi - vAx) / (vBx - vAx)
 
                 if (yAlo == y1lo) {
-                    return@mapNotNull Vec2(xlo.raw, y1lo.raw)
+                    return@mapNotNull if (yAhi == y1hi) {
+                        // Curve and segment intersect and have the same slope on this [window],
+                        if (xhi == x2) {
+                            // this is the end of the segment
+                            Vec2(x2.raw, y2.raw)
+                        } else {
+                            // we'll return a value in one of the next windows.
+                            null
+                        }
+                    } else {
+                        // Curve and segment stopped intersecting and having the same slope.
+                        Vec2(xlo.raw, y1lo.raw)
+                    }
                 }
 
                 if ((yAlo < y1lo) == (yAhi < y1hi)) {
+                    // Curve and segment have the same slope, but don't intersect
                     return@mapNotNull null
                 }
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/PreciseUnits.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/PreciseUnits.kt
@@ -168,10 +168,21 @@ value class PreciseSpeed(val micrometersPerSecond: Long) : Comparable<PreciseSpe
             micrometersPerSecond2 =
                 (micrometersPerSecond signalingTimes 1_000_000) / duration.microseconds
         )
+
+    /**
+     * Division floored towards -inf. A -0.5um/s-2 deceleration would normally round up to 0um/s-2
+     * which would create a less constrained step. This function instead rounds it to -1um/s-2.
+     */
+    fun floorDiv(duration: PreciseDuration): PreciseAcceleration =
+        PreciseAcceleration(
+            micrometersPerSecond2 =
+                (micrometersPerSecond signalingTimes 1_000_000).floorDiv(duration.microseconds)
+        )
 }
 
 val Double.metersPerSecond: PreciseSpeed
     get() = PreciseSpeed(micrometersPerSecond = (this * 1e6).toLong())
+
 /** kilometers per hour */
 val Double.kph: PreciseSpeed
     get() = PreciseSpeed(micrometersPerSecond = (this / 3.6e-6).toLong())

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/SpeedConstraint.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/SpeedConstraint.kt
@@ -24,7 +24,57 @@ interface SpeedConstraint : Constraint {
         speedCurves(context, currentState).mapNotNull { curve ->
             enactCurveDecision(context, currentState, curve)
         }
+
+    override fun truncateStep(
+        context: EnvelopeSimContext,
+        currentState: TrainState,
+        mergedState: TrainState,
+    ): TrainState =
+        speedCurves(context, currentState)
+            .asSequence()
+            .map { curve ->
+                if (
+                    curve.lerp(currentState.position.micrometers) ==
+                        currentState.speed.micrometersPerSecond
+                ) {
+                    val i =
+                        curve.firstStrictlyAfter(currentState.position.micrometers)
+                            ?: return@map mergedState
+                    val nextPosition = curve.xs[i].micrometers
+                    val nextSpeed = curve.ys[i].micrometersPerSecond
+                    if (
+                        nextPosition < mergedState.position &&
+                            arePointsAligned(
+                                currentState.position.micrometers,
+                                currentState.speed.micrometersPerSecond,
+                                nextPosition.micrometers,
+                                nextSpeed.micrometersPerSecond,
+                                mergedState.position.micrometers,
+                                mergedState.speed.micrometersPerSecond,
+                            )
+                    ) {
+                        return@map curve.advance(
+                            currentState,
+                            currentState.time + context.timeStep.seconds,
+                        )!!
+                    } else {
+                        return@map mergedState
+                    }
+                }
+
+                mergedState.truncate(currentState, curve)
+            }
+            .minByOrNull { state -> state.time } ?: mergedState
 }
+
+private fun arePointsAligned(
+    x0: Long,
+    y0: Long,
+    x1: Long,
+    y1: Long,
+    x2: Long,
+    y2: Long,
+): Boolean = if (x1 == x0 || x2 == x0) x1 == x2 else (y1 - y0) / (x1 - x0) == (y2 - y0) / (x2 - x0)
 
 fun enactCurveDecision(
     context: EnvelopeSimContext,

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/SpeedConstraint.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/SpeedConstraint.kt
@@ -62,7 +62,18 @@ interface SpeedConstraint : Constraint {
                     }
                 }
 
-                mergedState.truncate(currentState, curve)
+                val truncated = mergedState.truncate(currentState, curve)
+                if (truncated.time > currentState.time) {
+                    return@map truncated
+                }
+
+                val curveSpeed =
+                    curve.lerp(currentState.position.micrometers)?.micrometersPerSecond
+                        ?: return@map mergedState
+                curve.advance(
+                    currentState.copy(speed = curveSpeed),
+                    currentState.time + context.timeStep.seconds,
+                ) ?: mergedState
             }
             .minByOrNull { state -> state.time } ?: mergedState
 }
@@ -151,26 +162,36 @@ private fun Curve.advance(from: TrainState, to: PreciseDuration): TrainState? {
     val fromSpeed = lerp(from.position.micrometers)?.micrometersPerSecond ?: return null
     require(fromSpeed == from.speed)
 
-    val nextPointIndex = firstStrictlyAfter(from.position.micrometers) ?: return null
-    val toPosition = xs[nextPointIndex].micrometers
-    val toSpeed = ys[nextPointIndex].micrometersPerSecond
+    var nextPointIndex = firstStrictlyAfter(from.position.micrometers) ?: return null
 
-    val positionDelta = toPosition - from.position
-    val timeDelta =
-        if (toSpeed + from.speed == 0.micrometersPerSecond) {
+    while (true) {
+        val toPosition = xs[nextPointIndex].micrometers
+        val toSpeed = ys[nextPointIndex].micrometersPerSecond
+
+        val positionDelta = toPosition - from.position
+        val timeDelta =
+            if (toSpeed + from.speed == 0.micrometersPerSecond) {
+                return TrainState(
+                    time = to,
+                    position = from.position,
+                    speed = 0.micrometersPerSecond,
+                )
+            } else {
+                (2 * positionDelta) / (toSpeed + from.speed)
+            }
+
+        if (timeDelta > 0.microseconds) {
             return TrainState(
-                time = to,
-                position = from.position,
-                speed = 0.micrometersPerSecond,
-            )
-        } else {
-            (2 * positionDelta) / (toSpeed + from.speed)
+                    time = from.time + timeDelta,
+                    position = toPosition,
+                    speed = toSpeed,
+                )
+                .truncate(from, to)
         }
 
-    return TrainState(
-            time = from.time + timeDelta,
-            position = toPosition,
-            speed = toSpeed,
-        )
-        .truncate(from, to)
+        nextPointIndex++
+        if (nextPointIndex >= size) {
+            return null
+        }
+    }
 }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/SpeedConstraint.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/SpeedConstraint.kt
@@ -77,38 +77,50 @@ private fun tryEnactCurveDecision(
     val startSpeedLimit =
         curve.lerp(currentState.position.micrometers)?.micrometersPerSecond ?: return null
 
-    if (currentState.speed == startSpeedLimit) {
+    return if (currentState.speed == startSpeedLimit) {
         // The stock is on the curve, so we return the next point on the curve.
-
-        // Snap on the curve
-        val startSpeed = startSpeedLimit
-
-        val nextPointIndex =
-            curve.firstStrictlyAfter(currentState.position.micrometers) ?: return null
-        val endPosition = curve.xs[nextPointIndex].micrometers
-        val endSpeed = curve.ys[nextPointIndex].micrometersPerSecond
-        val positionDelta = endPosition - currentState.position
-        val timeDelta =
-            if (endSpeed + startSpeed == 0.micrometersPerSecond) {
-                return TrainState(
-                    time = currentState.time + context.timeStep.seconds,
-                    position = currentState.position,
-                    speed = 0.micrometersPerSecond,
-                )
-            } else {
-                (2 * positionDelta) / (endSpeed + startSpeed)
-            }
-        return currentState
-            .accelerate(context)
-            .copy(time = currentState.time + timeDelta, position = endPosition, speed = endSpeed)
-            .truncate(currentState, currentState.time + context.timeStep.seconds)
+        curve.advance(currentState, currentState.time + context.timeStep.seconds)
     } else if (currentState.speed < startSpeedLimit) {
         // The stock is below the curve
-
-        return currentState.accelerate(context).truncate(currentState, curve)
+        currentState.accelerate(context).truncate(currentState, curve)
     } else {
         // The stock is above the curve
-
-        return currentState.brake(context).truncate(currentState, curve)
+        currentState.brake(context).truncate(currentState, curve)
     }
+}
+
+/**
+ * Assuming this is a speed curve, fast-forward to the next point, up to the given time [to], from
+ * the given state [from].
+ *
+ * [from] must be on the curve, and must be strictly before [to].
+ */
+private fun Curve.advance(from: TrainState, to: PreciseDuration): TrainState? {
+    require(from.time < to)
+
+    val fromSpeed = lerp(from.position.micrometers)?.micrometersPerSecond ?: return null
+    require(fromSpeed == from.speed)
+
+    val nextPointIndex = firstStrictlyAfter(from.position.micrometers) ?: return null
+    val toPosition = xs[nextPointIndex].micrometers
+    val toSpeed = ys[nextPointIndex].micrometersPerSecond
+
+    val positionDelta = toPosition - from.position
+    val timeDelta =
+        if (toSpeed + from.speed == 0.micrometersPerSecond) {
+            return TrainState(
+                time = to,
+                position = from.position,
+                speed = 0.micrometersPerSecond,
+            )
+        } else {
+            (2 * positionDelta) / (toSpeed + from.speed)
+        }
+
+    return TrainState(
+            time = from.time + timeDelta,
+            position = toPosition,
+            speed = toSpeed,
+        )
+        .truncate(from, to)
 }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
@@ -902,8 +902,15 @@ fun step(
             .fold(mergedState) { mergedState, constraint ->
                 val truncatedState = constraint.truncateStep(context, currentState, mergedState)
 
-                check(currentState.position <= truncatedState.position) { "train went backwards" }
-                check(currentState.time < truncatedState.time) { "step didn't advance time" }
+                check(currentState.position <= truncatedState.position) {
+                    "constraint $constraint went backwards"
+                }
+                check(currentState.time < truncatedState.time) {
+                    "constraint $constraint didn't advance time"
+                }
+                check(truncatedState.time - currentState.time <= context.timeStep.seconds) {
+                    "constraint $constraint advanced too much time"
+                }
 
                 truncatedState
             }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
@@ -50,7 +50,7 @@ internal class PreciseIntegrationStep(
         val newEndSpeed = startSpeed + acceleration * newTimeDelta
         val newPositionDelta = newTimeDelta * (startSpeed + newEndSpeed) / 2
 
-        require(newPositionDelta < positionDelta)
+        check(newPositionDelta < positionDelta)
 
         return PreciseIntegrationStep(
             newTimeDelta,
@@ -284,8 +284,8 @@ data class TrainState(
                 pantograph = pantograph, // TODO interpoler le temps
             )
 
-        require(truncated.isBefore(this))
-        require(oldState.isBefore(truncated))
+        check(truncated.isBefore(this))
+        check(oldState.isBefore(truncated))
 
         return truncated
     }
@@ -315,8 +315,8 @@ data class TrainState(
                 pantograph = pantograph, // TODO interpoler le temps
             )
 
-        require(truncated.isBefore(this))
-        require(oldState.isBefore(truncated))
+        check(truncated.isBefore(this))
+        check(oldState.isBefore(truncated))
 
         return truncated
     }
@@ -351,8 +351,8 @@ data class TrainState(
         val truncated =
             copy(time = oldState.time + newTimeDelta, position = newEndPos, speed = newEndSpeed)
 
-        require(oldState.isBefore(truncated))
-        require(truncated.isBefore(this))
+        check(oldState.isBefore(truncated))
+        check(truncated.isBefore(this))
 
         return truncated
     }
@@ -858,14 +858,14 @@ fun step(
                 tracer?.decisions(it, nextStates)
 
                 for (nextState in nextStates) {
-                    require(currentState.position <= nextState.position) {
-                        "constraint $it made train go backwards"
+                    check(currentState.position <= nextState.position) {
+                        "constraint $constraint made train go backwards"
                     }
-                    require(currentState.time < nextState.time) {
-                        "constraint $it didn't advance time"
+                    check(currentState.time < nextState.time) {
+                        "constraint $constraint didn't advance time"
                     }
-                    require(nextState.time - currentState.time <= context.timeStep.seconds) {
-                        "constraint $it advanced too much time"
+                    check(nextState.time - currentState.time <= context.timeStep.seconds) {
+                        "constraint $constraint advanced too much time"
                     }
                 }
 
@@ -878,7 +878,7 @@ fun step(
     tracer?.mergedState(mergedState)
 
     val maxSpeed = context.rollingStock.maxSpeed.metersPerSecond
-    require(mergedState.speed <= maxSpeed || currentState.speed > maxSpeed) {
+    check(mergedState.speed <= maxSpeed || currentState.speed > maxSpeed) {
         "train is going too fast"
     }
 
@@ -887,8 +887,8 @@ fun step(
             .fold(mergedState) { mergedState, constraint ->
                 val truncatedState = constraint.truncateStep(context, currentState, mergedState)
 
-                require(currentState.position <= truncatedState.position) { "train went backwards" }
-                require(currentState.time < truncatedState.time) { "step didn't advance time" }
+                check(currentState.position <= truncatedState.position) { "train went backwards" }
+                check(currentState.time < truncatedState.time) { "step didn't advance time" }
 
                 truncatedState
             }

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
@@ -851,29 +851,29 @@ fun step(
 ): TrainState {
     tracer?.stepStart(currentState)
 
-    val mergedState =
-        constraints
-            .asSequence()
-            .flatMap { constraint ->
-                val nextStates = constraint.enactDecision(context, currentState)
+    val decisions =
+        constraints.asSequence().flatMap { constraint ->
+            val nextStates = constraint.enactDecision(context, currentState)
 
-                tracer?.decisions(constraint, nextStates)
+            tracer?.decisions(constraint, nextStates)
 
-                for (nextState in nextStates) {
-                    check(currentState.position <= nextState.position) {
-                        "constraint $constraint made train go backwards"
-                    }
-                    check(currentState.time < nextState.time) {
-                        "constraint $constraint didn't advance time"
-                    }
-                    check(nextState.time - currentState.time <= context.timeStep.seconds) {
-                        "constraint $constraint advanced too much time"
-                    }
+            for (nextState in nextStates) {
+                check(currentState.position <= nextState.position) {
+                    "constraint $constraint made train go backwards"
                 }
-
-                nextStates.asSequence().map { trainState -> Decision(trainState, constraint) }
+                check(currentState.time < nextState.time) {
+                    "constraint $constraint didn't advance time"
+                }
+                check(nextState.time - currentState.time <= context.timeStep.seconds) {
+                    "constraint $constraint advanced too much time"
+                }
             }
-            .reduceOrNull { a, b ->
+
+            nextStates.asSequence().map { trainState -> Decision(trainState, constraint) }
+        } + Decision(currentState.accelerate(context), null)
+    val mergedState =
+        decisions
+            .reduce { a, b ->
                 val mergedState = b.trainState.merge(currentState, a.trainState)
 
                 check(currentState.position <= mergedState.position) {
@@ -888,7 +888,7 @@ fun step(
 
                 Decision(mergedState, null)
             }
-            ?.trainState ?: return currentState.accelerate(context)
+            .trainState
 
     tracer?.mergedState(mergedState)
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
@@ -165,9 +165,9 @@ data class TrainState(
         val timeDelta = time - previous.time
         val constrainedTimeDelta = mostConstrained.time - previous.time
 
-        val acceleration = (speed - previous.speed) / timeDelta
+        val acceleration = (speed - previous.speed).floorDiv(timeDelta)
         val constrainedAcceleration =
-            (mostConstrained.speed - previous.speed) / constrainedTimeDelta
+            (mostConstrained.speed - previous.speed).floorDiv(constrainedTimeDelta)
         val newAcceleration = min(acceleration, constrainedAcceleration)
 
         // Use max instead of min, since going with the lesser acceleration for
@@ -187,7 +187,12 @@ data class TrainState(
             newSpeed = 0.micrometersPerSecond
         }
 
-        val newPosition = previous.position + (previous.speed + newSpeed) * newTimeDelta / 2
+        val newPosition =
+            if (newSpeed == 0.micrometersPerSecond && mostConstrained.speed == newSpeed) {
+                mostConstrained.position
+            } else {
+                previous.position + (previous.speed + newSpeed) * newTimeDelta / 2
+            }
 
         val newPantograph = pantograph.merge(mostConstrained.pantograph) // TODO interpoler le temps
 
@@ -344,8 +349,8 @@ data class TrainState(
             } else {
                 // This is like (2*newPositionDelta)/(newEndSpeed+startSpeed),
                 // but with less likeliness of timeDelta becoming zero.
-                newEndPos / (newEndSpeed + oldState.speed) -
-                    oldState.position / (newEndSpeed + oldState.speed)
+                2 * newEndPos / (newEndSpeed + oldState.speed) -
+                    2 * oldState.position / (newEndSpeed + oldState.speed)
             }
 
         val truncated =

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
@@ -892,11 +892,6 @@ fun step(
 
     tracer?.mergedState(mergedState)
 
-    val maxSpeed = context.rollingStock.maxSpeed.metersPerSecond
-    check(mergedState.speed <= maxSpeed || currentState.speed > maxSpeed) {
-        "train is going too fast"
-    }
-
     val truncatedState =
         constraints
             .fold(mergedState) { mergedState, constraint ->
@@ -915,6 +910,11 @@ fun step(
                 truncatedState
             }
             .truncate(currentState, context.path.length.meters)
+
+    val maxSpeed = context.rollingStock.maxSpeed.metersPerSecond
+    check(truncatedState.speed <= maxSpeed || currentState.speed > maxSpeed) {
+        "train is going too fast (speed=${truncatedState.speed}, max=$maxSpeed)"
+    }
 
     tracer?.truncatedState(truncatedState)
 

--- a/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
+++ b/core/osrd-mp/src/commonMain/kotlin/fr/sncf/osrd/trainsim/trainsim.kt
@@ -841,6 +841,8 @@ internal fun decelerationCurve(
     return curve
 }
 
+data class Decision(val trainState: TrainState, val constraint: Constraint?)
+
 fun step(
     context: EnvelopeSimContext,
     constraints: Iterable<Constraint>,
@@ -852,10 +854,10 @@ fun step(
     val mergedState =
         constraints
             .asSequence()
-            .flatMap {
-                val nextStates = it.enactDecision(context, currentState)
+            .flatMap { constraint ->
+                val nextStates = constraint.enactDecision(context, currentState)
 
-                tracer?.decisions(it, nextStates)
+                tracer?.decisions(constraint, nextStates)
 
                 for (nextState in nextStates) {
                     check(currentState.position <= nextState.position) {
@@ -869,11 +871,24 @@ fun step(
                     }
                 }
 
-                nextStates
+                nextStates.asSequence().map { trainState -> Decision(trainState, constraint) }
             }
-            .reduceOrNull { mostConstrained, decision ->
-                decision.merge(currentState, mostConstrained)
-            } ?: return currentState.accelerate(context)
+            .reduceOrNull { a, b ->
+                val mergedState = b.trainState.merge(currentState, a.trainState)
+
+                check(currentState.position <= mergedState.position) {
+                    "merge between ${a.constraint} and ${b.constraint} made train go backwards"
+                }
+                check(currentState.time < mergedState.time) {
+                    "merge between ${a.constraint} and ${b.constraint} didn't advance time"
+                }
+                check(mergedState.time - currentState.time <= context.timeStep.seconds) {
+                    "merge between ${a.constraint} and ${b.constraint} advanced too much time"
+                }
+
+                Decision(mergedState, null)
+            }
+            ?.trainState ?: return currentState.accelerate(context)
 
     tracer?.mergedState(mergedState)
 

--- a/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/trainsim/CurveTest.kt
+++ b/core/osrd-mp/src/commonTest/kotlin/fr/sncf/osrd/trainsim/CurveTest.kt
@@ -177,14 +177,26 @@ class CurveTest {
 
     @Test
     fun testIntersectsAtBeforeSameSlope() {
-        val p = dummyCurve.intersectsAt(-5, 15, 5, 5)
-        assertEquals(Vec2(0, 10), p)
+        val p = dummyCurve.intersectsAt(-5, 15, 10, 0)
+        assertEquals(Vec2(10, 0), p)
     }
 
     @Test
     fun testIntersectsAtBeforeSameSlopeSimple() {
         val p = simpleCurve.intersectsAt(-5, 15, 10, 0)
         assertEquals(Vec2(0, 10), p)
+    }
+
+    @Test
+    fun testIntersectsAtBeforeSameSlopeHalf() {
+        val p = dummyCurve.intersectsAt(-5, 15, 5, 5)
+        assertEquals(Vec2(5, 5), p)
+    }
+
+    @Test
+    fun testIntersectsAtBeforeSameSlopeHalfSimple() {
+        val p = simpleCurve.intersectsAt(-5, 15, 5, 5)
+        assertEquals(Vec2(5, 5), p)
     }
 
     @Test

--- a/core/src/main/kotlin/fr/sncf/osrd/trainsim/Simulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/trainsim/Simulation.kt
@@ -174,7 +174,10 @@ fun runSimulation(
     val provisionalStates = mutableListOf(TrainState.zero)
 
     margins.forEach { lower, upper, margin ->
-        val lowerI = maxEffortStates.binarySearch(lower.toPrecise())
+        val lowerI = provisionalStates.size - 1
+        check(provisionalStates[lowerI].position == maxEffortStates[lowerI].position)
+        check(provisionalStates[lowerI].position == lower.toPrecise())
+
         val upperI = maxEffortStates.binarySearch(upper.toPrecise())
 
         val prevUpperI = max(lowerI - 1, 0)


### PR DESCRIPTION
Fixes the bug where the train would speed up after encountering a deceleration curve, thus e.g. not respecting stops


Sorry there's a bunch of unrelated changes although they should be split into commits correctly