### PR TITLE
ui-charts: optimize picking layer color/index conversions 

### DIFF
--- a/front/ui/ui-charts/src/common/helpers/__tests__/colors.spec.ts
+++ b/front/ui/ui-charts/src/common/helpers/__tests__/colors.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { indexToColor, colorToIndex } from '../colors';
+
+describe('indexToColor', () => {
+  it('should roundtrip', () => {
+    const testCases = [0, 1, 0xff, 0x100, 0xff00, 0x420000, 0xffffff];
+    for (const index of testCases) {
+      expect(colorToIndex(indexToColor(index))).toBe(index);
+    }
+  });
+});

--- a/front/ui/ui-charts/src/common/helpers/colors.ts
+++ b/front/ui/ui-charts/src/common/helpers/colors.ts
@@ -25,6 +25,10 @@ export const WHITE_100 = 'rgb(255, 255, 255)';
  * These colors aim at representing the given indices on the picking layer.
  */
 export function indexToColor(index: number): string {
+  if (index > 0xffffff) {
+    throw new Error('Index too large');
+  }
+
   if (INDICES_TO_COLORS[index]) return INDICES_TO_COLORS[index];
 
   const color = `#${index.toString(16).padStart(6, '0')}`.toLowerCase();

--- a/front/ui/ui-charts/src/common/helpers/colors.ts
+++ b/front/ui/ui-charts/src/common/helpers/colors.ts
@@ -1,9 +1,4 @@
-import chroma from 'chroma-js';
-
-import type { RGBAColor } from '../types';
-
-const COLORS_TO_INDICES: Record<string, number> = {};
-const INDICES_TO_COLORS: Record<number, string> = {};
+import type { RGBColor } from '../types';
 
 // COLORS DEFINITIONS:
 export const BLACK_100 = 'rgb(0, 0, 0)';
@@ -24,34 +19,17 @@ export const WHITE_100 = 'rgb(255, 255, 255)';
  * generated as #000001, #000002 ... #0000ff, #000100 etc.
  * These colors aim at representing the given indices on the picking layer.
  */
-export function indexToColor(index: number): string {
+export function indexToColor(index: number): RGBColor {
   if (index > 0xffffff) {
     throw new Error('Index too large');
   }
 
-  if (INDICES_TO_COLORS[index]) return INDICES_TO_COLORS[index];
-
-  const color = `#${index.toString(16).padStart(6, '0')}`.toLowerCase();
-  COLORS_TO_INDICES[color] = index;
-  INDICES_TO_COLORS[index] = color;
-  return color;
+  return [(index >> 0) & 0xff, (index >> 8) & 0xff, (index >> 16) & 0xff];
 }
 
 /**
  * This function returns the index corresponding to the given color.
  */
-export function colorToIndex(color: string): number {
-  return COLORS_TO_INDICES[color.toLowerCase()];
-}
-
-function componentToHex(c: number): string {
-  return c.toString(16).padStart(2, '0').toLowerCase();
-}
-// The two following functions are just small helpers to help translating colors between RGB and
-// Hex:
-export function rgbToHex(r: number, g: number, b: number): string {
-  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
-}
-export function hexToRgb(color: string): RGBAColor {
-  return chroma(color).rgba();
+export function colorToIndex(color: RGBColor): number {
+  return (color[0] << 0) | (color[1] << 8) | (color[2] << 16);
 }

--- a/front/ui/ui-charts/src/common/hooks/useCanvas.ts
+++ b/front/ui/ui-charts/src/common/hooks/useCanvas.ts
@@ -3,7 +3,7 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'r
 import { isEqual } from 'lodash';
 
 import { PICKING_LAYERS, LAYERS } from '../consts';
-import { rgbToHex, colorToIndex } from '../helpers/colors';
+import { colorToIndex } from '../helpers/colors';
 import getPNGBlob from '../helpers/png';
 import { getPickingScalingRatio } from '../helpers/utils';
 import type {
@@ -307,8 +307,7 @@ export function useCanvas<T extends BaseChartContextType>(
           1
         ).data;
         if (a === 255) {
-          const color = rgbToHex(r, g, b);
-          const index = colorToIndex(color);
+          const index = colorToIndex([r, g, b]);
           const element = pickingState.pickingElements[layer][index];
           newHoveredItem = {
             layer,

--- a/front/ui/ui-charts/src/spaceTimeChart/components/ConflictLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/ConflictLayer.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { hexToRgb, indexToColor } from '../../common/helpers/colors';
+import { indexToColor } from '../../common/helpers/colors';
 import { drawAliasedRect } from '../../common/helpers/utils';
 import { useDraw, usePicking } from '../../common/hooks/useCanvas';
 import type { DrawingFunction, PickingDrawingFunction, PickingElement } from '../../common/types';
@@ -84,7 +84,7 @@ export const ConflictLayer = ({ conflicts }: ConflictLayerProps) => {
 
         const pickingElement: ConflictPickingElement = { type: 'conflict', conflictIndex };
         const index = registerPickingElement(pickingElement);
-        const color = hexToRgb(indexToColor(index));
+        const color = indexToColor(index);
 
         drawAliasedRect(
           imageData,

--- a/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { flatten, inRange } from 'lodash';
 
-import { hexToRgb, indexToColor } from '../../common/helpers/colors';
+import { indexToColor } from '../../common/helpers/colors';
 import { useDraw, usePicking } from '../../common/hooks/useCanvas';
 import type {
   CurveStyle,
@@ -635,7 +635,7 @@ export const PathLayer = ({
           point: stcContext.getPoint(path.points[0]),
         };
         const index = registerPickingElement(pickingElement);
-        const pointColor = hexToRgb(indexToColor(index));
+        const pointColor = indexToColor(index);
 
         drawAliasedDisc(
           imageData,
@@ -659,7 +659,7 @@ export const PathLayer = ({
               to: point,
             };
             const index = registerPickingElement(pickingElement);
-            const lineColor = hexToRgb(indexToColor(index));
+            const lineColor = indexToColor(index);
 
             // Skip segments linking two points on the same time value (these are flat steps, and paths shouldn't be
             // actionable on these steps):
@@ -686,7 +686,7 @@ export const PathLayer = ({
           point,
         };
         const index = registerPickingElement(pickingElement);
-        const lineColor = hexToRgb(indexToColor(index));
+        const lineColor = indexToColor(index);
         drawAliasedDisc(
           imageData,
           point,

--- a/front/ui/ui-charts/src/spaceTimeChart/components/Quadrilateral.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/Quadrilateral.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { hexToRgb, indexToColor } from '../../common/helpers/colors';
+import { indexToColor } from '../../common/helpers/colors';
 import { useDraw, usePicking } from '../../common/hooks/useCanvas';
 import type {
   PickingElement,
@@ -75,7 +75,7 @@ export const Quadrilateral = ({ id, vertices, style }: QuadrilateralProps) => {
 
       const pickingElement: QuadrilaterPickingElement = { type: 'quadrilateral', id };
       const index = registerPickingElement(pickingElement);
-      const color = hexToRgb(indexToColor(index));
+      const color = indexToColor(index);
 
       drawAliasedQuadrilateral(imageData, points, color, scalingRatio);
     },

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/BrokenLinkingLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/BrokenLinkingLayer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { hexToRgb, indexToColor } from '../../../common/helpers/colors';
+import { indexToColor } from '../../../common/helpers/colors';
 import { drawAliasedRect } from '../../../common/helpers/utils';
 import { useDraw, usePicking } from '../../../common/hooks/useCanvas';
 import type {
@@ -132,7 +132,7 @@ const BrokenLinkingLayer = ({
           direction: brokenLinking.direction,
         };
         const pickingIndex = registerPickingElement(pickingElement);
-        const color = hexToRgb(indexToColor(pickingIndex));
+        const color = indexToColor(pickingIndex);
 
         drawAliasedRect(
           imageData,

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/LinkingLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/LinkingLayer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { hexToRgb, indexToColor } from '../../../common/helpers/colors';
+import { indexToColor } from '../../../common/helpers/colors';
 import { drawAliasedRect } from '../../../common/helpers/utils';
 import { useDraw, usePicking } from '../../../common/hooks/useCanvas';
 import type {
@@ -74,7 +74,7 @@ const LinkingLayer = ({
           linkingId: linking.id,
         };
         const pickingIndex = registerPickingElement(pickingElement);
-        const color = hexToRgb(indexToColor(pickingIndex));
+        const color = indexToColor(pickingIndex);
 
         drawAliasedRect(
           imageData,

--- a/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
+++ b/front/ui/ui-charts/src/trackOccupancyDiagram/components/layers/OccupancyZonesLayer.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { sortBy } from 'lodash';
 
-import { hexToRgb, indexToColor } from '../../../common/helpers/colors';
+import { indexToColor } from '../../../common/helpers/colors';
 import { drawAliasedRect } from '../../../common/helpers/utils';
 import { useDraw, usePicking } from '../../../common/hooks/useCanvas';
 import type {
@@ -216,7 +216,7 @@ const OccupancyZonesLayer = ({
             pathId: instruction.zone.pathId,
           };
           const pickingIndex = registerPickingElement(pickingElement);
-          const color = hexToRgb(indexToColor(pickingIndex));
+          const color = indexToColor(pickingIndex);
 
           drawAliasedRect(
             imageData,


### PR DESCRIPTION
Using chroma to convert from a hex color to `RGBColor` adds significant overhead. On my machine, it takes ~25% of the `drawPicking()` CPU time. See this flamechart:

<img width="607" height="528" alt="out" src="https://github.com/user-attachments/assets/012a7368-3d13-42b4-bf89-9607fb55924a" />

Instead, make it so `indexToColor()` and `colorToIndex()` convert directly to/from `RGBColor` via bit operations.

This also allows us to drop `COLORS_TO_INDICES` and `INDICES_TO_COLORS` global state.

(A separate, first commit also adds a guard for the maximum supported index. See its commit message for details.)