### PR TITLE
editoast: fga: limit how many OpenFGA requests can be sent concurrently

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1746,6 +1746,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/editoast/fga/Cargo.toml
+++ b/editoast/fga/Cargo.toml
@@ -20,7 +20,8 @@ stdext = { workspace = true, optional = true }
 strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tokio-util = { version = "0.7" }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 url.workspace = true

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -19,18 +19,27 @@ pub use tuples::UntypedTuple;
 pub use tuples::UntypedUserset;
 pub use tuples::UserOrUserset;
 
+use futures::TryStreamExt as _;
+use futures::stream;
 use url::Url;
 
 use std::future::Future;
 use std::future::{self};
-
-use futures::TryStreamExt as _;
-use futures::stream;
+use std::sync::Arc;
 
 use crate::client::api::healthz::Health;
 
 pub const DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK: u32 = 50;
 pub const DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE: u64 = 100;
+
+/// The maximum number of concurrent requests the client is allowed to send.
+///
+/// This value should be proportional to
+/// [`OPENFGA_DATASTORE_MAX_OPEN_CONNS`](https://openfga.dev/docs/getting-started/setup-openfga/configuration#:~:text=OPENFGA_DATASTORE_MAX_OPEN_CONNS)
+/// which defaults to `30` and consistent with other OpenFGA configuration values impacting latency.
+///
+/// 🫳 🎩: works with a large number of concurrent requests that otherwise fail locally, adjust if necessary.
+const MAX_CONCURRENT_REQUESTS: usize = 50;
 
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -38,6 +47,7 @@ pub struct Client {
     authorization_model_id: Option<String>,
     settings: ConnectionSettings,
     inner: reqwest::Client,
+    semaphore: Arc<tokio::sync::Semaphore>,
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +116,26 @@ pub enum InitializationError {
 }
 
 impl Client {
+    fn new(settings: ConnectionSettings) -> Self {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_REQUESTS));
+        Self {
+            store: Store::default(),
+            authorization_model_id: None,
+            settings,
+            inner: reqwest::Client::new(),
+            semaphore,
+        }
+    }
+
+    async fn fetch(&self, request: reqwest::RequestBuilder) -> reqwest::Result<reqwest::Response> {
+        let _permit = self
+            .semaphore
+            .acquire()
+            .await
+            .expect("semaphore should never be closed");
+        request.send().await
+    }
+
     pub async fn is_healthy(&self) -> Result<bool, Error> {
         Ok(matches!(self.get_healthz().await?, Health::Serving))
     }

--- a/editoast/fga/src/client/api/authorization_models.rs
+++ b/editoast/fga/src/client/api/authorization_models.rs
@@ -38,7 +38,7 @@ impl Client {
                 .append_pair("page_size", page_size.to_string().as_str());
         }
 
