### PR TITLE
front : autofill train name and make field optional

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -857,8 +857,6 @@ const ItineraryModal = ({
             onRollingStockMessageChange={setRollingStockMessage}
             currentSubCategory={currentSubCategory}
             categoryColors={categoryColors}
-            submitAttempted={submitAttempted}
-            isNameEmpty={isNameEmpty}
           />
         </div>
         <div className="itinerary-modal-form-body" data-testid="itinerary-modal-form-body">

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -79,7 +79,7 @@ type ItineraryModalProps = {
 };
 
 export type ItineraryModalFormState = {
-  name?: string;
+  name: string;
   rollingStockId?: number;
   rollingStockName: string;
   speedLimitTag?: string;
@@ -178,6 +178,31 @@ export function setupStateWithTrainSchedule(
 
   return state;
 }
+
+const createDefaultTrainName = (stepsWithLocationOrInput: PathStepV2[]): string => {
+  const createDefaultStepName = (pathStep: PathStepV2): string => {
+    const location = pathStep.location;
+    if (!location) return '';
+    switch (location.type) {
+      case 'track_offset':
+        return `${location.track}+${Math.round(location.offset / 1000)}`;
+      case 'operational_point_part_reference': {
+        const op = location.operational_point;
+        switch (op.type) {
+          case 'domestic':
+            return op.main_code;
+          case 'uic':
+            return `UIC ${op.uic}`;
+          case 'id':
+            return `ID ${op.operational_point}`;
+        }
+      }
+    }
+  };
+  const origin = stepsWithLocationOrInput[0];
+  const destination = stepsWithLocationOrInput[stepsWithLocationOrInput.length - 1];
+  return `${createDefaultStepName(origin)} → ${createDefaultStepName(destination)}`;
+};
 
 const ItineraryModal = ({
   onTrainCreated,
@@ -597,7 +622,7 @@ const ItineraryModal = ({
     }
   };
 
-  const isNameEmpty = !modalFormState.name || modalFormState.name.trim() === '';
+  const isNameEmpty = modalFormState.name.trim() === '';
   const [submitAttempted, setSubmitAttempted] = useState(false);
 
   useEffect(() => {
@@ -741,12 +766,15 @@ const ItineraryModal = ({
   const submitItinerary = (trainType?: EditingTrainType) => {
     setSubmitAttempted(true);
     setBannerWiggle((c) => c + 1);
-    if (isNameEmpty) return;
 
     const stepsWithLocationOrInput = pathSteps.filter(
       (step) => !isEmptyStep(step, getInputForStep(step.id))
     );
     if (stepsWithLocationOrInput.length < 2) return;
+
+    const name = isNameEmpty
+      ? createDefaultTrainName(stepsWithLocationOrInput)
+      : modalFormState.name;
 
     const stepsWithStopAtDestination = stepsWithLocationOrInput.map((step, i) =>
       i === stepsWithLocationOrInput.length - 1
@@ -760,7 +788,7 @@ const ItineraryModal = ({
 
     setTrainState((oldTrainState: ItineraryModalTrainState) => ({
       ...oldTrainState,
-      name: modalFormState.name ?? '',
+      name,
       category: modalFormState.category ?? null,
       rollingStockId: modalFormState.rollingStockId,
       rollingStockName: modalFormState.rollingStockName,

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalFormHeader.tsx
@@ -1,12 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
-import {
-  ComboBox,
-  Input,
-  Select,
-  useDefaultComboBox,
-  type StatusWithMessage,
-} from '@osrd-project/ui-core';
+import { ComboBox, Input, Select, useDefaultComboBox } from '@osrd-project/ui-core';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { isEqual } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -33,8 +27,6 @@ type ItineraryModalFormHeaderProps = {
   onRollingStockMessageChange: (message?: string) => void;
   currentSubCategory?: SubCategory;
   categoryColors: CategoryColors;
-  submitAttempted?: boolean;
-  isNameEmpty?: boolean;
 };
 
 const ItineraryModalFormHeader = ({
@@ -44,8 +36,6 @@ const ItineraryModalFormHeader = ({
   onRollingStockMessageChange,
   currentSubCategory,
   categoryColors,
-  submitAttempted,
-  isNameEmpty,
 }: ItineraryModalFormHeaderProps) => {
   const { t } = useTranslation('operational-studies', {
     keyPrefix: 'manageTrainSchedule',
@@ -122,19 +112,6 @@ const ItineraryModalFormHeader = ({
   // Composition code/speed limit by tag
   const infraID = useInfraID();
   const speedLimitTags = useSpeedLimitTags(infraID);
-
-  // Train schedule name error
-  const [isNameBlurred, setIsNameBlurred] = useState(false);
-
-  const nameError: StatusWithMessage | undefined = useMemo(() => {
-    const shouldShowError = (isNameBlurred || submitAttempted) && isNameEmpty;
-    if (!shouldShowError) return undefined;
-
-    return {
-      status: 'error',
-      message: t('errorMessages.requiredField'),
-    };
-  }, [isNameBlurred, submitAttempted, isNameEmpty, t]);
 
   const rollingStockMessage = useMemo(() => {
     if (!rollingStockValue) {
@@ -241,9 +218,6 @@ const ItineraryModalFormHeader = ({
                 name: e.target.value,
               })
             }
-            onBlur={() => setIsNameBlurred(true)}
-            onFocus={() => setIsNameBlurred(false)}
-            statusWithMessage={nameError}
           />
         </div>
       </div>


### PR DESCRIPTION
Closes #18200 with a first implementation of the feature.
See expected behaviors in [osrd-project/osrd-confidential/issues/1697](https://github.com/osrd-project/osrd-confidential/issues/1697) (internal issue) and with @louisgreiner.

Some ideas for later : 
* A similar feature when creating a mission in NGE.
* Maybe change what is displayed in case of an Operational Point described with an UIC or with only an ID (the easiest solution was implemented, but we could get the main_code when the OP is an UIC).
* Add E2E tests ?