### PR TITLE
editoast: core_task: increase recursion limit

### DIFF
--- a/editoast/core_task/src/lib.rs
+++ b/editoast/core_task/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 mod envs;
 mod path_properties;
 


### PR DESCRIPTION
The change to the new trait solver causes a lint on nightly (and will eventually be a breaking change on stable). The main method to solve this would require using unsafe, which isn't allowed to us :/

However, we can just increase the recursion limit in this case.

See https://github.com/rust-lang/rust/issues/159228