### PR TITLE
editoast: export PathItemRelativeLocation in OpenAPI schema

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4761,41 +4761,7 @@ paths:
                           - path_item_relative_location
                           properties:
                             path_item_relative_location:
-                              oneOf:
-                              - type: object
-                                title: PathItemRelativeLocationExactPathItem
-                                required:
-                                - path_item_id
-                                - type
-                                properties:
-                                  path_item_id:
-                                    $ref: '#/components/schemas/NonBlankString'
-                                    description: Path item ID, when the operational point matches an item in the input path
-                                  type:
-                                    type: string
-                                    enum:
-                                    - exact_path_item
-                              - type: object
-                                title: PathItemRelativeLocationBetweenPathItems
-                                required:
-                                - previous_path_item_id
-                                - following_path_item_id
-                                - type
-                                properties:
-                                  following_path_item_id:
-                                    $ref: '#/components/schemas/NonBlankString'
-                                    description: Following path item ID, when the operational point is not one of the input path items
-                                  previous_path_item_id:
-                                    $ref: '#/components/schemas/NonBlankString'
-                                    description: Previous path item ID, when the operational point is not one of the input path items
-                                  type:
-                                    type: string
-                                    enum:
-                                    - between_path_items
-                              description: |-
-                                Position of an operational point on a path, relative to the input path items.
-                                If the OP matches an input path item, it is located using this path item's ID,
-                                else, if the path just passes by the OP, it is located using its previous and following path items IDs
+                              $ref: '#/components/schemas/PathItemRelativeLocation'
   /train_schedules/{id}:
     get:
       tags:
@@ -12858,6 +12824,42 @@ components:
               - operational_point_part_reference
         title: PathItemLocationOperationalPointPartReference
       description: The location of a path waypoint
