### PR TITLE
front: fix some time propagation bugs

### DIFF
--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -731,7 +731,7 @@ const TimeCell = ({
           onSelectMode={handleSelectPropagationMode}
           disableFromDeparture={column.id === 'requestedArrival' && isFirstRow}
           disableToDestination={column.id === 'requestedArrival' && isLastRow}
-          isOrigin={isFirstRow}
+          isOriginArrival={column.id === 'requestedArrival' && isFirstRow}
         />
       </div>
       <ClearButton

--- a/front/src/modules/timesStops/TimePropagationMenu.tsx
+++ b/front/src/modules/timesStops/TimePropagationMenu.tsx
@@ -15,7 +15,7 @@ type TimePropagationMenuProps = {
   onSelectMode: (mode: PropagationMode) => void;
   disableFromDeparture?: boolean;
   disableToDestination?: boolean;
-  isOrigin?: boolean;
+  isOriginArrival?: boolean;
 };
 
 const TimePropagationMenu = ({
@@ -26,7 +26,7 @@ const TimePropagationMenu = ({
   onSelectMode,
   disableFromDeparture = false,
   disableToDestination = false,
-  isOrigin = false,
+  isOriginArrival = false,
 }: TimePropagationMenuProps) => {
   const { t } = useTranslation('translation', { keyPrefix: 'timeStopTable.propagationMenu' });
   const shiftAllWaypointsDeltaLabel = formatPropagationDeltaLabelByMode(
@@ -43,13 +43,13 @@ const TimePropagationMenu = ({
     oldValue,
     newValue,
     'atThisWaypoint',
-    isOrigin
+    isOriginArrival
   );
   const toDestinationDeltaLabel = formatPropagationDeltaLabelByMode(
     oldValue,
     newValue,
     'toDestination',
-    isOrigin
+    isOriginArrival
   );
   const selectMode = (mode: PropagationMode) => () => onSelectMode(mode);
 

--- a/front/src/modules/timesStops/helpers/__tests__/stopDurationPropagation.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/stopDurationPropagation.spec.ts
@@ -133,7 +133,7 @@ describe('propagateStopDuration', () => {
 
       expect(updatedStartTime).toEqual(new Date('2026-01-01T17:50:00.000Z')); // 18:00 - 10min
       expect(scheduleByAt.op11?.stop_for).toBe('PT10M');
-      expect(scheduleByAt.op11?.arrival).toBeUndefined();
+      expect(scheduleByAt.op11?.arrival).toBeNull();
       expect(scheduleByAt.op17?.arrival).toBe('PT1H'); // 50min + 10min
     });
   });

--- a/front/src/modules/timesStops/helpers/__tests__/timePropagation.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/timePropagation.spec.ts
@@ -373,7 +373,7 @@ describe('Scenario 4 — +40 min at origin (OP1)', () => {
     requestedArrival: _18H00,
   } as unknown as TimesStopsRowNew;
 
-  // At origin, all modes use HH:mm delta regardless of mode (isOrigin = true).
+  // At origin, all modes use HH:mm delta regardless of mode (isOriginArrival = true).
   describe('formatPropagationDeltaLabelByMode', () => {
     it.each<PropagationMode>([
       'atThisWaypoint',

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -79,7 +79,7 @@ export const propagateStopDuration = (
       )
     : insertScheduleItemInOrder(
         shiftedSchedule,
-        { at: pathStepId, stop_for: newDuration.toISOString() },
+        { at: pathStepId, arrival: null, stop_for: newDuration.toISOString() },
         selectedTrain.path
       );
 

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -60,11 +60,11 @@ export const formatPropagationDeltaLabelByMode = (
   oldValue: Date | null,
   newValue: Date | null,
   mode: PropagationMode,
-  isOrigin = false
+  isOriginArrival = false
 ): string => {
-  // At the origin, propagation always uses HH:mm:ss delta (start_time shift),
+  // At the origin arrival, propagation always uses HH:mm:ss delta (start_time shift),
   // regardless of mode, to keep the label consistent with the actual propagation.
-  const delta = isOrigin
+  const delta = isOriginArrival
     ? computeDelta(oldValue, newValue)
     : computeDeltaForPropagationMode(oldValue, newValue, mode);
   return formatSignedDelta(delta ?? Duration.zero);

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -108,7 +108,7 @@ const propagateFromEditedPoint = (
       pathIndex: selectedTrain.path.findIndex((step) => step.id === item.at),
     }))
     .filter(({ item, pathIndex }) => {
-      if (item.arrival === null) return false;
+      if (!item.arrival) return false;
       return direction === 'fromDeparture'
         ? pathIndex > editedPathIndex
         : pathIndex >= editedPathIndex;

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -209,9 +209,11 @@ const useUpdateTimesStopsTable = (
         });
       } else {
         // Insert new schedule item in path order
-        const newItem: ScheduleItem = { at: pathStepId };
-        if (newArrival !== null && !isOrigin) newItem.arrival = newArrival;
-        if (newStopFor !== null) newItem.stop_for = newStopFor;
+        const newItem: ScheduleItem = {
+          at: pathStepId,
+          arrival: isOrigin ? null : newArrival,
+          stop_for: newStopFor,
+        };
         updatedSchedule = insertScheduleItemInOrder(currentSchedule, newItem, updatedPath);
       }
 


### PR DESCRIPTION
Fixes 2 propagation bugs:

- Commit 1 and 2: A waypoint with only a `stop_for` and an `undefined` `arrival` was issued an inconsistent `arrival` during propagation from a previous waypoint.

- Commit 3: The propagation menu was announcing a wrong shift for the origin departure when it was crossing midnight