### PR TITLE
front: have itinerary modal not overwrite last PathItem stop time

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -774,7 +774,7 @@ const ItineraryModal = ({
       : modalFormState.name;
 
     const stepsWithStopAtDestination = stepsWithLocationOrInput.map((step, i) =>
-      i === stepsWithLocationOrInput.length - 1
+      i === stepsWithLocationOrInput.length - 1 && !step.stopFor
         ? { ...step, stopFor: new Duration({ minutes: 0 }) }
         : step
     );


### PR DESCRIPTION
It would happen when editing a train with a non-zero stop time for the last path item

Closes https://github.com/OpenRailAssociation/osrd/issues/18481