### PR TITLE
front: add missing countryCode to match OP on TOD drop

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/hooks/useOccupancyZoneDrop.ts
@@ -47,6 +47,7 @@ function upsertPathStepTrack(
       uic: op.uic,
       secondaryCode: op.secondary_code,
       mainCode: op.main_code,
+      countryCode: op.country_code,
       // Never match by track/offset: we're switching the track
       track: '',
       offsetOnTrack: NaN,


### PR DESCRIPTION
when matching which Operational Point whose track to update when the user drops an occupation in the Track Occupancy Diagram, we were not passing the OP's country code, and thus we were not matching any domestic reference.

Closes #18476