### PR TITLE
front: stdcm: use debounced total length instead of rs length in preliminary pathfinding

### DIFF
--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -16,8 +16,10 @@ import {
   getLoadingGauge,
   getStdcmSpeedLimitByTag,
   getTrackSectionIdsByLoadingGauge,
+  getTotalLength,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
+import { useDebounce } from 'utils/hooks/useDebounce';
 
 import {
   getConsistChanges,
@@ -47,11 +49,17 @@ function pathStepsToLocations(pathSteps: StdcmPathStep[]): Array<
   );
 }
 
-const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefined) => {
+const useStaticPathfinding = (
+  workerStatus: WorkerStatus,
+  infra: Infra | undefined,
+  debounceMs = 1000
+) => {
   const pathSteps = useSelector(getStdcmPathSteps);
   const [pathStepsLocations, setPathStepsLocations] = useState(pathStepsToLocations(pathSteps));
 
   const speedLimitByTag = useSelector(getStdcmSpeedLimitByTag);
+  const totalLength = useSelector(getTotalLength);
+  const debouncedTotalLength = useDebounce(totalLength, debounceMs);
   const rollingStock = useStdcmLightRollingStock();
   const loadingGauge = useSelector(getLoadingGauge);
   const trackSectionIdsByLoadingGauge = useSelector(getTrackSectionIdsByLoadingGauge);
@@ -121,6 +129,7 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
         postPathfindingBlocks,
         infraId: infra.id,
         rollingStock,
+        totalLength: debouncedTotalLength,
         loadingGauge,
         speedLimitByTag,
         allowedTrackSections,
@@ -137,6 +146,7 @@ const useStaticPathfinding = (workerStatus: WorkerStatus, infra: Infra | undefin
   }, [
     pathStepsLocations,
     rollingStock,
+    debouncedTotalLength,
     speedLimitByTag,
     loadingGauge,
     trackSectionIdsByLoadingGauge,

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -89,7 +89,13 @@ const useStaticPathfinding = (
   useEffect(() => {
     const launchPathfinding = async () => {
       setPathfinding(undefined);
-      if (!infra || workerStatus !== 'READY' || !rollingStock || pathStepsLocations.length < 2) {
+      if (
+        !infra ||
+        workerStatus !== 'READY' ||
+        !rollingStock ||
+        debouncedTotalLength === undefined ||
+        pathStepsLocations.length < 2
+      ) {
         return;
       }
 

--- a/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
+++ b/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
@@ -8,24 +8,27 @@ import type {
 import { getPathfindingQuery } from 'modules/pathfinding/utils';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 
-type ConsistChange = {
+type PathfindingConsistChange = {
   index: number;
   rollingStockID: number;
+  totalLength: number;
   loadingGauge?: LoadingGaugeType;
   speedLimitByTag?: string | null;
 };
 
 type SegmentConstraints = {
   segmentRollingStock: LightRollingStock;
+  segmentTotalLength: number;
   segmentLoadingGauge?: LoadingGaugeType;
   segmentSpeedLimitByTag?: string | null;
 };
 
 type getSegmentConstraintsOptions = {
   segmentIndex: number;
-  consistChanges: ConsistChange[];
+  consistChanges: PathfindingConsistChange[];
   getLightRollingStockById: GetLightRollingStockById;
   rollingStock: LightRollingStock;
+  totalLength: number;
   loadingGauge?: LoadingGaugeType;
   speedLimitByTag?: string | null;
 };
@@ -33,12 +36,12 @@ type getSegmentConstraintsOptions = {
 type LaunchSegmentedPathfindingOptions = {
   pathSegmentsIndexes: number[];
   stdcmPathSteps: PathfindingItem[];
-  consistChanges: ConsistChange[];
+  consistChanges: PathfindingConsistChange[];
   getLightRollingStockById: GetLightRollingStockById;
   postPathfindingBlocks: PostPathfindingBlocks;
   infraId: number;
   rollingStock: LightRollingStock;
-  totalLength: number | undefined;
+  totalLength: number;
   loadingGauge?: LoadingGaugeType;
   speedLimitByTag?: string | null;
   allowedTrackSections?: string[];
@@ -52,13 +55,15 @@ type PostPathfindingBlocks = ReturnType<
   typeof osrdEditoastApi.endpoints.postInfraByInfraIdPathfindingBlocks.useLazyQuery
 >[0];
 
-export const getConsistChanges = (pathSteps: StdcmPathStep[]): ConsistChange[] =>
+export const getConsistChanges = (pathSteps: StdcmPathStep[]): PathfindingConsistChange[] =>
   pathSteps.flatMap((step, index) => {
-    if (!step.isVia || !step.consistChange?.rollingStockID) return [];
+    if (!step.isVia || !step.consistChange?.rollingStockID || !step.consistChange?.totalLength)
+      return [];
     return [
       {
         index,
         rollingStockID: step.consistChange.rollingStockID,
+        totalLength: step.consistChange.totalLength,
         loadingGauge: step.consistChange.loadingGauge,
         speedLimitByTag: step.consistChange.speedLimitByTag,
       },
@@ -66,7 +71,7 @@ export const getConsistChanges = (pathSteps: StdcmPathStep[]): ConsistChange[] =
   });
 
 export const getPathSegmentsIndexes = (
-  consistChanges: ConsistChange[],
+  consistChanges: PathfindingConsistChange[],
   totalSteps: number
 ): number[] => [0, ...consistChanges.map((change) => change.index), totalSteps - 1];
 
@@ -75,12 +80,14 @@ export const getSegmentConstraints = async ({
   consistChanges,
   getLightRollingStockById,
   rollingStock,
+  totalLength,
   loadingGauge,
   speedLimitByTag,
 }: getSegmentConstraintsOptions): Promise<SegmentConstraints> => {
   if (segmentIndex === 0) {
     return {
       segmentRollingStock: rollingStock,
+      segmentTotalLength: totalLength,
       segmentLoadingGauge: loadingGauge,
       segmentSpeedLimitByTag: speedLimitByTag,
     };
@@ -93,6 +100,7 @@ export const getSegmentConstraints = async ({
 
   return {
     segmentRollingStock,
+    segmentTotalLength: previousStep.totalLength,
     segmentLoadingGauge: previousStep.loadingGauge ?? loadingGauge,
     segmentSpeedLimitByTag: previousStep.speedLimitByTag ?? speedLimitByTag,
   };
@@ -125,12 +133,13 @@ export const launchSegmentedPathfinding = async ({
     const endSliceIndex = pathSegmentsIndexes[i + 1] + 1;
     const segmentSteps = stdcmPathSteps.slice(pathSegmentsIndexes[i], endSliceIndex);
 
-    const { segmentRollingStock, segmentLoadingGauge, segmentSpeedLimitByTag } =
+    const { segmentRollingStock, segmentTotalLength, segmentLoadingGauge, segmentSpeedLimitByTag } =
       await getSegmentConstraints({
         segmentIndex: i,
         consistChanges,
         getLightRollingStockById,
         rollingStock,
+        totalLength,
         loadingGauge,
         speedLimitByTag,
       });
@@ -138,7 +147,7 @@ export const launchSegmentedPathfinding = async ({
     const payload = getPathfindingQuery({
       infraId,
       rollingStock: segmentRollingStock,
-      totalLength,
+      totalLength: segmentTotalLength,
       pathSteps: segmentSteps,
       loadingGauge: segmentLoadingGauge,
       speedLimitByTag: segmentSpeedLimitByTag,

--- a/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
+++ b/front/src/applications/stdcm/utils/getConsistChangesConstraints.ts
@@ -38,6 +38,7 @@ type LaunchSegmentedPathfindingOptions = {
   postPathfindingBlocks: PostPathfindingBlocks;
   infraId: number;
   rollingStock: LightRollingStock;
+  totalLength: number | undefined;
   loadingGauge?: LoadingGaugeType;
   speedLimitByTag?: string | null;
   allowedTrackSections?: string[];
@@ -112,6 +113,7 @@ export const launchSegmentedPathfinding = async ({
   postPathfindingBlocks,
   infraId,
   rollingStock,
+  totalLength,
   loadingGauge,
   speedLimitByTag,
   allowedTrackSections,
@@ -136,6 +138,7 @@ export const launchSegmentedPathfinding = async ({
     const payload = getPathfindingQuery({
       infraId,
       rollingStock: segmentRollingStock,
+      totalLength,
       pathSteps: segmentSteps,
       loadingGauge: segmentLoadingGauge,
       speedLimitByTag: segmentSpeedLimitByTag,

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -74,24 +74,28 @@ export const matchPathStepAndOp = (
 export const getPathfindingQuery = ({
   infraId,
   rollingStock,
+  totalLength,
   pathSteps,
   loadingGauge,
   speedLimitByTag,
   allowedTrackSections,
 }: {
-  infraId?: number;
-  rollingStock?: Pick<
-    LightRollingStock,
-    'effort_curves' | 'loading_gauge' | 'max_speed' | 'length' | 'supported_signaling_systems'
-  >;
+  infraId: number | undefined;
+  rollingStock:
+    | Pick<
+        LightRollingStock,
+        'effort_curves' | 'loading_gauge' | 'max_speed' | 'length' | 'supported_signaling_systems'
+      >
+    | undefined;
+  totalLength: number | undefined;
   pathSteps: (PathfindingItem | null)[];
   loadingGauge?: LoadingGaugeType;
-  speedLimitByTag?: string | null;
-  allowedTrackSections?: string[];
+  speedLimitByTag: string | null | undefined;
+  allowedTrackSections: string[] | undefined;
 }): PostInfraByInfraIdPathfindingBlocksApiArg | null => {
   const origin = pathSteps.at(0);
   const destination = pathSteps.at(-1);
-  if (infraId && rollingStock && origin && destination) {
+  if (infraId && rollingStock && totalLength && origin && destination) {
     // Only origin and destination can be null so we can compact and we want to remove any via that would be null
     const pathItems: PathfindingInput['path_items'] = compact(pathSteps);
 
@@ -108,7 +112,7 @@ export const getPathfindingQuery = ({
           (s) => s.type
         ),
         rolling_stock_maximum_speed: rollingStock.max_speed,
-        rolling_stock_length: Math.round(mToMm(rollingStock.length)),
+        rolling_stock_length: Math.round(mToMm(totalLength)),
         speed_limit_tag: speedLimitByTag,
         allowed_track_sections: allowedTrackSections,
       },


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/18425
Close first part of #18423

The preliminary pathfinding was launched using the rolling stock length instead of the total length, and thus the total length was also missing from the dependency array launching it. This pr properly uses the total length in the pathfinding and its dependency array, though wraps it in a useDebounce to avoid triggering the pathfinding way too many times.