### PR TITLE
Space time chart, disable panning while dragging

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/configureHandlePan.ts
@@ -210,6 +210,7 @@ export function configureHandlePan({
           originalPacedExceptions,
           pacedGrid,
         });
+        return;
       }
     }
 


### PR DESCRIPTION
Closes #10630 

Previous code let the panning process continue as usual even at the instant we started dragging something, this was setting a fake `initialOffset` that was taken back when actually panning later on. If between this drag and pan we used the zoom to change the `xOffset` the second pan teleported to the previous `"panning" initialOffset`.