### PR TITLE
front: don't override user input for macro node trigram

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/node.ts
@@ -90,7 +90,7 @@ export const handleNodeOperation = async ({
           await updateMacroNode(state, dispatch, {
             ...indexNode,
             ...castNgeNode(node, netzgrafikDto.labels),
-            trigram: domesticReference,
+            trigram: node.betriebspunktName,
             dbId: indexNode.dbId,
             path_item_key: nodeKey,
           });


### PR DESCRIPTION
Fixes a [regression](https://github.com/OpenRailAssociation/osrd/commit/8a400757e11c6e4ee582b0b3b76887ac8d5bf679) on the UX of the network graph: don't override the user's input in the macro nodes.

This way, the user can type "whatever" they wants and we keep strictly this in the "trigram" macro node field:
- only the main code (`MES`)
- main code + secondary code (`NS/BV`)
- main code + country code (`SES#FR`)
- main code + secondary code + country code (`SS/BV#FR`)

<img width="1907" height="843" alt="image" src="https://github.com/user-attachments/assets/59682658-b666-4109-8066-f1514bf01d43" />
