### PR TITLE
front: stdcm: avoid requesting RS privileges needlessly

### DIFF
--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
@@ -190,6 +190,9 @@ const useFilterRollingStock = ({
   const userPrivilegesByRollingStockId = useAsyncMemo(async () => {
     // early exit if rollingstock is empty
     if (allRollingStocks.length === 0) return {};
+    // STDCM already reads all authorized rolling stocks with /light_rolling_stock?page_size=1000
+    // No need to send an additional *expensive* request.
+    if (isStdcm) return {};
     // call editoast
     const data = await getUserPrivileges({
       rolling_stock: allRollingStocks.map((rs) => rs.id),
@@ -198,6 +201,7 @@ const useFilterRollingStock = ({
     return data.rolling_stock || {};
   }, [
     getUserPrivileges,
+    isStdcm,
     allRollingStocks
       .map((rs) => rs.id)
       .sort()


### PR DESCRIPTION
`/light_rolling_stocks` already only sends authorized rolling stocks. Requesting their privileges a second time is not necessary and ends up being a very expensive request that overwhelm OpenFGA.

closes https://github.com/OpenRailAssociation/osrd/issues/18333

This does not fix the inherent issue of OpenFGA badly handling pressure. But not sending the request unlocks the release.

The real fix is described in https://github.com/OpenRailAssociation/osrd/issues/18393.