### PR TITLE
front: adjust start time based on paced interval for hourly timetables

### DIFF
--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -11,6 +11,7 @@ import type {
 import type { SimulationSummary, TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import type { Train } from 'reducers/osrdconf/types';
 import { Duration, type StartTime, addDurationToStartTime, startTimeToMs } from 'utils/duration';
+import { isTrainScheduleId } from 'utils/trainId';
 
 import { computeOptimisticRow, propagationToEdits } from './helpers/cellUpdate';
 import { computePowerRestrictionWarnings } from './helpers/powerRestrictionIncompatibility';
@@ -312,6 +313,15 @@ const TimeStopsTableWrapper = ({
     arrival: StartTime | null,
     propagationMode: PropagationMode
   ) => {
+    if (isTrainScheduleId(selectedTrain.id) && arrival instanceof Duration) {
+      const isOrigin = row.pathStepId === selectedTrain.path[0].id;
+      const interval = Duration.parse(selectedTrain.paced!.interval);
+      if (isOrigin && arrival >= interval) {
+        // TODO: display warning
+        arrival = new Duration({ milliseconds: arrival.ms % interval.ms });
+      }
+    }
+
     const singleEdit: PendingEdit = { rowId: row.id, field: 'requestedArrival', value: arrival };
     commitEdit(
       buildEditsForUpdate(singleEdit, {

--- a/front/src/modules/trainHeader/ExpandedTrainForm.tsx
+++ b/front/src/modules/trainHeader/ExpandedTrainForm.tsx
@@ -35,7 +35,7 @@ import type { Train } from 'reducers/osrdconf/types';
 import { Duration, type StartTime } from 'utils/duration';
 import { usePrevious } from 'utils/hooks/state';
 import { kmhToMs } from 'utils/physics';
-import { isOccurrenceId } from 'utils/trainId';
+import { isOccurrenceId, isTrainScheduleId } from 'utils/trainId';
 import { createFixedSelectOptions, createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 import RollingStockField from './RollingStockField';
@@ -301,6 +301,19 @@ const ExpandedTrainForm = ({
   const onFieldImmediateChange = useCallback(
     (fieldName: keyof TrainFieldsState, newValue: TrainFieldsState[typeof fieldName]) => {
       const newFields = { ...fields, [fieldName]: newValue };
+
+      if (
+        fieldName === 'service_interval' &&
+        newFields.service_interval &&
+        isTrainScheduleId(train.id) &&
+        newFields.departure_date instanceof Duration &&
+        newFields.departure_date.ms >= newFields.service_interval
+      ) {
+        // TODO: display warning
+        newFields.departure_date = new Duration({
+          milliseconds: newFields.departure_date.ms % newFields.service_interval,
+        });
+      }
 
       persistTrainIfNeeded(newFields);
       setFields(newFields);


### PR DESCRIPTION
Mockups are missing for the warning, so that part is left as a TODO.

- [x] Adjust when start time is edited
- [x] Adjust when interval is edited
- [ ] Times & stops table's first cell is not updated when the start time is adjusted by a modulo from the header

References: https://github.com/OpenRailAssociation/osrd/issues/17626