### PR TITLE
front: fix departure propagation to destination

### DIFF
--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -12,10 +12,11 @@ import type { SimulationSummary, TrainScheduleWithDetails } from 'modules/trainS
 import type { Train } from 'reducers/osrdconf/types';
 import { Duration, type StartTime, addDurationToStartTime, startTimeToMs } from 'utils/duration';
 
+import { ONE_DAY } from './consts';
 import { computeOptimisticRow, propagationToEdits } from './helpers/cellUpdate';
 import { computePowerRestrictionWarnings } from './helpers/powerRestrictionIncompatibility';
 import { propagateStopDuration } from './helpers/stopDurationPropagation';
-import { ONE_DAY, propagateTime } from './helpers/timePropagation';
+import { propagateTime } from './helpers/timePropagation';
 import useTimesStopsTableData from './hooks/useTimesStopsTableData';
 import useUpdateTimesStopsTable from './hooks/useUpdateTimesStopsTable';
 import TimesStopsTable from './TimesStopsTable';

--- a/front/src/modules/timesStops/consts.ts
+++ b/front/src/modules/timesStops/consts.ts
@@ -17,3 +17,5 @@ export const marginsUndefined = {
   calculatedMargin: undefined,
   diffMargins: undefined,
 } as const;
+
+export const ONE_DAY = new Duration({ hours: 24 });

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -3,9 +3,8 @@ import type { Train } from 'reducers/osrdconf/types';
 import { Duration, subtractDurationFromStartTime } from 'utils/duration';
 
 import { ONE_DAY } from '../consts';
-import type { StopDurationUpdate } from '../types';
+import type { StopDurationUpdate, PropagationResult } from '../types';
 import { insertScheduleItemInOrder } from './cellUpdate';
