### PR TITLE
editoast: views: protect project/study/scenario get by id endpoints

### DIFF
--- a/editoast/authz/src/v2/project.rs
+++ b/editoast/authz/src/v2/project.rs
@@ -161,6 +161,14 @@ pub fn project_privileges(user: User, project: Project) -> Protected<HashSet<Pro
     ))
 }
 
+pub fn project_privilege_check(project: Project, privilege: ProjectPrivilege) -> Protected<()> {
+    Protected::value(()).with_check(Check::HasProjectPrivilege(
+        Actor::Issuer,
+        privilege,
+        project,
+    ))
+}
+
 /// Lists all the projects a user has access to
 pub fn project_list(user: User) -> Protected<ResourcesList<Project>> {
     subject_roles(Subject::user(user)).then(move |openfga, roles| {

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -71,6 +71,8 @@ pub struct RunserverArgs {
     trains_traffic_path: Option<PathBuf>,
     #[command(flatten)]
     s3: S3Args,
+    #[clap(long, env = "ENABLE_PROJECT_PERMISSIONS")]
+    enable_project_permissions: bool,
 }
 
 /// Create and run the server
@@ -92,6 +94,7 @@ pub async fn runserver(
         dynamic_assets_path,
         trains_traffic_path,
         s3,
+        enable_project_permissions,
     }: RunserverArgs,
     postgres: PostgresConfig,
     valkey_config: ValkeyConfig,
@@ -125,6 +128,7 @@ pub async fn runserver(
         app_version,
         trains_traffic,
         s3_config: build_s3_config(s3),
+        enable_project_permissions,
     };
 
     let server = views::Server::new(config).await?;

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -222,6 +222,7 @@ pub async fn create_scenario(
 
 pub struct ScenarioFixtureSet {
     pub scenario: Scenario,
+    pub project_id: i64,
     pub timetable: Timetable,
     pub infra: Infra,
     pub train_schedule_set: TrainScheduleSet,
@@ -238,6 +239,7 @@ pub async fn create_scenario_fixtures_set(
     let scenario = create_scenario(conn, name, study.id, timetable.id, infra.id).await;
     ScenarioFixtureSet {
         scenario,
+        project_id: project.id,
         timetable,
         infra,
         train_schedule_set,

--- a/editoast/src/views/operational_studies/hierarchy/project.rs
+++ b/editoast/src/views/operational_studies/hierarchy/project.rs
@@ -1,4 +1,16 @@
+use super::OperationalStudiesOrderingParam;
+use crate::AppState;
+use crate::authentication;
+use crate::authorizers::SystemAuthorizer;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::views::AuthorizationError;
+use crate::views::pagination::PaginatedList;
+use crate::views::pagination::PaginationQueryParams;
+use crate::views::pagination::PaginationStats;
+use authz::ProjectPrivilege;
 use authz::Role;
+use authz::v2::project_privilege_check;
 use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
@@ -10,7 +22,10 @@ use chrono::Utc;
 use database::DbConnection;
 use database::DbConnectionPoolV2;
 use editoast_derive::EditoastError;
+use models::Document;
 use models::prelude::*;
+use models::project::Project;
+use models::tags::Tags;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_with::rust::double_option;
@@ -18,19 +33,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
-
-use super::OperationalStudiesOrderingParam;
-use crate::AppState;
-use crate::authentication;
-use crate::authorizers::SystemAuthorizer;
-use crate::error::InternalError;
-use crate::error::Result;
-use crate::views::pagination::PaginatedList;
-use crate::views::pagination::PaginationQueryParams;
-use crate::views::pagination::PaginationStats;
-use models::Document;
-use models::project::Project;
-use models::tags::Tags;
 
 #[derive(Debug, Error, EditoastError, derive_more::From)]
 #[editoast_error(base_id = "project")]
@@ -234,7 +236,13 @@ pub(in crate::views) struct ProjectIdParam {
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool,
+        openfga,
+        config,
+        ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(project_id): Path<i64>,
 ) -> Result<Json<ProjectWithStudyCount>> {
     let conn = db_pool.get().await?;
@@ -242,6 +250,13 @@ pub(in crate::views) async fn get(
         project_id,
     })
     .await?;
+
+    if config.enable_project_permissions {
+        project_privilege_check(authz::Project(project_id), ProjectPrivilege::HasAccess)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
+            .await?;
+    }
+
     Ok(Json(ProjectWithStudyCount::try_fetch(conn, project).await?))
 }
 
@@ -376,15 +391,15 @@ pub(in crate::views) async fn patch(
 pub mod tests {
     use super::*;
 
+    use crate::fixtures::create_project;
+    use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt as _;
+    use crate::views::test_app::test_app;
     use authz::ProjectGrant;
     use authz::v2::TestClientExt as _;
     use pretty_assertions::assert_eq;
-
+    use rstest::rstest;
     use serde_json::json;
-
-    use crate::fixtures::create_project;
-    use crate::views::test_app::TestRequestExt as _;
-    use crate::views::test_app::test_app;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_post() {
@@ -449,18 +464,97 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn project_get() {
-        let app = test_app!().skip_authz().build();
-        let db_pool = app.db_pool();
-
-        let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
-
+        let app = test_app!().build();
+        let project = create_project(&mut app.db_pool().get_ok(), "project").await;
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(project.id, ProjectGrant::Owner)
+            .create()
+            .await;
         let response: ProjectWithStudyCount = app
-            .get(format!("/projects/{}", created_project.id).as_str())
+            .get(&format!("/projects/{}", project.id))
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
 
-        assert_eq!(response.project, created_project);
+        assert_eq!(response.project, project);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_get_admin_allowed() {
+        let app = test_app!().build();
+        let project = create_project(&mut app.db_pool().get_ok(), "project").await;
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .with_project_grant(project.id, ProjectGrant::Owner)
+            .create()
+            .await;
+        app.get(&format!("/projects/{}", project.id))
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_ok();
+    }
+
+    #[rstest]
+    #[case::no_role(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await,
+        app
+            .user("bob", "Bob")
+            .with_project_grant(project.id, ProjectGrant::Owner)
+            .create()
+            .await
+    )]
+    #[case::no_grant(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await,
+        app
+            .user("bob", "Bob")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_get_forbidden(
+        #[case] app: TestApp,
+        #[case] project: Project,
+        #[case] user_forbidden: authz::identity::User,
+    ) {
+        let user_authorized = app
+            .user("alice", "Alice")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(project.id, ProjectGrant::Owner)
+            .create()
+            .await;
+        app.get(&format!("/projects/{}", project.id))
+            .by_user(user_forbidden.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.get(&format!("/projects/{}", project.id))
+            .by_user(user_authorized.as_ref())
+            .await
+            .assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn project_get_not_found() {
+        let app = test_app!().build();
+        let project_id = create_project(&mut app.db_pool().get_ok(), "project")
+            .await
+            .id;
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(&format!("/projects/{}", project_id + 1000))
+            .by_user(user.as_ref())
+            .await
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/operational_studies/hierarchy/scenario.rs
+++ b/editoast/src/views/operational_studies/hierarchy/scenario.rs
@@ -1,4 +1,7 @@
+use authz::ProjectPrivilege;
 use authz::Role;
+use authz::v2::project_privilege_check;
+use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -21,8 +24,11 @@ use utoipa::ToSchema;
 use super::OperationalStudiesOrderingParam;
 use super::project::ProjectError;
 use super::study::StudyError;
+use crate::AppState;
+use crate::authentication;
 use crate::error::InternalError;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -329,7 +335,13 @@ pub(in crate::views) async fn patch(
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool,
+        openfga,
+        config,
+        ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(ScenarioIdParam { scenario_id }): Path<ScenarioIdParam>,
 ) -> Result<Json<ScenarioResponse>> {
     let (details, project, study) = db_pool
@@ -359,6 +371,12 @@ pub(in crate::views) async fn get(
             ))
         })
         .await?;
+
+    if config.enable_project_permissions {
+        project_privilege_check(authz::Project(project.id), ProjectPrivilege::HasAccess)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
+            .await?;
+    }
 
     Ok(Json(ScenarioResponse::new(details, project, study)))
 }
@@ -418,17 +436,23 @@ pub(in crate::views) async fn list(
 
 #[cfg(test)]
 mod tests {
+    use authz::ProjectGrant;
     use pretty_assertions::assert_eq;
 
+    use rstest::rstest;
     use serde_json::json;
 
     use super::*;
+    #[cfg(test)]
+    use crate::fixtures::ScenarioFixtureSet;
     use crate::fixtures::create_empty_infra;
     use crate::fixtures::create_project;
     use crate::fixtures::create_scenario_fixtures_set;
     use crate::fixtures::create_study;
     use crate::fixtures::create_timetable;
     use crate::views::test_app;
+    use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt as _;
 
     pub fn scenario_url(scenario_id: Option<i64>) -> String {
         format!(
@@ -438,16 +462,96 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn get_scenario() {
-        let app = test_app!().skip_authz().build();
-        let pool = app.db_pool();
-
-        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
-
-        let url = scenario_url(Some(fixtures.scenario.id));
-        let response: ScenarioResponse = app.get(&url).await.assert_status_ok().json();
+    async fn scenarios_get() {
+        let app = test_app!().build();
+        let fixtures = create_scenario_fixtures_set(&mut app.db_pool().get_ok(), "scenario").await;
+        let user = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(fixtures.project_id, ProjectGrant::Owner)
+            .create()
+            .await;
+        let response: ScenarioResponse = app
+            .get(&format!("/scenarios/{}", fixtures.scenario.id))
+            .by_user(user.as_ref())
+            .await
+            .assert_status_ok()
+            .json();
 
         assert_eq!(response.scenario, fixtures.scenario);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn scenarios_get_admin_allowed() {
+        let app = test_app!().build();
+        let fixtures = create_scenario_fixtures_set(&mut app.db_pool().get_ok(), "scenario").await;
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+        app.get(&format!("/scenarios/{}", fixtures.scenario.id))
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_ok();
+    }
+
+    #[rstest]
+    #[case::no_role(
+        test_app!().build(),
+        create_scenario_fixtures_set(&mut app.db_pool().get_ok(), "scenario").await,
+        app
+            .user("bob", "Bob")
+            .with_project_grant(fixtures.project_id, ProjectGrant::Owner)
+            .create()
+            .await
+    )]
+    #[case::no_grant(
+        test_app!().build(),
+        create_scenario_fixtures_set(&mut app.db_pool().get_ok(), "scenario").await,
+        app
+            .user("bob", "Bob")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn scenario_get_forbidden(
+        #[case] app: TestApp,
+        #[case] fixtures: ScenarioFixtureSet,
+        #[case] user_forbidden: authz::identity::User,
+    ) {
+        let user_authorized = app
+            .user("alice", "Alice")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(fixtures.project_id, ProjectGrant::Owner)
+            .create()
+            .await;
+        app.get(&format!("/scenarios/{}", fixtures.scenario.id))
+            .by_user(user_forbidden.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.get(&format!("/scenarios/{}", fixtures.scenario.id))
+            .by_user(user_authorized.as_ref())
+            .await
+            .assert_status_ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn scenario_get_not_found() {
+        let app = test_app!().build();
+        let ScenarioFixtureSet { scenario, .. } =
+            create_scenario_fixtures_set(&mut app.db_pool().get_ok(), "scenario").await;
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
+
+        app.get(&format!("/scenarios/{}", scenario.id + 1000))
+            .by_user(user.as_ref())
+            .await
+            .assert_status_not_found();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/src/views/operational_studies/hierarchy/study.rs
+++ b/editoast/src/views/operational_studies/hierarchy/study.rs
@@ -1,4 +1,7 @@
+use authz::ProjectPrivilege;
 use authz::Role;
+use authz::v2::project_privilege_check;
+use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -20,8 +23,11 @@ use utoipa::ToSchema;
 
 use super::OperationalStudiesOrderingParam;
 use super::project::ProjectError;
+use crate::AppState;
+use crate::authentication;
 use crate::error::InternalError;
 use crate::error::Result;
+use crate::views::AuthorizationError;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::pagination::PaginationStats;
@@ -244,7 +250,13 @@ pub(in crate::views) async fn delete(
     )
 )]
 pub(in crate::views) async fn get(
-    State(db_pool): State<Arc<DbConnectionPoolV2>>,
+    State(AppState {
+        db_pool,
+        openfga,
+        config,
+        ..
+    }): State<AppState>,
+    Extension(authn_state): Extension<authentication::State>,
     Path(StudyIdParam { study_id }): Path<StudyIdParam>,
 ) -> Result<Json<StudyResponse>> {
     let (study_scenarios, project) = db_pool
@@ -266,6 +278,12 @@ pub(in crate::views) async fn get(
             Ok::<_, InternalError>((study_scenarios, project))
         })
         .await?;
+
+    if config.enable_project_permissions {
+        project_privilege_check(authz::Project(project.id), ProjectPrivilege::HasAccess)
+            .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
+            .await?;
+    }
 
     let study_response = StudyResponse::new(study_scenarios, project);
     Ok(Json(study_response))
@@ -445,15 +463,19 @@ pub(in crate::views) async fn list(
 
 #[cfg(test)]
 pub mod tests {
+    use authz::ProjectGrant;
+    use models::study::Study;
     use pretty_assertions::assert_eq;
 
+    use rstest::rstest;
     use serde_json::json;
 
     use super::*;
     use crate::fixtures::create_project;
     use crate::fixtures::create_study;
     use crate::views::test_app;
-    use models::study::Study;
+    use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt as _;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_post() {
@@ -514,35 +536,105 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_get() {
-        let app = test_app!().skip_authz().build();
-        let db_pool = app.db_pool();
+        let app = test_app!().build();
+        let project = create_project(&mut app.db_pool().get_ok(), "project").await;
+        let study = create_study(&mut app.db_pool().get_ok(), "study", project.id).await;
+        let user = app
+            .user("owner", "Owner")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(project.id, ProjectGrant::Owner)
+            .create()
+            .await;
 
-        let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
-
-        let created_study =
-            create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
-
-        let response: StudyResponse = app
-            .get(&format!("/studies/{}", created_study.id))
+        let StudyResponse {
+            study: response_study,
+            ..
+        } = app
+            .get(&format!("/studies/{}", study.id))
+            .by_user(user.as_ref())
             .await
             .assert_status_ok()
             .json();
 
-        assert_eq!(response.study, created_study);
-        assert_eq!(response.study.project_id, created_project.id);
+        assert_eq!(response_study, study);
+        assert_eq!(response_study.project_id, project.id);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn study_get_admins_allowed() {
+        let app = test_app!().build();
+        let project = create_project(&mut app.db_pool().get_ok(), "project").await;
+        let study = create_study(&mut app.db_pool().get_ok(), "study", project.id).await;
+        let admin = app
+            .user("admin", "Admin")
+            .with_roles([Role::Admin])
+            .create()
+            .await;
+
+        app.get(&format!("/studies/{}", study.id))
+            .by_user(admin.as_ref())
+            .await
+            .assert_status_ok();
+    }
+
+    #[rstest]
+    #[case::no_role(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        app
+            .user("bob", "Bob")
+            .with_project_grant(project_id, ProjectGrant::Owner)
+            .create()
+            .await
+    )]
+    #[case::no_grant(
+        test_app!().build(),
+        create_project(&mut app.db_pool().get_ok(), "project").await.id,
+        app
+            .user("bob", "Bob")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn study_get_forbidden(
+        #[case] app: TestApp,
+        #[case] project_id: i64,
+        #[case] user_forbidden: authz::identity::User,
+    ) {
+        let user_authorized = app
+            .user("alice", "Alice")
+            .with_roles([Role::OperationalStudies])
+            .with_project_grant(project_id, ProjectGrant::Owner)
+            .create()
+            .await;
+        let study = create_study(&mut app.db_pool().get_ok(), "study", project_id).await;
+
+        app.get(&format!("/studies/{}", study.id))
+            .by_user(user_forbidden.as_ref())
+            .await
+            .assert_status_forbidden();
+        app.get(&format!("/studies/{}", study.id))
+            .by_user(user_authorized.as_ref())
+            .await
+            .assert_status_ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn study_get_not_found() {
-        let app = test_app!().skip_authz().build();
-        let db_pool = app.db_pool();
+        let app = test_app!().build();
+        let mut conn = app.db_pool().get_ok();
 
-        let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
-
-        let created_study =
-            create_study(&mut db_pool.get_ok(), "test_study_name", created_project.id).await;
+        let created_project = create_project(&mut conn.clone(), "test_project_name").await;
+        let created_study = create_study(&mut conn, "test_study_name", created_project.id).await;
+        let user = app
+            .user("user", "User")
+            .with_roles([Role::OperationalStudies])
+            .create()
+            .await;
 
         app.get(&format!("/studies/{}", created_study.id + 1000))
+            .by_user(user.as_ref())
             .await
             .assert_status_not_found();
     }

--- a/editoast/src/views/server.rs
+++ b/editoast/src/views/server.rs
@@ -87,6 +87,7 @@ pub struct ServerConfig {
     pub app_version: Option<String>,
     pub s3_config: Option<S3Config>,
     pub trains_traffic: Arc<RwLock<timetable::similar_trains::trains_traffic::TrainsTrafficPool>>,
+    pub enable_project_permissions: bool,
 }
 
 pub struct Server {

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -170,6 +170,7 @@ impl TestAppBuilder {
             },
             trains_traffic: Arc::new(RwLock::new(self.trains_traffic)),
             s3_config: None,
+            enable_project_permissions: true,
         };
 
         // Setup tracing


### PR DESCRIPTION
Ref: #17546

Require users to have a project grant to use the following endpoints:
- `GET:/projects/{id}`.
- `GET:/study/{id}`: the issuer needs a grant on the project associated with the study.
- `GET:/scenario/{id}`: the issuer needs a grant on the project associated with that scenario.

Project permissions are currently disabled by default. They can be enabled by setting the `ENABLE_PROJECT_PERMISSIONS` environment variable to `true` in the runtime environment of the server before startup.