### PR TITLE
front: fix stdcm overtake secondary code from simulation results

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -96,7 +96,7 @@ const StdcmResultsTable = ({
                 ? '='
                 : step.name || t('reportSheet.unknown')}
             </td>
-            <td className={cx('ch', { 'muted-text': !isPathStep })}>{step.secondaryCode}</td>
+            <td className={cx('ch', { 'muted-text': !isPathStep })}>{step.secondaryCodeLabel}</td>
             <td className="stop">
               {isLastStep || step.stopDuration !== null ? dateToHHMM(step.time) : ''}
             </td>

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -57,6 +57,7 @@ export type StdcmResultsOperationalPoint = {
   name?: string;
   consistChange?: ConsistData;
   secondaryCode?: string | null;
+  secondaryCodeLabel?: string | null;
   stopDuration: Duration | null;
   stopEndTime: Date;
   trackName?: string;

--- a/front/src/applications/stdcm/utils/simulationOutputUtils.ts
+++ b/front/src/applications/stdcm/utils/simulationOutputUtils.ts
@@ -85,6 +85,7 @@ export const formatStdcmDataForSimulationTable = (
     return {
       name: !isPathStep && op.name === previousOp.name ? '=' : op.name || t('reportSheet.unknown'),
       secondaryCode: op.secondaryCode,
+      secondaryCodeLabel: op.secondaryCodeLabel,
       trackName,
       endTime,
       passageStop,

--- a/front/src/modules/SimulationReportSheet/SimulationTable.tsx
+++ b/front/src/modules/SimulationReportSheet/SimulationTable.tsx
@@ -105,7 +105,7 @@ const SimulationTable = ({
                   <TD style={row.stylesByColumn.name}>{row.name}</TD>
                 </View>
                 <View style={styles.simulation.chWidth}>
-                  <TD style={row.stylesByColumn.secondaryCode}>{row.secondaryCode}</TD>
+                  <TD style={row.stylesByColumn.secondaryCode}>{row.secondaryCodeLabel}</TD>
                 </View>
                 {!isStdcm && (
                   <View style={styles.simulation.trackWidth}>

--- a/front/src/modules/SimulationReportSheet/types.ts
+++ b/front/src/modules/SimulationReportSheet/types.ts
@@ -39,6 +39,7 @@ export type ConsistChangeData = {
 export type SimulationTableRow = {
   name: string | null;
   secondaryCode?: string | null;
+  secondaryCodeLabel?: string | null;
   trackName?: string;
   endTime: string | Date | null;
   passageStop: string | Date | null;

--- a/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
+++ b/front/src/modules/SimulationReportSheet/utils/formatSimulationReportSheet.ts
@@ -270,14 +270,19 @@ function consolidateOvertakesToSingleSteps(
         stopDuration: Duration.subtractDate(nextStep.time, step.time),
         stopEndTime: nextStep.time,
         stopType: StdcmStopTypes.OVERTAKE,
+        secondaryCodeLabel: 'O', // indicating an overtake
       };
       consolidatedSteps.push(consolidatedStep);
       i += 1; // to skip the next step, as we consolidated two overtake steps in one
     } else {
-      consolidatedSteps.push(step);
+      consolidatedSteps.push({
+        ...step,
+        secondaryCodeLabel: step.secondaryCode,
+      });
     }
   }
-  consolidatedSteps.push(steps[steps.length - 1]);
+  const lastStep = steps[steps.length - 1];
+  consolidatedSteps.push({ ...lastStep, secondaryCodeLabel: lastStep.secondaryCode });
   return consolidatedSteps;
 }
 


### PR DESCRIPTION
The front-end displays the secondary code of an OP in the simulation results. The format for an overtake OP is `"secondary_code": "0_1748"`. This commit now displays "O" (for "Overtake") instead of an id.

I don't know if I should have fixed this on `osrd-data`'s side.

Close https://github.com/OpenRailAssociation/osrd/issues/18240