### PR TITLE
front: adapt itinerary modal for hourly timetables

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -370,7 +370,6 @@
       "mandatoryField": "Pflichtfeld",
       "nameLengthLimit": "Der Name darf 128 Zeichen nicht überschreiten.",
       "noDelta": "Die Zugfolgezeit muss mindestens eine Minute betragen.",
-      "noDepartureTime": "Bitte geben Sie eine Abfahrtszeit ein.",
       "noDestination": "Das Ziel ist nicht definiert.",
       "noName": "Bitte wählen Sie einen Namen für den Zug.",
       "noOrigin": "Der Startpunkt ist nicht definiert.",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -371,7 +371,6 @@
       "mandatoryField": "Required field",
       "nameLengthLimit": "The name must not exceed 128 characters",
       "noDelta": "The headway between two trains has to be at least one minute.",
-      "noDepartureTime": "Please enter a departure time",
       "noDestination": "The destination is not defined",
       "noName": "Please choose a name for the train",
       "noOrigin": "The origin is not defined",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -371,7 +371,6 @@
       "mandatoryField": "Champ obligatoire",
       "nameLengthLimit": "Le nom ne doit pas dépasser 128 caractères",
       "noDelta": "L'intervalle entre deux trains doit être d'au moins une minute.",
-      "noDepartureTime": "Veuillez renseigner une heure de départ",
       "noDestination": "La destination n'est pas définie",
       "noName": "Veuillez choisir un nom pour le train",
       "noOrigin": "L'origine n'est pas définie",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -24,6 +24,7 @@ import type {
   TrainCategory,
   Distribution,
   Comfort,
+  TimetableType,
 } from 'common/api/osrdEditoastApi';
 import Banner from 'common/Banner';
 import { computeBBoxViewport } from 'common/Map/WarpedMap/core/helpers';
