### PR TITLE
editoast: require RestrictedReader in endpoints using rolling stocks

### DIFF
--- a/editoast/src/views/level_crossing_occupancy.rs
+++ b/editoast/src/views/level_crossing_occupancy.rs
@@ -618,7 +618,7 @@ mod tests {
         let user = app
             .user("authorized", "Authorized")
             .with_infra_grant(form.infra_id, InfraGrant::Reader)
-            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::RestrictedReader)
             .with_roles([Role::OperationalStudies])
             .create()
             .await;
@@ -663,7 +663,7 @@ mod tests {
         let user = app
             .user("authorized", "Authorized")
             .with_infra_grant(form.infra_id, InfraGrant::Reader)
-            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(rolling_stock.id, RollingStockGrant::RestrictedReader)
             .with_roles([Role::OperationalStudies])
             .create()
             .await;
@@ -741,7 +741,10 @@ mod tests {
         let user = app
             .user("authorized", "Authorized")
             .with_infra_grant(form.infra_id, InfraGrant::Reader)
-            .with_rolling_stock_grant(readable_rolling_stock.id, RollingStockGrant::Reader)
+            .with_rolling_stock_grant(
+                readable_rolling_stock.id,
+                RollingStockGrant::RestrictedReader,
+            )
             .with_roles([Role::OperationalStudies])
             .create()
             .await;

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -781,7 +781,7 @@ pub(in crate::views) async fn filter_readable_occurrences(
     let Ok(authorized_rolling_stocks) = SystemAuthorizer::new_infallible(openfga)
         .authorize(authz::v2::rolling_stock_list(
             user,
-            RollingStockPrivilege::CanRead,
+            RollingStockPrivilege::CanRestrictedRead,
         ))
         .await?
         .access()

--- a/editoast/src/views/timetable/conflicts.rs
+++ b/editoast/src/views/timetable/conflicts.rs
@@ -476,7 +476,7 @@ pub async fn filter_unauthorized_train_schedules_and_exceptions(
     };
     let system_authorizer = SystemAuthorizer::new_infallible(openfga);
     let Ok(authorized_train_schedules) =
-        authz::v2::rolling_stock_list(user, RollingStockPrivilege::CanRead)
+        authz::v2::rolling_stock_list(user, RollingStockPrivilege::CanRestrictedRead)
             .authorize(&system_authorizer)
             .await?
             .access()

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1013,9 +1013,12 @@ pub(in crate::views) async fn etcs_braking_curves(
     )
     .await?;
 
-    v2::rolling_stock_privilege_check(authz::RollingStock(rs.id), RollingStockPrivilege::CanRead)
-        .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
-        .await?;
+    v2::rolling_stock_privilege_check(
+        authz::RollingStock(rs.id),
+        RollingStockPrivilege::CanRestrictedRead,
+    )
+    .run::<AuthorizationError, _>(&authn_state.authorizer(&openfga))
+    .await?;
 
     // Compute simulation of a train schedule
     let (simulation_result, pathfinding_result) = train_simulation_ordered_batch(
@@ -1641,7 +1644,7 @@ pub(in crate::views) async fn occupancy_blocks(
                 authz::v2::rolling_stock_privileges(*user, authz::RollingStock(rolling_stock.id))
                     .map(async move |grants| {
                         grants
-                            .contains(&RollingStockPrivilege::CanRead)
+                            .contains(&RollingStockPrivilege::CanRestrictedRead)
                             .then_some(rolling_stock.name.clone())
                     })
             });
@@ -4303,7 +4306,10 @@ mod tests {
         let user = app
             .user("partially-authorized", "Partially authorized")
             .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
-            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(
+                readable_rolling_stock.id,
+                authz::RollingStockGrant::RestrictedReader,
+            )
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -4311,10 +4317,13 @@ mod tests {
         let authorized_user = app
             .user("authorized", "Authorized")
             .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
-            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(
+                readable_rolling_stock.id,
+                authz::RollingStockGrant::RestrictedReader,
+            )
             .with_rolling_stock_grant(
                 unreadable_rolling_stock.id,
-                authz::RollingStockGrant::Reader,
+                authz::RollingStockGrant::RestrictedReader,
             )
             .with_roles([authz::Role::OperationalStudies])
             .create()
@@ -4390,7 +4399,10 @@ mod tests {
         let user = app
             .user("partially-authorized", "Partially authorized")
             .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
-            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(
+                readable_rolling_stock.id,
+                authz::RollingStockGrant::RestrictedReader,
+            )
             .with_roles([authz::Role::OperationalStudies])
             .create()
             .await;
@@ -4398,10 +4410,13 @@ mod tests {
         let authorized_user = app
             .user("authorized", "Authorized")
             .with_infra_grant(small_infra.id, authz::InfraGrant::Reader)
-            .with_rolling_stock_grant(readable_rolling_stock.id, authz::RollingStockGrant::Reader)
+            .with_rolling_stock_grant(
+                readable_rolling_stock.id,
+                authz::RollingStockGrant::RestrictedReader,
+            )
             .with_rolling_stock_grant(
                 unreadable_rolling_stock.id,
-                authz::RollingStockGrant::Reader,
+                authz::RollingStockGrant::RestrictedReader,
             )
             .with_roles([authz::Role::OperationalStudies])
             .create()
@@ -4656,7 +4671,7 @@ mod tests {
             schedule,
             operational_point_reference,
             use_simulation,
-            Some(authz::RollingStockGrant::Reader),
+            Some(authz::RollingStockGrant::RestrictedReader),
         )
         .await
     }


### PR DESCRIPTION
Context: https://github.com/osrd-project/osrd-confidential/issues/1641

>[!NOTE]
The backend part of the PR is ready for review. I'm leaving it as a draft because the front-end update is not done yet.

Update the user grant required on the rolling stocks from `Reader` to `RestrictedReader` in the remaining endpoints that use internally rolling stocks but do not return confidential information about them (example: `GET:/timetable/{id}/conflicts`).