### PR TITLE
front: unify and update table midnight crossing behaviour

### DIFF
--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -51,22 +51,22 @@ type TimeStopsTableWrapperProps = {
 };
 
 const bumpMidnightCrossings = (rows: TimesStopsRowNew[]): TimesStopsRowNew[] => {
-  let lastArrival: StartTime | null = null;
+  let lastDeparture: StartTime | null = null;
   return rows.map((row) => {
     if (row.requestedArrival === null) return row;
-    if (lastArrival !== null && row.requestedArrival < lastArrival) {
-      const bumped = addDurationToStartTime(row.requestedArrival, ONE_DAY);
-      lastArrival = bumped;
-      return {
+    if (lastDeparture !== null && row.requestedArrival < lastDeparture) {
+      const bumpedRow = {
         ...row,
-        requestedArrival: bumped,
+        requestedArrival: addDurationToStartTime(row.requestedArrival, ONE_DAY),
         requestedDeparture:
           row.requestedDeparture !== null
             ? addDurationToStartTime(row.requestedDeparture, ONE_DAY)
             : null,
       };
+      lastDeparture = bumpedRow.requestedDeparture ?? bumpedRow.requestedArrival;
+      return bumpedRow;
     }
-    lastArrival = row.requestedArrival;
+    lastDeparture = row.requestedDeparture ?? row.requestedArrival;
     return row;
   });
 };

--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -10,9 +10,8 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import type { SimulationSummary, TrainScheduleWithDetails } from 'modules/trainSchedule/types';
 import type { Train } from 'reducers/osrdconf/types';
-import { Duration, type StartTime, addDurationToStartTime, startTimeToMs } from 'utils/duration';
+import { Duration, type StartTime, startTimeToMs } from 'utils/duration';
 
-import { ONE_DAY } from './consts';
 import { computeOptimisticRow, propagationToEdits } from './helpers/cellUpdate';
 import { getRowsToUpdateFromSimulation } from './helpers/fillTimesFromSimulation';
 import { computePowerRestrictionWarnings } from './helpers/powerRestrictionIncompatibility';
@@ -48,27 +47,6 @@ type TimeStopsTableWrapperProps = {
   voltages?: PathPropertiesFormatted['voltages'];
   isSimulationDataLoading?: boolean;
   rollingStock?: RollingStock;
-};
-
-const bumpMidnightCrossings = (rows: TimesStopsRowNew[]): TimesStopsRowNew[] => {
-  let lastDeparture: StartTime | null = null;
-  return rows.map((row) => {
-    if (row.requestedArrival === null) return row;
-    if (lastDeparture !== null && row.requestedArrival < lastDeparture) {
-      const bumpedRow = {
-        ...row,
-        requestedArrival: addDurationToStartTime(row.requestedArrival, ONE_DAY),
-        requestedDeparture:
-          row.requestedDeparture !== null
-            ? addDurationToStartTime(row.requestedDeparture, ONE_DAY)
-            : null,
-      };
-      lastDeparture = bumpedRow.requestedDeparture ?? bumpedRow.requestedArrival;
-      return bumpedRow;
-    }
-    lastDeparture = row.requestedDeparture ?? row.requestedArrival;
-    return row;
-  });
 };
 
 const TimeStopsTableWrapper = ({
@@ -130,16 +108,13 @@ const TimeStopsTableWrapper = ({
   }
 
   const optimisticRows = useMemo(() => {
-    let copyRows: TimesStopsRowNew[] = rows;
-    if (optimisticEdits) {
-      const editMap = new Map(optimisticEdits.map((e): [string, PendingEdit] => [e.rowId, e]));
-      copyRows = rows.map((row) => {
-        const edit = editMap.get(row.id);
-        return edit ? { ...row, ...computeOptimisticRow(row, edit) } : row;
-      });
-    }
+    if (!optimisticEdits) return rows;
 
-    return bumpMidnightCrossings(copyRows);
+    const editMap = new Map(optimisticEdits.map((e): [string, PendingEdit] => [e.rowId, e]));
+    return rows.map((row) => {
+      const edit = editMap.get(row.id);
+      return edit ? { ...row, ...computeOptimisticRow(row, edit) } : row;
+    });
   }, [rows, optimisticEdits]);
 
   const startTime = useMemo(

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -23,7 +23,7 @@ import type { ReceptionSignal } from 'common/api/osrdEditoastApi';
 import { SkeletonLoader } from 'common/Loaders';
 import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
 import { useDateTimeLocale } from 'utils/date';
-import { type Duration, type StartTime, subtractStartTime } from 'utils/duration';
+import { type Duration, type StartTime, startTimeToMs, subtractStartTime } from 'utils/duration';
 
 import DurationCell, { type DurationCellHandle } from './DurationCell';
 import { getRowsToUpdateFromSimulation } from './helpers/fillTimesFromSimulation';
@@ -800,34 +800,51 @@ const TimesStopsTable = ({
     ])
   );
 
-  const getRowDayOffset = (row: Row<TimesStopsTableFeatures, TimesStopsRowNew>): number | null => {
-    if (!row.original.pathStepId) return null;
-    const arrival = row.original.computedArrival ?? row.original.requestedArrival;
-    if (!arrival) return null;
-    const diff = subtractStartTime(
-      truncateStartTimeToDay(arrival),
-      truncateStartTimeToDay(startTime)
+  const computeDayOffset = (time: StartTime): number =>
+    Math.round(
+      subtractStartTime(truncateStartTimeToDay(time), truncateStartTimeToDay(startTime)).total(
+        'day'
+      )
     );
-    return diff.total('day');
+
+  const honouredAlong = (rowSequence: Row<TimesStopsTableFeatures, TimesStopsRowNew>[]) => {
+    let honoured = true;
+    return rowSequence.map(({ original: { requestedArrival, computedArrival } }) => {
+      if (requestedArrival && computedArrival) {
+        honoured = startTimeToMs(requestedArrival) === startTimeToMs(computedArrival);
+      }
+      return honoured;
+    });
   };
 
   const tableRows = table.getRowModel().rows;
 
   /**
    * For each row, compute the effective day offset relative to the train start time.
-   * Non-path-step rows (e.g. via points without times) inherit the previous row's offset
-   * so that day-change banners are only shown when the day actually changes.
+   * Times are read from the simulation between two honoured requested times.
+   * It is ignored otherwise.
+   * The floor is the day the train leaves the previous row on,
+   * so a row with no time inherits it and a stop crossing midnight moves what follows.
    */
-  const effectiveDayOffsets = tableRows.reduce<number[]>((acc, row, i) => {
-    const rawOffset = getRowDayOffset(row);
-    if (rawOffset !== null) {
-      acc.push(rawOffset);
-    } else {
-      const prevOffset = i > 0 ? acc[i - 1] : 0;
-      acc.push(prevOffset);
-    }
-    return acc;
-  }, []);
+  const honouredBefore = honouredAlong(tableRows);
+  const honouredAfter = honouredAlong(tableRows.toReversed()).reverse();
+  const readsSimulation = honouredBefore.map((before, i) => before && honouredAfter[i]);
+  const effectiveDayOffsets: number[] = [];
+  let floor = 0;
+
+  for (const [index, { original }] of tableRows.entries()) {
+    const { requestedArrival, computedArrival, requestedDeparture, computedDeparture } = original;
+    const arrival = readsSimulation[index]
+      ? (computedArrival ?? requestedArrival)
+      : requestedArrival;
+    const departure = readsSimulation[index]
+      ? (computedDeparture ?? requestedDeparture)
+      : requestedDeparture;
+
+    const offset = arrival ? Math.max(computeDayOffset(arrival), floor) : floor;
+    effectiveDayOffsets.push(offset);
+    floor = departure ? Math.max(offset, computeDayOffset(departure)) : offset;
+  }
 
   const virtualizedWrapperRef = React.useRef<HTMLDivElement>(null);
 
@@ -911,7 +928,6 @@ const TimesStopsTable = ({
             const rowIndex = virtualRow.index;
             const row = tableRows[rowIndex];
 
-            const rowArrivalDate = row.original.computedArrival ?? row.original.requestedArrival;
             const dayOffset = effectiveDayOffsets[rowIndex];
             const prevDayOffset = rowIndex > 0 ? effectiveDayOffsets[rowIndex - 1] : 0;
             const hasDayChanged = dayOffset > prevDayOffset;
@@ -927,8 +943,13 @@ const TimesStopsTable = ({
 
             let dayChangeLabel = null;
             if (hasDayChanged) {
-              if (rowArrivalDate instanceof Date) {
-                dayChangeLabel = rowArrivalDate.toLocaleDateString(dateTimeLocale, {
+              // Derived from the computed offset, not from the row time, which the offset may have outrun.
+              if (startTime instanceof Date) {
+                dayChangeLabel = new Date(
+                  startTime.getFullYear(),
+                  startTime.getMonth(),
+                  startTime.getDate() + dayOffset
+                ).toLocaleDateString(dateTimeLocale, {
                   day: 'numeric',
                   month: 'long',
                   year: 'numeric',

--- a/front/src/modules/timesStops/helpers/__tests__/timePropagation.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/timePropagation.spec.ts
@@ -4,11 +4,7 @@ import type { Train } from 'reducers/osrdconf/types';
 import { addDurationToStartTime, Duration, type StartTime } from 'utils/duration';
 
 import type { PropagationMode, TimesStopsRowNew } from '../../types';
-import {
-  adjustFollowingWaypointsForMidnight,
-  formatPropagationDeltaLabelByMode,
-  propagateTime,
-} from '../timePropagation';
+import { formatPropagationDeltaLabelByMode, propagateTime } from '../timePropagation';
 
 // time constants
 
@@ -135,14 +131,6 @@ describe('Scenario 1 — +10 min at OP11', () => {
       expect(toComputedArrival(updatedStartTime, scheduleByAt['op17'].arrival!)).toEqual(_19H00); // 18:50 -> 19:00
     });
   });
-
-  describe('adjustFollowingWaypointsForMidnight', () => {
-    it('OP17 still after OP11 → should not trigger midnight crossing', () => {
-      const updatedSchedule = adjustFollowingWaypointsForMidnight(_18H40, 'op11', train);
-      const scheduleByAt = Object.fromEntries(updatedSchedule.map((item) => [item.at, item]));
-      expect(scheduleByAt['op17']?.arrival).toBe('PT50M'); // 50min > 40min (OP11 new offset) → unchanged
-    });
-  });
 });
 
 // Scenario 2 — +30 min at OP11 (18:30 → 19:00)
@@ -221,17 +209,6 @@ describe('Scenario 2 — +30 min at OP11', () => {
       expect(scheduleByAt['op17']?.arrival).toBe('PT50M'); // offset unchanged
       expect(toComputedArrival(updatedStartTime, scheduleByAt['op11'].arrival!)).toEqual(_19H00);
       expect(toComputedArrival(updatedStartTime, scheduleByAt['op17'].arrival!)).toEqual(_19H20);
-    });
-  });
-
-  describe('adjustFollowingWaypointsForMidnight', () => {
-    it('OP17 falls before OP11 → should trigger midnight crossing to next day 18:50', () => {
-      const updatedSchedule = adjustFollowingWaypointsForMidnight(_19H00, 'op11', train);
-      const scheduleByAt = Object.fromEntries(updatedSchedule.map((item) => [item.at, item]));
-      expect(scheduleByAt['op17']?.arrival).toBe('PT24H50M'); // 50min < 60min (OP11 new offset) → midnight crossing (+24h to original offset)
-      expect(toComputedArrival(_18H00, scheduleByAt['op17'].arrival!)).toEqual(
-        _18H50_MIDNIGHT_CROSSING
-      );
     });
   });
 });
@@ -344,21 +321,6 @@ describe('Scenario 3 — -40 min at OP11', () => {
       expect(scheduleByAt['op17']?.arrival).toBe('PT50M'); // offset unchanged
       expect(toComputedArrival(updatedStartTime, scheduleByAt['op11'].arrival!)).toEqual(_17H50); // 18:30 -> 17:50
       expect(toComputedArrival(updatedStartTime, scheduleByAt['op17'].arrival!)).toEqual(_18H10); // 18:50 -> 18:10
-    });
-  });
-
-  describe('adjustFollowingWaypointsForMidnight', () => {
-    it('OP17 falls before OP11 → should trigger midnight crossing to next day 18:50', () => {
-      const updatedSchedule = adjustFollowingWaypointsForMidnight(
-        _17H50_MIDNIGHT_CROSSING,
-        'op11',
-        train
-      );
-      const scheduleByAt = Object.fromEntries(updatedSchedule.map((item) => [item.at, item]));
-      expect(scheduleByAt['op17']?.arrival).toBe('PT24H50M'); // 50min < 23h50m (OP11 new offset) → midnight crossing
-      expect(toComputedArrival(_18H00, scheduleByAt['op17'].arrival!)).toEqual(
-        _18H50_MIDNIGHT_CROSSING
-      );
     });
   });
 });

--- a/front/src/modules/timesStops/helpers/arrivalCascade.ts
+++ b/front/src/modules/timesStops/helpers/arrivalCascade.ts
@@ -11,27 +11,36 @@ export const cascadeArrivals = ({
   schedule,
   path,
   fromPathIndex,
-  baseline,
   shift = (arrival: Duration) => arrival,
 }: {
   schedule: ScheduleItem[];
   path: PathItem[];
   fromPathIndex: number;
-  baseline: Duration;
   shift?: (arrival: Duration) => Duration;
 }): ScheduleItem[] => {
   const pathIndexById = new Map(path.map((step, index) => [step.id, index]));
 
-  const affectedItems = schedule
-    .map((item) => ({ item, pathIndex: pathIndexById.get(item.at) ?? -1 }))
-    .filter(({ item, pathIndex }) => !!item.arrival && pathIndex >= fromPathIndex)
+  const scheduledItems = schedule
+    .flatMap((item) => {
+      const pathIndex = pathIndexById.get(item.at);
+      return pathIndex === undefined ? [] : [{ item, pathIndex }];
+    })
     .sort((a, b) => a.pathIndex - b.pathIndex);
 
-  let lastOffset = baseline;
+  let lastOffset = Duration.zero;
   const adjustments = new Map<string, string>();
 
-  for (const { item } of affectedItems) {
-    const shifted = shift(Duration.parse(item.arrival!));
+  for (const { item, pathIndex } of scheduledItems) {
+    if (!item.arrival) continue;
+    const arrival = Duration.parse(item.arrival);
+
+    // Points before fromPathIndex are only used to find the lastOffset to use.
+    if (pathIndex < fromPathIndex) {
+      lastOffset = arrival;
+      continue;
+    }
+
+    const shifted = shift(arrival);
     const adjusted = shifted.ms < lastOffset.ms ? shifted.add(ONE_DAY) : shifted;
     adjustments.set(item.at, adjusted.toISOString());
     lastOffset = adjusted;

--- a/front/src/modules/timesStops/helpers/arrivalCascade.ts
+++ b/front/src/modules/timesStops/helpers/arrivalCascade.ts
@@ -1,0 +1,43 @@
+import type { PathItem, ScheduleItem } from 'common/api/osrdEditoastApi';
+import { Duration } from 'utils/duration';
+
+import { ONE_DAY } from '../consts';
+
+/**
+ * Shift the scheduled arrivals from fromPathIndex on.
+ * Cascade midnight crossings for any arrival that ends up before the previous one.
+ */
+export const cascadeArrivals = ({
+  schedule,
+  path,
+  fromPathIndex,
+  baseline,
+  shift = (arrival: Duration) => arrival,
+}: {
+  schedule: ScheduleItem[];
+  path: PathItem[];
+  fromPathIndex: number;
+  baseline: Duration;
+  shift?: (arrival: Duration) => Duration;
+}): ScheduleItem[] => {
+  const pathIndexById = new Map(path.map((step, index) => [step.id, index]));
+
+  const affectedItems = schedule
+    .map((item) => ({ item, pathIndex: pathIndexById.get(item.at) ?? -1 }))
+    .filter(({ item, pathIndex }) => !!item.arrival && pathIndex >= fromPathIndex)
+    .sort((a, b) => a.pathIndex - b.pathIndex);
+
+  let lastOffset = baseline;
+  const adjustments = new Map<string, string>();
+
+  for (const { item } of affectedItems) {
+    const shifted = shift(Duration.parse(item.arrival!));
+    const adjusted = shifted.ms < lastOffset.ms ? shifted.add(ONE_DAY) : shifted;
+    adjustments.set(item.at, adjusted.toISOString());
+    lastOffset = adjusted;
+  }
+
+  return schedule.map((item) =>
+    adjustments.has(item.at) ? { ...item, arrival: adjustments.get(item.at) } : item
+  );
+};

--- a/front/src/modules/timesStops/helpers/arrivalCascade.ts
+++ b/front/src/modules/timesStops/helpers/arrivalCascade.ts
@@ -5,7 +5,7 @@ import { ONE_DAY } from '../consts';
 
 /**
  * Shift the scheduled arrivals from fromPathIndex on.
- * Cascade midnight crossings for any arrival that ends up before the previous one.
+ * Cascade midnight crossings for any arrival that ends up before the previous departure.
  */
 export const cascadeArrivals = ({
   schedule,
@@ -31,19 +31,23 @@ export const cascadeArrivals = ({
   const adjustments = new Map<string, string>();
 
   for (const { item, pathIndex } of scheduledItems) {
-    if (!item.arrival) continue;
+    const stop = item.stop_for ? Duration.parse(item.stop_for) : Duration.zero;
+    if (!item.arrival) {
+      lastOffset = lastOffset.add(stop);
+      continue;
+    }
     const arrival = Duration.parse(item.arrival);
 
     // Points before fromPathIndex are only used to find the lastOffset to use.
     if (pathIndex < fromPathIndex) {
-      lastOffset = arrival;
+      lastOffset = arrival.add(stop);
       continue;
     }
 
     const shifted = shift(arrival);
     const adjusted = shifted.ms < lastOffset.ms ? shifted.add(ONE_DAY) : shifted;
     adjustments.set(item.at, adjusted.toISOString());
-    lastOffset = adjusted;
+    lastOffset = adjusted.add(stop);
   }
 
   return schedule.map((item) =>

--- a/front/src/modules/timesStops/helpers/arrivalCascade.ts
+++ b/front/src/modules/timesStops/helpers/arrivalCascade.ts
@@ -5,7 +5,8 @@ import { ONE_DAY } from '../consts';
 
 /**
  * Shift the scheduled arrivals from fromPathIndex on.
- * Cascade midnight crossings for any arrival that ends up before the previous departure.
+ * Whole days are then added or removed,
+ * so each arrival is consistent with the previous departure.
  */
 export const cascadeArrivals = ({
   schedule,
@@ -45,7 +46,8 @@ export const cascadeArrivals = ({
     }
 
     const shifted = shift(arrival);
-    const adjusted = shifted.ms < lastOffset.ms ? shifted.add(ONE_DAY) : shifted;
+    const daysShift = Math.ceil((lastOffset.ms - shifted.ms) / ONE_DAY.ms);
+    const adjusted = shifted.add(new Duration({ days: daysShift }));
     adjustments.set(item.at, adjusted.toISOString());
     lastOffset = adjusted.add(stop);
   }

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -51,25 +51,25 @@ export const propagateStopDuration = (
       ? new Date(selectedTrain.start_time)
       : new Duration({ milliseconds: selectedTrain.start_time });
 
+  // Set the edited point's new duration (its arrival stays the same)
+  const updatedScheduleStop: ScheduleItem[] = editedItem
+    ? currentSchedule.map((item) =>
+        item.at === pathStepId ? { ...item, stop_for: newDuration.toISOString() } : item
+      )
+    : insertScheduleItemInOrder(
+        currentSchedule,
+        { at: pathStepId, arrival: null, stop_for: newDuration.toISOString() },
+        selectedTrain.path
+      );
+
   // Shift every scheduled arrival after the edited point by +delta, in path order. Bump +24h
-  // if a shifted arrival ends up before the previous one.
-  // Then set the edited point's new duration (its arrival stays the same).
-  const shiftedSchedule = cascadeArrivals({
-    schedule: currentSchedule,
+  // if a shifted arrival ends up before the previous departure.
+  const updatedSchedule = cascadeArrivals({
+    schedule: updatedScheduleStop,
     path: selectedTrain.path,
     fromPathIndex: editedPathIndex + 1,
     shift: (arrival) => arrival.add(delta),
   });
-
-  const updatedSchedule: ScheduleItem[] = editedItem
-    ? shiftedSchedule.map((item) =>
-        item.at === pathStepId ? { ...item, stop_for: newDuration.toISOString() } : item
-      )
-    : insertScheduleItemInOrder(
-        shiftedSchedule,
-        { at: pathStepId, arrival: null, stop_for: newDuration.toISOString() },
-        selectedTrain.path
-      );
 
   const updatedStartTime =
     update.propagationMode === 'fromDeparture'

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -46,7 +46,6 @@ export const propagateStopDuration = (
   // The edited point's current schedule state, if it already has one.
   const currentSchedule = selectedTrain.schedule ?? [];
   const editedItem = currentSchedule.find((item) => item.at === pathStepId);
-  const editedOffset = editedItem?.arrival ? Duration.parse(editedItem.arrival) : null;
   const currentStartTime =
     timetableType === 'CALENDAR'
       ? new Date(selectedTrain.start_time)
@@ -59,7 +58,6 @@ export const propagateStopDuration = (
     schedule: currentSchedule,
     path: selectedTrain.path,
     fromPathIndex: editedPathIndex + 1,
-    baseline: editedOffset ?? Duration.zero,
     shift: (arrival) => arrival.add(delta),
   });
 

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -35,8 +35,7 @@ export const propagateStopDuration = (
     return undefined;
 
   const pathStepId = update.row.pathStepId;
-  const pathIndexById = new Map(selectedTrain.path.map((step, index) => [step.id, index]));
-  const editedPathIndex = pathIndexById.get(pathStepId) ?? -1;
+  const editedPathIndex = selectedTrain.path.findIndex((step) => step.id === pathStepId);
   if (editedPathIndex < 0) return undefined;
 
   // Delta between the old and new stop duration — drives every shift below.

--- a/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
+++ b/front/src/modules/timesStops/helpers/stopDurationPropagation.ts
@@ -2,8 +2,8 @@ import type { ScheduleItem, TimetableType } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 import { Duration, subtractDurationFromStartTime } from 'utils/duration';
 
-import { ONE_DAY } from '../consts';
 import type { StopDurationUpdate, PropagationResult } from '../types';
+import { cascadeArrivals } from './arrivalCascade';
 import { insertScheduleItemInOrder } from './cellUpdate';
 import { formatSignedDelta } from './utils';
 
@@ -55,24 +55,14 @@ export const propagateStopDuration = (
 
   // Shift every scheduled arrival after the edited point by +delta, in path order. Bump +24h
   // if a shifted arrival ends up before the previous one.
-  const affectedItems = currentSchedule
-    .map((item) => ({ item, pathIndex: pathIndexById.get(item.at) ?? -1 }))
-    .filter(({ item, pathIndex }) => !!item.arrival && pathIndex > editedPathIndex)
-    .sort((a, b) => a.pathIndex - b.pathIndex);
-
-  const adjustments = new Map<string, string>();
-  let lastOffset = editedOffset ?? Duration.zero;
-  for (const { item } of affectedItems) {
-    const shifted = Duration.parse(item.arrival!).add(delta);
-    const adjusted = shifted.ms < lastOffset.ms ? shifted.add(ONE_DAY) : shifted;
-    adjustments.set(item.at, adjusted.toISOString());
-    lastOffset = adjusted;
-  }
-
-  // Apply the shifts above, then set the edited point's new duration (its arrival stays the same).
-  const shiftedSchedule = currentSchedule.map((item) =>
-    adjustments.has(item.at) ? { ...item, arrival: adjustments.get(item.at) } : item
-  );
+  // Then set the edited point's new duration (its arrival stays the same).
+  const shiftedSchedule = cascadeArrivals({
+    schedule: currentSchedule,
+    path: selectedTrain.path,
+    fromPathIndex: editedPathIndex + 1,
+    baseline: editedOffset ?? Duration.zero,
+    shift: (arrival) => arrival.add(delta),
+  });
 
   const updatedSchedule: ScheduleItem[] = editedItem
     ? shiftedSchedule.map((item) =>

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -7,7 +7,6 @@ import {
   subtractStartTime,
 } from 'utils/duration';
 
-import { ONE_DAY } from '../consts';
 import type {
   ArrivalUpdate,
   BatchTimesUpdate,
@@ -15,6 +14,7 @@ import type {
   PropagationMode,
   PropagationResult,
 } from '../types';
+import { cascadeArrivals } from './arrivalCascade';
 import { propagateStopDuration } from './stopDurationPropagation';
 import { truncateStartTimeToSecond, formatSignedDelta } from './utils';
 
@@ -87,52 +87,25 @@ const propagateFromEditedPoint = (
     timetableType === 'CALENDAR'
       ? new Date(selectedTrain.start_time)
       : new Duration({ milliseconds: selectedTrain.start_time });
+  const isFromDeparture = direction === 'fromDeparture';
   // For fromDeparture: the train's start time shifts by delta. For toDestination: it stays the same.
-  const newStartTime =
-    direction === 'fromDeparture'
-      ? addDurationToStartTime(currentStartTime, delta)
-      : currentStartTime;
+  const newStartTime = isFromDeparture
+    ? addDurationToStartTime(currentStartTime, delta)
+    : currentStartTime;
 
-  // Compute shifted offsets for all affected items, sorted by path order.
-  const affectedItems = Iterator.from(selectedTrain.schedule ?? [])
-    .map((item) => ({
-      item,
-      pathIndex: selectedTrain.path.findIndex((step) => step.id === item.at),
-    }))
-    .filter(({ item, pathIndex }) => {
-      if (!item.arrival) return false;
-      return direction === 'fromDeparture'
-        ? pathIndex > editedPathIndex
-        : pathIndex >= editedPathIndex;
-    })
-    .toArray();
-
-  // Apply cascade: each waypoint is compared against the previous one.
-  // If it falls before, it crossed midnight and gets +24h.
-  // For fromDeparture: the edited item is excluded from the loop, but its offset is the baseline —
+  // For fromDeparture: the edited item is excluded from the cascade, but its offset is the baseline —
   // any shifted offset that falls before it gets +24h.
-  // For toDestination: the edited item is included in the loop, so start at 0.
+  // For toDestination: the edited item is part of the cascade, so the baseline is 0.
   const editedItem = selectedTrain.schedule?.find((item) => item.at === editedPathStepId);
   const editedOldOffset = editedItem?.arrival ? Duration.parse(editedItem.arrival) : null;
-  let lastOffset =
-    direction === 'fromDeparture' && editedOldOffset !== null
-      ? editedOldOffset
-      : new Duration({ seconds: 0 });
-  const adjustments = new Map<string, string>();
 
-  for (const { item } of affectedItems) {
-    const shifted =
-      direction === 'fromDeparture'
-        ? Duration.parse(item.arrival!).sub(delta)
-        : Duration.parse(item.arrival!).add(delta);
-    const adjustedArrival = shifted.ms < lastOffset.ms ? shifted.add(ONE_DAY) : shifted;
-    adjustments.set(item.at, adjustedArrival.toISOString());
-    lastOffset = adjustedArrival;
-  }
-
-  const updatedSchedule = (selectedTrain.schedule ?? []).map((item) =>
-    adjustments.has(item.at) ? { ...item, arrival: adjustments.get(item.at) } : item
-  );
+  const updatedSchedule = cascadeArrivals({
+    schedule: selectedTrain.schedule ?? [],
+    path: selectedTrain.path,
+    fromPathIndex: isFromDeparture ? editedPathIndex + 1 : editedPathIndex,
+    baseline: (isFromDeparture ? editedOldOffset : null) ?? Duration.zero,
+    shift: (arrival) => (isFromDeparture ? arrival.sub(delta) : arrival.add(delta)),
+  });
 
   return {
     updatedPath: selectedTrain.path,
@@ -169,27 +142,12 @@ export const adjustFollowingWaypointsForMidnight = (
   const startTime = new Date(selectedTrain.start_time);
   const editedPathIndex = selectedTrain.path.findIndex((step) => step.id === editedPathStepId);
 
-  const itemsAfterUpdatedStep = Iterator.from(selectedTrain.schedule ?? [])
-    .map((item) => ({
-      item,
-      pathIndex: selectedTrain.path.findIndex((step) => step.id === item.at),
-    }))
-    .filter(({ item, pathIndex }) => item.arrival && pathIndex > editedPathIndex)
-    .toArray();
-
-  let lastOffset = Duration.subtractDate(newValue, startTime);
-  const adjustments = new Map<string, string>();
-
-  for (const { item } of itemsAfterUpdatedStep) {
-    const itemOffset = Duration.parse(item.arrival!);
-    const adjustedArrival = itemOffset.ms < lastOffset.ms ? itemOffset.add(ONE_DAY) : itemOffset;
-    adjustments.set(item.at, adjustedArrival.toISOString());
-    lastOffset = adjustedArrival;
-  }
-
-  return (selectedTrain.schedule ?? []).map((item) =>
-    adjustments.has(item.at) ? { ...item, arrival: adjustments.get(item.at) } : item
-  );
+  return cascadeArrivals({
+    schedule: selectedTrain.schedule ?? [],
+    path: selectedTrain.path,
+    fromPathIndex: editedPathIndex + 1,
+    baseline: Duration.subtractDate(newValue, startTime),
+  });
 };
 
 export const propagateTime = (

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -1,4 +1,4 @@
-import type { ScheduleItem, TimetableType } from 'common/api/osrdEditoastApi';
+import type { TimetableType } from 'common/api/osrdEditoastApi';
 import type { Train } from 'reducers/osrdconf/types';
 import {
   Duration,
@@ -128,26 +128,6 @@ const propagateShiftAll = (
     updatedSchedule: selectedTrain.schedule ?? [],
     updatedStartTime: addDurationToStartTime(currentStartTime, delta),
   };
-};
-
-/**
- * For atThisWaypoint: waypoints after the edited point that now fall before it in time
- * must be on the next day.
- */
-export const adjustFollowingWaypointsForMidnight = (
-  newValue: Date,
-  editedPathStepId: string,
-  selectedTrain: Train
-): ScheduleItem[] => {
-  const startTime = new Date(selectedTrain.start_time);
-  const editedPathIndex = selectedTrain.path.findIndex((step) => step.id === editedPathStepId);
-
-  return cascadeArrivals({
-    schedule: selectedTrain.schedule ?? [],
-    path: selectedTrain.path,
-    fromPathIndex: editedPathIndex + 1,
-    baseline: Duration.subtractDate(newValue, startTime),
-  });
 };
 
 export const propagateTime = (

--- a/front/src/modules/timesStops/helpers/timePropagation.ts
+++ b/front/src/modules/timesStops/helpers/timePropagation.ts
@@ -93,17 +93,12 @@ const propagateFromEditedPoint = (
     ? addDurationToStartTime(currentStartTime, delta)
     : currentStartTime;
 
-  // For fromDeparture: the edited item is excluded from the cascade, but its offset is the baseline —
-  // any shifted offset that falls before it gets +24h.
-  // For toDestination: the edited item is part of the cascade, so the baseline is 0.
-  const editedItem = selectedTrain.schedule?.find((item) => item.at === editedPathStepId);
-  const editedOldOffset = editedItem?.arrival ? Duration.parse(editedItem.arrival) : null;
-
+  // For fromDeparture: the edited item is excluded from the cascade.
+  // For toDestination: the edited item is part of the cascade.
   const updatedSchedule = cascadeArrivals({
     schedule: selectedTrain.schedule ?? [],
     path: selectedTrain.path,
     fromPathIndex: isFromDeparture ? editedPathIndex + 1 : editedPathIndex,
-    baseline: (isFromDeparture ? editedOldOffset : null) ?? Duration.zero,
     shift: (arrival) => (isFromDeparture ? arrival.sub(delta) : arrival.add(delta)),
   });
 

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -141,7 +141,17 @@ const useUpdateTimesStopsTable = (
         update.field === 'stopDuration'
           ? propagateStopDuration(update, selectedTrain, scenario.timetable_type)
           : propagateTime(update, selectedTrain, scenario.timetable_type);
-      if (propagatedResult) return { ...propagatedResult, updatedMargins: selectedTrain.margins };
+      if (propagatedResult)
+        return {
+          ...propagatedResult,
+          // The days must be right before saving
+          updatedSchedule: cascadeArrivals({
+            schedule: propagatedResult.updatedSchedule,
+            path: propagatedResult.updatedPath,
+            fromPathIndex: 1,
+          }),
+          updatedMargins: selectedTrain.margins,
+        };
 
       const { pathStepId, updatedPath } = upsertPathStep(update.row, selectedTrain.path, allRows);
       const currentSchedule = selectedTrain.schedule ?? [];
@@ -220,17 +230,16 @@ const useUpdateTimesStopsTable = (
         updatedSchedule = insertScheduleItemInOrder(currentSchedule, newItem, updatedPath);
       }
 
-      // For atThisWaypoint: stops after the edited point that now fall before it in time
-      // must be bumped to the next day.
-      if (update.propagationMode === 'atThisWaypoint') {
-        updatedSchedule = cascadeArrivals({
+      return {
+        updatedPath,
+        // The days must be right before saving
+        updatedSchedule: cascadeArrivals({
           schedule: updatedSchedule,
           path: updatedPath,
-          fromPathIndex: updatedPath.findIndex((step) => step.id === pathStepId) + 1,
-        });
-      }
-
-      return { updatedPath, updatedSchedule, updatedMargins: selectedTrain.margins };
+          fromPathIndex: 1,
+        }),
+        updatedMargins: selectedTrain.margins,
+      };
     },
     [selectedTrain, allRows, computeUpdatedMargins, scenario.timetable_type]
   );

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -37,6 +37,7 @@ import {
 } from 'utils/trainId';
 
 import { MarginUnit } from '../consts';
+import { cascadeArrivals } from '../helpers/arrivalCascade';
 import {
   upsertPathStep,
   applyScheduleEdit,
@@ -46,7 +47,7 @@ import {
   insertScheduleItemInOrder,
 } from '../helpers/cellUpdate';
 import { propagateStopDuration } from '../helpers/stopDurationPropagation';
-import { adjustFollowingWaypointsForMidnight, propagateTime } from '../helpers/timePropagation';
+import { propagateTime } from '../helpers/timePropagation';
 import type {
   CellUpdate,
   OptimisticEdit,
@@ -228,9 +229,11 @@ const useUpdateTimesStopsTable = (
         update.value instanceof Date &&
         !isOrigin
       ) {
-        updatedSchedule = adjustFollowingWaypointsForMidnight(update.value, pathStepId, {
-          ...selectedTrain,
+        updatedSchedule = cascadeArrivals({
           schedule: updatedSchedule,
+          path: selectedTrain.path,
+          fromPathIndex: selectedTrain.path.findIndex((step) => step.id === pathStepId) + 1,
+          baseline: Duration.subtractDate(update.value, new Date(selectedTrain.start_time)),
         });
       }
 
@@ -242,9 +245,11 @@ const useUpdateTimesStopsTable = (
         newState.departure !== null &&
         newState.departure instanceof Date
       ) {
-        updatedSchedule = adjustFollowingWaypointsForMidnight(newState.departure, pathStepId, {
-          ...selectedTrain,
+        updatedSchedule = cascadeArrivals({
           schedule: updatedSchedule,
+          path: selectedTrain.path,
+          fromPathIndex: selectedTrain.path.findIndex((step) => step.id === pathStepId) + 1,
+          baseline: Duration.subtractDate(newState.departure, new Date(selectedTrain.start_time)),
         });
       }
 

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -225,8 +225,8 @@ const useUpdateTimesStopsTable = (
       if (update.propagationMode === 'atThisWaypoint') {
         updatedSchedule = cascadeArrivals({
           schedule: updatedSchedule,
-          path: selectedTrain.path,
-          fromPathIndex: selectedTrain.path.findIndex((step) => step.id === pathStepId) + 1,
+          path: updatedPath,
+          fromPathIndex: updatedPath.findIndex((step) => step.id === pathStepId) + 1,
         });
       }
 

--- a/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
+++ b/front/src/modules/timesStops/hooks/useUpdateTimesStopsTable.ts
@@ -222,34 +222,11 @@ const useUpdateTimesStopsTable = (
 
       // For atThisWaypoint: stops after the edited point that now fall before it in time
       // must be bumped to the next day.
-      if (
-        (update.field === 'requestedArrival' || update.field === 'requestedDeparture') &&
-        update.propagationMode === 'atThisWaypoint' &&
-        update.value !== null &&
-        update.value instanceof Date &&
-        !isOrigin
-      ) {
+      if (update.propagationMode === 'atThisWaypoint') {
         updatedSchedule = cascadeArrivals({
           schedule: updatedSchedule,
           path: selectedTrain.path,
           fromPathIndex: selectedTrain.path.findIndex((step) => step.id === pathStepId) + 1,
-          baseline: Duration.subtractDate(update.value, new Date(selectedTrain.start_time)),
-        });
-      }
-
-      // Same idea for stop duration: a longer stop can push the departure past the next stop's
-      // arrival, so following stops get bumped too — including at the origin, unlike above.
-      if (
-        update.field === 'stopDuration' &&
-        update.propagationMode === 'atThisWaypoint' &&
-        newState.departure !== null &&
-        newState.departure instanceof Date
-      ) {
-        updatedSchedule = cascadeArrivals({
-          schedule: updatedSchedule,
-          path: selectedTrain.path,
-          fromPathIndex: selectedTrain.path.findIndex((step) => step.id === pathStepId) + 1,
-          baseline: Duration.subtractDate(newState.departure, new Date(selectedTrain.start_time)),
         });
       }
 


### PR DESCRIPTION
This PR unifies a part of the propagation logic, especially the midnight crossing part.

It also changes the midnight crossing behaviour.

An arrival time at a waypoint is shifted by days if its arrival:
- is before the previous waypoint **departure time** (and not arrival time) : +24h (or more if needed)

- is before the previous waypoint with a fixed arrival time + all the stopping times fixed between them: +24h (or more if needed). NB: this can lead the simulation to weird results since it is completely free to dispatch the +24h across the intermediate waypoints.

- is more than 24h after the previous waypoint : -24h. It is then not possible anymore to have more than 24h between two following waypoints but it automatically handles the shift of 24h when the previous times are updated. This shift was made anyway if we ever touched the point that was at +24h. _**This point can be discussed**._

To place the pass midnight header, times are read from the simulation between two honoured requested time and from the requested times only otherwise (simulation is ignored).

Follow-up PRs are coming to continue the logic unifying work.