### PR TITLE
front: add explanation for path not found scenarios with blocking work schedules

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -140,10 +140,12 @@
     "getSimulation": "Get the simulation",
     "infoMessage": "This simulation doesn't ensure the availability of the path.",
     "results": {
+      "blockingWorkSchedule": "work between {{startTime}} and {{endTime}}",
       "changeSearchCriteria": "You can modify your search criteria to find a solution.",
       "displayAll": "Display all operational points",
       "displayMain": "Display main operational points",
       "downloadSimulationSheet": "Download simulation report sheet",
+      "mainConflicts": "Here are the main conflicts encountered:",
       "modal": {
         "LongFRET": "Long path freight (3 regions minimum, 4 in IDF)",
         "addComment": "Observations",
@@ -209,8 +211,8 @@
           "hazardousMaterialsNormal": "This will be verified by a timetable planner and the simulation may be rejected."
         }
       },
+      "nearestReachedPoint": "The nearest point to the destination reached is <strong>{{name}}</strong> at {{time}}.",
       "notFound": "No path was found for this configuration",
-      "pathNotFound": "Clash with existing train and/or work schedules.",
       "retainThisSimulation": "Retain this simulation",
       "simulationDownstream": "Simulation automatically computed as no capacity was found for the requested criteria: the tolerance <underline>before</underline> departure time was increased.",
       "simulationName": {
@@ -227,6 +229,7 @@
         "errorMessage": "We are sorry that we could not process your request. The LMR team has been notified and will be aware of the situation as soon as possible.",
         "failed": "A technical issue has occurred"
       },
+      "tooMuchTraffic": "Too much traffic is in conflict on this route.",
       "transferSheetToRailManager": "Send to GESICO"
     },
     "stopCalculation": "Stop"

