### PR TITLE
front: fix simple oxlint violations

### DIFF
--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -52,7 +52,6 @@
     "no-else-return": "off",
     "no-floating-promises": "off",
     "no-inline-comments": "off",
-    "no-lonely-if": "off",
     "no-loop-func": "off",
     "no-misused-promises": "off",
     "no-misused-spread": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -58,7 +58,6 @@
     "no-throw-literal": "off",
     "no-unassigned-import": "off",
     "no-underscore-dangle": "off",
-    "no-unnecessary-template-expression": "off",
     "no-unnecessary-type-conversion": "off",
     "no-unnecessary-type-parameters": "off",
     "no-unsafe-argument": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -71,7 +71,6 @@
     "no-unsafe-assignment": "off",
     "no-unsafe-enum-comparison": "off",
     "no-unsafe-member-access": "off",
-    "no-unsafe-optional-chaining": "off",
     "no-unsafe-type-assertion": "off",
     "no-useless-constructor": "off",
     "no-useless-default-assignment": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -46,7 +46,6 @@
     "no-array-index-key": "off",
     "no-await-in-loop": "off",
     "no-base-to-string": "off",
-    "no-confusing-non-null-assertion": "off",
     "no-confusing-void-expression": "off",
     "no-duplicate-type-constituents": "off",
     "no-else-return": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -45,7 +45,6 @@
     "max-lines": "off",
     "no-array-index-key": "off",
     "no-await-in-loop": "off",
-    "no-base-to-string": "off",
     "no-confusing-void-expression": "off",
     "no-else-return": "off",
     "no-floating-promises": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -78,7 +78,6 @@
     "prefer-nullish-coalescing": "off",
     "prefer-readonly-parameter-types": "off",
     "prefer-tag-over-role": "off",
-    "preserve-caught-error": "off",
     "radix": "off",
     "react-in-jsx-scope": "off",
     "require-array-sort-compare": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -79,7 +79,6 @@
     "prefer-tag-over-role": "off",
     "radix": "off",
     "react-in-jsx-scope": "off",
-    "require-array-sort-compare": "off",
     "require-mock-type-parameters": "off",
     "require-unicode-regexp": "off",
     "restrict-template-expressions": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -47,7 +47,6 @@
     "no-await-in-loop": "off",
     "no-base-to-string": "off",
     "no-confusing-void-expression": "off",
-    "no-duplicate-type-constituents": "off",
     "no-else-return": "off",
     "no-floating-promises": "off",
     "no-inline-comments": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -75,7 +75,6 @@
     "prefer-nullish-coalescing": "off",
     "prefer-readonly-parameter-types": "off",
     "prefer-tag-over-role": "off",
-    "radix": "off",
     "react-in-jsx-scope": "off",
     "require-mock-type-parameters": "off",
     "require-unicode-regexp": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -59,7 +59,6 @@
     "no-unassigned-import": "off",
     "no-underscore-dangle": "off",
     "no-unnecessary-template-expression": "off",
-    "no-unnecessary-type-arguments": "off",
     "no-unnecessary-type-conversion": "off",
     "no-unnecessary-type-parameters": "off",
     "no-unsafe-argument": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -58,7 +58,6 @@
     "no-throw-literal": "off",
     "no-unassigned-import": "off",
     "no-underscore-dangle": "off",
-    "no-unnecessary-boolean-literal-compare": "off",
     "no-unnecessary-template-expression": "off",
     "no-unnecessary-type-arguments": "off",
     "no-unnecessary-type-conversion": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -73,7 +73,6 @@
     "no-useless-return": "off",
     "no-warning-comments": "off",
     "only-throw-error": "off",
