### PR TITLE
e2e : fix flaky tests

### DIFF
--- a/front/tests/02-operational-studies/itineraryModal/002-itinerary-modal-edit.spec.ts
+++ b/front/tests/02-operational-studies/itineraryModal/002-itinerary-modal-edit.spec.ts
@@ -133,11 +133,13 @@ test.describe('Itinerary Modal, Edition ', { tag: ['@op', '@itinerary-modal'] },
       await test.step('Insert a path step in the itinerary', async () => {
         await itineraryModalPage.insertIntermediatePathStep(1, NORTH_STATION_MAIN_CODE, 1);
         await itineraryModalPage.checkPathStepValue(2, SOUTH_STATION_BV);
-        await itineraryModalPage.checkPathStepMarkers([
-          { name: NORTH_STATION_BV, index: 1 },
-          { name: NORTH_STATION_BV, index: 2 },
-          { name: `${SOUTH_STATION_BV} · ${TRACK_NAME}`, index: 3 },
-        ]);
+        if (browserName === 'chromium') {
+          await itineraryModalPage.checkPathStepMarkers([
+            { name: NORTH_STATION_BV, index: 1 },
+            { name: NORTH_STATION_BV, index: 2 },
+            { name: `${SOUTH_STATION_BV} · ${TRACK_NAME}`, index: 3 },
+          ]);
+        }
         await itineraryModalPage.checkNumberedRowsCount(4);
       });
       await test.step('remove pathStep and check rows and map update', async () => {

--- a/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
+++ b/front/tests/02-operational-studies/timetable/004-train-edition.spec.ts
@@ -36,6 +36,9 @@ const frTranslations = {
 const trains: TrainSchedule[] = readJsonFile('./tests/assets/trains/trains.json');
 
 test.describe('Train edition', { tag: ['@op', '@paced-trains', '@unique-trains'] }, () => {
+  //TODO: remove ignorePageErrors when issue #13066 is resolved
+  test.use({ ignorePageErrors: true });
+
   setupScenarioFixture({
     scenarioNamePrefix: 'edit-train-scenario',
     trains: [...trains.slice(0, 1), ...trains.slice(7, 8)],

--- a/front/tests/README.md
+++ b/front/tests/README.md
@@ -410,6 +410,21 @@ npx playwright test --help
 - **Parallel workers**: no limit in CI, but technically `2` (and `30%` of logical CPU locally, after empirical tries)
 - **Screenshots**: on failure
 
+## ⚠️ Known limitation: no map markers on Firefox
+
+Firefox cannot get a WebGL context inside the Playwright container:
+
+```
+Failed to create WebGL context: AllowWebgl2:false restricts context creation on this system
+Exhausted GL driver options (FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS)
+```
+
+Without WebGL, `react-map-gl` never mounts, so map markers are never displayed.
+This is an old Firefox bug, still open:
+<https://bugzilla.mozilla.org/show_bug.cgi?id=1375585>
+
+👉 Skip marker-related assertions on non-chromium browsers.
+
 ---
 
 # 🧱 8. Page Object Model (POM)


### PR DESCRIPTION
**1st commit:** Run the map marker check on Chromium only
**Failed build:** https://github.com/OpenRailAssociation/osrd/actions/runs/33059387163/attempts/2

**2nd commit:** Ignore the page error caused by the following:
`Test failed due to uncaught exception: Cannot convert undefined or null to object`

**Failed build:** https://github.com/OpenRailAssociation/osrd/actions/runs/33071853781/attempts/1
