### PR TITLE
front: fix time display in std for hourly timetable mode

### DIFF
--- a/front/ui/ui-charts/src/common/layers/TimeCaptions.tsx
+++ b/front/ui/ui-charts/src/common/layers/TimeCaptions.tsx
@@ -45,9 +45,15 @@ const HOURS_FORMATTER = (t: number, pixelsPerMinute: number) =>
     pixelsPerMinute > 1 ? HOUR_OPTIONS_LONG : HOUR_OPTIONS_SHORT
   );
 
-// Signed integer hour count relative to time origin 0, used for the hourly
-// pattern mode (e.g. hourly timetables): …, -2, -1, 0, 1, 2, …
-const HOURLY_HOURS_FORMATTER = (t: number) => `${Math.round(t / HOUR)}`;
+// Signed time relative to time origin 0, used for the hourly pattern mode
+// (e.g. hourly timetables): …, -02:00, -01:00, 00:00, 01:00, 02:00, …
+const HOURLY_HOURS_FORMATTER = (t: number) => {
+  const sign = t < 0 ? '-' : '';
+  const totalMinutes = Math.round(Math.abs(t) / MINUTE);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${sign}${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+};
 
 const DATES_FORMATER = (t: number) => new Date(t).toLocaleDateString(undefined, DATE_OPTIONS);
 

--- a/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
+++ b/front/ui/ui-charts/src/common/layers/TimeGraduations.tsx
@@ -7,13 +7,13 @@ import type { TimeChartContextType, DrawingFunction } from '../../common/types';
 import { BLACK_ALPHA_25, GREY_50 } from '../helpers/colors';
 import { useDraw } from '../hooks/useCanvas';
 
-// Signed `Xh MM` string for hourly pattern mode (e.g. -1h30, 0h05, 2h15).
+// Signed `HH:MM` string for hourly pattern mode (e.g. -01:30, 00:05, 02:15).
 function formatHourlyTime(t: number): string {
   const sign = t < 0 ? '-' : '';
   const abs = Math.abs(t);
-  const h = Math.floor(abs / HOUR);
-  const m = Math.floor((abs % HOUR) / MINUTE);
-  return `${sign}${h}h${m.toString().padStart(2, '0')}`;
+  const hours = Math.floor(abs / HOUR);
+  const minutes = Math.floor((abs % HOUR) / MINUTE);
+  return `${sign}${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 }
 
 const TimeGraduations = () => {


### PR DESCRIPTION
the format should match "01:00, 02:00" not "1, 2"

closes https://github.com/OpenRailAssociation/osrd/issues/18382