-import { type PropagationResult } from './timePropagation';
 import { formatSignedDelta } from './utils';
 
 export const formatStopDurationDeltaLabel = (

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -2,9 +2,10 @@ import type { ScheduleItem, TimetableType } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 import { Duration, subtractDurationFromStartTime } from 'utils/duration';
 
+import { ONE_DAY } from '../consts';
 import type { StopDurationUpdate } from '../types';
 import { insertScheduleItemInOrder } from './cellUpdate';
-import { formatSignedDelta, ONE_DAY, type PropagationResult } from './timePropagation';
+import { formatSignedDelta, type PropagationResult } from './timePropagation';
 
 export const formatStopDurationDeltaLabel = (
   oldValue: Duration | null,

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -5,7 +5,8 @@ import { Duration, subtractDurationFromStartTime } from 'utils/duration';
 import { ONE_DAY } from '../consts';
 import type { StopDurationUpdate } from '../types';
 import { insertScheduleItemInOrder } from './cellUpdate';
-import { formatSignedDelta, type PropagationResult } from './timePropagation';
+import { type PropagationResult } from './timePropagation';
+import { formatSignedDelta } from './utils';
 
 export const formatStopDurationDeltaLabel = (
   oldValue: Duration | null,

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -7,10 +7,9 @@ import {
   subtractStartTime,
 } from 'utils/duration';
 
+import { ONE_DAY } from '../consts';
 import type { ArrivalUpdate, CellUpdate, PropagationMode } from '../types';
 import { truncateStartTimeToSecond } from './utils';
-
-export const ONE_DAY = new Duration({ hours: 24 });
 
 export type PropagationResult = {
   updatedPath: PathItem[];

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -195,12 +195,12 @@ export const propagateTime = (
 
   const oldValue = update.row[update.field];
   const newValue = update.value;
-  const isOriginUpdate = isOriginArrivalUpdate(update);
+  const isOriginArrival = isOriginArrivalUpdate(update);
   const isShiftAllPropagation = update.propagationMode === 'shiftAllWaypoints';
   // Origin and shiftAll use HH:mm:ss delta only. toDestination uses full datetime (can produce D+1).
   // fromDeparture uses HH:mm:ss only since start_time absorbs the shift.
   const delta =
-    isOriginUpdate || isShiftAllPropagation
+    isOriginArrival || isShiftAllPropagation
       ? computeDelta(oldValue, newValue)
       : computeDeltaForPropagationMode(oldValue, newValue, update.propagationMode);
   if (delta === null) return undefined;
@@ -219,8 +219,8 @@ export const propagateTime = (
     );
   }
 
-  if (isOriginUpdate || update.propagationMode === 'shiftAllWaypoints') {
-    if (!isOriginUpdate) return propagateShiftAll(delta, selectedTrain, timetableType);
+  if (isOriginArrival || update.propagationMode === 'shiftAllWaypoints') {
+    if (!isOriginArrival) return propagateShiftAll(delta, selectedTrain, timetableType);
     let result: PropagationResult | undefined;
     if (isShiftAllPropagation || update.propagationMode === 'toDestination')
       result = propagateShiftAll(delta, selectedTrain, timetableType);

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -9,6 +9,7 @@ import {
 
 import { ONE_DAY } from '../consts';
 import type { ArrivalUpdate, CellUpdate, PropagationMode, PropagationResult } from '../types';
+import { propagateStopDuration } from './stopDurationPropagation';
 import { truncateStartTimeToSecond, formatSignedDelta } from './utils';
 
 const isOriginArrivalUpdate = (update: CellUpdate): update is ArrivalUpdate =>
@@ -203,6 +204,20 @@ export const propagateTime = (
       ? computeDelta(oldValue, newValue)
       : computeDeltaForPropagationMode(oldValue, newValue, update.propagationMode);
   if (delta === null) return undefined;
+
+  // A departure update propagated toDestination is the same delta applied to the stop duration.
+  if (update.field === 'requestedDeparture' && update.propagationMode === 'toDestination') {
+    return propagateStopDuration(
+      {
+        row: update.row,
+        field: 'stopDuration',
+        value: (update.row.stopDuration ?? Duration.zero).add(delta).total('second'),
+        propagationMode: 'toDestination',
+      },
+      selectedTrain,
+      timetableType
+    );
+  }
 
   if (isOriginUpdate || update.propagationMode === 'shiftAllWaypoints') {
     if (!isOriginUpdate) return propagateShiftAll(delta, selectedTrain, timetableType);

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -9,7 +9,7 @@ import {
 
 import { ONE_DAY } from '../consts';
 import type { ArrivalUpdate, CellUpdate, PropagationMode } from '../types';
-import { truncateStartTimeToSecond } from './utils';
+import { truncateStartTimeToSecond, formatSignedDelta } from './utils';
 
 export type PropagationResult = {
   updatedPath: PathItem[];
@@ -45,15 +45,6 @@ const computeDeltaForPropagationMode = (
     : oldValue && newValue
       ? subtractStartTime(truncateStartTimeToSecond(newValue), truncateStartTimeToSecond(oldValue))
       : null;
-
-export const formatSignedDelta = (delta: Duration) => {
-  const sign = delta.ms >= 0 ? '+' : '-';
-  const label = delta
-    .abs()
-    .round('second')
-    .toLocaleString(undefined, { style: 'digital', hours: '2-digit' });
-  return `${sign}${label}`;
-};
 
 export const formatPropagationDeltaLabelByMode = (
   oldValue: Date | null,

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -1,4 +1,4 @@
-import type { PathItem, ScheduleItem, TimetableType } from 'common/api/osrdEditoastApi';
+import type { ScheduleItem, TimetableType } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 import {
   Duration,
@@ -8,14 +8,8 @@ import {
 } from 'utils/duration';
 
 import { ONE_DAY } from '../consts';
-import type { ArrivalUpdate, CellUpdate, PropagationMode } from '../types';
+import type { ArrivalUpdate, CellUpdate, PropagationMode, PropagationResult } from '../types';
 import { truncateStartTimeToSecond, formatSignedDelta } from './utils';
-
-export type PropagationResult = {
-  updatedPath: PathItem[];
-  updatedSchedule: ScheduleItem[];
-  updatedStartTime: StartTime;
-};
 
 const isOriginArrivalUpdate = (update: CellUpdate): update is ArrivalUpdate =>
   update.field === 'requestedArrival' && update.row.opOnPathIndex === 0;

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -169,6 +169,15 @@ export function formatDigitsAndUnit(fullValue: string | number | undefined, unit
   return `${round(extractedValue, digits)}${NO_BREAK_SPACE}${extractedUnit}`;
 }
 
+export const formatSignedDelta = (delta: Duration) => {
+  const sign = delta.ms >= 0 ? '+' : '-';
+  const label = delta
+    .abs()
+    .round('second')
+    .toLocaleString(undefined, { style: 'digital', hours: '2-digit' });
+  return `${sign}${label}`;
+};
+
 export function disabledTextColumn(
   key: string,
   title: string,

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -1,4 +1,9 @@
-import type { PathItemLocation, ReceptionSignal } from 'common/api/osrdEditoastApi';
+import type {
+  PathItemLocation,
+  ReceptionSignal,
+  PathItem,
+  ScheduleItem,
+} from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
 import type { SuggestedOP } from 'modules/trainSchedule/types';
 import type { Duration, StartTime } from 'utils/duration';
@@ -119,6 +124,12 @@ export type PropagationMode =
   | 'fromDeparture'
   | 'atThisWaypoint'
   | 'toDestination';
+
+export type PropagationResult = {
+  updatedPath: PathItem[];
+  updatedSchedule: ScheduleItem[];
+  updatedStartTime: StartTime;
+};
 
 export type StopPropagationMode = Exclude<PropagationMode, 'shiftAllWaypoints'>;
 


### PR DESCRIPTION
This PR corrects the behaviour when propagating a change of `requested departure time` to destination.
It not shifts the `stopping time` instead of the waypoint `requested arrival time`, correcting also a bug we had on the origin requested departure time update to destination.

The first 3 commits are moves to avoid an import circle between `timePropagation` and `stopDurationPropagation`. Commit 4 is the behaviour change.
Commit 5 is the renaming of `isOriginUpdate` to `isOriginArrival` to be clearer that it only concerns arrival.

Test will be added once all the behaviour will be updated https://github.com/OpenRailAssociation/osrd/issues/18280. A follow-up issue is open for that https://github.com/OpenRailAssociation/osrd/issues/18339.