### PR TITLE
front: rename timetable mode calendar to chronological

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -239,7 +239,7 @@
         "zero_length_path": "Abfahrt und Ankunft sind identisch"
       },
       "invalidTrains": "Einige Züge sind ungültig",
-      "modeCalendar": "Chronologisch sortieren",
+      "modeChronological": "Chronologisch sortieren",
       "modeTrainScheduleSet": "Nach Paket sortieren",
       "noSpeedLimitTagsShort": "Keiner",
       "noTrainSchedule": "Kein Eintrag",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -239,7 +239,7 @@
         "zero_length_path": "Departure and arrival are identical"
       },
       "invalidTrains": "Some trains are invalid",
-      "modeCalendar": "Sort chronologically",
+      "modeChronological": "Sort chronologically",
       "modeTrainScheduleSet": "Sort by train schedule set",
       "noSpeedLimitTagsShort": "None",
       "noTrainSchedule": "No train schedule",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -239,7 +239,7 @@
         "zero_length_path": "L'origine et la destination sont identiques"
       },
       "invalidTrains": "Certains trains sont invalides",
-      "modeCalendar": "Trier chronologiquement",
+      "modeChronological": "Trier chronologiquement",
       "modeTrainScheduleSet": "Trier par paquet",
       "noSpeedLimitTagsShort": "Aucun",
       "noTrainSchedule": "Aucune circulation",

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/Timetable.tsx
@@ -46,7 +46,7 @@ const Timetable = ({
   const { trainSchedules, upsertTrainSchedules } = useTimetableContext();
 
   const [showTrainDetails, setShowTrainDetails] = useState(false);
-  const [timetableMode, setTimetableMode] = useState<TimetableMode>('calendar');
+  const [timetableMode, setTimetableMode] = useState<TimetableMode>('chronological');
   const [expandedTrainScheduleSetIds, setExpandedTrainScheduleSetIds] = useState<Set<number>>(
     new Set()
   );

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableToolbar.tsx
@@ -265,11 +265,11 @@ const TimetableToolbar = ({
           <div className="timetable-sort-switch">
             <button
               className={cx('timetable-mode-button', {
-                active: timetableMode === 'calendar',
+                active: timetableMode === 'chronological',
               })}
-              data-testid="timetable-calendar-mode-button"
-              title={t('timetable.modeCalendar')}
-              onClick={() => setTimetableMode('calendar')}
+              data-testid="timetable-chronological-mode-button"
+              title={t('timetable.modeChronological')}
+              onClick={() => setTimetableMode('chronological')}
               type="button"
             >
               <Calendar />

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TrainList.tsx
@@ -160,7 +160,7 @@ const TrainList = ({
     () => (trainSchedules: TrainScheduleWithDetails[]) =>
       trainSchedules.map((trainSchedule, index) => (
         <div key={`timetable-train-card-${trainSchedule.id}`} data-train-id={trainSchedule.id}>
-          {timetableMode === 'calendar' && showDepartureDates[index] && (
+          {timetableMode === 'chronological' && showDepartureDates[index] && (
             <div className="scenario-timetable-departure-date">{currentDepartureDates[index]}</div>
           )}
           {!isPacedTrainWithDetails(trainSchedule) ? (
@@ -229,7 +229,7 @@ const TrainList = ({
 
   return (
     <Virtualizer>
-      {timetableMode === 'calendar' && trainsToItems(trainSchedulesWithDetails)}
+      {timetableMode === 'chronological' && trainsToItems(trainSchedulesWithDetails)}
       {timetableMode === 'trainScheduleSet' &&
         (trainSchedulesByTrainScheduleSets ? (
           trainSchedulesByTrainScheduleSets

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/types.ts
@@ -31,4 +31,4 @@ export type TimetableFilters = {
   setTrainCategoryFilter: (categoryOption: TrainCategoryFilter) => void;
 };
 
-export type TimetableMode = 'calendar' | 'trainScheduleSet';
+export type TimetableMode = 'chronological' | 'trainScheduleSet';


### PR DESCRIPTION
Renamed the calendar timetable sort mode to chronological, since calendar is already used elsewhere in the app and was confusing.