### PR TITLE
editoast: capture tracing's output in tests

### DIFF
--- a/editoast/common/src/lib.rs
+++ b/editoast/common/src/lib.rs
@@ -19,6 +19,7 @@ use utoipa::ToSchema;
 pub fn setup_tracing_for_test() {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
         .without_time()
         .pretty()
         .try_init()

--- a/editoast/common/src/tracing.rs
+++ b/editoast/common/src/tracing.rs
@@ -10,6 +10,9 @@ use url::Url;
 pub enum Stream {
     Stderr,
     Stdout,
+    /// Setup the logging with `tracing_subscriber::fmt::TestWriter`,
+    /// which enables libtest output capturing.
+    TestWriter,
 }
 
 #[derive(Debug)]
@@ -50,10 +53,10 @@ pub fn create_tracing_subscriber<T: SpanExporter + 'static>(
         .pretty()
         .with_file(true)
         .with_line_number(false);
-    let fmt_layer = if tracing_config.stream == Stream::Stderr {
-        fmt_layer.with_writer(std::io::stderr).boxed()
-    } else {
-        fmt_layer.boxed()
+    let fmt_layer = match tracing_config.stream {
+        Stream::Stderr => fmt_layer.with_writer(std::io::stderr).boxed(),
+        Stream::Stdout => fmt_layer.boxed(),
+        Stream::TestWriter => fmt_layer.with_test_writer().boxed(),
     };
     // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/index.html#runtime-configuration-with-layers
     let telemetry_layer = match tracing_config.telemetry {

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -234,6 +234,7 @@ impl Continuation {
 fn setup_tracing() {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
         .without_time()
         .pretty()
         .try_init()

--- a/editoast/fga/src/client/queries.rs
+++ b/editoast/fga/src/client/queries.rs
@@ -468,6 +468,7 @@ mod tests {
     fn setup_tracing() {
         tracing_subscriber::fmt()
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
             .without_time()
             .pretty()
             .try_init()

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -181,7 +181,7 @@ impl TestAppBuilder {
             None
         };
         let tracing_config = TracingConfig {
-            stream: Stream::Stdout,
+            stream: Stream::TestWriter,
             telemetry,
             directives: vec![],
             span_uploading: SpanUploading::BackgroundBatched,


### PR DESCRIPTION
Unfortunately, libtest output capture doesn't work by redirecting stdout/stderr, but with special mechanisms embeded in the std::io functions. The default `tracing_subscriber` writers bypass those. Using `tracing_subscriber::fmt::TestWriter`, we can get this behavior back.

In short, no more enormous wall of logs when running `cargo test` \o/