### PR TITLE
front: fix unique train handling in isDraggingOccupancyZoneId()

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -419,10 +419,7 @@ const SpaceTimeChartWrapper = ({
 
       // When dragging a paced train, mark all compliant occupancy zones as
       // being dragged
-      if (
-        isOccurrenceId(trainId) &&
-        extractTrainScheduleIdFromOccurrenceId(trainId) !== draggingOccupancyZoneBaseTrainId
-      ) {
+      if (extractTrainScheduleIdFromTrainId(trainId) !== draggingOccupancyZoneBaseTrainId) {
         return false;
       }
       const { exception } = findTrainScheduleAndException(trainSchedulesWithDetails ?? [], trainId);


### PR DESCRIPTION
Unique trains don't pass the isOccurrenceId() check, thus we never check that they match draggingOccupancyZoneBaseTrainId. Fix this by dropping the isOccurrenceId() check and using
extractTrainScheduleIdFromTrainId().

To test, create two unique trains, open the TOD, and drag one of them. Only a single curve should be dragged.

Closes: https://github.com/OpenRailAssociation/osrd/issues/18290