### PR TITLE
editoast: increase the maximum number of postgres connections available when running tests

### DIFF
--- a/editoast/database/src/db_connection_pool.rs
+++ b/editoast/database/src/db_connection_pool.rs
@@ -375,7 +375,8 @@ impl DbConnectionPoolV2 {
         let (test_db_name, test_db_url) = create_test_database(osrd_conn, test_name).await?;
         let url = Url::parse(&test_db_url).expect("Failed to parse postgresql url");
         tracing::info!(%url, "Using test database URL");
-        let pool = create_connection_pool(url, 2)?.into();
+        let max_connections = 8; // arbitrary number: used to be 2 but some tests needed more
+        let pool = create_connection_pool(url, max_connections)?.into();
         Ok(Self {
             pool,
             osrd_pool,


### PR DESCRIPTION
>[!NOTE]
I might be missing some context on why we only have 2 available connections when running a test.

It used to be 2, which caused deadlocks when a test needed 3 or more Postgres connections simultaneously to execute.

When this situation happens it might be a sign of code smell: I tumbled on it once so far in a case where both the endpoint and its test kept a connection open until it was dropped at the end of their scope (`let conn = [...];`), but then the endpoint needed another connection later on, before the two prior connections could be released.
=> Neither the test or the endpoint should have kept those connections open in the first place in that case so it could be fixed without increasing the number of available connections in the pool, but there might be valid reasons to use more than 2 connections at once when testing something.

Limiting the pool to 2 connections seems arbitrary and too much restrictive nonetheless and it should be increased unless there is a good reason to keep it that low (?).