### PR TITLE
front: fix lint by adding missing parameter type in ExtraOccurenceForm

### DIFF
--- a/front/src/modules/trainHeader/ExtraOccurrenceForm.tsx
+++ b/front/src/modules/trainHeader/ExtraOccurrenceForm.tsx
@@ -72,7 +72,7 @@ const ExtraOccurrenceForm = ({
             { key: 's', label: '' },
           ]}
           padChar="0"
-          onChange={(milliseconds) => {
+          onChange={(milliseconds: number) => {
             setAddedExceptionDate(new Duration({ milliseconds }));
           }}
           small


### PR DESCRIPTION
I have a lint error related to this missing type locally, but not in ci. I suspect it may be due to an npm version mismatch. Still, adding the type can't hurt.