+    PathItemRelativeLocation:
+      oneOf:
+      - type: object
+        title: PathItemRelativeLocationExactPathItem
+        required:
+        - path_item_id
+        - type
+        properties:
+          path_item_id:
+            $ref: '#/components/schemas/NonBlankString'
+            description: Path item ID, when the operational point matches an item in the input path
+          type:
+            type: string
+            enum:
+            - exact_path_item
+      - type: object
+        title: PathItemRelativeLocationBetweenPathItems
+        required:
+        - previous_path_item_id
+        - following_path_item_id
+        - type
+        properties:
+          following_path_item_id:
+            $ref: '#/components/schemas/NonBlankString'
+            description: Following path item ID, when the operational point is not one of the input path items
+          previous_path_item_id:
+            $ref: '#/components/schemas/NonBlankString'
+            description: Previous path item ID, when the operational point is not one of the input path items
+          type:
+            type: string
+            enum:
+            - between_path_items
+      description: |-
+        Position of an operational point on a path, relative to the input path items.
+        If the OP matches an input path item, it is located using this path item's ID,
+        else, if the path just passes by the OP, it is located using its previous and following path items IDs
     PathProperties:
       type: object
       description: Properties along a path. Each property is optional since it depends on what the user requests.

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1464,7 +1464,7 @@ pub(in crate::views) async fn occupancy_blocks(
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[schema(as = PacedTrainTrackOccupancyForm)]
+#[schema(as = TrainScheduleTrackOccupancyForm)]
 pub(in crate::views) struct TrackOccupancyForm {
     train_schedule_ids: Vec<i64>,
     operational_point_reference: OperationalPointReference,
@@ -1475,7 +1475,7 @@ pub(in crate::views) struct TrackOccupancyForm {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
-#[schema(as = PacedTrainTrackOccupancy)]
+#[schema(as = TrainScheduleTrackOccupancy)]
 pub(in crate::views) struct TrackOccupancy {
     #[serde(flatten)]
     #[schema(inline)]

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1483,7 +1483,6 @@ pub(in crate::views) struct TrackOccupancy {
     #[serde(flatten)]
     #[schema(inline)]
     time_window: TimeWindow,
-    #[schema(inline)]
     path_item_relative_location: PathItemRelativeLocation,
 }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2846,22 +2846,7 @@ export type PostTrainSchedulesTrackOccupancyApiResponse =
       duration: string;
       time_begin: number;
     } & {
-      /** Position of an operational point on a path, relative to the input path items.
-        If the OP matches an input path item, it is located using this path item's ID,
-        else, if the path just passes by the OP, it is located using its previous and following path items IDs */
-      path_item_relative_location:
-        | {
-            /** Path item ID, when the operational point matches an item in the input path */
-            path_item_id: NonBlankString;
-            type: 'exact_path_item';
-          }
-        | {
-            /** Following path item ID, when the operational point is not one of the input path items */
-            following_path_item_id: NonBlankString;
-            /** Previous path item ID, when the operational point is not one of the input path items */
-            previous_path_item_id: NonBlankString;
-            type: 'between_path_items';
-          };
+      path_item_relative_location: PathItemRelativeLocation;
     })[];
   }[];
 export type PostTrainSchedulesTrackOccupancyApiArg = {
@@ -5335,6 +5320,19 @@ export type TrainScheduleSimulationSummaryResult = {
   };
   train_schedule: SimulationSummaryResult;
 };
+export type PathItemRelativeLocation =
+  | {
+      /** Path item ID, when the operational point matches an item in the input path */
+      path_item_id: NonBlankString;
+      type: 'exact_path_item';
+    }
+  | {
+      /** Following path item ID, when the operational point is not one of the input path items */
+      following_path_item_id: NonBlankString;
+      /** Previous path item ID, when the operational point is not one of the input path items */
+      previous_path_item_id: NonBlankString;
+      type: 'between_path_items';
+    };
 export type CoreSimpleEnvelope = {
   /** List of positions of a train
     Both positions (in mm) and times (in ms) must have the same length */

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -3022,6 +3022,53 @@ class PatchOperationCopyOperation(CopyOperation):
     op: Literal["copy"]
 
 
+class PathItemRelativeLocationExactPathItem(BaseModel):
+    """
+    Position of an operational point on a path, relative to the input path items.
+    If the OP matches an input path item, it is located using this path item's ID,
+    else, if the path just passes by the OP, it is located using its previous and following path items IDs
+    """
+
+    path_item_id: Annotated[str, Field(min_length=1)]
+    """
+    Path item ID, when the operational point matches an item in the input path
+    """
+    type: Literal["exact_path_item"]
+
+
+class PathItemRelativeLocationBetweenPathItems(BaseModel):
+    """
+    Position of an operational point on a path, relative to the input path items.
+    If the OP matches an input path item, it is located using this path item's ID,
+    else, if the path just passes by the OP, it is located using its previous and following path items IDs
+    """
+
+    following_path_item_id: Annotated[str, Field(min_length=1)]
+    """
+    Following path item ID, when the operational point is not one of the input path items
+    """
+    previous_path_item_id: Annotated[str, Field(min_length=1)]
+    """
+    Previous path item ID, when the operational point is not one of the input path items
+    """
+    type: Literal["between_path_items"]
+
+
+class PathItemRelativeLocation(
+    RootModel[
+        PathItemRelativeLocationExactPathItem | PathItemRelativeLocationBetweenPathItems
+    ]
+):
+    root: (
+        PathItemRelativeLocationExactPathItem | PathItemRelativeLocationBetweenPathItems
+    )
+    """
+    Position of an operational point on a path, relative to the input path items.
+    If the OP matches an input path item, it is located using this path item's ID,
+    else, if the path just passes by the OP, it is located using its previous and following path items IDs
+    """
+
+
 class Curves(BaseModel):
     """
     Property f64 values along a path. Each value is associated to a range of the path.


### PR DESCRIPTION
Clients may want to manipulate this type directly instead of fishing it in a deeply nested structure.

See https://github.com/OpenRailAssociation/osrd/pull/18174#discussion_r3812117409