### PR TITLE
front: remove useEffects from useWorkerStatus

### DIFF
--- a/front/src/modules/pathfinding/hooks/useWorkerStatus.ts
+++ b/front/src/modules/pathfinding/hooks/useWorkerStatus.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { skipToken } from '@reduxjs/toolkit/query';
 
@@ -29,25 +29,23 @@ export default function useWorkerStatus({
     }
   );
 
-  useEffect(() => {
-    if (infraId) {
-      setShouldPoll(true);
-    }
-  }, [infraId]);
+  const [prevInfraId, setPrevInfraId] = useState(infraId);
+  if (infraId !== prevInfraId) {
+    setPrevInfraId(infraId);
+    setShouldPoll(true);
+  }
 
-  useEffect(() => {
-    if (workerStatus) {
-      switch (workerStatus) {
-        case 'READY':
-        case 'ERROR': {
-          setShouldPoll(false);
-          break;
-        }
-        default:
-          break;
+  if (shouldPoll) {
+    switch (workerStatus) {
+      case 'READY':
+      case 'ERROR': {
+        setShouldPoll(false);
+        break;
       }
+      default:
+        break;
     }
-  }, [workerStatus]);
+  }
 
   return workerStatus;
 }


### PR DESCRIPTION
This prevents re-renders when infraId and workerStatus change, i believe.

See
https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes