### PR TITLE
front: prevent consecutive identical nodes

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -484,9 +484,14 @@ const getNgeTrainrunSectionsWithNodes = (
   const trainrunSections: TrainrunSectionDto[] = groupedTrainSchedules.flatMap(
     ([trainSchedule, returnTrainSchedule], index) => {
       // Figure out the primary node key for each path item
-      const pathNodeKeys = trainSchedule.path.map((pathItem) => {
-        const node = state.getNodeByKey(MacroEditorState.getPathKey(pathItem.location));
-        return node!.path_item_key;
+      const pathNodeKeys: string[] = [];
+      trainSchedule.path.forEach((pathItem) => {
+        const nodeKey = state.getNodeByKey(
+          MacroEditorState.getPathKey(pathItem.location)
+        )!.path_item_key;
+        if (pathNodeKeys.at(-1) !== nodeKey) {
+          pathNodeKeys.push(nodeKey);
+        }
       });
 
       const startTime = new Date(trainSchedule.start_time);


### PR DESCRIPTION
Light fix to remove duplicate consecutive nodes to prevent NGE cycle detection error :woman_shrugging: 

_Cf [this issue](https://github.com/OpenRailAssociation/osrd/issues/18206)_

Close https://github.com/OpenRailAssociation/osrd/issues/18206