### PR TITLE
editoast: fix macro_nodes trigram for international OP model

### DIFF
--- a/editoast/migrations/2026-08-24-160744-0000_fix-international-op-macro_nodes/down.sql
+++ b/editoast/migrations/2026-08-24-160744-0000_fix-international-op-macro_nodes/down.sql
@@ -1,0 +1,16 @@
+UPDATE macro_node
+SET
+    path_item_key = REPLACE(path_item_key, '#FR', ''),
+    trigram = REPLACE(trigram, '#FR', '')
+WHERE
+    path_item_key LIKE 'domestic:%#FR' AND
+    trigram LIKE '%#FR';
+
+UPDATE macro_node
+SET
+    path_item_key = REPLACE(path_item_key, 'domestic:', 'domestic:FR-'),
+    trigram = REPLACE(trigram, '#FR', '')
+WHERE
+    path_item_key LIKE 'domestic:%' AND
+    trigram LIKE '%#FR' AND
+    path_item_key NOT LIKE 'domestic:%#FR';

--- a/editoast/migrations/2026-08-24-160744-0000_fix-international-op-macro_nodes/up.sql
+++ b/editoast/migrations/2026-08-24-160744-0000_fix-international-op-macro_nodes/up.sql
@@ -1,0 +1,11 @@
+-- delete like domestic:MES/BV#FR
+-- macro_nodes created between 6th August and today will be lost, this is intentional
+DELETE FROM macro_node WHERE path_item_key LIKE '%#FR' AND trigram LIKE '%#FR';
+
+-- update (MES/BV, domestic:FR-MES/BV) -> (MES/BV#FR, domestic:MES/BV#FR)
+UPDATE macro_node
+SET
+    path_item_key = REPLACE(path_item_key, 'domestic:FR-', 'domestic:') || '#FR',
+    trigram = trigram || '#FR'
+WHERE
+    path_item_key LIKE 'domestic:FR-%'

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
@@ -70,6 +70,7 @@ export const handleNodeOperation = async ({
               MacroEditorState.decodeDomesticReference(domesticReference);
             const { main_code } = decodedDomesticReference;
             let { secondary_code, country_code } = decodedDomesticReference;
+            // TODO: be permissive here? allow typing "MES", "MES/BV", "MES/BV#FR" or "MES#FR"
             if (!secondary_code || country_code === '??') {
               const fetched = await fetchStationSecondaryCodeCountryCode(
                 decodedDomesticReference,
@@ -90,7 +91,7 @@ export const handleNodeOperation = async ({
           await updateMacroNode(state, dispatch, {
             ...indexNode,
             ...castNgeNode(node, netzgrafikDto.labels),
-            trigram: domesticReference,
+            trigram: node.betriebspunktName, // keep what the user typed
             dbId: indexNode.dbId,
             path_item_key: nodeKey,
           });

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -317,7 +317,7 @@ export const loadAndIndexNge = async (
             pathItem.location.type === 'operational_point_part_reference' &&
             pathItem.location.operational_point.type === 'domestic'
               ? pathItem.location.operational_point.main_code
-              : null,
+              : null, // TODO: do something for the uic trigrams?
           labels: [],
           // we put the nodes on a grid
           position_x: (nbNodesIndexed % 8) * 200,


### PR DESCRIPTION
(not sure exactly what's the aimed model tho)

Currently (last migrations), the macro_node attributes are like:
- `path_item_key = "domestic:FR-WS/BV"`
- `trigram = "WS/BV"`

However, the front-end expects this:
https://github.com/OpenRailAssociation/osrd/blob/57abe276581e3f71e53b2574fbbc281c7f1a17e3/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/MacroEditorState.ts#L262-L268

Which breaks the pre-international OP network graphs.

This migration intends to set like:
- `path_item_key = "domestic:WS/BV#FR"`
- `trigram = "WS/BV#FR"`

This migration:
1. deletes new macro_nodes created by the previous migration `adapt_node_path_item_key`
2. update the remaining nodes to fit with the above convention

This should fix the old network graphs that have been destructured in this model migration.

Close https://github.com/OpenRailAssociation/osrd/issues/18033