@@ -39,7 +40,7 @@ import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { PathStep, PathStepMetadata, PathStepV2 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { addElementAtIndex } from 'utils/array';
-import { Duration, startTimeToDate } from 'utils/duration';
+import { Duration, type StartTime, startTimeToDate } from 'utils/duration';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { msToKmh } from 'utils/physics';
 
@@ -65,7 +66,7 @@ import { computePathStepCoordinates, getOpKey, isOpRefMetadata } from './utils';
 type ItineraryModalProps = {
   onTrainCreated: () => void;
   trainScheduleToEditData?: TrainScheduleToEditData;
-  defaultStartTime?: Date;
+  defaultStartTime?: StartTime;
 };
 
 export type ItineraryModalFormState = {
@@ -79,7 +80,7 @@ export type ItineraryModalFormState = {
 export type ItineraryModalTrainState = {
   name: string;
   category: TrainCategory | null;
-  startTime: Date;
+  startTime: StartTime;
   initialSpeed?: number;
   labels: string[];
   rollingStockId?: number;
@@ -94,16 +95,20 @@ export type ItineraryModalTrainState = {
   timeWindow: Duration;
   interval: Duration;
   addedExceptions: {
-    startTime: Date;
+    startTime: StartTime;
   }[];
   editingTrainType: 'uniqueTrain' | 'pacedTrain' | 'occurrence';
   speedLimitByTag?: string;
 };
 
-function blankNewTrainState(startTime?: Date): ItineraryModalTrainState {
+function blankNewTrainState(
+  startTime: StartTime | undefined,
+  timetableType: TimetableType
+): ItineraryModalTrainState {
+  startTime ??= timetableType === 'CALENDAR' ? new Date() : Duration.zero;
   return {
     name: '',
-    startTime: startTime ?? new Date(),
+    startTime,
     initialSpeed: 0,
     labels: [],
     rollingStockId: undefined,
@@ -170,14 +175,14 @@ const ItineraryModal = ({
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTrainSchedule.itineraryModal',
   });
-  const { workerStatus } = useScenarioContext();
+  const { workerStatus, scenario } = useScenarioContext();
   const mapSettings = useMapSettings();
   const dispatch = useAppDispatch();
   const { updateViewport } = useMapSettingsActions();
   const infraId = useInfraID();
 
   const [trainState, setTrainState] = useState<ItineraryModalTrainState>(
-    blankNewTrainState(defaultStartTime)
+    blankNewTrainState(defaultStartTime, scenario.timetable_type)
   );
 
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -215,7 +220,7 @@ const ItineraryModal = ({
           category: train.category ?? undefined,
         });
       } else {
-        setTrainState(blankNewTrainState(defaultStartTime));
+        setTrainState(blankNewTrainState(defaultStartTime, scenario.timetable_type));
         setModalFormState({
           name: '',
           rollingStockName: '',
@@ -227,7 +232,7 @@ const ItineraryModal = ({
 
       setWasInitialized(true);
     }
-  }, [wasInitialized, trainScheduleToEditData]);
+  }, [wasInitialized, trainScheduleToEditData, scenario.timetable_type]);
 
   const { categoryColors, currentSubCategory } = useCategoryColors(modalFormState.category);
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
@@ -38,7 +38,7 @@ function normalizeFirstWaypointTimes(
 export function formatTrainSchedulePayload(trainState: ItineraryModalTrainState): TrainSchedule {
   const { pathSteps, startTime } = normalizeFirstWaypointTimes(
     compact(trainState.pathSteps),
-    trainState.startTime.getTime()
+    startTimeToMs(trainState.startTime)
   );
 
   return {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/validateTrainSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/helpers/validateTrainSchedule.ts
@@ -7,7 +7,6 @@ import { MAX_TIMEWINDOW_MINUTES } from '../consts';
 
 export type TrainScheduleConfErrorCode =
   | 'noOrigin'
-  | 'noDepartureTime'
   | 'noDestination'
   | 'noRollingStock'
   | 'noName'
@@ -21,9 +20,6 @@ export function validateTrainSchedule(train: TrainSchedule): TrainScheduleConfEr
 
   if (train.path[0] === null) {
     errors.push('noOrigin');
-  }
-  if (!train.start_time) {
-    errors.push('noDepartureTime');
   }
   if (train.path.at(-1) === null) {
     errors.push('noDestination');

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useCreateTrainSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useCreateTrainSchedule.ts
@@ -10,6 +10,8 @@ import {
 import { setFailure, setSuccess } from 'reducers/main';
 import { updateSelectedTrain } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
+import { useDateTimeLocale, timeToLocaleString } from 'utils/date';
+import { startTimeToMs } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import { formatEditoastIdToTrainScheduleId } from 'utils/trainId';
 
@@ -24,6 +26,7 @@ export function useCreateTrainSchedule(
 ) {
   const dispatch = useAppDispatch();
   const { t } = useTranslation('operational-studies', { keyPrefix: 'manageTrainSchedule' });
+  const dateTimeLocale = useDateTimeLocale();
 
   const { sandboxId, timetableId } = useScenarioContext();
   const { upsertTrainSchedules } = useTimetableContext();
@@ -64,7 +67,7 @@ export function useCreateTrainSchedule(
 
       const newAddedExceptions = trainState.addedExceptions.map(({ startTime: exStartTime }) => ({
         key: '', // TODO : remove this when the key will be removed from the model
-        start_time: { value: exStartTime.getTime() },
+        start_time: { value: startTimeToMs(exStartTime) },
       }));
 
       if (newAddedExceptions.length > 0) {
@@ -106,7 +109,7 @@ export function useCreateTrainSchedule(
       dispatch(
         setSuccess({
           title: isPacedTrainMode ? t('pacedTrains.added') : t('trainAdded'),
-          text: `${trainState.name}: ${trainState.startTime.toLocaleTimeString()}`,
+          text: `${trainState.name}: ${timeToLocaleString(trainState.startTime, dateTimeLocale)}`,
         })
       );
       upsertTrainSchedules([trainScheduleToUpsert]);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -34,6 +34,7 @@ import {
 } from 'reducers/simulationResults';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch, type AppDispatch } from 'store';
+import { useDateTimeLocale, timeToLocaleString } from 'utils/date';
 import { Duration, type StartTime, startTimeToMs } from 'utils/duration';
 import { formatEditoastIdToTrainScheduleId, isOccurrenceId } from 'utils/trainId';
 
@@ -282,6 +283,7 @@ const useUpdateTrainSchedule = (
     keyPrefix: 'manageTrainSchedule',
   });
   const dispatch = useAppDispatch();
+  const dateTimeLocale = useDateTimeLocale();
 
   const { timetableId } = useScenarioContext();
 
@@ -301,7 +303,7 @@ const useUpdateTrainSchedule = (
           trainState.editingTrainType === 'uniqueTrain'
             ? t('uniqueTrainUpdated')
             : t('pacedTrainUpdated'),
-        text: `${trainState.name}: ${trainState.startTime.toLocaleString()}`,
+        text: `${trainState.name}: ${timeToLocaleString(trainState.startTime, dateTimeLocale)}`,
       })
     );
     dispatch(updateAlreadySelectedTrainId(editedTrainId));

--- a/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ScenarioContent.tsx
@@ -27,6 +27,7 @@ import type { PanelSelectionMode } from 'modules/simulationResult/components/Spa
 import { setFailure } from 'reducers/main';
 import type { TrainId } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
+import { Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import { usePrevious } from 'utils/hooks/state';
 
@@ -217,7 +218,7 @@ const ScenarioContent = ({ activeBoards, toggleBoard }: ScenarioContentProps) =>
     () =>
       scenario.timetable_type === 'CALENDAR'
         ? computeLatestMidnight(trainSchedules ?? [], new Date())
-        : undefined,
+        : Duration.zero,
     [scenario.timetable_type, trainSchedules]
   );
 


### PR DESCRIPTION
_See individual commits._

With these changes, one can now create new train schedules in hourly timetables.