### PR TITLE
editoast: allow restricted readers to read light rolling stocks

### DIFF
--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -353,8 +353,17 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn list_light_rolling_stock() {
-        let app = test_app!().skip_authz().build();
-        app.get("/light_rolling_stock").await.assert_status_ok();
+        // TODO update this test:
+        // - Create and persist rolling stocks in the DB.
+        // - Give the user retricted reading rights on some of them
+        // - Assert that the list of returned rolling stocks matches the light representation of the
+        //   authorized rolling stocks for the user.
+        let app = test_app!().build();
+        let user = app.user("user", "User").create().await;
+        app.get("/light_rolling_stock")
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -414,89 +423,98 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock() {
-        // GIVEN
         let app = test_app!().build();
         let db_pool = app.db_pool();
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
 
-        let rs_name = "fast_rolling_stock_name";
-        let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
-
-        // a user with a read grant on the rolling stock
-        let user = app
+        let user_restricted_reader = app
             .user("authorized", "Authorized")
-            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
             .create()
             .await;
 
-        // WHEN
         let response: LightRollingStockWithLiveries = app
-            .get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
-            .by_user(&user.info)
+            .get(format!("/light_rolling_stock/{}", rolling_stock.id).as_str())
+            .by_user(user_restricted_reader.as_ref())
             .await
             .assert_status_ok()
             .json();
 
-        // THEN
-        assert_eq!(response.rolling_stock.id, fast_rolling_stock.id);
+        assert_eq!(response.rolling_stock.id, rolling_stock.id);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_light_rolling_stock_by_name() {
-        // GIVEN
         let app = test_app!().build();
         let db_pool = app.db_pool();
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
 
-        let rs_name = "fast_rolling_stock_name";
-        let fast_rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
-
-        // a user with a read grant on the rolling stock
         let user = app
             .user("authorized", "Authorized")
-            .with_rolling_stock_grant(fast_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
             .create()
             .await;
 
-        // WHEN
         let response: LightRollingStockWithLiveries = app
-            .get(format!("/light_rolling_stock/name/{rs_name}").as_str())
+            .get(format!("/light_rolling_stock/name/{}", rolling_stock.name).as_str())
             .by_user(&user.info)
             .await
             .assert_status_ok()
             .json();
 
-        // THEN
-        assert_eq!(response.rolling_stock.id, fast_rolling_stock.id);
-        assert_eq!(response.rolling_stock.name, fast_rolling_stock.name);
+        assert_eq!(response.rolling_stock.id, rolling_stock.id);
+        assert_eq!(response.rolling_stock.name, rolling_stock.name);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_unexisting_light_rolling_stock() {
-        let app = test_app!().skip_authz().build();
-
-        app.get(format!("/light_rolling_stock/{}", -1).as_str())
+    async fn get_nonexistent_light_rolling_stock_by_id() {
+        // Note: the endpoint currently returns 403 Forbidden over 404 Not Found. This is not by
+        // design but a random behavior due to the way it is implemented.
+        let app = test_app!().build();
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        app.get(format!("/light_rolling_stock/{}", i64::MAX).as_str())
+            .by_user(admin.as_ref())
             .await
             .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_light_rolling_stock_without_permission() {
+    async fn get_nonexistent_light_rolling_stock_by_name() {
+        // Note: the endpoint currently returns 404 Not Found over 403 Forbidden. This is not by
+        // design but a random behavior due to the way it is implemented.
+        let app = test_app!().build();
+        let user = app.user("admin", "Admin").create().await;
+        app.get(format!("/light_rolling_stock/name/{}", "nonexistent_rolling_stock").as_str())
+            .by_user(user.as_ref())
+            .await
+            .assert_status_not_found();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn get_light_rolling_stock_requires_reader_grant() {
         let app = test_app!().build();
         let db_pool = app.db_pool();
+        let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
 
-        let fast_rolling_stock =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_name").await;
-
-        // a user that has the role to reach the endpoint but no read grant on the rolling stock
-        let user = app
-            .user("unauthorized", "Unauthorized")
-            .with_roles([authz::Role::OperationalStudies])
+        let user_no_grant = app.user("alice", "Alice").create().await;
+        let user_reader = app
+            .user("bob", "Bob")
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
             .create()
             .await;
 
-        app.get(format!("/light_rolling_stock/{}", fast_rolling_stock.id).as_str())
-            .by_user(&user.info)
+        app.get(format!("/light_rolling_stock/{}", rolling_stock.id).as_str())
+            .by_user(&user_no_grant.info)
             .await
             .assert_status_forbidden();
+        app.get(format!("/light_rolling_stock/{}", rolling_stock.id).as_str())
+            .by_user(&user_reader.info)
+            .await
+            .assert_status_ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -103,7 +103,7 @@ pub(in crate::views) async fn list(
         let Ok(authorized_rolling_stocks) = system_authorizer
             .authorize(authz::v2::rolling_stock_list(
                 user,
-                RollingStockPrivilege::CanRead,
+                RollingStockPrivilege::CanRestrictedRead,
             ))
             .await?
             .access()
@@ -161,7 +161,7 @@ pub(in crate::views) async fn get(
 ) -> Result<Json<LightRollingStockWithLiveries>> {
     v2::rolling_stock_privilege_check(
         authz::RollingStock(light_rolling_stock_id),
-        RollingStockPrivilege::CanRead,
+        RollingStockPrivilege::CanRestrictedRead,
     )
     .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
     .await?;
@@ -206,7 +206,7 @@ pub(in crate::views) async fn get_by_name(
 
     v2::rolling_stock_privilege_check(
         authz::RollingStock(rolling_stock.id),
-        RollingStockPrivilege::CanRead,
+        RollingStockPrivilege::CanRestrictedRead,
     )
     .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
     .await?;
@@ -375,8 +375,8 @@ mod tests {
         let _rs_no_grant = create_fast_rolling_stock(&mut db_pool.get_ok(), "rs_no_grant").await;
         let user = app
             .user("user_identity", "user_name")
-            .with_rolling_stock_grant(rs_1.id, RollingStockGrant::Reader)
-            .with_rolling_stock_grant(rs_2.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rs_1.id, RollingStockGrant::RestrictedReader)
+            .with_rolling_stock_grant(rs_2.id, RollingStockGrant::RestrictedReader)
             .create()
             .await;
         let response: LightRollingStockWithLiveriesCountList = app
@@ -429,7 +429,7 @@ mod tests {
 
         let user_restricted_reader = app
             .user("authorized", "Authorized")
-            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::RestrictedReader)
             .create()
             .await;
 
@@ -451,7 +451,7 @@ mod tests {
 
         let user = app
             .user("authorized", "Authorized")
-            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, authz::RollingStockGrant::RestrictedReader)
             .create()
             .await;
 
@@ -495,15 +495,15 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_light_rolling_stock_requires_reader_grant() {
+    async fn get_light_rolling_stock_requires_restricted_reader_grant() {
         let app = test_app!().build();
         let db_pool = app.db_pool();
         let rolling_stock = create_fast_rolling_stock(&mut db_pool.get_ok(), "rolling_stock").await;
 
         let user_no_grant = app.user("alice", "Alice").create().await;
-        let user_reader = app
+        let user_restricted_reader = app
             .user("bob", "Bob")
-            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::RestrictedReader)
             .create()
             .await;
 
@@ -512,7 +512,7 @@ mod tests {
             .await
             .assert_status_forbidden();
         app.get(format!("/light_rolling_stock/{}", rolling_stock.id).as_str())
-            .by_user(&user_reader.info)
+            .by_user(&user_restricted_reader.info)
             .await
             .assert_status_ok();
     }


### PR DESCRIPTION
Context: https://github.com/osrd-project/osrd-confidential/issues/1641

>[!NOTE]
The backend part of the PR is ready for review. I'm leaving it as a draft because the front-end update is not done yet.

- Give access to the endpoint related to light rolling stocks to any user with at least a `RestrictedReader` grant on them.
- Refactorize the related tests.

The first commit of the PR is a test refactorization.