### PR TITLE
front: split occupancy blocks that span over track occupancy OPs

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/SpaceTimeChartWrapper.tsx
@@ -89,7 +89,7 @@ import getPanelOccurrenceCounts from './helpers/getPanelOccurrenceCounts';
 import getTrainExceptionTypes from './helpers/getTrainExceptionTypes';
 import type { ExistingLinking } from './helpers/linkings';
 import makeProjectedTrains from './helpers/makeProjectedTrains';
-import { getOccupancyBlocks } from './helpers/utils';
+import { getOccupancyBlocks, splitOccupancyBlocks } from './helpers/utils';
 import {
   parseOccupancyZonePathId,
   formatOccupancyZonePathId,
@@ -521,7 +521,16 @@ const SpaceTimeChartWrapper = ({
     }
   }, [selectedProjectionId, trainScheduleProjections.length]);
 
-  const occupancyBlocks = getOccupancyBlocks(cutProjectedTrains);
+  const occupancyBlocks = useMemo(
+    () =>
+      splitOccupancyBlocks(
+        getOccupancyBlocks(cutProjectedTrains),
+        (trackOccupancyDiagramsData ?? []).map(
+          ({ operationalPointPosition }) => operationalPointPosition
+        )
+      ),
+    [cutProjectedTrains, trackOccupancyDiagramsData]
+  );
 
   const isZoomAtDefault = xZoom === timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX);
   const handleResetClick = useCallback(() => {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/splitOccupancyBlocks.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/splitOccupancyBlocks.spec.ts
@@ -1,0 +1,44 @@
+import type { OccupancyBlock } from '@osrd-project/ui-charts';
+import { describe, it, expect } from 'vitest';
+
+import { splitOccupancyBlocks } from '../utils';
+
+const BLOCK: OccupancyBlock = {
+  spaceStart: 0,
+  spaceEnd: 100,
+  timeStart: 0,
+  timeEnd: 1000,
+  color: 'red',
+};
+
+describe('splitOccupancyBlocks', () => {
+  it('should return the blocks untouched when there is no position to split at', () => {
+    expect(splitOccupancyBlocks([BLOCK], [])).toEqual([BLOCK]);
+  });
+
+  it('should leave a block which does not span any position untouched', () => {
+    expect(splitOccupancyBlocks([BLOCK], [150])).toEqual([BLOCK]);
+  });
+
+  it('should leave a block bounded by a position untouched', () => {
+    expect(splitOccupancyBlocks([BLOCK], [0, 100])).toEqual([BLOCK]);
+  });
+
+  it('should split a block spanning a position, keeping its time range on both parts', () => {
+    expect(splitOccupancyBlocks([BLOCK], [40])).toEqual([
+      { ...BLOCK, spaceStart: 0, spaceEnd: 40 },
+      { ...BLOCK, spaceStart: 40, spaceEnd: 100 },
+    ]);
+  });
+
+  it('should split a block at every position it spans, whatever their order', () => {
+    const expected = [
+      { ...BLOCK, spaceStart: 0, spaceEnd: 40 },
+      { ...BLOCK, spaceStart: 40, spaceEnd: 70 },
+      { ...BLOCK, spaceStart: 70, spaceEnd: 100 },
+    ];
+
+    expect(splitOccupancyBlocks([BLOCK], [40, 70])).toEqual(expected);
+    expect(splitOccupancyBlocks([BLOCK], [70, 40])).toEqual(expected);
+  });
+});

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/utils.ts
@@ -88,6 +88,27 @@ export const getOccupancyBlocks = (trains: IndividualTrainProjection[]): Occupan
     }));
   });
 
+export const splitOccupancyBlocks = (
+  blocks: OccupancyBlock[],
+  positions: number[]
+): OccupancyBlock[] => {
+  if (positions.length === 0) return blocks;
+
+  const sortedPositions = [...positions].sort((a, b) => a - b);
+
+  return blocks.flatMap((block) => {
+    const innerPositions = sortedPositions.filter(
+      (position) => position > block.spaceStart && position < block.spaceEnd
+    );
+    if (innerPositions.length === 0) return block;
+
+    const bounds = [block.spaceStart, ...innerPositions, block.spaceEnd];
+    return bounds
+      .slice(0, -1)
+      .map((spaceStart, index) => ({ ...block, spaceStart, spaceEnd: bounds[index + 1] }));
+  });
+};
+
 export const isTrainSelected = (
   trainId: TrainId,
   chart: 'std' | 'tod',

--- a/front/ui/ui-charts/src/spaceTimeChart/components/OccupancyBlockLayer.tsx
+++ b/front/ui/ui-charts/src/spaceTimeChart/components/OccupancyBlockLayer.tsx
@@ -41,7 +41,7 @@ export const OccupancyBlockLayer = ({ occupancyBlocks }: OccupancyBlockLayerProp
     (ctx, { getTimePixel, getSpacePixel }) => {
       for (const occupancyBlock of occupancyBlocks) {
         const x = getTimePixel(occupancyBlock.timeStart);
-        const y = getSpacePixel(occupancyBlock.spaceStart);
+        const y = getSpacePixel(occupancyBlock.spaceStart, true);
         const width = getTimePixel(occupancyBlock.timeEnd) - x;
         const height = getSpacePixel(occupancyBlock.spaceEnd) - y;
 


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/issues/18273

Before
<img width="712" height="432" alt="Screenshot 2026-09-08 145647" src="https://github.com/user-attachments/assets/f6da1b2e-6620-42c8-a5c7-11b9ad2f0726" />


After
<img width="578" height="436" alt="after" src="https://github.com/user-attachments/assets/ba3e0555-a386-4bbb-9009-6dd31f51ca99" />

You can test by making sure no signal state is drawn on the track occupancy diagram part of the STD
