### PR TITLE
front: improve search journey solution fetch and display

### DIFF
--- a/front/src/applications/searchJourney/SearchJourneyView.tsx
+++ b/front/src/applications/searchJourney/SearchJourneyView.tsx
@@ -25,8 +25,13 @@ const SearchJourneyView = () => {
   const { loading, error } = useSearchJourneyEnv();
   const journeys = useSelector(getSearchJourneyJourneys);
   const selectedSolution = useSelector(getSearchJourneySelectedSolution);
-  const { geometry, markers, trainNames, operationalPointNames } =
-    useSearchJourneySolutionDetails(selectedSolution);
+  const {
+    geometry,
+    markers,
+    trainNames,
+    operationalPointNames,
+    loading: solutionDetailsLoading,
+  } = useSearchJourneySolutionDetails(selectedSolution);
 
   const resultsSectionRef = useRef<HTMLDivElement>(null);
 
@@ -55,10 +60,14 @@ const SearchJourneyView = () => {
             <SearchJourneyMap />
             {journeys && (
               <div ref={resultsSectionRef} className="search-journey-results-section">
-                <SearchJourneyResults
-                  trainNames={trainNames}
-                  operationalPointNames={operationalPointNames}
-                />
+                {solutionDetailsLoading ? (
+                  <Loader position="center" className="mt-5" />
+                ) : (
+                  <SearchJourneyResults
+                    trainNames={trainNames}
+                    operationalPointNames={operationalPointNames}
+                  />
+                )}
               </div>
             )}
             {selectedSolution && <SearchJourneyResultsMap geometry={geometry} markers={markers} />}

--- a/front/src/applications/searchJourney/hooks/useSearchJourney.ts
+++ b/front/src/applications/searchJourney/hooks/useSearchJourney.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { setSearchJourneyResults } from 'reducers/searchJourney';
+import { clearSearchJourneyResults, setSearchJourneyResults } from 'reducers/searchJourney';
 import {
   getSearchJourneyDestination,
   getSearchJourneyInfraId,
@@ -52,6 +52,7 @@ export default function useSearchJourney() {
 
     setRequestStatus(SEARCH_JOURNEY_REQUEST_STATUS.pending);
     setError(null);
+    dispatch(clearSearchJourneyResults());
     const request = postSearchJourneys({
       journeySearchQuery: {
         infra_id: infraId,

--- a/front/src/applications/searchJourney/hooks/useSearchJourneySolutionDetails.ts
+++ b/front/src/applications/searchJourney/hooks/useSearchJourneySolutionDetails.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 
@@ -52,6 +52,7 @@ export default function useSearchJourneySolutionDetails(solution?: SearchJourney
   const [operationalPointNames, setOperationalPointNames] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const dataSolutionRef = useRef<SearchJourneySolution | undefined>(undefined);
 
   useEffect(() => {
     if (!infraId || !solution || solution.length === 0) {
@@ -59,6 +60,7 @@ export default function useSearchJourneySolutionDetails(solution?: SearchJourney
       setMarkers([]);
       setTrainNames({});
       setOperationalPointNames({});
+      dataSolutionRef.current = solution;
       return undefined;
     }
 
@@ -165,6 +167,7 @@ export default function useSearchJourneySolutionDetails(solution?: SearchJourney
           setMarkers(newMarkers);
           setTrainNames(newTrainNames);
           setOperationalPointNames(newOperationalPointNames);
+          dataSolutionRef.current = solution;
         }
       } catch (e) {
         if (!cancelled) setError(e as Error);
@@ -178,5 +181,12 @@ export default function useSearchJourneySolutionDetails(solution?: SearchJourney
     };
   }, [infraId, solution, dispatch]);
 
-  return { geometry, markers, trainNames, operationalPointNames, loading, error };
+  return {
+    geometry,
+    markers,
+    trainNames,
+    operationalPointNames,
+    loading: loading || solution !== dataSolutionRef.current,
+    error,
+  };
 }

--- a/front/src/reducers/searchJourney/index.ts
+++ b/front/src/reducers/searchJourney/index.ts
@@ -83,6 +83,10 @@ export const searchJourneySlice = createSlice({
     selectSearchJourneySolution(state: Draft<SearchJourneyState>, action: PayloadAction<number>) {
       state.selectedSolutionIndex = action.payload;
     },
+    clearSearchJourneyResults(state: Draft<SearchJourneyState>) {
+      state.journeys = undefined;
+      state.selectedSolutionIndex = undefined;
+    },
     resetSearchJourneyConfig() {
       return searchJourneyInitialState;
     },
@@ -96,6 +100,7 @@ export const {
   updateSearchJourneyDestination,
   setSearchJourneyResults,
   selectSearchJourneySolution,
+  clearSearchJourneyResults,
   resetSearchJourneyConfig,
 } = searchJourneySlice.actions;
 


### PR DESCRIPTION
close #18385 
Improve how the solutions are fetch and display.

Now we wait for all the solutions details data, including op's names to display the solutions, so that there is no clipping anymore between op uid and name.

Also when filling a new request, the previous results, became stale, so we clear them, to not be in a state where solution and request are not linked.