### PR TITLE
front: fix the linkings on stops of no duration

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/computePossibleLinkings.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/__tests__/computePossibleLinkings.spec.ts
@@ -73,6 +73,64 @@ describe('computePossibleLinkings', () => {
     );
   });
 
+  it('should link a train whose stop lasts no time to the next one', () => {
+    const linkings = computePossibleLinkings([
+      arriving({
+        localTrackName: TRACK_1,
+        editoastId: 1,
+        startTime: 10 * MINUTE,
+        endTime: 10 * MINUTE,
+      }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 40 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([[formatEditoastIdToTrainScheduleId(1), formatEditoastIdToTrainScheduleId(2)]])
+    );
+  });
+
+  it('should link a train to the next one whose stop lasts no time', () => {
+    const linkings = computePossibleLinkings([
+      arriving({ localTrackName: TRACK_1, editoastId: 1, startTime: 0, endTime: 10 * MINUTE }),
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 30 * MINUTE,
+        endTime: 30 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([[formatEditoastIdToTrainScheduleId(1), formatEditoastIdToTrainScheduleId(2)]])
+    );
+  });
+
+  it('should link two trains handing the track over at the same instant', () => {
+    const linkings = computePossibleLinkings([
+      departing({
+        localTrackName: TRACK_1,
+        editoastId: 2,
+        startTime: 10 * MINUTE,
+        endTime: 10 * MINUTE,
+      }),
+      arriving({
+        localTrackName: TRACK_1,
+        editoastId: 1,
+        startTime: 10 * MINUTE,
+        endTime: 10 * MINUTE,
+      }),
+    ]);
+
+    expect(linkings).toEqual(
+      new Map([[formatEditoastIdToTrainScheduleId(1), formatEditoastIdToTrainScheduleId(2)]])
+    );
+  });
+
   it('should return no linking when there is no occupancy', () => {
     expect(computePossibleLinkings([])).toEqual(new Map());
   });

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/computePossibleLinkings.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/computePossibleLinkings.ts
@@ -20,8 +20,9 @@ export type LinkableOccupancy = {
 };
 
 /**
- * One end of an occupancy block, as scanned along the time axis. A block of no duration — a train
- * crossing the track without stopping — yields a single `instant` endpoint instead of a pair.
+ * One end of an occupancy block, as scanned along the time axis. A block of no duration yields a
+ * single `instant` endpoint instead of a pair: a train crossing the track, or stopping there for
+ * no time at all.
  */
 type BlockEndpoint = {
   time: number;
@@ -37,6 +38,16 @@ type BlockEndpoint = {
 const ENDPOINT_RANK: Record<BlockEndpoint['type'], number> = { end: 0, instant: 1, start: 2 };
 
 /**
+ * At equal times and ranks, which happens between blocks of no duration, the arriving train is
+ * scanned before the departing one it hands the track over to.
+ */
+const BLOCK_RANK: Record<LinkableOccupancy['blockType'], number> = {
+  incoming: 0,
+  via: 1,
+  outgoing: 2,
+};
+
+/**
  * A linking is possible between two occupancies of a same track when the first train ends its path
  * there, the second one starts its path there, both stand still, and nothing else occupies the
  * track in between.
@@ -45,8 +56,8 @@ const ENDPOINT_RANK: Record<BlockEndpoint['type'], number> = { end: 0, instant: 
  * `TrainId` keys.
  *
  * Rather than comparing every pair of occupancies, the blocks of a track are cut into endpoints,
- * sorted by time, then scanned once: a linking is found when the end of an incoming block is
- * immediately followed by the start of an outgoing one, no other block being open in between.
+ * sorted by time, then scanned once: a linking is found when an incoming block ends where an
+ * outgoing one starts, no other block being open in between.
  *
  * @returns the possible linkings, from the source (arriving) train to the target (departing) one.
  * Since no other train may occupy the track in between, a train can be the source of at most one
@@ -73,16 +84,27 @@ export default function computePossibleLinkings(
             { time: occupancy.endTime, type: 'end', occupancy },
           ]
     );
-    endpoints.sort((a, b) => a.time - b.time || ENDPOINT_RANK[a.type] - ENDPOINT_RANK[b.type]);
+    endpoints.sort(
+      (a, b) =>
+        a.time - b.time ||
+        ENDPOINT_RANK[a.type] - ENDPOINT_RANK[b.type] ||
+        BLOCK_RANK[a.occupancy.blockType] - BLOCK_RANK[b.occupancy.blockType]
+    );
 
     let linkingSource: LinkableOccupancy | null = null;
     let openBlocks = 0;
 
     for (const { type, occupancy } of endpoints) {
+      // A stop of no duration holds the whole occupancy in one instant, where the train both
+      // reaches the track and leaves it.
       const isLinkingArrival =
-        type === 'end' && occupancy.blockType === 'incoming' && occupancy.isStop;
+        (type === 'end' || type === 'instant') &&
+        occupancy.blockType === 'incoming' &&
+        occupancy.isStop;
       const isLinkingDeparture =
-        type === 'start' && occupancy.blockType === 'outgoing' && occupancy.isStop;
+        (type === 'start' || type === 'instant') &&
+        occupancy.blockType === 'outgoing' &&
+        occupancy.isStop;
       const isTrackFree = openBlocks === 0;
 
       if (isLinkingArrival) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getLinkableOccupancyData.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChartWrapper/helpers/getLinkableOccupancyData.ts
@@ -37,11 +37,13 @@ export default function getLinkableOccupancyData(
   }
 
   const schedule = exceptionPathAndSchedule?.schedule ?? train.schedule;
-  const hasStop =
+  const initialSpeed = exception?.initial_speed?.value ?? train.initialSpeed;
+
+  const stopsAtPathStart = blockType === 'outgoing' && !initialSpeed;
+  const hasScheduledStop =
     location.type === 'exact_path_item' &&
     !!schedule?.some(({ at, stop_for }) => at === location.path_item_id && !isNil(stop_for));
-  const initialSpeed = exception?.initial_speed?.value ?? train.initialSpeed;
-  const isStop = hasStop || (blockType === 'outgoing' && !initialSpeed);
+  const isStop = stopsAtPathStart || hasScheduledStop;
 
   return { blockType, isStop, active: !exception?.disabled };
 }


### PR DESCRIPTION
Closes #18291

No linking could be created as soon as one of the two trains stopped for no time, or had no stop declared where its path ends.

You can use [this timetable](https://github.com/user-attachments/files/32009685/timetable-18291-0s-stop-at-dijon.json) to test.
