### PR TITLE
front: reset rtk on impersonate

### DIFF
--- a/front/src/utils/hooks/useAuth.ts
+++ b/front/src/utils/hooks/useAuth.ts
@@ -3,11 +3,7 @@ import { useCallback, useEffect } from 'react';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useDispatch, useSelector } from 'react-redux';
 
-import {
-  addTagTypes,
-  osrdEditoastApi,
-  type SearchResultItemUser,
-} from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type SearchResultItemUser } from 'common/api/osrdEditoastApi';
 import { osrdGatewayApi } from 'common/api/osrdGatewayApi';
 import { setImpersonatedUser, updateAuthzUser } from 'reducers/user';
 import { getIsUserLogged, getImpersonatedUser, getUsername } from 'reducers/user/userSelectors';
@@ -57,7 +53,7 @@ function useAuth() {
       impersonated = undefined;
     }
     dispatch(setImpersonatedUser(impersonated));
-    dispatch(osrdEditoastApi.util.invalidateTags(addTagTypes.map((t) => ({ type: t }))));
+    dispatch(osrdEditoastApi.util.resetApiState());
   }, []);
 
   return {


### PR DESCRIPTION
Fix #18207

Invalidate cache is not enought, we need to reset the API state (which clear all the cache).

When invalidating cache, in fact we don't touch the cache itself,  we are asking every subscriptions to redo an API  fetch.  
If call is a success, then the cache is updated. 

But in case of an error (like a 403) the cache is not updated, and so we still have the old value when using a `useQuery`.