### PR TITLE
front: catch errors thrown by NGE and display them

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/NGE.tsx
@@ -3,6 +3,10 @@ import { useEffect, useRef, useState } from 'react';
 import type { NetzgrafikDto, Operation } from '@osrd-project/netzgrafik-frontend';
 import { useTranslation } from 'react-i18next';
 
+import { setFailure } from 'reducers/main';
+import { useAppDispatch } from 'store';
+import { castErrorToFailure, getErrorMessage } from 'utils/error';
+
 import { EMPTY_DTO } from './consts';
 
 type NGEElement = HTMLElement & {
@@ -39,10 +43,12 @@ const frameSrc = `
  */
 const NGE = ({ activeFilterSettingId, dto, onOperation, onLoad }: NGEProps) => {
   const { i18n } = useTranslation();
+  const dispatch = useAppDispatch();
 
   const frameRef = useRef<HTMLIFrameElement>(null);
 
   const [ngeRootElement, setNgeRootElement] = useState<NGEElement | null>(null);
+  const [ngeError, setNgeError] = useState<unknown>();
 
   useEffect(() => {
     const frame = frameRef.current!;
@@ -74,8 +80,14 @@ const NGE = ({ activeFilterSettingId, dto, onOperation, onLoad }: NGEProps) => {
 
   useEffect(() => {
     if (ngeRootElement && dto) {
-      // eslint-disable-next-line react/immutability
-      ngeRootElement.netzgrafikDto = dto;
+      try {
+        // eslint-disable-next-line react/immutability
+        ngeRootElement.netzgrafikDto = dto;
+        setNgeError(undefined);
+      } catch (error) {
+        dispatch(setFailure(castErrorToFailure(error)));
+        setNgeError(error);
+      }
     }
   }, [dto, ngeRootElement]);
 
@@ -101,7 +113,13 @@ const NGE = ({ activeFilterSettingId, dto, onOperation, onLoad }: NGEProps) => {
     return () => {};
   }, [onOperation, ngeRootElement]);
 
-  return <iframe ref={frameRef} srcDoc={frameSrc} title="NGE" className="nge-iframe-container" />;
+  return !ngeError ? (
+    <iframe ref={frameRef} srcDoc={frameSrc} title="NGE" className="nge-iframe-container" />
+  ) : (
+    <div title="NGE" className="nge-error-container">
+      {getErrorMessage(ngeError)}
+    </div>
+  );
 };
 
 export default NGE;

--- a/front/src/styles/scss/applications/operationalStudies/_nge.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_nge.scss
@@ -3,3 +3,9 @@
   height: 100%;
   border-radius: 10px;
 }
+
+.nge-error-container {
+  height: 42px;
+  padding: 10px;
+  color: var(--error80);
+}


### PR DESCRIPTION
This is a lightweight safeguard for errors such as "Cycle detection". It keeps the application usable while the underlying NGE issue is handled separately.

This fix comes from https://github.com/OpenRailAssociation/osrd/pull/17928

Reduces the criticity of https://github.com/OpenRailAssociation/osrd/issues/18206