### PR TITLE
devx: suggest .env config for arm64 postgis override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 # Direnv
 .envrc
 .direnv
+.env
 
 # Helper script
 .osrd-compose-state

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ xdg-open http://localhost:4000/
 
 Linux or WSL users can use `./osrd-compose host` instead of `docker compose` to enable host networking: it can be useful to launch services in a debugger.
 
-macOS users on Apple Silicon should make sure to set an arm64 image name for Postgres/PostGIS (to prevent slow amd64 emulation). This image name can be set by running `export OSRD_POSTGIS_IMAGE='nickblah/postgis:16-postgis-3'` before the first `docker compose` command.
+macOS users on Apple Silicon should make sure to set an arm64 image name for Postgres/PostGIS (to prevent slow amd64 emulation). This image name can be set by creating a `.env` with `OSRD_POSTGIS_IMAGE='nickblah/postgis:16-postgis-3'` in it, before running the first `docker compose` command.
 
 The last-minute train (STDCM) module needs additional setup: start by creating a scenario, copy its ID from its URL, then run:
 


### PR DESCRIPTION
Follow-up of aborted #18341.

Instead of suggesting Apple Silicon-based macOS developers to export a specific environment variable on the start on any session they use our docker-compose file, this commit suggest the usage of the .env file that is read by Docker Compose (and their clones).

This also ignore `.env` from the repository through `.gitignore` to make it less noisy for users (without asking for them to do it locally through `.git/info/exclude`).