-        let response = self.inner.get(url).send().await?;
+        let response = self.fetch(self.inner.get(url)).await?;
         let Response {
             authorization_models,
             continuation_token,
@@ -58,10 +58,7 @@ impl Client {
             .join(format!("stores/{store_id}/authorization-models").as_str())
             .unwrap();
         let response = self
-            .inner
-            .post(url)
-            .json(authorization_model)
-            .send()
+            .fetch(self.inner.post(url).json(authorization_model))
             .await?;
 
         #[derive(serde::Deserialize)]

--- a/editoast/fga/src/client/api/healthz.rs
+++ b/editoast/fga/src/client/api/healthz.rs
@@ -20,7 +20,7 @@ impl Client {
         }
 
         let url = self.base_url().join("healthz").unwrap();
-        let response = self.inner.get(url).send().await?;
+        let response = self.fetch(self.inner.get(url)).await?;
         let Response { status } = response.json::<Message<_>>().await?.try_success()?;
         Ok(status)
     }

--- a/editoast/fga/src/client/api/queries.rs
+++ b/editoast/fga/src/client/api/queries.rs
@@ -99,14 +99,11 @@ impl Client {
             .join(format!("stores/{store_id}/batch-check").as_str())
             .unwrap();
         let response = self
-            .inner
-            .post(url)
-            .json(&Request {
+            .fetch(self.inner.post(url).json(&Request {
                 checks,
                 authorization_model_id,
                 consistency,
-            })
-            .send()
+            }))
             .await?;
 
         #[derive(serde::Deserialize)]
@@ -144,7 +141,7 @@ impl Client {
             .base_url()
             .join(format!("stores/{store_id}/check").as_str())
             .unwrap();
-        let response = self.inner.post(url).json(&request).send().await?;
+        let response = self.fetch(self.inner.post(url).json(&request)).await?;
 
         #[derive(serde::Deserialize)]
         struct Response {
@@ -192,7 +189,7 @@ impl Client {
             .base_url()
             .join(format!("stores/{store_id}/list-objects").as_str())
             .unwrap();
-        let response = self.inner.post(url).json(&request).send().await?;
+        let response = self.fetch(self.inner.post(url).json(&request)).await?;
 
         #[derive(serde::Deserialize)]
         struct Response {
@@ -251,7 +248,7 @@ impl Client {
             .base_url()
             .join(format!("stores/{store_id}/list-users").as_str())
             .unwrap();
-        let response = self.inner.post(url).json(&request).send().await?;
+        let response = self.fetch(self.inner.post(url).json(&request)).await?;
 
         #[derive(serde::Deserialize)]
         struct Response {

--- a/editoast/fga/src/client/api/stores.rs
+++ b/editoast/fga/src/client/api/stores.rs
@@ -34,7 +34,7 @@ impl Client {
             url.query_pairs_mut()
                 .append_pair("page_size", page_size.to_string().as_str());
         }
-        let response = self.inner.get(url).send().await?;
+        let response = self.fetch(self.inner.get(url)).await?;
 
         let Response {
             stores,
@@ -56,7 +56,7 @@ impl Client {
         };
 
         let url = self.base_url().join("stores").unwrap();
-        let response = self.inner.post(url).json(&request).send().await?;
+        let response = self.fetch(self.inner.post(url).json(&request)).await?;
 
         let store = response.json::<Message<_>>().await?.try_success()?;
         Ok(store)
@@ -68,7 +68,7 @@ impl Client {
             .base_url()
             .join(format!("stores/{store_id}").as_str())
             .unwrap();
-        let response = self.inner.delete(url).send().await?;
+        let response = self.fetch(self.inner.delete(url)).await?;
         if response.status().is_success() {
             Ok(())
         } else {

--- a/editoast/fga/src/client/api/tuples.rs
+++ b/editoast/fga/src/client/api/tuples.rs
@@ -159,16 +159,13 @@ impl Client {
             .unwrap();
 
         let response = self
-            .inner
-            .post(url)
-            .json(&Request {
+            .fetch(self.inner.post(url).json(&Request {
                 tuple_key,
                 page_size,
                 authorization_model_id,
                 consistency,
                 continuation_token,
-            })
-            .send()
+            }))
             .await?;
         let Response {
             tuples,
@@ -234,16 +231,13 @@ impl Client {
             .join(format!("stores/{store_id}/write").as_str())
             .unwrap();
         let response = self
-            .inner
-            .post(url)
-            .json(&Request {
+            .fetch(self.inner.post(url).json(&Request {
                 writes: Writes { tuple_keys: writes },
                 deletes: Deletes {
                     tuple_keys: deletes,
                 },
                 authorization_model_id,
-            })
-            .send()
+            }))
             .await?;
         if response.status().is_success() {
             Ok(())

--- a/editoast/fga/src/client/stores.rs
+++ b/editoast/fga/src/client/stores.rs
@@ -18,12 +18,7 @@ impl Client {
         store_name: &str,
         settings: ConnectionSettings,
     ) -> Result<Self, InitializationError> {
-        let mut client = Self {
-            store: Store::default(),
-            authorization_model_id: None,
-            settings,
-            inner: reqwest::Client::new(),
-        };
+        let mut client = Self::new(settings);
 
         client.store = client
             .find_store(store_name)
@@ -39,12 +34,7 @@ impl Client {
         store_name: &str,
         settings: ConnectionSettings,
     ) -> Result<Self, InitializationError> {
-        let mut client = Self {
-            store: Store::default(),
-            authorization_model_id: None,
-            settings,
-            inner: reqwest::Client::new(),
-        };
+        let mut client = Self::new(settings);
         if client.settings.reset_store
             && let Some(store) = client.find_store(store_name).await?
         {


### PR DESCRIPTION
closes #18397 

OpenFGA can crumble under a sudden load of requests and never recover. Mostly because of the configured maximum number of open PostgreSQL connections that is shared by the workers of all concurrent requests.

The queue smoothes the load OpenFGA receives. The value of 50 concurrent requests was chosen arbitrarily and didn't seem to have much impact on the overall completion time.

How to test:

1. stdcm user
2. in an stdcm group
3. right infra privilege
4. at least 400 rolling stock grants to the group
5. open rolling stock editor
6. check the `/authz/me/privileges` works and that all the rolling stocks are in the same batch