### PR TITLE
front: disable restricted reader grant

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -464,8 +464,7 @@
       "edit": "write",
       "full": "full access",
       "none": "no access",
-      "read": "read",
-      "restricted_read": "restricted read"
+      "read": "read"
     },
     "permission": "Permission",
     "permissionDenied": "You don't have permission to perform this action",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -464,8 +464,7 @@
       "edit": "écriture",
       "full": "accès total",
       "none": "pas d'accès",
-      "read": "lecture",
-      "restricted_read": "lecture limitée"
+      "read": "lecture"
     },
     "permission": "Permission",
     "permissionDenied": "Vous n'avez pas la permission de réaliser cette action",

--- a/front/src/common/authorization/components/GrantsManager.tsx
+++ b/front/src/common/authorization/components/GrantsManager.tsx
@@ -12,7 +12,8 @@ function getGrantLabel(userPrivileges: Set<Privilege>): keyof typeof GRANTS_LABE
   if (userPrivileges.has('can_delete')) return 'OWNER';
   if (userPrivileges.has('can_write')) return 'WRITER';
   if (userPrivileges.has('can_read')) return 'READER';
-  if (userPrivileges.has('can_restricted_read')) return 'RESTRICTED_READER';
+  // TODO_GRANT: Able RESTRICTED_READER when backend supports it
+  // if (userPrivileges.has('can_restricted_read')) return 'RESTRICTED_READER';
   return 'NONE';
 }
 

--- a/front/src/common/authorization/consts.ts
+++ b/front/src/common/authorization/consts.ts
@@ -1,7 +1,8 @@
 // The order is important here, as it is used to determine the order of the grants
 export enum GRANTS_LABEL {
   NONE = 'none',
-  RESTRICTED_READER = 'restricted_read',
+  // TODO_GRANT: Able RESTRICTED_READER when backend supports it
+  // RESTRICTED_READER = 'restricted_read',
   READER = 'read',
   WRITER = 'edit',
   OWNER = 'full',

--- a/front/src/common/authorization/utils/generateGrantSelectProps.ts
+++ b/front/src/common/authorization/utils/generateGrantSelectProps.ts
@@ -6,8 +6,9 @@ import { GRANTS_LABEL } from '../consts';
 
 function getRequiredPrivilegesToAddGrant(grant: keyof typeof GRANTS_LABEL): Privilege[] {
   switch (grant) {
-    case 'RESTRICTED_READER':
-      return ['can_share_read'];
+    // TODO_GRANT: Able RESTRICTED_READER when backend supports it
+    // case 'RESTRICTED_READER':
+    //   return ['can_share_restricted_read'];
     case 'READER':
       return ['can_share_read'];
     case 'WRITER':
@@ -61,9 +62,14 @@ const generateGrantSelectProps = ({
   // if the subject's option is not found, we return only its grant and in readonly mode
   const subjectValueIndex = allowedOptions.findIndex((option) => option.value === subjectGrant);
   if (subjectValueIndex < 0) {
+    // TODO_GRANT: use Grant type instead of GRANTS_LABEL when backend supports it
+    const subjectGrantLabel =
+      subjectGrant in GRANTS_LABEL
+        ? GRANTS_LABEL[subjectGrant as keyof typeof GRANTS_LABEL]
+        : GRANTS_LABEL.NONE;
     const options = [
       {
-        label: t(`authorization.grants.${GRANTS_LABEL[subjectGrant || 'NONE']}`),
+        label: t(`authorization.grants.${subjectGrantLabel}`),
         value: subjectGrant,
       },
     ];

--- a/front/src/reducers/infra/generateGrantSelectProps.spec.ts
+++ b/front/src/reducers/infra/generateGrantSelectProps.spec.ts
@@ -33,10 +33,6 @@ describe('generateSelectPropsForGrant', () => {
       value: { label: 'authorization.grants.read', value: 'READER' },
       options: [
         { label: 'authorization.grants.none', value: undefined },
-        {
-          label: 'authorization.grants.restricted_read',
-          value: 'RESTRICTED_READER',
-        },
         { label: 'authorization.grants.read', value: 'READER' },
         { label: 'authorization.grants.edit', value: 'WRITER' },
         { label: 'authorization.grants.full', value: 'OWNER' },


### PR DESCRIPTION
back is not ready to support it

‘restricted_read’ has been removed from the translation file; please do not forget to add it back in