### PR TITLE
front: disable to destination propagation for destination departure

### DIFF
--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -730,7 +730,7 @@ const TimeCell = ({
           newValue={editedDate}
           onSelectMode={handleSelectPropagationMode}
           disableFromDeparture={column.id === 'requestedArrival' && isFirstRow}
-          disableToDestination={column.id === 'requestedArrival' && isLastRow}
+          disableToDestination={isLastRow}
           isOriginArrival={column.id === 'requestedArrival' && isFirstRow}
         />
       </div>


### PR DESCRIPTION
This PR disable the propagation option `to destination` on the `requested departure time` update at destination. It was already disabled for `requested arrival time` and `stopping time`, so it was weird to keep it there.