### PR TITLE
front: don't use 12-hour format for computed time cells

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -72,6 +72,7 @@ const formatTime = (t: StartTime, locale: Intl.Locale) =>
         hour: '2-digit',
         minute: '2-digit',
         second: '2-digit',
+        hour12: false,
       })
     : t.toLocaleString(locale, { style: 'digital', hours: '2-digit' });
 


### PR DESCRIPTION
We don't support the 12-hour format for those cells, since "AM" or "PM"
may overflow the cell and truncate the time with an ellipsis otherwise.

This is not a problem even in regions that culturally use AM/PM, because
timetable planners typically use the 24-hour format anyway.

Closes #18406

# How to test??

Install firefox, then set the browser language to "English (US)" using this dropdown (the "Choose..." button won't change the way times are displayed):
<img width="1968" height="655" alt="Capture d&#39;écran 2026-09-04 102102" src="https://github.com/user-attachments/assets/1249a1d0-554a-462a-ba44-f792ce1c4858" />

then set the OSRD language to english (in the upper right menu)