### PR TITLE
editoast: un-allow dependency_on_unit_never_type_fallback

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -26,7 +26,6 @@ members = [
 
 [workspace.lints.rust]
 async_fn_in_trait = "allow" # all of our public traits are only used inside the project
-dependency_on_unit_never_type_fallback = "allow" # this is caused by tracing, we can't do anything about it
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
This lint has been removed on nightly, since the never type is stabilized and the breaking fallback change is live.

It's now a type checking hard error, not a warning. Also, we don't need to allow it anymore, even on stable.