--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -140,7 +140,7 @@
     "getSimulation": "Get the simulation",
     "infoMessage": "This simulation doesn't ensure the availability of the path.",
     "results": {
-      "blockingWorkSchedule": "work between {{startTime}} and {{endTime}}",
+      "blockingWorkSchedule": "work after {{name}} between {{startTime}} and {{endTime}}",
       "changeSearchCriteria": "You can modify your search criteria to find a solution.",
       "displayAll": "Display all operational points",
       "displayMain": "Display main operational points",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -140,10 +140,12 @@
     "getSimulation": "Obtenir la simulation",
     "infoMessage": "Cette simulation n'offre pas la garantie de disponibilité du sillon.",
     "results": {
+      "blockingWorkSchedule": "travaux entre {{startTime}} et {{endTime}}",
       "changeSearchCriteria": "Vous pouvez modifier vos critères de recherche pour trouver une solution.",
       "displayAll": "Afficher tous les jalons",
       "displayMain": "Afficher les jalons principaux",
       "downloadSimulationSheet": "Télécharger la fiche de simulation",
+      "mainConflicts": "Voici les principaux conflits rencontrés :",
       "modal": {
         "LongFRET": "Long parcours Fret (3 régions minimum, 4 en IDF)",
         "addComment": "Commentaire",
@@ -209,8 +211,8 @@
           "hazardousMaterialsNormal": "La simulation sera vérifiée par un horairiste lors du traitement du sillon, et pourrait être irrecevable."
         }
       },
+      "nearestReachedPoint": "Le PR le plus proche de la destination trouvé est <strong>{{name}}</strong> à {{time}}.",
       "notFound": "Aucun passage n'a été trouvé pour cette configuration",
-      "pathNotFound": "Incompatibilité avec des sillons et/ou planches travaux existants.",
       "retainThisSimulation": "Retenir cette simulation",
       "simulationDownstream": "Simulation lancée automatiquement en raison de l’absence de capacité avec les paramètres demandés : la tolérance <underline>avant</underline> l’heure de départ a été augmentée.",
       "simulationName": {
@@ -227,6 +229,7 @@
         "errorMessage": "Nous sommes désolés de ne pas avoir pu traiter votre demande. L’équipe LMR a été notifiée et prendra connaissance de la situation dès que possible.",
         "failed": "Un problème technique est survenu"
       },
+      "tooMuchTraffic": "Trop de circulations sont en conflit sur ce trajet.",
       "transferSheetToRailManager": "Transmettre à GESICO"
     },
     "stopCalculation": "Arrêter"

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -140,7 +140,7 @@
     "getSimulation": "Obtenir la simulation",
     "infoMessage": "Cette simulation n'offre pas la garantie de disponibilité du sillon.",
     "results": {
-      "blockingWorkSchedule": "travaux entre {{startTime}} et {{endTime}}",
+      "blockingWorkSchedule": "travaux après {{name}} entre {{startTime}} et {{endTime}}",
       "changeSearchCriteria": "Vous pouvez modifier vos critères de recherche pour trouver une solution.",
       "displayAll": "Afficher tous les jalons",
       "displayMain": "Afficher les jalons principaux",

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmPathNotFoundDetails.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmPathNotFoundDetails.tsx
@@ -1,0 +1,78 @@
+import { uniqBy } from 'lodash';
+import { Trans, useTranslation } from 'react-i18next';
+
+import type { StdcmPathNotFoundOutput } from 'applications/stdcm/types';
+import { timeToLocaleStringRounded, useDateTimeLocale } from 'utils/date';
+
+type StdcmPathNotFoundDetailsProps = {
+  outputs: StdcmPathNotFoundOutput;
+  showAlternativeSimulationsInfo: boolean;
+};
+
+/** Explains why no path was found, so the user can reformulate their request. */
+const StdcmPathNotFoundDetails = ({
+  outputs,
+  showAlternativeSimulationsInfo,
+}: StdcmPathNotFoundDetailsProps) => {
+  const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
+  const dateTimeLocale = useDateTimeLocale();
+
+  const formatTime = (isoDate: string) =>
+    timeToLocaleStringRounded(new Date(isoDate), dateTimeLocale);
+
+  const lastReachedOperationalPoint = outputs.last_reached_operational_point;
+  // The work schedules delaying the train the most, then the one nearest to the destination.
+  // The same work can be planned on several days, only display it once.
+  const workSchedules = uniqBy(
+    [...outputs.most_blocking_work_schedules, ...outputs.nearest_to_destination_work_schedules],
+    'obj_id'
+  );
+
+  return (
+    <div className="simulation-failure" data-testid="stdcm-path-not-found-details">
+      <span className="title">{t('notFound')}</span>
+
+      {lastReachedOperationalPoint && (
+        <span className="nearest-reached-point" data-testid="stdcm-nearest-reached-point">
+          <Trans components={{ strong: <strong /> }}>
+            {t('nearestReachedPoint', {
+              name: lastReachedOperationalPoint.operational_point.name,
+              time: formatTime(lastReachedOperationalPoint.arrival_time),
+            })}
+          </Trans>
+        </span>
+      )}
+
+      {workSchedules.length > 0 ? (
+        <div className="blocking-work-schedules" data-testid="stdcm-blocking-work-schedules">
+          <span className="conflicts-title">{t('mainConflicts')}</span>
+          <ul>
+            {workSchedules.map(({ id, start_date_time, end_date_time }) => (
+              <li key={id}>
+                <span>
+                  &bull;&nbsp;
+                  {t('blockingWorkSchedule', {
+                    startTime: formatTime(start_date_time),
+                    endTime: formatTime(end_date_time),
+                  })}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <span className="too-much-traffic" data-testid="stdcm-too-much-traffic">
+          {t('tooMuchTraffic')}
+        </span>
+      )}
+
+      <span className="change-criteria">{t('changeSearchCriteria')}</span>
+
+      {showAlternativeSimulationsInfo && (
+        <div className="alternative-simulations-info">{t('simulationsWithConflicts')}</div>
+      )}
+    </div>
+  );
+};
+
+export default StdcmPathNotFoundDetails;

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmPathNotFoundDetails.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmPathNotFoundDetails.tsx
@@ -22,10 +22,11 @@ const StdcmPathNotFoundDetails = ({
 
   const lastReachedOperationalPoint = outputs.last_reached_operational_point;
   // The work schedules delaying the train the most, then the one nearest to the destination.
-  // The same work can be planned on several days, only display it once.
+  // The same work schedule can be reported in both lists, only display it once.
   const workSchedules = uniqBy(
     [...outputs.most_blocking_work_schedules, ...outputs.nearest_to_destination_work_schedules],
-    'obj_id'
+    ({ last_op, start_date_time, end_date_time }) =>
+      `${last_op.id}-${start_date_time}-${end_date_time}`
   );
 
   return (
@@ -47,11 +48,12 @@ const StdcmPathNotFoundDetails = ({
         <div className="blocking-work-schedules" data-testid="stdcm-blocking-work-schedules">
           <span className="conflicts-title">{t('mainConflicts')}</span>
           <ul>
-            {workSchedules.map(({ id, start_date_time, end_date_time }) => (
-              <li key={id}>
+            {workSchedules.map(({ last_op, start_date_time, end_date_time }) => (
+              <li key={`${last_op.id}-${start_date_time}-${end_date_time}`}>
                 <span>
                   &bull;&nbsp;
                   {t('blockingWorkSchedule', {
+                    name: last_op.name,
                     startTime: formatTime(start_date_time),
                     endTime: formatTime(end_date_time),
                   })}

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -37,6 +37,7 @@ import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
 import SendToRailwayManagerModal from './SendToRailwayManagerModal';
 import StdcmFeedback from './StdcmFeedback';
+import StdcmPathNotFoundDetails from './StdcmPathNotFoundDetails';
 import StdcmResultsTable from './StdcmResultsTable';
 import StdcmSimulationNavigator from './StdcmSimulationNavigator';
 import StdcmSimulationReportSheet from './StdcmSimulationReportSheet';
@@ -101,6 +102,9 @@ const StdcmResults = ({
   const hasSimulationResults = hasResults(outputs);
   const traceId = outputs && ('results' in outputs ? outputs.results.traceId : outputs.traceId);
 
+  // The simulation failed: the outputs only hold the explanation of the failure.
+  const pathNotFoundOutputs = outputs && !hasSimulationResults ? outputs : undefined;
+
   const simulationReportSheetNumber = useMemo(
     () => generateCodeNumber(),
     [selectedSimulation.index]
@@ -121,11 +125,15 @@ const StdcmResults = ({
   }, [outputs]);
 
   const markersInfo = useMemo(() => {
-    if (!hasSimulationResults) {
-      return [];
+    if (hasSimulationResults) {
+      return extractMarkersInfo(outputs.results.simulationPathSteps);
     }
-    return extractMarkersInfo(outputs.results.simulationPathSteps);
-  }, [hasSimulationResults, outputs]);
+    // Still display the requested waypoints on the map when explaining a path-not-found result.
+    if (pathNotFoundOutputs) {
+      return extractMarkersInfo(selectedSimulation.inputs.pathSteps);
+    }
+    return [];
+  }, [hasSimulationResults, outputs, pathNotFoundOutputs, selectedSimulation.inputs.pathSteps]);
 
   const [similarTrains, setSimilarTrains] = useState<SimilarTrainWithSecondaryCode[]>([]);
   const [areSegmentsLoading, setAreSegmentsLoading] = useState(true);
@@ -428,16 +436,12 @@ const StdcmResults = ({
                   )}
                 </div>
               ) : (
-                <div className="simulation-failure">
-                  <span className="title">{t('notFound')}</span>
-                  <span className="change-criteria">{t('pathNotFound')}</span>
-                  <span>{t('changeSearchCriteria')}</span>
-                  {!alternativePath && !displayInfoMessage && (
-                    <div className="alternative-simulations-info">
-                      {t('simulationsWithConflicts')}
-                    </div>
-                  )}
-                </div>
+                pathNotFoundOutputs && (
+                  <StdcmPathNotFoundDetails
+                    outputs={pathNotFoundOutputs}
+                    showAlternativeSimulationsInfo={!alternativePath && !displayInfoMessage}
+                  />
+                )
               )}
               <StdcmFeedback />
             </div>
@@ -446,8 +450,13 @@ const StdcmResults = ({
               <DefaultBaseMap
                 mapId="stdcm-map-result"
                 infraId={infraId}
-                geometry={hasSimulationResults ? outputs?.pathProperties.geometry : undefined}
+                geometry={
+                  hasSimulationResults
+                    ? outputs.pathProperties.geometry
+                    : pathNotFoundOutputs?.partialPathGeometry
+                }
                 pathStepMarkers={markersInfo}
+                // The partial path reached before the simulation failed is drawn in red.
                 isFeasible={hasSimulationResults}
                 mapSettings={mapSettings}
                 updateMapSettings={updateMapSettings}

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -7,6 +7,7 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import fileDownload from 'js-file-download';
 import { head, last } from 'lodash';
 import { useTranslation, Trans } from 'react-i18next';
+import { Marker } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
 import type { SimilarTrainWithSecondaryCode, StdcmResultsOutput } from 'applications/stdcm/types';
@@ -104,6 +105,7 @@ const StdcmResults = ({
 
   // The simulation failed: the outputs only hold the explanation of the failure.
   const pathNotFoundOutputs = outputs && !hasSimulationResults ? outputs : undefined;
+  const lastReachedOperationalPoint = pathNotFoundOutputs?.last_reached_operational_point;
 
   const simulationReportSheetNumber = useMemo(
     () => generateCodeNumber(),
@@ -461,7 +463,19 @@ const StdcmResults = ({
                 mapSettings={mapSettings}
                 updateMapSettings={updateMapSettings}
                 updateViewport={updateViewport}
-              />
+              >
+                {lastReachedOperationalPoint && (
+                  <Marker
+                    longitude={lastReachedOperationalPoint.geographic.coordinates[0]}
+                    latitude={lastReachedOperationalPoint.geographic.coordinates[1]}
+                  >
+                    <div
+                      className="last-reached-point-marker"
+                      data-testid="stdcm-map-result-marker-last-reached"
+                    />
+                  </Marker>
+                )}
+              </DefaultBaseMap>
             </div>
           </div>
           {isDebugMode && traceId && (

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -34,6 +34,7 @@ import { useDateTimeLocale } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
 
 import { adjustInputByDirection, adjustPayloadByDirection } from '../utils/adjustSimulationInputs';
+import fetchPathNotFoundDetails from '../utils/fetchPathNotFoundDetails';
 import fetchPathProperties from '../utils/fetchPathProperties';
 import { checkStdcmConf, formatStdcmPayload } from '../utils/formatStdcmConf';
 import computeChartData from '../utils/stdcmComputeChartData';
@@ -156,7 +157,7 @@ const useStdcm = ({
         speedDistanceDiagramData: chartData,
       };
     } else {
-      outputs = response;
+      outputs = await fetchPathNotFoundDetails(response, infraId, dispatch);
     }
 
     return {
@@ -194,9 +195,6 @@ const useStdcm = ({
   ) => {
     const simulationsToAdd: Omit<StdcmSimulation, 'index'>[] = [];
     try {
-      const currentSimulation = await createSimulation(currentSimulationInputs, payload, response);
-      simulationsToAdd.push(currentSimulation);
-
       setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.pending_additional);
 
       const payloadUpstream = adjustPayloadByDirection(payload, 'upstream');
@@ -209,7 +207,11 @@ const useStdcm = ({
       const promiseUpstream = getPostTimetableByIdStdcmPromise(upstream, 'upstream');
       const promiseDownstream = getPostTimetableByIdStdcmPromise(downstream, 'downstream');
 
-      // Run two additional requests for alternative simulations
+      // The failure explanation of the current simulation is fetched while the two
+      // additional requests for alternative simulations are running.
+      const currentSimulation = await createSimulation(currentSimulationInputs, payload, response);
+      simulationsToAdd.push(currentSimulation);
+
       const [resUp, resDown] = await Promise.all([promiseUpstream, promiseDownstream]);
 
       // Handle error cases

--- a/front/src/applications/stdcm/styles/_results.scss
+++ b/front/src/applications/stdcm/styles/_results.scss
@@ -432,6 +432,18 @@
       box-shadow:
         0 0 0 2px rgba(255, 255, 255, 0.75) inset,
         0 0 0 1px rgba(0, 0, 0, 0.25) inset;
+
+      .last-reached-point-marker {
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background-color: rgba(0, 0, 0, 1);
+        box-shadow:
+          0 0 0 1px rgba(255, 255, 255, 1) inset,
+          0 0 0 1px rgba(255, 255, 255, 1),
+          0 0 0 2px rgba(255, 0, 183, 1),
+          0 0 0 4.5px rgba(255, 157, 51, 0.4);
+      }
     }
   }
 

--- a/front/src/applications/stdcm/styles/_results.scss
+++ b/front/src/applications/stdcm/styles/_results.scss
@@ -373,6 +373,35 @@
           line-height: 24px;
         }
 
+        .nearest-reached-point {
+          line-height: 24px;
+          margin-bottom: 24px;
+        }
+
+        .blocking-work-schedules {
+          margin-bottom: 24px;
+
+          .conflicts-title {
+            display: block;
+            line-height: 24px;
+          }
+
+          ul {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+
+            li {
+              line-height: 24px;
+            }
+          }
+        }
+
+        .too-much-traffic {
+          line-height: 24px;
+          margin-bottom: 24px;
+        }
+
         .alternative-simulations-info {
           padding: 22px 40px 26px 40px;
           text-align: center;

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -1,6 +1,7 @@
 import type { STDCM_REQUEST_STATUS } from 'applications/stdcm/consts';
 import type {
   GeoJsonPoint,
+  GeoJsonLineString,
   Conflict,
   LightRollingStock,
   LightRollingStockWithLiveries,
@@ -32,6 +33,11 @@ export type StdcmSuccessResponse = Extract<StdcmResponseWithTraceId, { status: '
 export type StdcmPathNotFound = Extract<StdcmResponseWithTraceId, { status: 'path_not_found' }>;
 
 export type StdcmResponse = StdcmPathNotFound | StdcmSuccessResponse;
+
+export type StdcmPathNotFoundOutput = StdcmPathNotFound & {
+  /** Geometry of the partial path reached, drawn in red on the result map */
+  partialPathGeometry?: GeoJsonLineString;
+};
 
 export type StdcmPathProperties = PathProperties & {
   manchetteOperationalPoints?: PathWaypoint[];
@@ -147,7 +153,7 @@ export type StdcmConflictsOutput = {
   conflicts: Conflict[];
 };
 
-export type StdcmSimulationOutputs = StdcmResultsOutput | StdcmPathNotFound;
+export type StdcmSimulationOutputs = StdcmResultsOutput | StdcmPathNotFoundOutput;
 
 export type StdcmSimulation = {
   index: number;

--- a/front/src/applications/stdcm/utils/fetchPathNotFoundDetails.ts
+++ b/front/src/applications/stdcm/utils/fetchPathNotFoundDetails.ts
@@ -1,0 +1,34 @@
+import type { StdcmPathNotFound, StdcmPathNotFoundOutput } from 'applications/stdcm/types';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import type { AppDispatch } from 'store';
+
+/**
+ * Adds the geometry of the partial path reached to a path_not_found response,
+ * to draw it on the result map.
+ */
+const fetchPathNotFoundDetails = async (
+  response: StdcmPathNotFound,
+  infraId: number,
+  dispatch: AppDispatch
+): Promise<StdcmPathNotFoundOutput> => {
+  const partialPathfindingResult = response.partial_pathfinding_result;
+  if (!partialPathfindingResult) return response;
+
+  try {
+    const { geometry } = await dispatch(
+      osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.initiate({
+        infraId,
+        pathPropertiesInput: {
+          track_section_ranges: partialPathfindingResult.path.track_section_ranges,
+        },
+      })
+    ).unwrap();
+    return { ...response, partialPathGeometry: geometry };
+  } catch (error) {
+    // The failure is still displayed, without its map
+    console.error('Error fetching the partial path properties:', error);
+    return response;
+  }
+};
+
+export default fetchPathNotFoundDetails;

--- a/front/src/common/Map/DefaultBaseMap.tsx
+++ b/front/src/common/Map/DefaultBaseMap.tsx
@@ -87,9 +87,14 @@ const DefaultBaseMap = ({
   };
 
   useEffect(() => {
-    const points = geometry ?? {
-      coordinates: compact(pathStepMarkers.map((step) => step.coordinates)),
-      type: 'LineString',
+    // The markers are taken into account too: when only a part of the path could be
+    // computed, the geometry alone doesn't cover all the requested path steps.
+    const points = {
+      coordinates: [
+        ...(geometry?.coordinates ?? []),
+        ...compact(pathStepMarkers.map((step) => step.coordinates)),
+      ],
+      type: 'LineString' as const,
     };
     if (points.coordinates.length >= 2) {
       const newViewport = computeBBoxViewport(bbox(points), viewport);

--- a/front/src/common/Map/components/ItineraryLayer.tsx
+++ b/front/src/common/Map/components/ItineraryLayer.tsx
@@ -13,6 +13,9 @@ type ItineraryLayerProps = {
 const FEASIBLE_COLOR = 'rgba(210, 225, 0, 0.75)';
 const INFEASIBLE_COLOR = '#eaa72b';
 const STDCM_ASSETS_COLOR = '#3c8aff';
+const STDCM_ASSETS_HALO_COLOR = '#CEF6FF';
+const STDCM_INFEASIBLE_COLOR = 'rgba(255, 0, 183, 1)';
+const STDCM_INFEASIBLE_HALO_COLOR = 'rgba(255, 157, 51, 0.4)';
 
 export default function ItineraryLayer({
   layerOrder,
@@ -28,7 +31,7 @@ export default function ItineraryLayer({
 
   let lineColor = FEASIBLE_COLOR;
   if (!isFeasible) {
-    lineColor = INFEASIBLE_COLOR;
+    lineColor = showStdcmAssets ? STDCM_INFEASIBLE_COLOR : INFEASIBLE_COLOR;
   } else if (showStdcmAssets) {
     lineColor = STDCM_ASSETS_COLOR;
   }
@@ -40,7 +43,7 @@ export default function ItineraryLayer({
           type="line"
           paint={{
             'line-width': 5,
-            'line-color': '#CEF6FF',
+            'line-color': isFeasible ? STDCM_ASSETS_HALO_COLOR : STDCM_INFEASIBLE_HALO_COLOR,
           }}
           layerOrder={layerOrder}
         />


### PR DESCRIPTION
front part of [#804](https://github.com/osrd-project/osrd-confidential/issues/804). Branched off [ecn/work-schedules-failure-explainer](https://github.com/OpenRailAssociation/osrd/pull/17938), so core and editoast need to be rebuilt from that branch.

When no capacity is found, it displays: the furthest PR reached with its time, the blocking work schedules (or "too much traffic" if there are none)

I can provide a dataset to test with. 
