### PR TITLE
Fix copy paste round trip bug

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import { useTimetableContext } from 'applications/operationalStudies/hooks/useTimetableContext';
 import BoardWrapper from 'applications/operationalStudies/views/Scenario/components/BoardWrapper';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { useSubCategoryContext } from 'common/SubCategoryContext';
@@ -41,8 +42,11 @@ const TimetableBoardWrapper = ({
 }: TimetableBoardWrapperProps) => {
   const { openModal } = useContext(ModalContext);
 
-  const { scenario, sandboxId } = useScenarioContext();
+  const { scenario, sandboxId, timetableId } = useScenarioContext();
   const { trainSchedules, removeTrainSchedules, upsertTrainSchedules } = useTimetableContext();
+
+  const [getTimetableRoundTrips] =
+    osrdEditoastApi.endpoints.getTimetableByIdRoundTrips.useLazyQuery();
 
   const { id: selectedTrainId } = useSelector(getSelectedTrain) || {};
 
@@ -187,14 +191,25 @@ const TimetableBoardWrapper = ({
       return;
     }
 
-    await copyTrainSchedulesToClipboard(selectedTrainScheduleIds, trainSchedules);
-    dispatch(
-      setSuccess({
-        title: t('main.copyTimetable.title'),
-        text: t('main.copyTimetable.text', { count: selectedTrainScheduleIds.length }),
-      })
-    );
-  }, [selectedTrainScheduleIds, trainSchedules]);
+    try {
+      const { results: trainScheduleRoundTrips } = await getTimetableRoundTrips({
+        id: timetableId,
+      }).unwrap();
+      await copyTrainSchedulesToClipboard(
+        selectedTrainScheduleIds,
+        trainSchedules,
+        trainScheduleRoundTrips
+      );
+      dispatch(
+        setSuccess({
+          title: t('main.copyTimetable.title'),
+          text: t('main.copyTimetable.text', { count: selectedTrainScheduleIds.length }),
+        })
+      );
+    } catch (e) {
+      dispatch(setFailure(castErrorToFailure(e)));
+    }
+  }, [selectedTrainScheduleIds, trainSchedules, getTimetableRoundTrips, timetableId]);
 
   const handlePaste = useCallback(async () => {
     let data = null;
@@ -238,16 +253,27 @@ const TimetableBoardWrapper = ({
       }
 
       event.preventDefault();
-      await copyTrainSchedulesToClipboard(selectedTrainScheduleIds, trainSchedules);
-      await handleTrainsDelete(selectedTrainId, true);
-      dispatch(
-        setSuccess({
-          title: t('main.cutTimetable.title'),
-          text: t('main.cutTimetable.text', { count: selectedTrainScheduleIds.length }),
-        })
-      );
+      try {
+        const { results: trainScheduleRoundTrips } = await getTimetableRoundTrips({
+          id: timetableId,
+        }).unwrap();
+        await copyTrainSchedulesToClipboard(
+          selectedTrainScheduleIds,
+          trainSchedules,
+          trainScheduleRoundTrips
+        );
+        await handleTrainsDelete(selectedTrainId, true);
+        dispatch(
+          setSuccess({
+            title: t('main.cutTimetable.title'),
+            text: t('main.cutTimetable.text', { count: selectedTrainScheduleIds.length }),
+          })
+        );
+      } catch (e) {
+        dispatch(setFailure(castErrorToFailure(e)));
+      }
     },
-    [selectedTrainScheduleIds, trainSchedules, selectedTrainId]
+    [selectedTrainScheduleIds, trainSchedules, selectedTrainId, getTimetableRoundTrips, timetableId]
   );
 
   const handleDeleteTrainSchedules = () => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/utils.ts
@@ -65,20 +65,6 @@ const formatTrainSchedulesForExport = (
   };
 };
 
-export const copyTrainSchedulesToClipboard = async (
-  selectedTimeTableIdsFromClick: number[],
-  trainSchedules: Map<number, TrainScheduleResponse>
-) => {
-  const { formattedTrainSchedules } = formatTrainSchedulesForExport(
-    trainSchedules,
-    selectedTimeTableIdsFromClick
-  );
-  const jsonString = JSON.stringify({ train_schedules: formattedTrainSchedules });
-  const blob = new Blob([jsonString], { type: 'text/plain' });
-  const clipboardItem = new ClipboardItem({ [blob.type]: blob });
-  await navigator.clipboard.write([clipboardItem]);
-};
-
 /**
  * turns editoast ids into corresponding indexes in exported arrays
  */
@@ -145,6 +131,22 @@ export const buildTimetableExportPayload = (
     train_schedules: formattedTrainSchedules,
     round_trips: (mappedRoundTrips?.length ?? 0) > 0 ? mappedRoundTrips : undefined,
   };
+};
+
+export const copyTrainSchedulesToClipboard = async (
+  selectedTimeTableIdsFromClick: number[],
+  trainSchedules: Map<number, TrainScheduleResponse>,
+  roundTrips: RoundTrips
+) => {
+  const clipboardPayload = buildTimetableExportPayload(
+    trainSchedules,
+    selectedTimeTableIdsFromClick,
+    roundTrips
+  );
+  const jsonString = JSON.stringify(clipboardPayload);
+  const blob = new Blob([jsonString], { type: 'text/plain' });
+  const clipboardItem = new ClipboardItem({ [blob.type]: blob });
+  await navigator.clipboard.write([clipboardItem]);
 };
 
 export const exportTrainSchedules = (


### PR DESCRIPTION
### Description

Now `copyTrainSchedulesToClipboard` includes the round trips of the copied trains in the clipboard payload. 
Also extracted the repeated `getTimetableByIdRoundTrips` query (duplicated in `RoundTripsModal` and `TimetableToolbar`) into a shared `useTimetableRoundTrips` hook.

close #15898 