### PR TITLE
front: split and refresh front's README

### DIFF
--- a/front/ARCHITECTURE.md
+++ b/front/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Project architecture of OSRD's front
+
+> [!WARNING]
+> This is a somewhat outdated description on how the code is sorted in the app, pending a potential
+> folders structure change and code reorganization.
+
+## Homepage `/src/main`
+
+Landing is done in `/main` where we can find `app.js` for routing purpose and `home.js` as homepage
+with cards linking to different applications.
+
+OSRD's front is organized in 5 main `applications/`.
+
+## Applications `/src/applications`
+
+All applications are contained in a single folder, have a `home` JS/TS file and views & components
+organized in folders.
+
+**The components propose the main JS/TS file and eventually another folder with same name containing
+some minor subcomponents linked to.**
+
+- components/
+- views/
+- [editor/](#infrastructure-editor-editor)
+  - components/
+- [operationalStudies/](#operational-studies-operationalstudies)
+  - components/
+  - views/
+- [referenceMap/](#reference-map-referencemap)
+- [stdcm/](#short-term-dcm-stdcm)
+  - views/
+
+### Operational Studies `operationalStudies/`
+
+The operational studies application enables capacity studies to be carried out on a given
+infrastructure.
+
+#### Folder's tree
+
+- **components/**
+  - **Helpers/**
+  - **ManageTrainSchedule/**
+  - **Project/**
+  - **Scenario/**
+  - **SimulationResults/**
+  - **Study/**
+- consts.ts
+- Home.tsx
+- **views/**
+  - ManageTrainSchedule.tsx
+  - Project.js
+  - Scenario.js
+  - SimulationResults.tsx
+  - Study.js
+
+The functional workflow works as follows:
+
+- create a project `applications/operationalStudies/Home.js`
+- create a study in this project `applications/operationalStudies/views/Project.js`
+- choose an infrastructure to create a scenario in the study
+  `applications/operationalStudies/views/Study.js`
+
+Once in a scenario `applications/operationalStudies/views/Scenario.js` you have to add trains in the
+timetable `applications/operationalStudies/views/ManageTrainSchedule.tsx`. To do so:
+
+- choose an infrastructure & timetable _DEPRECATED: will be removed soon_
+- choose a rolling stock `common/rollingStockSelector` and a composition code
+- define a path on the map with crossing points (the path takes into account the restrictions of the
+  material and the infrastructure)
+- determine possible margins
+- choose the number of trains to add
+
+Then, the simulation results `applications/operationalStudies/SimulationResults` appear as (top to
+bottom):
+
+- The details of the current train and a module for controlling the time cursor
+- A fixed width timeline to explore the whole study
+- A space-time graph displaying all the trains projected on a given path
+- The space-speed graph of the selected train
+- The graph of curves and gradients of the selected train
+- The train sheet of the selected train
+- The map showing the route, the position of the trains in time and space, and the status of the
+  signaling with the current block occupation
+
+### Short-term DCM `stdcm/`
+
+STDCM makes it possible to find paths through the residual capacity of a timetable, without
+conflicts.
+
+### Infrastructure editor `editor/`
+
+OSRD's infrastructure editor allows you to edit the linear and point objects of a given
+infrastructure, and then run simulations based on this information. It is possible to modify the
+existing infrastructure as well as to create a new one.
+
+### Reference map `referenceMap/`
+
+This is an implementation reference for all map concerns. It aims to display all layers and propose
+a ready-to-use map component reference. When adding a new common layer inside an application map
+component, please add it first to this application.
+
+## Common components `/src/common`
+
+All common code (and shared components) supposed to be in `common/`.
+
+## CSS `/src/styles`
+
+## Translation `/public/locales`
+
+Any translation key used in the code must at least be present in `/public/locales/en` and
+`/public/locales/fr`, other languages are work in progress. You can use
+`npm run i18n-checker` to see a complete list of unused and missing French and English
+keys. You can use `./scripts/i18n-order-checker.sh --fix` to automatically sort translation keys.

--- a/front/README.md
+++ b/front/README.md
@@ -1,280 +1,74 @@
 # OSRD's Front
 
-## How to launch project for development purpose?
+This directory contains the `front` project of OSRD, i.e. the graphical web-based interface. It is
+written in [Typescript](https://www.typescriptlang.org/) using [React](https://react.dev/) and
+cover all the features of OSRD. It sits on top of `editoast` and is served through our `gateway`.
 
-### Inside of Docker
+Note that this directory also contains the [`osrd-ui`](./ui/) project in `ui/` that aims to package
+our [own design system and reusable components](https://ui.osrd.fr/).
 
-A Docker Compose override is provided in `docker/docker-compose.front.yml` to run the frontend in
-watch mode together with the rest of the OSRD stack. The osrd-compose script can be used to start
-OSRD in this mode:
+## Development setup
 
-```sh
-./osrd-compose dev-front build
-./osrd-compose up -d
-```
-
-The first time the container starts up, the osrd-ui library will be missing. This will trigger some
-build errors, which should go away as soon as osrd-ui gets built. Restarting the front container
-helps getting rid of lingering oxlint errors.
-
-### Outside of Docker
-
-If for some reason you can't or don't want to use the docker image during development, you can run
-the server directly from your development host.
-
-Everything else is still needed, so let's use `osrd-compose` with the `ext-front` flag:
-
-```sh
-./osrd-compose ext-front build
-./osrd-compose up -d
-```
-
-Make sure `npm` is [installed](https://nodejs.org/en/download), then run:
-
-```sh
-cd ./front/
-npm install
-npm run build-ui
-npm start -- --host 127.0.0.1
-```
-
-Don’t be fooled by Vite’s start message: you should then navigate to http://localhost:4000/ (not `:3000`!)
-to open OSRD, as requests must pass through the `gateway`.
-
-> [!NOTE]
-> We use `--host 127.0.0.1` to let Vite know it should also bind to Docker's `bridge`
-> network interface, so the `gateway` can proxy the requests accordingly.
-
-## IDE integrations
-
-Make sure you configure your IDE to enable Oxfmt and Oxlint integrations.
-
-### VSCode
-
-To format and lint your code directly from your VSCode editor, enable the [Oxc extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode), and to configure it in `.vscode/settings.json` like this:
-
-```jsonc
-{
-  // ...your previous settings...
-  "oxc.configPath": "front/.oxlintrc.json",
-  "oxc.fmt.configPath": "front/.oxfmtrc.json",
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "oxc.oxc-vscode"
-}
-```
+You can learn how to setup your machine to run the `front` in [`SETUP.md`](./SETUP.md).
 
 ## Commands
 
-### `npm start`
+We defined some commands in `package.json` you can easily run through `npm run`:
 
-Runs the app in a local development environment.
+- `npm start` runs the app in a local development environment. See [`SETUP.md`](./SETUP.md) to understand how
+to run it properly alongside the rest of OSRD's backend components.
+- `npm run build` builds the app for production into the `build` folder, ready to be served as static files
+by the `gateway`.
+- `npm run build-ui` builds the `osrd-ui` packages that are needed to run the `front`.
+- `npm run lint` launches our linters to check for formatting and best practices problems in the code. You can fix
+most of them automatically with `npm run lint-fix`.
+- `npm run test` launches the test runner in the interactive watch mode. Use `npm run test-debug` if you need a more
+verbose output from tests.
+- `npm run e2e-tests` launches end-to-end tests. See below for more information on how to write and run tests.
+- `npm run generate-types` syncs `front` with `editoast`'s endpoints and data types, reading their `openapi.yaml`
+and generating our own Typescript file at `./src/common/api/generatedEditoastApi.ts`.
+- `npm run i18n-checker` and `npm run i18n-api-errors` check for missing (or redundant) keys in our locales.
 
-This requires the other services (api, core, postgres…) to be running in your local environment as
-well.
-
-See [Main Readme](../README.md) if you need more information to run the docker.
-
-### `npm run test`
-
-Launches the test runner in the interactive watch mode.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.
-
-### `npm run generate-types`
-
-Update endpoints and data-types in /src/common/api/generatedEditoastApi.ts from openapi.yaml
-
-### `npm run e2e-tests`
-
-Launches end to end tests.
-
-It requires:
-
-- Ensure the [stack is running](./tests/README.md#requirements)
-- Install [Playwright dependencies](./tests/README.md#install-specific-e2e-tests-dependencies)
-- Then [run the tests](./tests/README.md#run-e2e-tests)
-
-For more details/tips/troubleshoot/alternatives, or if you're using a Linux distribution other than Ubuntu or
-Debian, refer to the dedicated [README](./tests/README.md).
-
-## Design rules
-
-OSRD's front is based upon [SNCF Bootstrap](https://designmetier-bootstrap.sncf.fr/). It aims to
-follow SNCF's design system guidelines, although the style has deviated quite a bit due to
-components requiring a specific design.
-
-# Code organization, folders structure & modules descriptions
+## Project architecture
 
 | Name          | Description & links                                                                               |
 | ------------- | ------------------------------------------------------------------------------------------------- |
-| applications/ | Main applications ([see below](#applications-srcapplications))                                    |
+| applications/ | [Main applications](./ARCHITECTURE.md#applications-srcapplications)                               |
 | assets/       | Some pictures & osm static mapstyles                                                              |
-| common/       | Common components (applications, map layers & design) ([see below](#common-components-srccommon)) |
+| common/       | [Common components (applications, maps & design)](./ARCHITECTURE.md#common-components-srccommon)  |
 | config/       | Some config files for all project                                                                 |
-| `env.ts`      | Backend urls                                                                                      |
-| `i18n.js`     | Translation configuration ([see below](#translation-publiclocales))                               |
-| `index.tsx`   | Obvious, no ?                                                                                     |
 | main/         | Landing & home pages                                                                              |
-| reducers/     | Redux store                                                                                       |
-| `Store.ts`    | Redux store config                                                                                |
-| styles/       | All SCSS code ([see below](#css-srcstyles))                                                       |
+| modules/      | Reusable code between applications                                                                |
+| reducers/     | Redux store reducers                                                                              |
+| store/        | Redux store config                                                                                |
+| styles/       | [All SCSS code](./ARCHITECTURE.md#css-srcstyles)                                                  |
+| test-data/    | Utilitaries to generate data for tests                                                            |
 | types/        | Typescript types configuration                                                                    |
 | utils/        | Some common generic helpers                                                                       |
+| `i18n.ts`     | [Translation configuration](./ARCHITECTURE.md#translation-publiclocales)                          |
+| `index.tsx`   | Entry point of the app                                                                            |
 
-## Homepage `/src/main`
+Learn more on how we organize the front's code in our [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
-Landing is done in `/main` where we can find `app.js` for routing purpose and `home.js` as homepage
-with cards linking to different applications.
+## Coding style guidelines
 
-OSRD's front is organized in 5 main `applications/`.
+We heavily rely on our formatters and linters (`oxfmt` and `oxlint`) to enforce a common style guide
+and best practices. You can run `npm run lint` to spot the problems locally; they will be caught anyway
+in CI. You can fix some of them automatically using `npm run lint-fix` too.
 
-## Applications `/src/applications`
+We also have other (maybe outdated) rules described on [our developer website](https://osrd.fr/en/docs/guides/contribute/contribute-code/frontend-conventions/).
 
-All applications are contained in a single folder, have a `home` JS/TS file and views & components
-organized in folders.
+## Writing and running tests
 
-**The components propose the main JS/TS file and eventually another folder with same name containing
-some minor subcomponents linked to.**
+To learn more on how we write tests in the `front` (beside end-to-end tests), head to [`TESTING.md`](./TESTING.md).
 
-- components/
-- views/
-- [editor/](#infrastructure-editor-editor)
-  - components/
-- [opendata/](#opendata-importation-opendata)
-  - components/
-  - views/
-- [operationalStudies/](#operational-studies-operationalstudies)
-  - components/
-  - views/
-- [referenceMap/](#reference-map-referencemap)
-- [stdcm/](#short-term-dcm-stdcm)
-  - views/
+To run our end-to-end tests, make sure the [stack is running](./tests/README.md#requirements),
+install [Playwright dependencies](./tests/README.md#install-specific-e2e-tests-dependencies) and
+[run the tests](./tests/README.md#run-e2e-tests). For more details/tips/troubleshoot/alternatives,
+or if you're using a Linux distribution other than Ubuntu or Debian, refer to the
+dedicated [README](./tests/README.md).
 
-### Operational Studies `operationalStudies/`
-
-The operational studies application enables capacity studies to be carried out on a given
-infrastructure.
-
-#### Folder's tree
-
-- **components/**
-  - **Helpers/**
-  - **ManageTrainSchedule/**
-  - **Project/**
-  - **Scenario/**
-  - **SimulationResults/**
-  - **Study/**
-- consts.ts
-- Home.tsx
-- **views/**
-  - ManageTrainSchedule.tsx
-  - Project.js
-  - Scenario.js
-  - SimulationResults.tsx
-  - Study.js
-
-The functional workflow works as follows:
-
-- create a project `applications/operationalStudies/Home.js`
-- create a study in this project `applications/operationalStudies/views/Project.js`
-- choose an infrastructure to create a scenario in the study
-  `applications/operationalStudies/views/Study.js`
-
-Once in a scenario `applications/operationalStudies/views/Scenario.js` you have to add trains in the
-timetable `applications/operationalStudies/views/ManageTrainSchedule.tsx`. To do so:
-
-- choose an infrastructure & timetable _DEPRECATED: will be removed soon_
-- choose a rolling stock `common/rollingStockSelector` and a composition code
-- define a path on the map with crossing points (the path takes into account the restrictions of the
-  material and the infrastructure)
-- determine possible margins
-- choose the number of trains to add
-
-Then, the simulation results `applications/operationalStudies/SimulationResults` appear as (top to
-bottom):
-
-- The details of the current train and a module for controlling the time cursor
-- A fixed width timeline to explore the whole study
-- A space-time graph displaying all the trains projected on a given path
-- The space-speed graph of the selected train
-- The graph of curves and gradients of the selected train
-- The train sheet of the selected train
-- The map showing the route, the position of the trains in time and space, and the status of the
-  signaling with the current block occupation
-
-### Short-term DCM `stdcm/`
-
-STDCM makes it possible to find paths through the residual capacity of a timetable, without
-conflicts.
-
-### Infrastructure editor `editor/`
-
-OSRD's infrastructure editor allows you to edit the linear and point objects of a given
-infrastructure, and then run simulations based on this information. It is possible to modify the
-existing infrastructure as well as to create a new one.
-
-### Reference map `referenceMap/`
-
-This is an implementation reference for all map concerns. It aims to display all layers and propose
-a ready-to-use map component reference. When adding a new common layer inside an application map
-component, please add it first to this application.
-
-## Common components `/src/common`
-
-All common code (and shared components) supposed to be in `common/`.
-
-## CSS `/src/styles`
-
-## Translation `/public/locales`
-
-Any translation key used in the code must at least be present in `/public/locales/en` and
-`/public/locales/fr`, other languages are work in progress. You can use
-`npm run i18n-checker` to see a complete list of unused and missing French and English
-keys. You can use `./scripts/i18n-order-checker.sh --fix` to automatically sort translation keys.
-
-# Other
-
-## Coding style Policy
-
-### Javascript / Javascript-React
-
-- `oxlint` is used as linter and `oxfmt` as formatter. Both are configured as `devDependencies` to
-  enforce default oxlint configuration eventually overridden by [airbnb rules](https://airbnb.io/javascript/)
-  translation. A few rules (see oxlintrc) has been disabled and will be re-enabled in the near future:
-  - 'no-named-as-default': 'off',
-  - 'react/jsx-props-no-spreading': 0,
-  - 'react/static-property-placement': 0,
-- Please push commits exclusively dedicated to styling issues
-
-You may also use `npm run lint-fix` to format/lint.
-
-## Dependencies
-
-### Cross project
-
-- [i18n](https://www.i18next.com/) internationalization framework for javascript. Please keep it
-  simple.
-- [nivo](https://nivo.rocks/) Dataviz lib built on top of d3 and react. For certain generic viz.
-  Could be used as a basis to render our special viz more adapted to react & d3- packages
-  nivo/circle-packing and nivo/line
-- [turf.js](https:/turf.js) Javascript geospatial and analysis. Imported on a per-package basis
-- [react-rnd](https://github.com/bokuweb/react-rnd) Excellent container for resizable - movable
-  visual component
-- immer - simplified immutable state control
-
-### Editor module
-
-- https://www.npmjs.com/package/@rjsf/core
-- https://www.npmjs.com/package/reselect
-
-### devDependencies
-
-- Better docs: still in use ? with
-- jsdocs
-
-### Updating Dependencies
+## Updating dependencies
 
 When `package.json` changes (new packages or updated versions), developers may have issues running
 the app with Docker. New packages or versions might not be recognized by Docker.
@@ -284,7 +78,6 @@ To fix this, follow these steps:
 1. After pulling new changes, run `npm install` to update local dependencies.
 2. If issues persist, delete `node_modules` and run `npm install` again.
 3. Run `docker compose build --no-cache` to rebuild Docker images from scratch with new
-
    dependencies.
 
 This ensures developers can run the app with the latest dependencies using Docker.

--- a/front/SETUP.md
+++ b/front/SETUP.md
@@ -1,0 +1,77 @@
+# Development setup for OSRD's front
+
+## Setting up your editor
+
+A large majority of our contributors uses [VS Code](https://code.visualstudio.com/) and our
+development experience is tailored to this IDE, but you should be able to use any common, updated
+editor on a daily basis, as long as your configure it accordingly.
+
+Make sure you enable those extensions or the equivalent features in your editor:
+
+- [Oxc extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode), to lint
+  your code using `oxlint` and format it using `oxfmt` automatically following our styleguide.
+
+If you are using VSCode and the Oxc extension, make sure this configuration is set in your
+workspace settings (`.vscode/settings.json`):
+
+```jsonc
+{
+  // ...your previous settings...
+  "oxc.configPath": "front/.oxlintrc.json",
+  "oxc.fmt.configPath": "front/.oxfmtrc.json",
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "oxc.oxc-vscode"
+}
+```
+
+## Running the project
+
+There are two main ways of running OSRD's `front`: either _inside_ of OSRD's Docker Compose system,
+or _outside_ of it (while the backend parts are still running inside of it).
+
+### Inside of Docker
+
+A Docker Compose override is provided in `docker/docker-compose.front.yml` to run the frontend in
+watch mode together with the rest of the OSRD stack. The `osrd-compose` script can be used to start
+OSRD in this mode:
+
+```sh
+# in the root of osrd's monorepo, not in front
+./osrd-compose dev-front build
+./osrd-compose up -d
+```
+
+The first time the container starts up, the `osrd-ui` library will be missing. This will trigger some
+build errors, which should go away as soon as `osrd-ui` gets built. Restarting the `front` container
+helps getting rid of lingering `oxlint` errors.
+
+### Outside of Docker
+
+If for some reason you can't or don't want to use the docker image during development, you can run
+the server directly from your development host.
+
+Everything else is still needed, so let's use `osrd-compose` with the `ext-front` flag:
+
+```sh
+# in the root of osrd's monorepo, not in front
+./osrd-compose ext-front build
+./osrd-compose up -d
+```
+
+Now that everything else is running, make sure `npm` is installed (from
+[nodejs.org](https://nodejs.org/en/download)), then run:
+
+```sh
+cd ./front/
+npm install
+npm run build-ui
+npm start -- --host 127.0.0.1
+```
+
+Don’t be fooled by Vite’s start message: you should then navigate to http://localhost:4000/ (not `:3000`!)
+to open OSRD. It's necessary, as requests to both the backend APIs and our frontend development server
+must pass through the `gateway`.
+
+> [!NOTE]
+> We use `--host 127.0.0.1` to let Vite know it should also bind to Docker's `bridge`
+> network interface, so the `gateway` can proxy the requests accordingly.


### PR DESCRIPTION
This is a very simple, low-effort split of the front README into multiple files, to make it clearer.

This comes from discussions in #16751; I'll create a `GUIDELINES.md` later to write the result of our best practices discussions.

I also completed the existing parts with up-to-date data, at least for the `npm run` commands and the directory organisation table.