### PR TITLE
front: remove whole file eslint-disable rules

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -64,7 +64,7 @@ const Editor = () => {
   const isLocked = useSelector(getInfraLockStatus);
   const editorState = useSelector(getEditorState);
   const { data: switchTypes } = useSwitchTypes(infraID);
-  /* eslint-disable @typescript-eslint/no-explicit-any */
+  /* eslint-disable-next-line typescript/no-explicit-any */
   const [toolAndState, setToolAndState] = useState<FullTool<any>>({
     tool: TOOLS[TOOL_NAMES.SELECTION],
     state: TOOLS[TOOL_NAMES.SELECTION].getInitialState({ infraID, switchTypes }),

--- a/front/src/common/BootstrapSNCF/InputSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/InputSNCF.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/no-autofocus */
 import React, { type InputHTMLAttributes, type ReactNode } from 'react';
 
 import cx from 'classnames';
@@ -138,6 +137,7 @@ const InputSNCF = ({
           >
             <input
               data-testid={`${id}-input`}
+              /* eslint-disable-next-line jsx-a11y/no-autofocus */
               autoFocus={focus}
               type={type}
               onChange={onChange}

--- a/front/src/common/Map/WarpedMap/DataLoader.tsx
+++ b/front/src/common/Map/WarpedMap/DataLoader.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useEffect, useMemo, useState } from 'react';
 
 import { featureCollection } from '@turf/helpers';
@@ -61,6 +60,7 @@ const DataLoader = ({ bbox, getGeoJSONs, layers }: DataLoaderProps) => {
 
     mapRef.fitBounds(bbox, { animate: false });
     setTimeout(() => {
+      /* eslint-disable-next-line no-console */
       console.time(TIME_LABEL);
       setState('render');
     }, 0);

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/no-autofocus */
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Rocket } from '@osrd-project/ui-icons';
@@ -233,6 +232,7 @@ const TypeAndPath = ({ onSubmit }: TypeAndPathProps) => {
               value={inputText}
               onChange={(e) => handleInput(e.target.value, e.target.selectionStart!)}
               placeholder={t('inputOPMainCodesExample')}
+              /* eslint-disable-next-line jsx-a11y/no-autofocus */
               autoFocus
               data-testid="type-and-path-input"
             />

--- a/front/src/modules/timesStops/DurationCell.tsx
+++ b/front/src/modules/timesStops/DurationCell.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import {
   useReducer,
   useRef,
@@ -552,8 +550,10 @@ const DurationCell = ({
 
   return (
     <>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
         ref={containerRef}
+        /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
         tabIndex={0}
         className="duration-cell"
         data-testid="duration-cell"

--- a/front/src/modules/timesStops/TimesStopsInput.tsx
+++ b/front/src/modules/timesStops/TimesStopsInput.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-useless-fragment */
 import { useCallback, useEffect, useState } from 'react';
 
 import { X } from '@osrd-project/ui-icons';
@@ -58,6 +57,7 @@ const createClearViaButton = ({
       </button>
     );
   }
+  /* eslint-disable-next-line react/jsx-no-useless-fragment */
   return <></>;
 };
 

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { keyColumn, createTextColumn } from '@sdziadkowiec/react-datasheet-grid';
 import dayjs from 'dayjs';
 import type { TFunction } from 'i18next';
@@ -43,6 +42,41 @@ export const truncateStartTimeToDay = (date: StartTime): StartTime => {
     return new Duration({ days: Math.floor(date.total('day')) });
   }
 };
+
+/** Convert receptionSignal enum to onStopSignal boolean */
+export function receptionSignalToSignalBooleans(receptionSignal?: ReceptionSignal) {
+  if (isNil(receptionSignal)) {
+    return { shortSlipDistance: undefined, onStopSignal: undefined };
+  }
+  if (receptionSignal === 'STOP') {
+    return { shortSlipDistance: false, onStopSignal: true };
+  }
+  if (receptionSignal === 'SHORT_SLIP_STOP') {
+    return { shortSlipDistance: true, onStopSignal: true };
+  }
+  return { shortSlipDistance: false, onStopSignal: false };
+}
+
+export function calculateStepTimeAndDays(
+  startTime?: Date | null,
+  duration?: Duration | null
+): TimeExtraDays | undefined {
+  if (!startTime || !duration) {
+    return undefined;
+  }
+
+  const start = dayjs(startTime);
+  const dur = dayjs.duration(duration.ms);
+
+  const waypointArrivalTime = start.add(dur);
+  const daySinceDeparture = waypointArrivalTime.diff(start, 'day');
+  const time: TimeString = waypointArrivalTime.format('HH:mm:ss');
+
+  return {
+    time,
+    daySinceDeparture,
+  };
+}
 
 export const formatSuggestedViasToRowVias = (
   operationalPoints: SuggestedOP[],
@@ -341,27 +375,6 @@ export function durationSinceStartTime(
   return Duration.subtractDate(step.toDate(), startTime);
 }
 
-export function calculateStepTimeAndDays(
-  startTime?: Date | null,
-  duration?: Duration | null
-): TimeExtraDays | undefined {
-  if (!startTime || !duration) {
-    return undefined;
-  }
-
-  const start = dayjs(startTime);
-  const dur = dayjs.duration(duration.ms);
-
-  const waypointArrivalTime = start.add(dur);
-  const daySinceDeparture = waypointArrivalTime.diff(start, 'day');
-  const time: TimeString = waypointArrivalTime.format('HH:mm:ss');
-
-  return {
-    time,
-    daySinceDeparture,
-  };
-}
-
 /** Convert onStopSignal boolean to receptionSignal enum */
 export function onStopSignalToReceptionSignal(
   onStopSignal?: boolean,
@@ -374,20 +387,6 @@ export function onStopSignalToReceptionSignal(
     return shortSlipDistance ? 'SHORT_SLIP_STOP' : 'STOP';
   }
   return 'OPEN';
-}
-
-/** Convert receptionSignal enum to onStopSignal boolean */
-export function receptionSignalToSignalBooleans(receptionSignal?: ReceptionSignal) {
-  if (isNil(receptionSignal)) {
-    return { shortSlipDistance: undefined, onStopSignal: undefined };
-  }
-  if (receptionSignal === 'STOP') {
-    return { shortSlipDistance: false, onStopSignal: true };
-  }
-  if (receptionSignal === 'SHORT_SLIP_STOP') {
-    return { shortSlipDistance: true, onStopSignal: true };
-  }
-  return { shortSlipDistance: false, onStopSignal: false };
 }
 
 export const getOperationalPointName = (

--- a/front/src/store/listeners/user.ts
+++ b/front/src/store/listeners/user.ts
@@ -1,14 +1,7 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { osrdGatewayApi } from 'common/api/osrdGatewayApi';
 import { loginError, loginSuccess, logoutSuccess } from 'reducers/user';
 
 import type { AppStartListening } from './types';
-
-export default function addUserListeners(startListening: AppStartListening) {
-  handleAuthAuthenticateSuccess(startListening);
-  handleAuthAuthenticateFailed(startListening);
-  handleAuthLogoutSuccess(startListening);
-}
 
 function handleAuthAuthenticateSuccess(startListening: AppStartListening) {
   startListening({
@@ -52,4 +45,10 @@ function handleAuthLogoutSuccess(startListening: AppStartListening) {
       listenerApi.dispatch(logoutSuccess());
     },
   });
+}
+
+export default function addUserListeners(startListening: AppStartListening) {
+  handleAuthAuthenticateSuccess(startListening);
+  handleAuthAuthenticateFailed(startListening);
+  handleAuthLogoutSuccess(startListening);
 }

--- a/front/ui/ui-charts/src/spaceTimeChart/utils/scales.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/utils/scales.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { clamp, inRange } from 'lodash';
 
 import type {
@@ -270,6 +269,24 @@ export function getSpaceBreakpoints(from: number, to: number, tree: NormalizedSc
   return res;
 }
 
+export function sideOffset(
+  origin: number,
+  newScale: number,
+  rectStart: number | Date,
+  rectEnd: number | Date,
+  chartSideSizePx: number,
+  axisPadding: number = 0
+) {
+  const rectCenter = (Number(rectStart) + Number(rectEnd)) / 2;
+  const newChartSize = chartSideSizePx * newScale;
+  // newChartBorder is the x or y origin after zoom
+  // it’s normally the same as rectStart (the left or top most part of the rectangle)
+  // but if we reach max zoom we can’t use rectStart as the chart displayed origin
+  // because it doesn’t garentees that the zoom rectangle stays exactly at the center of the chart after the zoom
+  const newChartBorder = rectCenter - newChartSize / 2;
+  return (origin - newChartBorder) / newScale - axisPadding * 2;
+}
+
 /**
  * in most cases, after the rectangle zoom, the screen will be centered
  * on the center of the rectangle the user drew.
@@ -318,22 +335,4 @@ export function computeRectZoomOffsets({
   return !swapAxes
     ? { xOffset: timeOffset, yOffset: spaceOffset }
     : { xOffset: spaceOffset, yOffset: timeOffset };
-}
-
-export function sideOffset(
-  origin: number,
-  newScale: number,
-  rectStart: number | Date,
-  rectEnd: number | Date,
-  chartSideSizePx: number,
-  axisPadding: number = 0
-) {
-  const rectCenter = (Number(rectStart) + Number(rectEnd)) / 2;
-  const newChartSize = chartSideSizePx * newScale;
-  // newChartBorder is the x or y origin after zoom
-  // it’s normally the same as rectStart (the left or top most part of the rectangle)
-  // but if we reach max zoom we can’t use rectStart as the chart displayed origin
-  // because it doesn’t garentees that the zoom rectangle stays exactly at the center of the chart after the zoom
-  const newChartBorder = rectCenter - newChartSize / 2;
-  return (origin - newChartBorder) / newScale - axisPadding * 2;
 }

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -82,23 +82,22 @@ const ComboBox = <T,>({
   const inputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLInputElement>(null);
 
-  const removeFocus = () => {
+  const removeFocus = useCallback(() => {
     setIsInputFocused(false);
     setActiveSuggestionIndex(-1);
     setTimeout(() => {
       inputRef.current?.blur();
     }, 0);
     resetSuggestions();
-  };
+  }, [resetSuggestions]);
 
-  /* eslint-disable react-hooks/exhaustive-deps */
   const focusInput = useCallback(() => {
     if (isInputFocused) {
       removeFocus();
     } else {
       inputRef.current?.focus();
     }
-  }, [inputRef, isInputFocused]);
+  }, [inputRef, isInputFocused, removeFocus]);
 
   const normalizedInputValue = useMemo(() => inputValue.trim().toLowerCase(), [inputValue]);
 
@@ -234,12 +233,12 @@ const ComboBox = <T,>({
     setIsInputFocused(true);
   };
 
-  const clearInput = () => {
+  const clearInput = useCallback(() => {
     setInputValue('');
     onChange?.('');
     resetSuggestions();
     focusInput();
-  };
+  }, [resetSuggestions, onChange, focusInput]);
 
   useOutsideClick(showSuggestions || isInputFocused ? wrapperRef : null, onFieldBlur);
 

--- a/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
+++ b/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 
 import Input, { type InputProps } from '../Input';
 import Popover from '../InputPopover';
@@ -31,8 +30,11 @@ const TolerancePicker = ({
   testIdPrefix,
   ...inputProps
 }: TolerancePickerProps) => {
-  const formatToleranceValue = (minusIndex: number, plusIndex: number) =>
-    `-${TOLERANCE_RANGES[minusIndex]?.label || ''}/+${TOLERANCE_RANGES[plusIndex]?.label || ''}`;
+  const formatToleranceValue = useCallback(
+    (minusIndex: number, plusIndex: number) =>
+      `-${TOLERANCE_RANGES[minusIndex]?.label || ''}/+${TOLERANCE_RANGES[plusIndex]?.label || ''}`,
+    []
+  );
 
   const [showPicker, setShowPicker] = useState(false);
   const [inputValue, setInputValue] = useState(formatToleranceValue(0, 0));
@@ -47,6 +49,7 @@ const TolerancePicker = ({
     if (minusToleranceIndex < 0 || plusToleranceIndex < 0) {
       const invalidTolerance = minusToleranceIndex < 0 ? minusTolerance : plusTolerance;
 
+      /* eslint-disable-next-line react/set-state-in-effect */
       setWarningStatus({
         status: 'warning',
         message:
@@ -58,7 +61,7 @@ const TolerancePicker = ({
     }
 
     setInputValue(formatToleranceValue(minusToleranceIndex, plusToleranceIndex));
-  }, [minusTolerance, plusTolerance]);
+  }, [formatToleranceValue, minusTolerance, plusTolerance, translateWarningMessage]);
 
   return (
     <div data-testid={testIdPrefix ? `${testIdPrefix}` : undefined} className="ui-tolerance-picker">


### PR DESCRIPTION
There were a few `// eslint-disable` comments in our codebase, which is a bad practice: we should always use `// eslint-disable-next-line` instead, to make sure we only disable rules on specific instances of violations of our best practices.

To do so, I either had to move things around, move the disable comment to be more precise or fix little dependencies errors.