-    "prefer-enum-initializers": "off",
     "prefer-nullish-coalescing": "off",
     "prefer-readonly-parameter-types": "off",
     "prefer-tag-over-role": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -30,7 +30,6 @@
   ],
   "rules": {
     "array-callback-return": "off",
-    "await-thenable": "off",
     "checked-requires-onchange-or-readonly": "off",
     "click-events-have-key-events": "off",
     "consistent-return": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -70,7 +70,6 @@
     "no-unsafe-enum-comparison": "off",
     "no-unsafe-member-access": "off",
     "no-unsafe-type-assertion": "off",
-    "no-useless-constructor": "off",
     "no-useless-default-assignment": "off",
     "no-useless-return": "off",
     "no-warning-comments": "off",

--- a/front/.oxlintrc.json
+++ b/front/.oxlintrc.json
@@ -76,7 +76,6 @@
     "no-warning-comments": "off",
     "only-throw-error": "off",
     "prefer-enum-initializers": "off",
-    "prefer-includes": "off",
     "prefer-nullish-coalescing": "off",
     "prefer-readonly-parameter-types": "off",
     "prefer-tag-over-role": "off",

--- a/front/scripts/i18n-api-errors.ts
+++ b/front/scripts/i18n-api-errors.ts
@@ -69,7 +69,7 @@ async function checkI18N(
       fs.readFileSync(new URL(localized_i18n_error_path, import.meta.url), 'utf8')
     );
     // Init the i18n system
-    const i18n = await i18next.createInstance(
+    const i18n = i18next.createInstance(
       {
         lng: locale,
         resources: {

--- a/front/scripts/i18n-api-errors.ts
+++ b/front/scripts/i18n-api-errors.ts
@@ -31,8 +31,8 @@ async function checkI18N(
 
   if (
     !(
-      error.properties &&
-      'enum' in error.properties?.type &&
+      error.properties?.type &&
+      'enum' in error.properties.type &&
       Array.isArray(error.properties.type.enum) &&
       error.properties.type.enum.length !== 0 &&
       typeof error.properties.type.enum[0] === 'string'

--- a/front/src/applications/editor/components/LinearMetadata/tooltip.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/tooltip.tsx
@@ -9,7 +9,7 @@ type LinearMetadataTooltipProps<T> = {
   schema: JSONSchema7;
 };
 
-export const LinearMetadataTooltip = <T extends Record<string, unknown>>({
+export const LinearMetadataTooltip = <T extends Record<string, string | number>>({
   item,
   point,
   schema,

--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -131,7 +131,7 @@ function getRangeEditionTool<T extends EditorRange>({
                   entityId && entityId !== entity.properties.id
                     ? {
                         ...entity,
-                        properties: { ...entity.properties, id: `${entityId}` },
+                        properties: { ...entity.properties, id: entityId },
                       }
                     : entity;
                 setState({

--- a/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLeftPanel.tsx
@@ -114,7 +114,7 @@ const SwitchEditionLeftPanel = () => {
           if (id && id !== entityToSave.properties.id) {
             const savedEntity = {
               ...entityToSave,
-              properties: { ...entityToSave.properties, id: `${id}` },
+              properties: { ...entityToSave.properties, id },
             };
             setState({
               ...state,

--- a/front/src/applications/operationalStudies/components/AddNewCard.tsx
+++ b/front/src/applications/operationalStudies/components/AddNewCard.tsx
@@ -26,7 +26,7 @@ const AddNewCard = ({ testId, className, modalComponent, item, onOpenModal }: Ad
   return (
     <div
       data-testid={testId}
-      className={`${className}`}
+      className={className}
       {...(!newProjectStudyScenarioAllowed && { 'aria-disabled': true })}
       role="button"
       tabIndex={0}

--- a/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainTrackProjectionLazyLoader.ts
@@ -27,10 +27,6 @@ export default class TrainTrackProjectionLazyLoader extends TrainProjectionLazyL
    */
   declare readonly options: TrainTrackProjectionLazyLoaderOptions;
 
-  constructor(options: TrainTrackProjectionLazyLoaderOptions) {
-    super(options);
-  }
-
   async processBatch(ids: number[]) {
     const { infraId, timetableId, path, electricalProfileSetId } = this.options;
 

--- a/front/src/applications/operationalStudies/hooks/useMultiSelection.ts
+++ b/front/src/applications/operationalStudies/hooks/useMultiSelection.ts
@@ -15,7 +15,7 @@ const useMultiSelection = <T extends { id: number }>(
   const toggleSelection = useCallback(
     (id: number) => {
       setSelectedItemIds(
-        selectedItemIds.indexOf(id) !== -1
+        selectedItemIds.includes(id)
           ? selectedItemIds.filter((selectedItemId) => selectedItemId !== id)
           : selectedItemIds.concat([id])
       );

--- a/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/TrainScheduleSetCartItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ImportTrainScheduleSets/TrainScheduleSetCartItem.tsx
@@ -37,7 +37,7 @@ const TrainScheduleSetCartItem = ({
         <SegmentedControl
           value={importType}
           getOptionLabel={(set) => t(`importType.${set}`)}
-          getOptionValue={(set) => `${set}`}
+          getOptionValue={(set) => set}
           getOptionIcon={renderOptionIcon}
           onChange={(set) => upsertToCart(trainScheduleSet.id, set)}
           options={TRAINSCHEDULESET_IMPORT_TYPE}

--- a/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts
@@ -789,5 +789,5 @@ export const loadNgeDto = async (
   ).unwrap();
 
   await loadAndIndexNge(state, trainSchedules, dispatch, t, subCategories, notes);
-  return await getNgeDto(state, groupedTrainSchedules, subCategories, notes);
+  return getNgeDto(state, groupedTrainSchedules, subCategories, notes);
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/PathStepItem.tsx
@@ -182,7 +182,7 @@ const PathStepItem = ({
       .sort((a, b) => {
         const aIsNum = !isNaN(Number(a));
         const bIsNum = !isNaN(Number(b));
-        if (aIsNum && bIsNum) return parseInt(a) - parseInt(b);
+        if (aIsNum && bIsNum) return parseInt(a, 10) - parseInt(b, 10);
         if (aIsNum) return -1;
         if (bIsNum) return 1;
         return a.localeCompare(b);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/utils.ts
@@ -51,7 +51,7 @@ export const getOpKey = (location: PathItemLocation | null): string | null => {
   if (!location || location.type === 'track_offset') return null;
   const op = location.operational_point;
   if (op.type === 'domestic') return `${op.country_code} ${op.main_code} ${op.secondary_code}`;
-  if (op.type === 'id') return `${op.operational_point}`;
+  if (op.type === 'id') return op.operational_point;
   if (op.type === 'uic') return `${op.uic} ${op.secondary_code}`;
   return null;
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/NGE/types.ts
@@ -43,10 +43,10 @@ export type TransitionDto = {
 };
 
 export enum PortAlignment {
-  Top,
-  Bottom,
-  Left,
-  Right,
+  Top = 0,
+  Bottom = 1,
+  Left = 2,
+  Right = 3,
 }
 
 export type TrainrunDto = {

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -295,7 +295,7 @@ const PacedTrainItem = ({
     dispatch(
       setSuccess({
         title: t('timetable.pacedTrainAdded'),
-        text: `${pacedTrainName}`,
+        text: pacedTrainName,
       })
     );
   };

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/UniqueTrainItem.tsx
@@ -137,7 +137,7 @@ const UniqueTrainItem = ({
       dispatch(
         setSuccess({
           title: t('timetable.trainAdded'),
-          text: `${trainName}`,
+          text: trainName,
         })
       );
     } catch (e) {

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/useFilterTrainSchedules.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/useFilterTrainSchedules.ts
@@ -127,8 +127,8 @@ const useFilterTrainSchedules = (
 
           if (isMainCategory(category)) {
             if (category.main_category !== trainCategoryFilter) return false;
-          } else {
-            if (category.sub_category_code !== trainCategoryFilter) return false;
+          } else if (category.sub_category_code !== trainCategoryFilter) {
+            return false;
           }
         }
       }

--- a/front/src/applications/rollingStockEditor/helpers/defaultValues.ts
+++ b/front/src/applications/rollingStockEditor/helpers/defaultValues.ts
@@ -33,7 +33,7 @@ export function makeEffortCurve(selectedMode: string): ValueOf<EffortCurveForms>
 export const getDefaultRollingStockMode = (selectedMode: string | null): EffortCurveForms | null =>
   selectedMode
     ? {
-        [`${selectedMode}`]: makeEffortCurve(selectedMode),
+        [selectedMode]: makeEffortCurve(selectedMode),
       }
     : null;
 

--- a/front/src/applications/rollingStockEditor/helpers/powerRestrictions.ts
+++ b/front/src/applications/rollingStockEditor/helpers/powerRestrictions.ts
@@ -38,6 +38,8 @@ export const getElectricalProfilesAndPowerRestrictions = (
 export const orderSelectorList = (list: (string | null)[]) => {
   const index = list.includes('O') ? 2 : 1;
   return isNull(list[0]) || list[0] === 'O'
-    ? list.slice(0, index).concat(list.slice(index).sort())
-    : list.sort();
+    ? /* eslint-disable-next-line typescript/require-array-sort-compare */
+      list.slice(0, index).concat(list.slice(index).sort())
+    : /* eslint-disable-next-line typescript/require-array-sort-compare */
+      list.sort();
 };

--- a/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
+++ b/front/src/applications/stdcm/components/DebugView/DebugMap.tsx
@@ -212,7 +212,7 @@ const DebugMap = ({ failureData, simulationData }: DebugMapProps) => {
             <strong>{hovered.point.lastOPName}</strong>
           </div>
           <div>at: {hovered.point.at}</div>
-          <div>caused by: {hovered.point.source?.toString()}</div>
+          <div>caused by: {JSON.stringify(hovered.point.source)}</div>
           <div>time lost: {fmtSeconds(hovered.point.time_lost)}</div>
           <div>best remaining: {fmtSeconds(hovered.point.best_remaining_time)}</div>
           <div>travel time: {fmtSeconds(hovered.point.current_travel_time)}</div>

--- a/front/src/applications/stdcm/components/StdcmLoader.tsx
+++ b/front/src/applications/stdcm/components/StdcmLoader.tsx
@@ -93,7 +93,7 @@ const StdcmLoader = ({
   return (
     <div
       ref={loaderRef}
-      className={cx('stdcm-loader', `${loaderStatus.status}`, {
+      className={cx('stdcm-loader', loaderStatus.status, {
         'with-fade-in-animation':
           loaderStatus.status === 'loader-absolute' && loaderStatus.firstLaunch,
         'with-slide-animation':

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -287,10 +287,10 @@ const useStdcm = ({
                 await handleSuccess(result, payload);
                 break;
               case 'preprocessing_simulation_error':
-                await handleRejection(result.error);
+                handleRejection(result.error);
                 break;
               case 'internal_error':
-                await handleRejection(result.error);
+                handleRejection(result.error);
             }
             break;
           }

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -85,7 +85,7 @@ const fetchPathProperties = async (
     };
   } catch (error) {
     console.error('Error fetching path properties:', error);
-    throw new Error('Path properties could not be fetched.');
+    throw new Error('Path properties could not be fetched.', { cause: error });
   }
 };
 

--- a/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
@@ -68,7 +68,7 @@ const DropdownSNCF = ({
             {titleContent}
             {noArrow && (
               <i
-                className={`${isDropdownShown ? 'icons-arrow-up' : 'icons-arrow-down'}`}
+                className={isDropdownShown ? 'icons-arrow-up' : 'icons-arrow-down'}
                 aria-hidden="true"
               />
             )}

--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -41,13 +41,13 @@ export type LinearMetadataDatavizProps<T> = IntervalItemBaseProps<T> & {
   /**
    * Event when mouse leaves data item
    */
-  onMouseLeave?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void;
 
   /**
    * Event when the mouse move on a data item
    */
   onMouseMove?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    e: React.MouseEvent<HTMLDivElement>,
     item: LinearMetadataItem<T>,
     index: number,
     point: number // point on the linear metadata

--- a/front/src/common/IntervalsDataViz/types.ts
+++ b/front/src/common/IntervalsDataViz/types.ts
@@ -38,7 +38,7 @@ export type IntervalItemBaseProps<T> = {
    * Event on click on a data item
    */
   onClick?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    e: React.MouseEvent<HTMLDivElement>,
     item: LinearMetadataItem<T>,
     index: number,
     point: number // point on the linear metadata
@@ -53,7 +53,7 @@ export type IntervalItemBaseProps<T> = {
    * Event on click on a data item
    */
   onDoubleClick?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    e: React.MouseEvent<HTMLDivElement>,
     item: LinearMetadataItem<T>,
     index: number,
     point: number // point on the linear metadata
@@ -63,7 +63,7 @@ export type IntervalItemBaseProps<T> = {
    * Event when mouse enter into data item
    */
   onMouseEnter?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    e: React.MouseEvent<HTMLDivElement>,
     item: LinearMetadataItem<T>,
     index: number,
     point: number // point on the linear metadata
@@ -73,7 +73,7 @@ export type IntervalItemBaseProps<T> = {
    * Event when mouse over a data item
    */
   onMouseOver?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    e: React.MouseEvent<HTMLDivElement>,
     item: LinearMetadataItem<T>,
     index: number,
     point: number // point on the linear metadata

--- a/front/src/common/IntervalsDataViz/utils.ts
+++ b/front/src/common/IntervalsDataViz/utils.ts
@@ -1,32 +1,14 @@
 import type { CSSProperties } from 'react';
 
-import { isNil, isNaN, omit, values } from 'lodash';
+import { isNil, omit, values } from 'lodash';
 
 import type { LinearMetadataItem } from './types';
-
-/**
- * Simple function that take an input and try to convert it as a number.
- */
-export function castToNumber(value: unknown): number | null | undefined {
-  if (isNil(value)) return value;
-
-  if (typeof value === 'boolean') return +value;
-  if (value === '') return null;
-
-  const stringValue = `${value}`;
-  const castValue = +stringValue;
-
-  return isNaN(castValue) || Math.abs(castValue) === Infinity ? null : castValue;
-}
 
 /**
  * Given a number, shorten it in string.
  * Example 1234 -> 1.2K
  */
-export function shortNumber(value: unknown): string {
-  let num = castToNumber(value);
-  if (isNil(num)) return '';
-
+export function shortNumber(num: number): string {
   if (Math.abs(num) < 1000) {
     return `${Math.round(num)}`;
   }

--- a/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/OperationalPoints.tsx
@@ -58,7 +58,7 @@ function getFilterHighlighted(
     ];
   else if (data.highlightedArea) result = ['within', data.highlightedArea];
 
-  if (reverseCondition === true) {
+  if (reverseCondition) {
     return ['!=', result, true];
   }
   return result;

--- a/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
+++ b/front/src/common/Map/Layers/InfraObjectLayers/extensions/SNCF/PSL.tsx
@@ -29,7 +29,7 @@ export function getPSLSpeedValueLayerProps({
   colors: Theme;
   sourceTable?: string;
   layersSettings: LayersSettings;
-  t?: TFunction<'translation'>;
+  t?: TFunction;
 }): OmitLayer<SymbolLayerSpecification> {
   const res: OmitLayer<SymbolLayerSpecification> = {
     type: 'symbol',

--- a/front/src/common/Map/Layers/useMapBlankStyle.ts
+++ b/front/src/common/Map/Layers/useMapBlankStyle.ts
@@ -35,7 +35,7 @@ const useMapBlankStyle = (): MapProps['mapStyle'] => {
     const isDefaultSpriteValid = await isValidUrl(ponctualObjectsSprites.url);
 
     const sprites: (Sprite | null)[] = await Promise.all([
-      isDefaultSpriteValid ? ponctualObjectsSprites : null,
+      Promise.resolve(isDefaultSpriteValid ? ponctualObjectsSprites : null),
       ...signalingSystems.map(async (id) => {
         const signalingSystemsURL = `${SPRITES_URL}/${id}/sprites`;
         const isValid = await isValidUrl(signalingSystemsURL);

--- a/front/src/common/Map/Search/useSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/useSearchOperationalPoint.tsx
@@ -66,7 +66,7 @@ export default function useSearchOperationalPoint({
         object: 'operationalpoint',
         query: [
           'and',
-          ['=', ['main_code'], `${searchQuery}`],
+          ['=', ['main_code'], searchQuery],
           ['=', ['infra_id'], infraId],
           stdcmPerimeterOperationalpointsFilter,
         ],

--- a/front/src/common/Map/components/LayersModal.tsx
+++ b/front/src/common/Map/components/LayersModal.tsx
@@ -134,7 +134,7 @@ const LayersModal = ({
         </div>
         <div className="row">
           {layers.map(({ layer, icon }) => (
-            <div className="col-lg-6" key={`${layer}`}>
+            <div className="col-lg-6" key={layer}>
               <div className="d-flex align-items-center mt-2">
                 <SwitchSNCF
                   id={`map-layer-${layer}`}

--- a/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
+++ b/front/src/common/api/editoastStream/postTimetableByIdStdcm.ts
@@ -44,7 +44,7 @@ export default function postTimetableByIdStdcm(args: PostTimetableByIdStdcmApiAr
             callback({ ...data, traceId });
           } catch (e) {
             console.error(e);
-            throw new Error(`Error while JSON parse ${line}`);
+            throw new Error(`Error while JSON parse ${line}`, { cause: e });
           }
         }
       }

--- a/front/src/common/authorization/utils/generateGrantSelectProps.ts
+++ b/front/src/common/authorization/utils/generateGrantSelectProps.ts
@@ -76,7 +76,7 @@ const generateGrantSelectProps = ({
 
   // In case of not owner of the resource, we need to remove all options below the subject one.
   // A user can't revoke a grant if he is not owner
-  if (userPrivileges.has('can_share_ownership') === false) {
+  if (!userPrivileges.has('can_share_ownership')) {
     const filteredOptions = allowedOptions.filter((_, index) => index >= subjectValueIndex);
     return {
       value: allowedOptions[subjectValueIndex],

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -47,8 +47,7 @@ function getConflictTrainNames(
       // Check if the exception has a name change group
       // Otherwise, the name is `${pacedTrainName}/+`
       const namedException = trainSchedule.paced.exceptions.find(
-        // TODO_EXCEPTION: remove `!` when using TrainSchedulingException type
-        (exception) => exception.id! === train.exception_id && exception.train_name
+        (exception) => train.exception_id === exception.id && exception.train_name
       );
       trainNames.push(
         namedException ? namedException.train_name!.value : `${trainSchedule.train_name}/+`

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
@@ -135,8 +135,9 @@ const ActionsBar = ({
     );
   }
 
-  const lockButtonTitle =
-    infra.locked === true ? t('infraManagement.actions.unlock') : t('infraManagement.actions.lock');
+  const lockButtonTitle = infra.locked
+    ? t('infraManagement.actions.unlock')
+    : t('infraManagement.actions.lock');
   return (
     <>
       <button

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
@@ -62,7 +62,7 @@ const InfraSelectorModalBodyEdition = ({
   const handleSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
       const status = await validateFile(event.target.files[0]);
-      if (status === true) {
+      if (status) {
         setErrorMessage(undefined);
         setSelectedFile(event.target.files[0]);
       }

--- a/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
+++ b/front/src/modules/pathfinding/components/IncompatibleConstraints/IncompatibleConstraints.tsx
@@ -166,7 +166,7 @@ const IncompatibleConstraints = ({
             type: key as IncompatibleConstraintType,
             start: e.range.start * ratio,
             end: e.range.end * ratio,
-            value: 'value' in e ? `${e.value}` : undefined,
+            value: 'value' in e ? e.value : undefined,
             bbox: bbox(
               lineSliceAlong(geometry as LineString, e.range.start * ratio, e.range.end * ratio, {
                 units: 'millimeters',

--- a/front/src/modules/pathfinding/components/IncompatibleConstraints/utils.ts
+++ b/front/src/modules/pathfinding/components/IncompatibleConstraints/utils.ts
@@ -68,5 +68,5 @@ export function getSegmentsConstraints(
 }
 
 export function getSizeOfEnabledFilters(filters: FiltersConstrainstState) {
-  return Object.values(filters).filter((value) => value.enabled === true).length;
+  return Object.values(filters).filter((value) => value.enabled).length;
 }

--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.ts
@@ -204,7 +204,7 @@ const useFilterRollingStock = ({
     isStdcm,
     allRollingStocks
       .map((rs) => rs.id)
-      .sort()
+      .sort((a, b) => a - b)
       .join('|'),
   ]);
 

--- a/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
+++ b/front/src/modules/timesStops/RequestedTimeColumnHeader.tsx
@@ -44,7 +44,7 @@ const RequestedTimeColumnHeader = ({
 
   const items: OSRDMenuItem[] = [
     {
-      title: `${t(`columnHeader.${field}.overwriteAll`, { count: overwriteRequestTimesCount })}`,
+      title: t(`columnHeader.${field}.overwriteAll`, { count: overwriteRequestTimesCount }),
       icon: <ArrowLeft />,
       onClick: () => {
         setOpen(false);
@@ -62,7 +62,7 @@ const RequestedTimeColumnHeader = ({
 
   if (fillRequestTimesCount !== 0 && fillRequestTimesCount !== overwriteRequestTimesCount) {
     items.push({
-      title: `${t(`columnHeader.${field}.fillEmpty`, { count: fillRequestTimesCount })}`,
+      title: t(`columnHeader.${field}.fillEmpty`, { count: fillRequestTimesCount }),
       icon: <ArrowLeft />,
       onClick: () => {
         setOpen(false);

--- a/front/src/modules/timesStops/TimeCell.tsx
+++ b/front/src/modules/timesStops/TimeCell.tsx
@@ -132,12 +132,12 @@ const clampTimeState = (state: TimeState): TimeState => {
       case 0:
         return '00';
       case 1:
-        if (parseInt(digits) * 10 > Math.floor(max)) {
+        if (parseInt(digits, 10) * 10 > Math.floor(max)) {
           return digits.padStart(2, '0');
         }
         return digits.padEnd(2, '0');
       case 2:
-        if (parseInt(digits) > max) {
+        if (parseInt(digits, 10) > max) {
           return max.toString().padStart(2, '0');
         }
         return digits;
@@ -231,7 +231,7 @@ const computeDigitState = (state: TimeState, digit: string): TimeState => {
     focusedSection === 'minutes' &&
     hasNoDigits(state.hours) &&
     hasNoDigits(state.minutes) &&
-    parseInt(digit) > 2
+    parseInt(digit, 10) > 2
   ) {
     return {
       ...state,

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -446,9 +446,7 @@ const TimesStopsTable = ({
     />
   );
 
-  const returnStepStatusCell = (
-    info: CellContext<TimesStopsTableFeatures, TimesStopsRowNew, unknown>
-  ) => {
+  const returnStepStatusCell = (info: CellContext<TimesStopsTableFeatures, TimesStopsRowNew>) => {
     if (info.table.options.meta!.isComputedDataPending) {
       return <span data-testid="step-status">&nbsp;</span>;
     }
@@ -498,7 +496,7 @@ const TimesStopsTable = ({
   };
 
   const returnOPOnPathIndexCell = (
-    info: CellContext<TimesStopsTableFeatures, TimesStopsRowNew, unknown>
+    info: CellContext<TimesStopsTableFeatures, TimesStopsRowNew>
   ) => <span data-testid="row-index">{info.row.original.opOnPathIndex + 1}</span>;
 
   const returnTrackNameCell = (

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -81,7 +81,7 @@ export function calculateStepTimeAndDays(
 export const formatSuggestedViasToRowVias = (
   operationalPoints: SuggestedOP[],
   pathSteps: PathStep[],
-  t: TFunction<'translation', undefined>,
+  t: TFunction,
   startTime?: Date,
   tableType?: TableType
 ): TimesStopsInputRow[] => {

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -392,7 +392,7 @@ export function onStopSignalToReceptionSignal(
   if (isNil(onStopSignal)) {
     return undefined;
   }
-  if (onStopSignal === true) {
+  if (onStopSignal) {
     return shortSlipDistance ? 'SHORT_SLIP_STOP' : 'STOP';
   }
   return 'OPEN';

--- a/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
+++ b/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
@@ -31,7 +31,7 @@ const timeColumn = (isOutputTable: boolean) =>
     pasteValue: ({ value }) => ({ time: value }),
     minWidth: isOutputTable ? 110 : 170,
     isCellEmpty: ({ rowData }) => !rowData,
-  }) as Partial<Column<TimeExtraDays | undefined, string, string>>;
+  }) as Partial<Column<TimeExtraDays | undefined, string>>;
 
 function durationColumn() {
   const format = (duration: Duration | null | undefined) => String(duration?.total('second') ?? '');

--- a/front/src/modules/trainHeader/utils/trainProperties.ts
+++ b/front/src/modules/trainHeader/utils/trainProperties.ts
@@ -17,7 +17,7 @@ export const getShortDepartureDate = (train: Train, locale?: Intl.Locale) =>
 
 export const getShortCategoryName = (
   train: Train,
-  t: TFunction<'translation'>,
+  t: TFunction,
   subCategories: SubCategory[]
 ): string | undefined => {
   const category = train.category;
@@ -27,7 +27,7 @@ export const getShortCategoryName = (
   return findSubCategory(subCategories, category)?.name;
 };
 
-export const getComfortType = (train: Train, t: TFunction<'translation'>): string | null =>
+export const getComfortType = (train: Train, t: TFunction): string | null =>
   train.comfort ? t(`translation:rollingStock.comfortTypes.${train.comfort}`) : '';
 
 export const getServiceInterval = (train: PacedTrain): number =>

--- a/front/src/utils/hooks/useDebounce.ts
+++ b/front/src/utils/hooks/useDebounce.ts
@@ -19,7 +19,7 @@ export const useDebounce = <T = string | number>(value: T, delay: number): T => 
 /**
  * Debounce function
  */
-export const useDebouncedFunc = <T = (number | null) | (string | null)>(
+export const useDebouncedFunc = <T = number | string | null>(
   value: T,
   delay: number,
   func: (newValue: T) => void

--- a/front/tests/pages/operational-studies/times-stops-table-page.ts
+++ b/front/tests/pages/operational-studies/times-stops-table-page.ts
@@ -455,7 +455,7 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     ]);
 
     return {
-      index: parseInt(indexText ?? '0'),
+      index: parseInt(indexText ?? '0', 10),
       status: cleanWhitespace(statusClass) as TimesStopsTableRow['status'],
       stationName: cleanWhitespace(stationName),
       stationCh: cleanWhitespace(stationCh),

--- a/front/tests/pages/stdcm/consist-change-section.ts
+++ b/front/tests/pages/stdcm/consist-change-section.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 
 import {
   expectFieldsToHaveValues,
@@ -9,10 +9,6 @@ import type { ConsistChangeFields } from '../../utils/stdcm-types';
 import ViaSection from './via-section';
 
 class ConsistChangeSection extends ViaSection {
-  constructor(page: Page) {
-    super(page);
-  }
-
   private getEditConsistButton(viaNumber: number): Locator {
     return this.getViaCard(viaNumber).getByTestId('edit-consist');
   }

--- a/front/ui/storybook/stories/ui-core/TextArea.stories.tsx
+++ b/front/ui/storybook/stories/ui-core/TextArea.stories.tsx
@@ -6,7 +6,7 @@ import { type Meta, type StoryObj, type Decorator } from '@storybook/react-vite'
 import '@osrd-project/ui-core/dist/theme.css';
 
 const withControlledValue: Decorator = (Story, ctx) => {
-  const [value, setValue] = useState<string>(String(ctx.args.value ?? ''));
+  const [value, setValue] = useState<string>(ctx.args.value as string);
   return (
     <Story
       args={{

--- a/front/ui/ui-charts/src/spaceTimeChart/utils/scales.ts
+++ b/front/ui/ui-charts/src/spaceTimeChart/utils/scales.ts
@@ -141,9 +141,10 @@ export function getNormalizedScaleAtPosition(
     if (!pickLast) {
       if (position <= node.limit) node = node.left;
       else node = node.right;
+    } else if (position >= node.limit) {
+      node = node.right;
     } else {
-      if (position >= node.limit) node = node.right;
-      else node = node.left;
+      node = node.left;
     }
   }
   return node;

--- a/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/SpeedSpaceChart.tsx
@@ -241,7 +241,7 @@ const SpeedSpaceChart = ({
       style={{
         width: `${width}px`,
         height: `${height}px`,
-        backgroundColor: `${backgroundColor}`,
+        backgroundColor,
         position: 'relative',
       }}
       tabIndex={0}

--- a/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/common/DetailsBox.tsx
@@ -156,7 +156,7 @@ const DetailsBox = ({
                           )}
                           <div
                             style={{
-                              color: ETCS_COLOR_DICTIONARY[brakingCurveType].toString(),
+                              color: ETCS_COLOR_DICTIONARY[brakingCurveType].hex(),
                             }}
                           >
                             {brakingCurveType}
@@ -166,7 +166,7 @@ const DetailsBox = ({
                               key={endOfCurve}
                               className="number-text"
                               style={{
-                                color: ETCS_COLOR_DICTIONARY[brakingCurveType].toString(),
+                                color: ETCS_COLOR_DICTIONARY[brakingCurveType].hex(),
                               }}
                             >
                               {speedValues

--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/electricalProfile.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/drawElements/electricalProfile.ts
@@ -107,7 +107,7 @@ export const drawElectricalProfile = ({ ctx, width, height, store }: DrawFunctio
           ctx.fillStyle = '#000';
           ctx.font = '600 14px IBM Plex Sans';
           ctx.textAlign = 'center';
-          ctx.fillText(`${electricalProfile}`, xStart + profileWidth / 2, topLayer / 2);
+          ctx.fillText(electricalProfile, xStart + profileWidth / 2, topLayer / 2);
 
           // Draw begin and end position
           ctx.fillStyle = 'rgb(49, 46, 43)';
@@ -115,14 +115,14 @@ export const drawElectricalProfile = ({ ctx, width, height, store }: DrawFunctio
 
           ctx.textAlign = 'right';
           ctx.fillText(
-            `${(start || 0).toFixed(1)}`,
+            (start || 0).toFixed(1),
             xStart - (MARGIN_POSITION_TEXT + profileNameOverflow / 2),
             topLayer / 2
           );
 
           ctx.textAlign = 'left';
           ctx.fillText(
-            `${end!.toFixed(1)}`,
+            end!.toFixed(1),
             xStart + profileWidth + (MARGIN_POSITION_TEXT + profileNameOverflow / 2),
             topLayer / 2
           );

--- a/front/ui/ui-charts/src/speedSpaceChart/components/layers/SpeedLimitTagsLayer.tsx
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/layers/SpeedLimitTagsLayer.tsx
@@ -52,7 +52,7 @@ const SpeedLimitTagsLayer = ({ width, marginTop, store }: SpeedLimitTagsLayerPro
         },
         speeds: store.speeds,
       };
-      await drawSpeedLimitTags({
+      drawSpeedLimitTags({
         ctx,
         width,
         height: marginTop,
@@ -77,7 +77,7 @@ const SpeedLimitTagsLayer = ({ width, marginTop, store }: SpeedLimitTagsLayerPro
     const updateTooltip = async () => {
       const currentCanvas = canvas.current as HTMLCanvasElement;
       const ctx = currentCanvas.getContext('2d') as CanvasRenderingContext2D;
-      tooltip.current = await computeTooltip({ ctx, width, height: marginTop, store });
+      tooltip.current = computeTooltip({ ctx, width, height: marginTop, store });
     };
     updateTooltip();
   }, [width, marginTop, store]);

--- a/front/ui/ui-core/src/components/Checkbox/CheckboxList.tsx
+++ b/front/ui/ui-core/src/components/Checkbox/CheckboxList.tsx
@@ -7,7 +7,7 @@ import { type CheckboxTreeItem } from './type';
 
 export type CheckboxListProps = {
   items: CheckboxTreeItem[];
-  onClickItem: (e: React.MouseEvent<HTMLInputElement, MouseEvent>, item: CheckboxTreeItem) => void;
+  onClickItem: (e: React.MouseEvent<HTMLInputElement>, item: CheckboxTreeItem) => void;
   small?: boolean;
   label?: string;
   readOnly?: boolean;

--- a/front/ui/ui-core/src/components/Checkbox/CheckboxTree.tsx
+++ b/front/ui/ui-core/src/components/Checkbox/CheckboxTree.tsx
@@ -28,10 +28,7 @@ const CheckboxesTree = ({
   onChange,
   computeNewItemsTree,
 }: CheckboxesTreeProps) => {
-  const handleClick = (
-    e: React.MouseEvent<HTMLInputElement, MouseEvent>,
-    item: CheckboxTreeItem
-  ) => {
+  const handleClick = (e: React.MouseEvent<HTMLInputElement>, item: CheckboxTreeItem) => {
     const newItems = computeNewItemsTree
       ? computeNewItemsTree(items, item)
       : defaultComputeNewItemsTree(items, item);

--- a/front/ui/ui-core/src/components/Checkbox/type.ts
+++ b/front/ui/ui-core/src/components/Checkbox/type.ts
@@ -1,9 +1,9 @@
 import { type CheckboxProps } from './Checkbox';
 
 export enum CheckboxState {
-  UNCHECKED,
-  CHECKED,
-  INDETERMINATE,
+  UNCHECKED = 0,
+  CHECKED = 1,
+  INDETERMINATE = 2,
 }
 
 export type ItemStates = Record<number, CheckboxState>;

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -201,12 +201,10 @@ const ComboBox = <T,>({
           const exactSuggestion = suggestionsByLabel.get(normalizedInputValue);
           if (exactSuggestion) {
             selectSuggestion(exactSuggestion);
+          } else if (showAddCustomValue) {
+            confirmCustomValue();
           } else {
-            if (showAddCustomValue) {
-              confirmCustomValue();
-            } else {
-              onAddCustomValue?.(inputValue);
-            }
+            onAddCustomValue?.(inputValue);
           }
         }
         break;

--- a/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
+++ b/front/ui/ui-core/src/components/ComboBox/ComboBox.tsx
@@ -276,7 +276,7 @@ const ComboBox = <T,>({
 
   return (
     <div
-      data-testid={testIdPrefix ? `${testIdPrefix}` : undefined}
+      data-testid={testIdPrefix ? testIdPrefix : undefined}
       className="ui-combo-box"
       style={{ '--number-of-suggestions': numberOfSuggestionsToShow } as React.CSSProperties}
       ref={wrapperRef}

--- a/front/ui/ui-core/src/components/DatePicker/DatePicker.tsx
+++ b/front/ui/ui-core/src/components/DatePicker/DatePicker.tsx
@@ -52,7 +52,7 @@ export const DatePicker = (props: DatePickerProps) => {
   const { testIdPrefix } = props;
 
   return (
-    <div data-testid={testIdPrefix ? `${testIdPrefix}` : undefined} className="ui-date-picker">
+    <div data-testid={testIdPrefix ? testIdPrefix : undefined} className="ui-date-picker">
       <div>
         <Input
           testIdPrefix={testIdPrefix}

--- a/front/ui/ui-core/src/components/DurationInput/__tests__/useDurationInput.spec.tsx
+++ b/front/ui/ui-core/src/components/DurationInput/__tests__/useDurationInput.spec.tsx
@@ -81,7 +81,7 @@ describe('useDurationInput', () => {
       ))
     );
 
-    await act(() => {
+    await act(async () => {
       result.current.handleChange(
         result.current.fields[1],
         '3'.padStart(result.current.fields[1].digits!, '3')
@@ -108,7 +108,7 @@ describe('useDurationInput', () => {
     );
 
     const lastField = result.current.fields.at(-1)!;
-    await act(() => {
+    await act(async () => {
       result.current.handleChange(lastField, '3'.padStart(lastField.digits!, '3'));
     });
     expect(mockFocus).not.toHaveBeenCalled();
@@ -133,7 +133,7 @@ describe('useDurationInput', () => {
         ))
       );
 
-      await act(() => {
+      await act(async () => {
         result.current.handleKeyDown(result.current.fields[0], {
           key,
           preventDefault: () => {
@@ -168,7 +168,7 @@ describe('useDurationInput', () => {
       ))
     );
 
-    await act(() => {
+    await act(async () => {
       result.current.handleKeyDown(result.current.fields[1], {
         key: 'ArrowLeft',
         preventDefault: () => {
@@ -208,7 +208,7 @@ describe('useDurationInput', () => {
 
     const firstField = result.current.fields[0];
 
-    await act(() => {
+    await act(async () => {
       render(
         <input
           key="firstInput"
@@ -231,7 +231,7 @@ describe('useDurationInput', () => {
 
     const firstField = result.current.fields[0];
 
-    await act(() => {
+    await act(async () => {
       render(
         <input
           key={`firstInput`}

--- a/front/ui/ui-core/src/components/TimePicker.tsx
+++ b/front/ui/ui-core/src/components/TimePicker.tsx
@@ -118,12 +118,16 @@ const TimePicker = ({
       if (!displaySeconds) {
         const [h, m] = value.split(':');
         if (h !== undefined && m !== undefined) {
-          onTimeChange({ hours: parseInt(h), minutes: parseInt(m) });
+          onTimeChange({ hours: parseInt(h, 10), minutes: parseInt(m, 10) });
         }
       } else {
         const [h, m, s] = value.split(':');
         if (h !== undefined && m !== undefined && s !== undefined) {
-          onTimeChange({ hours: parseInt(h), minutes: parseInt(m), seconds: parseInt(s) });
+          onTimeChange({
+            hours: parseInt(h, 10),
+            minutes: parseInt(m, 10),
+            seconds: parseInt(s, 10),
+          });
         }
       }
     },

--- a/front/ui/ui-core/src/components/TimePicker.tsx
+++ b/front/ui/ui-core/src/components/TimePicker.tsx
@@ -143,9 +143,9 @@ const TimePicker = ({
   const closeModal = useCallback(() => setIsModalOpen(false), []);
 
   return (
-    <div data-testid={testIdPrefix ? `${testIdPrefix}` : undefined} className="ui-time-picker">
+    <div data-testid={testIdPrefix ? testIdPrefix : undefined} className="ui-time-picker">
       <Input
-        testIdPrefix={testIdPrefix ? `${testIdPrefix}` : undefined}
+        testIdPrefix={testIdPrefix ? testIdPrefix : undefined}
         {...otherProps}
         className={cx('input', 'time-input', otherProps.className)}
         type="time"

--- a/front/ui/ui-core/src/components/TokenInput.tsx
+++ b/front/ui/ui-core/src/components/TokenInput.tsx
@@ -66,7 +66,7 @@ const TokenInput = ({
     }
   };
 
-  const focusInput = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  const focusInput = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       inputRef.current?.focus();
     }

--- a/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
+++ b/front/ui/ui-core/src/components/TolerancePicker/TolerancePicker.tsx
@@ -64,7 +64,7 @@ const TolerancePicker = ({
   }, [formatToleranceValue, minusTolerance, plusTolerance, translateWarningMessage]);
 
   return (
-    <div data-testid={testIdPrefix ? `${testIdPrefix}` : undefined} className="ui-tolerance-picker">
+    <div data-testid={testIdPrefix ? testIdPrefix : undefined} className="ui-tolerance-picker">
       <div>
         <Input
           testIdPrefix={testIdPrefix}


### PR DESCRIPTION
We have a very long list of rules that we disable in `.oxlintrc.json`. Those settings were grandfathered from some old eslint configuration, but it's quite beneficial to reduce this list, as those lints can find actual code smells!

In this pull request, I fix 15 ones that I deemed both uncontroversial and easy to fix. A commit-by-commit review is _highly_ recommanded: each commit contains the name of the lint being re-enabled.

I started from the rules that had the least number of violations in our codebase, but there are still 55 rules left after this pull request, some more controversial, but most of them still uncontroversial but with way more violations.