### PR TITLE
clean up ui-charts css

### DIFF
--- a/front/ui/index.css
+++ b/front/ui/index.css
@@ -13,6 +13,7 @@
   --color-black-25: #00000040;
   --color-black-50: #94918e;
   --color-black-75: #000000bf;
+  --color-black-85: #000000d9;
   --color-black-100: #000000;
   /* white */
   --color-white-25: #ffffff;

--- a/front/ui/ui-charts/src/chronogram/styles/main.css
+++ b/front/ui/ui-charts/src/chronogram/styles/main.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import '../../../../index.css';
+@import '../../common/styles/index.css';
 
 .ui-chronogram {
   --chronogram-manchette-header-height: 33px;
@@ -8,9 +9,7 @@
   position: relative;
   width: 100%;
   border-radius: 10px;
-  box-shadow:
-    0 4px 9px rgba(0, 0, 0, 0.06),
-    0 1px 2px rgba(0, 0, 0, 0.19);
+  box-shadow: var(--ui-charts-shadow-charts);
 
   .chronogram-manchette-container {
     height: 100%;

--- a/front/ui/ui-charts/src/common/styles/index.css
+++ b/front/ui/ui-charts/src/common/styles/index.css
@@ -1,0 +1,3 @@
+:root {
+  --ui-charts-shadow-charts: 0 4px 9px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.19);
+}

--- a/front/ui/ui-charts/src/manchette/styles/manchette.css
+++ b/front/ui/ui-charts/src/manchette/styles/manchette.css
@@ -1,3 +1,5 @@
+@import '../../common/styles/index.css';
+
 .ui-manchette-container {
   .menu-wrapper {
     position: absolute;
@@ -15,7 +17,6 @@
     @apply border-black-25;
     display: flex;
     height: 40px;
-    width: inherit;
     position: sticky;
     bottom: 0;
     left: 0;
@@ -64,10 +65,8 @@
 }
 
 .ui-manchette-space-time-chart-wrapper {
+  box-shadow: var(--ui-charts-shadow-charts);
   border-radius: 10px;
-  box-shadow:
-    0px 4px 9px rgba(0, 0, 0, 0.06),
-    0px 1px 2px rgba(0, 0, 0, 0.19);
   opacity: 1;
   background-color: rgba(255, 255, 255, 1);
   width: 100%;

--- a/front/ui/ui-charts/src/manchette/styles/menu.css
+++ b/front/ui/ui-charts/src/manchette/styles/menu.css
@@ -1,32 +1,32 @@
 .ui-manchette-menu {
   @apply bg-grey-5;
   width: 305px;
-  border: 0.0625rem solid #b6b2af;
+  border: 1px solid #b6b2af;
   border-radius: 0.5rem;
   box-shadow:
-    0 0.375rem 1.3125rem -0.3125rem rgba(101, 169, 232, 0.341810533216783),
-    0 1rem 1.875rem -0.3125rem rgba(0, 0, 0, 0.2),
-    0 0.1875rem 0.3125rem -0.125rem rgba(0, 0, 0, 0.1),
-    inset 0 0 0 0.0625rem #ffffff;
+    0 6px 21px -5px rgba(101, 169, 232, 0.341810533216783),
+    0 16px 30px -5px rgba(0, 0, 0, 0.2),
+    0 3px 5px -2px rgba(0, 0, 0, 0.1),
+    inset 0 0 0 1px var(--color-white-100);
 
   .menu-item {
     width: 100%;
-    height: 2.75rem;
+    height: 44px;
     font-size: 0.875rem;
     display: flex;
     align-items: center;
 
     &:not(:first-child) {
-      border-top: 0.0625rem solid #ffffff;
+      border-top: 1px solid var(--color-white-100);
     }
 
     &:not(:only-of-type, :last-child) {
-      border-bottom: 0.0625rem solid #d3d1cf;
+      border-bottom: 1px solid #d3d1cf;
     }
 
     .icon {
       @apply text-primary-40;
-      padding-inline: 1rem;
+      padding-inline: 16px;
     }
   }
 }

--- a/front/ui/ui-charts/src/manchette/styles/waypoint.css
+++ b/front/ui/ui-charts/src/manchette/styles/waypoint.css
@@ -1,4 +1,4 @@
-.ui-manchette-container .waypoint {
+.waypoint {
   @apply text-grey-80;
   height: 32px;
   line-height: 1.5rem;
@@ -11,8 +11,7 @@
     position: relative;
     opacity: 0.6;
     flex-grow: 1;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline: auto;
     min-width: 12px;
     align-self: stretch;
     &::after {
@@ -24,15 +23,17 @@
       @apply bg-grey-40;
     }
   }
+
   .waypoint-name {
     max-width: 190px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
   }
+
   .waypoint-ch {
     font-size: 0.875rem;
-    margin: 0 2px;
+    margin-inline: 2px;
     width: 16px;
     text-align: left;
     & + .waypoint-separator {
@@ -45,7 +46,7 @@
     @apply text-grey-50;
     font-size: 0.75rem;
     font-weight: 400;
-    width: calc(41px - 8px); /* 8px is the padding-left */
+    width: calc(41px - 12px); /* 12px is the padding-left */
   }
 
   &:not(.menu-active):hover,

--- a/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
+++ b/front/ui/ui-charts/src/speedSpaceChart/styles/main.css
@@ -1,93 +1,95 @@
 @import 'tailwindcss';
 @import '../../../../index.css';
+@import '../../common/styles/index.css';
 
 .base-margin-top {
-  margin-top: 1.6875rem;
+  margin-top: 27px;
 }
 
 #curve-layer,
 #declivity-layer,
 #front-interactivity-layer {
-  margin-left: 3rem;
-  margin-top: 1.6875rem;
+  margin-left: 48px;
+  margin-top: 27px;
 }
 
 #front-interactivity-layer {
-  box-shadow:
-    0 0.0625rem 0,
-    125rem 0 rgba(0, 0, 0, 0.19);
-  box-shadow: 0 0.25rem 0.5625rem 0 rgba(0, 0, 0, 0.06);
+  box-shadow: var(--ui-charts-shadow-charts);
 }
 
 #interaction-button-container {
   display: flex;
   position: absolute;
-  align-items: stretch;
-  background: var(--white100);
-  border: 1px solid var(--black10);
+  align-items: center;
+  background: var(--color-white-100);
+  border: 1px solid var(--color-black-10);
   border-radius: 5px;
-  margin-right: 0.75rem;
+  margin-right: 12px;
   top: 7px;
   right: 7px;
   overflow: hidden;
 
   button {
     outline: none;
-    background: var(--white100);
-    color: var(--black100);
-    padding: 0 7px;
+    background: var(--color-white-100);
+    color: var(--color-black-100);
+    padding: 4px 8px;
 
     &:first-child {
       border-radius: 5px 0 0 5px;
     }
 
     &:not(:last-child) {
-      border-right: 1px solid var(--black10);
+      border-right: 1px solid var(--color-black-10);
     }
 
     &:hover {
-      background-color: var(--primary5);
+      background-color: var(--color-primary-5);
     }
   }
 
   .reset-button svg {
-    transform: rotate(180deg) translate(0, 2px);
-  }
-
-  .menu-button svg {
-    transform: translate(0, -1px);
+    transform: rotate(180deg);
   }
 
   .reset-button-disabled {
-    color: var(--black25);
+    color: var(--color-black-25);
     cursor: inherit;
 
     &:hover {
-      background-color: var(--white100);
+      background-color: var(--color-white-100);
     }
   }
 }
 
 #details-box {
-  min-width: 7.1875rem;
-  background-color: rgb(0, 0, 0, 0.85);
-  border-radius: 0.5rem;
-  box-shadow: 0 0.25rem 0.375rem -0.125rem rgba(0, 0, 0, 0.28);
-  font-family: 'IBM Plex Sans';
+  @apply font-sans;
+  min-width: 115px;
+  background-color: var(--color-black-85);
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -2px rgb(0 0 0 / 0.28);
   font-weight: 400;
-  font-size: 14px;
-  color: rgb(255, 255, 255);
+  font-size: 0.875rem;
+  color: var(--color-white-100);
   align-items: flex-start;
 
+  .etcs-grid,
+  #base-speed-text,
+  #mareco-speed-text,
+  #electrical-mode-text,
+  #power-restriction-text {
+    @apply font-mono;
+  }
+
   span {
-    height: 1.25rem;
-    padding: 0 0.25rem 0 0.25rem;
+    height: 20px;
+    padding: 0 4px;
   }
 
   hr {
-    border-top: 0.0313rem solid rgba(255, 255, 255, 0.5);
-    margin-top: 0.4375rem;
-    margin-bottom: 0.1875rem;
+    border-top: 0.5px solid var(--color-white-50);
+    margin-top: 7px;
+    margin-bottom: 3px;
   }
 
   .default-details-box {
@@ -101,14 +103,13 @@
     flex-direction: column;
     min-height: 0;
     height: 100%;
-    background-color: rgba(255, 255, 255, 0.1);
-    padding: 8px 16px 8px 12px;
+    background-color: rgb(255 255 255 / 0.1);
+    padding: 8px 16px;
   }
 
   .etcs-grid {
     display: grid;
     justify-self: start;
-    font-family: 'IBM Plex Mono', monospace;
     line-height: 14px;
     column-gap: 24px;
     row-gap: 18px;
@@ -127,48 +128,41 @@
     }
   }
 
-  #base-speed-text {
-    color: rgba(255, 255, 255, 0.75);
-    font-family: 'IBM Plex Mono', monospace;
+  #base-speed-text,
+  #speed-difference-text {
+    color: var(--color-white-75);
   }
 
   #mareco-speed-text {
-    font-family: 'IBM Plex Mono', monospace;
     font-weight: 600;
   }
 
   #speed-difference-text {
     font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.75);
   }
 
   #mode-text {
-    color: rgb(255, 247, 0);
-  }
-
-  #electrical-mode-text,
-  #power-restriction-text {
-    font-family: 'IBM Plex Mono', monospace;
+    color: var(--color-highlight-30);
   }
 
   #effort-text {
-    color: rgb(112, 193, 229);
+    color: var(--color-info-30);
   }
 }
 
 #settings-panel {
   position: absolute;
   display: flex;
-  min-width: 32.875rem;
+  min-width: 526px;
   max-width: 100%;
   padding-left: 12px;
   padding-right: 28px;
   margin-right: 20px;
-  color: rgb(49, 46, 43);
-  border-radius: 0 0.625rem 0 0;
-  backdrop-filter: blur(0.3125rem);
-  box-shadow: inset 0 0 0 0.0625rem rgb(255, 255, 255);
-  border: solid 0.0625rem rgba(0, 0, 0, 0.1);
+  color: var(--color-grey-80);
+  border-radius: 0 10px 0 0;
+  backdrop-filter: blur(5px);
+  box-shadow: inset 0 0 0 1px var(--color-white-100);
+  border: solid 1px var(--color-black-10);
   z-index: 10;
 
   .settings-panel-section {
@@ -203,24 +197,24 @@
     cursor: pointer;
 
     span {
-      color: rgb(121, 118, 113);
+      color: var(--color-grey-50);
     }
   }
 }
 
 #tooltip {
