### PR TITLE
editoast: relax unique constraint on published train schedule sets

### DIFF
--- a/editoast/migrations/2026-09-08-081035-0000_train_schedule_set_unique_published_include_type/down.sql
+++ b/editoast/migrations/2026-09-08-081035-0000_train_schedule_set_unique_published_include_type/down.sql
@@ -1,0 +1,12 @@
+DROP INDEX train_schedule_set_catalog_entry_name_published_unique;
+
+-- This will intentionally fail in case of duplicates to avoid data loss
+--
+-- If you really want to migrate down, here's how to delete non-calendar
+-- duplicates:
+--
+-- ```sql
+-- DELETE FROM train_schedule_set AS ts1 WHERE ts1.published = TRUE AND ts1.timetable_type != 'CALENDAR' AND (SELECT TRUE FROM train_schedule_set AS ts2 WHERE ts2.name=ts1.name AND ts2.catalog_entry_id=ts1.catalog_entry_id  AND ts2.published = true AND ts2.id != ts1.id);
+-- ```
+CREATE UNIQUE INDEX train_schedule_set_catalog_entry_name_published_unique ON train_schedule_set (catalog_entry_id, name)
+WHERE published = TRUE;

--- a/editoast/migrations/2026-09-08-081035-0000_train_schedule_set_unique_published_include_type/up.sql
+++ b/editoast/migrations/2026-09-08-081035-0000_train_schedule_set_unique_published_include_type/up.sql
@@ -1,0 +1,4 @@
+DROP INDEX train_schedule_set_catalog_entry_name_published_unique;
+
+CREATE UNIQUE INDEX train_schedule_set_catalog_entry_name_published_unique ON train_schedule_set (catalog_entry_id, name, timetable_type)
+WHERE published = TRUE;


### PR DESCRIPTION
Now train schedule sets can share the same name and catalogue entry if they are for different timetable types.

Fixes #18467