### PR TITLE
front: stdcm: stop launching pathfinding from warning box as it is frequently recreated

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -376,8 +376,7 @@ const StdcmConfig = ({
           >
             {effectiveFormErrors && (
               <StdcmWarningBox
-                infra={infra}
-                workerStatus={pathfindingWorkerStatus}
+                pathfinding={pathfinding}
                 errorInfos={effectiveFormErrors}
                 removeOriginArrivalTime={removeOriginArrivalTime}
                 removeDestinationArrivalTime={removeDestinationArrivalTime}

--- a/front/src/applications/stdcm/components/StdcmWarningBox.tsx
+++ b/front/src/applications/stdcm/components/StdcmWarningBox.tsx
@@ -3,25 +3,22 @@ import { Alert } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import type { Infra, WorkerStatus } from 'common/api/osrdEditoastApi';
+import type { PathfindingResult } from 'common/api/osrdEditoastApi';
 
-import useStaticPathfinding from '../hooks/useStaticPathfinding';
 import { StdcmConfigErrorTypes, type StdcmConfigErrors } from '../types';
 
 const SHORT_TEXT_ERRORS = [StdcmConfigErrorTypes.INFRA_NOT_LOADED];
 
 type StdcmWarningBoxProps = {
-  infra?: Infra;
-  workerStatus: WorkerStatus;
+  pathfinding: PathfindingResult | undefined;
   errorInfos: StdcmConfigErrors;
   removeOriginArrivalTime: () => void;
   removeDestinationArrivalTime: () => void;
 };
 
 const StdcmWarningBox = ({
-  infra,
-  workerStatus,
   errorInfos: { errorType, errorDetails },
+  pathfinding,
   removeOriginArrivalTime,
   removeDestinationArrivalTime,
 }: StdcmWarningBoxProps) => {
@@ -31,7 +28,6 @@ const StdcmWarningBox = ({
   const hasMissingFields = (errorDetails?.missingFields?.length ?? 0) > 0;
   const hasRouteErrors = (errorDetails?.routeErrors?.length ?? 0) > 0;
 
-  const { pathfinding } = useStaticPathfinding(workerStatus, infra);
   const hasIncompatibleConstraints =
     pathfinding?.status === 'failure' &&
     pathfinding.failed_status === 'pathfinding_not_found' &&


### PR DESCRIPTION
Close part of the second part of https://github.com/OpenRailAssociation/osrd/issues/18423 (to fully solve it consist changes should be stabilized (and perhaps debounced but it's orthogonal))

The stdcm warning box is frequently recreated, causing the pathfinding to fire each time for no reason, while its parent component already holds a pathfinding result. Instead pass this pathfinding result as a prop.