-  height: 2.5rem;
-  width: 15.375rem;
+  @apply font-sans;
+  height: 40px;
+  width: 246px;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: rgba(0, 0, 0, 0.85);
+  background-color: var(--color-black-85);
   border-radius: 0.625rem;
-  color: rgb(255, 255, 255);
-  font-family: 'IBM Plex Sans', sans-serif;
+  color: var(--color-white-100);
   font-size: 0.875rem;
   font-weight: 400;
-  line-height: 1.25rem;
+  line-height: 20px;
 }
 
 .speed-space-slider-container {

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/styles/main.css
@@ -45,9 +45,9 @@
 
     .track-line {
       margin-right: 16px;
-      font-family: 'IBM Plex Sans';
       font-weight: 400;
-      font-size: 12px;
+      font-size: 0.75rem;
+      @apply font-sans;
       @apply text-grey-50;
     }
 
@@ -61,7 +61,7 @@
         0 0 0 2.5px var(--outer-border-color);
       padding: 2px 6px;
       font-weight: 600;
-      font-size: 14px;
+      font-size: 0.875rem;
       line-height: 20px;
       @apply text-white-100;
     }
@@ -94,7 +94,7 @@
 .close-track-occupancy-panel {
   position: absolute;
   right: 0;
-  margin: 0.875rem;
+  margin: 14px;
 }
 
 #tracks-layer,


### PR DESCRIPTION
close #18364 

cleanup css in ui-charts: 
 - fixed CSS variables in speedSpaceChart 
 - introduced a shared --shadow-charts variable to remove duplicated box-shadows 
 - enforced the rem (font-size) / px (everything else) convention across the remaining files