### PR TITLE
front: allow Promise to be returned from API mock endpoint

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/__tests__/useLoadCatalog.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/__tests__/useLoadCatalog.spec.ts
@@ -176,7 +176,7 @@ describe('useLoadCatalog', () => {
 
   it('should early return if catalogData is undefined', async () => {
     // Never-resolving promise: catalogData stays undefined for the whole test
-    getAllCatalogEntries.mockReturnValue(new Promise<never>(() => {}) as never);
+    getAllCatalogEntries.mockReturnValue(new Promise<never>(() => {}));
 
     const { result } = renderHookWithStore(() => useLoadCatalog());
 

--- a/front/src/common/api/__mocks__/osrdEditoastApi.ts
+++ b/front/src/common/api/__mocks__/osrdEditoastApi.ts
@@ -10,6 +10,11 @@ import { osrdEditoastApi } from '../osrdEditoastApi';
 type Endpoints = (typeof osrdEditoastApi)['endpoints'];
 
 /**
+ * A Promise or its direct result.
+ */
+type PromiseOr<T> = T | Promise<T>;
+
+/**
  * Given an endpoint type, extract its argument and result types and build a
  * mock function type.
  *
@@ -18,7 +23,7 @@ type Endpoints = (typeof osrdEditoastApi)['endpoints'];
  * returned by the endpoint if it wasn't mocked.
  */
 type MockQueryFn<E> = E extends { Types: { QueryArg: infer A; ResultType: infer R } }
-  ? Mock<(arg: A) => QueryReturnValue<R, ApiError>>
+  ? Mock<(arg: A) => PromiseOr<QueryReturnValue<R, ApiError>>>
   : never;
 
 /**


### PR DESCRIPTION
rtk-query's `queryFn` can return a result, or a `Promise`. Reflect this in the API mock endpoints types, so that tests can call `mockReturnValue()` with a Promise.

This allows us to drop a cast in `useLoadCatalog()` tests.

The name "PromiseOr" is inspired by Dart's [`FutureOr`](https://api.flutter.dev/flutter/dart-async/FutureOr-class.html).