### PR TITLE
front: use arm64-based image for Postgres automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ xdg-open http://localhost:4000/
 
 Linux or WSL users can use `./osrd-compose host` instead of `docker compose` to enable host networking: it can be useful to launch services in a debugger.
 
-macOS users on Apple Silicon should make sure to set an arm64 image name for Postgres/PostGIS (to prevent slow amd64 emulation). This image name can be set by running `export OSRD_POSTGIS_IMAGE='nickblah/postgis:16-postgis-3'` before the first `docker compose` command.
+macOS users on Apple Silicon should also use `./osrd-compose` to let them use an arm64-native image of Postgres + PostGIS automatically.
 
 The last-minute train (STDCM) module needs additional setup: start by creating a scenario, copy its ID from its URL, then run:
 

--- a/osrd-compose
+++ b/osrd-compose
@@ -153,6 +153,11 @@ if has_flag "playwright"; then
     compose_files+=("$OVERRIDE_DIR/docker-compose.playwright.yml")
 fi
 
+# Set to an alternative postgis image if we are running on an arm64-based processor, i.e. Apple Silicon
+# (we don't want to run postgres in Rosetta, and the default postgis/postgis container image is x86_64 only)
+if [[ $(uname -m) == 'arm64' ]] && [ -z "$OSRD_POSTGIS_IMAGE" ]; then
+    export OSRD_POSTGIS_IMAGE='nickblah/postgis:16-postgis-3'
+fi
 
 # Check if DOCKER_SOCKET is already set
 if [ -z "$DOCKER_SOCKET" ]; then


### PR DESCRIPTION
We used to only suggest that to all macOS-based users, but it's very cumbersome to remember to run this `export` command every time… let's do it automatically.