### PR TITLE
front: allow multiline string in itinerarylayer props

### DIFF
--- a/front/src/common/Map/components/ItineraryLayer.tsx
+++ b/front/src/common/Map/components/ItineraryLayer.tsx
@@ -1,11 +1,11 @@
 import { Source } from 'react-map-gl/maplibre';
 
-import type { GeoJsonLineString } from 'common/api/osrdEditoastApi';
+import type { GeoJsonLineString, GeoJsonMultiLineString } from 'common/api/osrdEditoastApi';
 import { OrderedLayer } from 'common/Map/Layers';
 
 type ItineraryLayerProps = {
   layerOrder: number;
-  geometry?: GeoJsonLineString;
+  geometry?: GeoJsonMultiLineString | GeoJsonLineString;
   showStdcmAssets?: boolean;
   isFeasible?: boolean;
 };


### PR DESCRIPTION
closes #17607 

We will need multiLineString in order to display backtracks correctly, once backend will be done. 

On the frontend part, we only need to add this to the geometry type in `ItineraryLayer`, maplibre handles it.