### PR TITLE
front: use explicit type for generatePathAndSchedule() return value

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/ngeToOsrd/trainrun.ts
@@ -331,7 +331,7 @@ export const generatePathAndSchedule = (
   baseDate?: Date,
   trainrunDirection: TRAINRUN_DIRECTIONS = TRAINRUN_DIRECTIONS.FORWARD,
   state?: MacroEditorState
-) => {
+): Pick<TrainSchedule, 'start_time' | 'path' | 'schedule'> => {
   let sections = trainrunSections;
   if (trainrunDirection === TRAINRUN_DIRECTIONS.BACKWARD) {
     sections = [...trainrunSections].reverse();


### PR DESCRIPTION
This makes it clearer what this function returns, and ensures it has the correct type: a handful of TrainSchedule fields.