### PR TITLE
editoast: fix `path_item_times` docstring

### DIFF
--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -151,14 +151,18 @@ pub struct SimulationPowerRestrictionItem {
 pub struct ReportTrain {
     /// List of positions of a train
     /// Both positions (in mm) and times (in ms) must have the same length
+    /// The length of positions and times is arbitrary and comes from a curve simplification
+    /// made in core
     pub positions: Vec<u64>,
+    /// List of times of a train
+    /// The first value is always `0` and the last one is always the total duration of the simulation.
     pub times: Vec<u64>,
     /// List of speeds associated to a position
     pub speeds: Vec<f64>,
     /// Total energy consumption
     pub energy_consumption: f64,
     /// Time in ms at which the train *arrives* at each path item given as input of the pathfinding
-    /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+    /// The first value is always `0` (beginning of the path) and the last one, the arrival time of the path's last step.
     ///
     /// In case multiple path items are at the same position, the stop duration
     /// of the earlier ones are added to the path item time of the next. For

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5955,7 +5955,7 @@ components:
             minimum: 0
           description: |-
             Time in ms at which the train *arrives* at each path item given as input of the pathfinding
-            The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+            The first value is always `0` (beginning of the path) and the last one, the arrival time of the path's last step.
 
             In case multiple path items are at the same position, the stop duration
             of the earlier ones are added to the path item time of the next. For
@@ -5971,6 +5971,8 @@ components:
           description: |-
             List of positions of a train
             Both positions (in mm) and times (in ms) must have the same length
+            The length of positions and times is arbitrary and comes from a curve simplification
+            made in core
         speeds:
           type: array
           items:
@@ -5983,6 +5985,9 @@ components:
             type: integer
             format: int64
             minimum: 0
+          description: |-
+            List of times of a train
+            The first value is always `0` and the last one is always the total duration of the simulation.
     CoreRoutingRequirement:
       type: object
       required:

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4584,7 +4584,7 @@ export type CoreReportTrain = {
   /** Total energy consumption */
   energy_consumption: number;
   /** Time in ms at which the train *arrives* at each path item given as input of the pathfinding
-    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+    The first value is always `0` (beginning of the path) and the last one, the arrival time of the path's last step.
     
     In case multiple path items are at the same position, the stop duration
     of the earlier ones are added to the path item time of the next. For
@@ -4593,10 +4593,14 @@ export type CoreReportTrain = {
     of A plus 2s. */
   path_item_times: number[];
   /** List of positions of a train
-    Both positions (in mm) and times (in ms) must have the same length */
+    Both positions (in mm) and times (in ms) must have the same length
+    The length of positions and times is arbitrary and comes from a curve simplification
+    made in core */
   positions: number[];
   /** List of speeds associated to a position */
   speeds: number[];
+  /** List of times of a train
+    The first value is always `0` and the last one is always the total duration of the simulation. */
   times: number[];
 };
 export type CoreRoutingZoneRequirement = {

--- a/osrd_schemas/osrd_schemas/models.py
+++ b/osrd_schemas/osrd_schemas/models.py
@@ -254,7 +254,7 @@ class CoreReportTrain(BaseModel):
     path_item_times: list[PathItemTime]
     """
     Time in ms at which the train *arrives* at each path item given as input of the pathfinding
-    The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+    The first value is always `0` (beginning of the path) and the last one, the arrival time of the path's last step.
 
     In case multiple path items are at the same position, the stop duration
     of the earlier ones are added to the path item time of the next. For
@@ -266,12 +266,18 @@ class CoreReportTrain(BaseModel):
     """
     List of positions of a train
     Both positions (in mm) and times (in ms) must have the same length
+    The length of positions and times is arbitrary and comes from a curve simplification
+    made in core
     """
     speeds: list[float]
     """
     List of speeds associated to a position
     """
     times: list[Time]
+    """
+    List of times of a train
+    The first value is always `0` and the last one is always the total duration of the simulation.
+    """
 
 
 class CoreRoutingZoneRequirement(BaseModel):


### PR DESCRIPTION
Fix a wrong editoast docstring description of core behavior on `path_item_times`.