### PR TITLE
e2e: fix and extend times stops table test coverage

### DIFF
--- a/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
@@ -84,10 +84,10 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
       await timesStopsTablePage.verifyColumnCount(departureRow, EXPECTED_COLUMN_COUNT);
     });
 
-    await test.step('Verify computed arrival cells contain no editable input', async () => {
-      await Promise.all(
-        [departureRow, via1Row].map((row) => timesStopsTablePage.verifyComputedArrivalReadOnly(row))
-      );
+    await test.step('Verify computed arrival cells are read-only', async () => {
+      for (const row of [departureRow, via1Row]) {
+        await timesStopsTablePage.verifyComputedArrivalIsReadOnly(row);
+      }
     });
 
     await test.step('Verify computed departure shows empty-dot marker on rows without a stop', async () => {
@@ -161,14 +161,14 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
     });
 
     await test.step('Verify via 1 row has no status class (no requested arrival)', async () => {
-      await timesStopsTablePage.verifyRowStatus(via1Row, STATUS_CLASSES.NONE);
+      await timesStopsTablePage.verifyRowStatusNeutral(via1Row);
     });
 
     await test.step('Verify via 2 row with requested arrival shows a schedule status', async () =>
       await timesStopsTablePage.verifyRowStatus(via2Row, STATUS_CLASSES.WARNING_MARGIN));
 
     await test.step('Waypoint row (no schedule, no simulation) has neutral status', async () => {
-      await timesStopsTablePage.verifyRowStatus(waypointRow, STATUS_CLASSES.NONE);
+      await timesStopsTablePage.verifyRowStatusNeutral(waypointRow);
     });
 
     await test.step('Destination row has a schedule status (has requested arrival constraint)', async () => {

--- a/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
@@ -176,7 +176,7 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
   });
 
   /** *************** Test 3 **************** */
-  test('Empty editable cells show the + placeholder', async ({ timesStopsTablePage }) => {
+  test('+ placeholder visibility in editable cells', async ({ timesStopsTablePage }) => {
     const departureRow = timesStopsTablePage.getRow(ROW_INDEX_ORIGIN);
     const via1Row = timesStopsTablePage.getRow(ROW_INDEX_VIA_A);
     const via2Row = timesStopsTablePage.getRow(ROW_INDEX_VIA_B);

--- a/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
@@ -1,7 +1,11 @@
 import {
   COMPUTED_THEORETICAL_MARGIN_DEPARTURE,
+  DAY_CHANGE_LABEL,
   EXPECTED_COLUMN_COUNT,
+  EXPECTED_POWER_RESTRICTION_OPTIONS,
   EXPECTED_ROW_COUNT,
+  MARGINS_DIFFERENCE_DEPARTURE,
+  MARGINS_DIFFERENCE_VIA_B,
   POWER_RESTRICTION_C1,
   REAL_MARGIN_DEPARTURE,
   REQUESTED_MARGIN_DEPARTURE,
@@ -16,6 +20,7 @@ import {
   STOP_DURATION_NONE,
   STOP_DURATION_VIA_A,
   STOP_DURATION_VIA_B,
+  TRACK_NAME_ORIGIN,
   myTrain,
 } from '../../assets/operation-studies/simulation-result/times-stops-table-const';
 import test from '../../page-object-fixture';
@@ -43,6 +48,7 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
     await test.step(`Verify ${EXPECTED_ROW_COUNT} data rows and at least one date-separator row`, async () => {
       await timesStopsTablePage.verifyDataRowCount(EXPECTED_ROW_COUNT);
       await timesStopsTablePage.verifyDateSeparatorVisible();
+      await timesStopsTablePage.verifyDateSeparatorText(DAY_CHANGE_LABEL);
     });
 
     await test.step('Verify non-empty station names on all rows', async () => {
@@ -84,10 +90,11 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
       await timesStopsTablePage.verifyColumnCount(departureRow, EXPECTED_COLUMN_COUNT);
     });
 
-    await test.step('Verify computed arrival cells are read-only', async () => {
+    await test.step('Verify computed cells are read-only', async () => {
       for (const row of [departureRow, via1Row]) {
         await timesStopsTablePage.verifyComputedArrivalIsReadOnly(row);
       }
+      await timesStopsTablePage.verifyComputedDepartureIsReadOnly(via2Row);
     });
 
     await test.step('Verify computed departure shows empty-dot marker on rows without a stop', async () => {
@@ -98,6 +105,15 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
     await test.step('Verify op-name dot visible on explicit path-step rows, absent on intermediate waypoint', async () => {
       await timesStopsTablePage.verifyOpNameDotVisible(departureRow);
       await timesStopsTablePage.verifyOpNameDotAbsent(waypointRow);
+    });
+
+    await test.step('Verify track dot only on path-step rows whose track was requested', async () => {
+      await timesStopsTablePage.verifyTrackNameDotVisible(departureRow);
+      await timesStopsTablePage.verifyTrackNameDotVisible(via1Row);
+      await timesStopsTablePage.verifyTrackName(departureRow, TRACK_NAME_ORIGIN);
+      await timesStopsTablePage.verifyTrackNameDotAbsent(via2Row);
+      await timesStopsTablePage.verifyTrackNameDotAbsent(destRow);
+      await timesStopsTablePage.verifyTrackNameDotAbsent(waypointRow);
     });
   });
 
@@ -138,8 +154,19 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
       );
     });
 
-    await test.step('Verify margins-difference column is rendered on departure row', async () => {
-      await timesStopsTablePage.verifyMarginsDifferencePresent(departureRow);
+    await test.step('Verify the power restriction selector offers the rolling stock codes plus the empty set symbol', async () => {
+      await timesStopsTablePage.verifyPowerRestrictionOptions(
+        via1Row,
+        EXPECTED_POWER_RESTRICTION_OPTIONS
+      );
+    });
+
+    await test.step(`Verify margins difference shows ${MARGINS_DIFFERENCE_DEPARTURE} on the departure row and ${MARGINS_DIFFERENCE_VIA_B} on via 2`, async () => {
+      await timesStopsTablePage.verifyMarginsDifferenceText(
+        departureRow,
+        MARGINS_DIFFERENCE_DEPARTURE
+      );
+      await timesStopsTablePage.verifyMarginsDifferenceText(via2Row, MARGINS_DIFFERENCE_VIA_B);
     });
 
     await test.step('Verify computed theoretical margin and real margin present on via 2 row (has requested arrival)', async () => {
@@ -149,6 +176,30 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
   });
 
   /** *************** Test 3 **************** */
+  test('Empty editable cells show the + placeholder', async ({ timesStopsTablePage }) => {
+    const departureRow = timesStopsTablePage.getRow(ROW_INDEX_ORIGIN);
+    const via1Row = timesStopsTablePage.getRow(ROW_INDEX_VIA_A);
+    const via2Row = timesStopsTablePage.getRow(ROW_INDEX_VIA_B);
+    const waypointRow = timesStopsTablePage.getRow(ROW_INDEX_WAYPOINT);
+
+    await test.step('Empty requested arrival and departure show +', async () => {
+      await timesStopsTablePage.verifyArrivalPlaceholderVisible(via1Row);
+      await timesStopsTablePage.verifyDeparturePlaceholderVisible(via1Row);
+    });
+
+    await test.step('Empty stop duration shows +', async () => {
+      await timesStopsTablePage.verifyDurationPlaceholderVisible(waypointRow);
+      await timesStopsTablePage.verifyDurationPlaceholderVisible(departureRow);
+    });
+
+    await test.step('Filled cells show no +', async () => {
+      await timesStopsTablePage.verifyArrivalPlaceholderHidden(via2Row);
+      await timesStopsTablePage.verifyDeparturePlaceholderHidden(via2Row);
+      await timesStopsTablePage.verifyDurationPlaceholderHidden(via2Row);
+    });
+  });
+
+  /** *************** Test 4 **************** */
   test('Row status indicators', async ({ timesStopsTablePage }) => {
     const departureRow = timesStopsTablePage.getRow(ROW_INDEX_ORIGIN);
     const via1Row = timesStopsTablePage.getRow(ROW_INDEX_VIA_A);

--- a/front/tests/02-operational-studies/simulation-result/003-times-stops-table-edits.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/003-times-stops-table-edits.spec.ts
@@ -1,5 +1,8 @@
 import {
+  COMPUTED_THEORETICAL_MARGIN_VIA_B,
+  COMPUTED_THEORETICAL_MARGIN_VIA_B_AFTER_MARGIN_EDIT,
   EDIT_ARRIVAL_VIA_A,
+  EDIT_DEPARTURE_VIA_A,
   EDIT_DEPARTURE_VIA_B,
   EMPTY_TIME_PLACEHOLDER,
   MARGIN_EDIT_DISPLAY,
@@ -7,7 +10,11 @@ import {
   MARGIN_MIN_PER_100KM_DISPLAY,
   MARGIN_MIN_PER_100KM_VALUE,
   MARGIN_UNIT_MIN_PER_100KM,
+  MARGIN_UNIT_PERCENT,
+  MARGINS_DIFFERENCE_VIA_B,
+  MARGINS_DIFFERENCE_VIA_B_AFTER_MARGIN_EDIT,
   NO_POWER_RESTRICTION_VALUE,
+  REAL_MARGIN_VIA_B,
   REQUESTED_ARRIVAL_VIA_B,
   REQUESTED_DEPARTURE_VIA_B,
   ROW_INDEX_ORIGIN,
@@ -27,6 +34,7 @@ test.describe('Times Stops Table — Edits', { tag: ['@op', '@times-stops'] }, (
   setupScenarioFixture({
     scenarioNamePrefix: SCENARIO_NAME_PREFIX,
     trains: myTrain,
+    scope: 'test',
   });
 
   test.beforeEach('Wait for the times-stops table', async ({ scenarioTimetableSection }) => {
@@ -70,9 +78,22 @@ test.describe('Times Stops Table — Edits', { tag: ['@op', '@times-stops'] }, (
         await timesStopsTablePage.verifyComputedArrivalChanged(destRow, destinationArrivalBefore);
       });
 
+      await test.step('Set then clear a requested departure on via 1 and verify the cell returns to "+"', async () => {
+        await timesStopsTablePage.editRequestedDeparture(via1Row, EDIT_DEPARTURE_VIA_A);
+        await timesStopsTablePage.verifyRequestedDepartureValue(via1Row, EDIT_DEPARTURE_VIA_A);
+        await timesStopsTablePage.waitForSimulation();
+
+        await timesStopsTablePage.clearRequestedDeparture(via1Row);
+        await timesStopsTablePage.verifyRequestedDepartureValue(via1Row, EMPTY_TIME_PLACEHOLDER);
+        await timesStopsTablePage.verifyDeparturePlaceholderVisible(via1Row);
+        await timesStopsTablePage.verifyRequestedArrivalValue(via1Row, EMPTY_TIME_PLACEHOLDER);
+        await timesStopsTablePage.waitForSimulation();
+      });
+
       await test.step('Clear requested arrival for via 2 and verify computed arrival remains attached', async () => {
         await timesStopsTablePage.clearRequestedArrival(via2Row);
         await timesStopsTablePage.verifyRequestedArrivalValue(via2Row, EMPTY_TIME_PLACEHOLDER);
+        await timesStopsTablePage.verifyArrivalPlaceholderVisible(via2Row);
         await timesStopsTablePage.verifyComputedArrivalAttached(via2Row);
       });
     }
@@ -170,6 +191,16 @@ test.describe('Times Stops Table — Edits', { tag: ['@op', '@times-stops'] }, (
       await timesStopsTablePage.verifyMarginPlaceholderVisible(waypointRow);
     });
 
+    await test.step('Verify the calculated margin columns of via 2 before any margin is set', async () => {
+      await timesStopsTablePage.waitForSimulation();
+      await timesStopsTablePage.verifyComputedTheoreticalMarginText(
+        via2Row,
+        COMPUTED_THEORETICAL_MARGIN_VIA_B
+      );
+      await timesStopsTablePage.verifyRealMarginText(via2Row, REAL_MARGIN_VIA_B);
+      await timesStopsTablePage.verifyMarginsDifferenceText(via2Row, MARGINS_DIFFERENCE_VIA_B);
+    });
+
     await test.step(`Set ${MARGIN_EDIT_DISPLAY} margin → value displayed, placeholder hidden`, async () => {
       await timesStopsTablePage.waitForSimulation();
       await timesStopsTablePage.editRequestedMargin(waypointRow, MARGIN_EDIT_VALUE);
@@ -186,12 +217,24 @@ test.describe('Times Stops Table — Edits', { tag: ['@op', '@times-stops'] }, (
       await timesStopsTablePage.verifyInheritedMarginStyle(via2Row);
     });
 
-    await test.step(`Switching unit to ${MARGIN_MIN_PER_100KM_DISPLAY} and committing updates the display accordingly`, async () => {
-      await timesStopsTablePage.editRequestedMarginWithUnit(
-        waypointRow,
-        MARGIN_MIN_PER_100KM_VALUE,
-        MARGIN_UNIT_MIN_PER_100KM
+    await test.step('Verify the calculated margin columns of via 2 were recomputed', async () => {
+      await timesStopsTablePage.verifyComputedTheoreticalMarginText(
+        via2Row,
+        COMPUTED_THEORETICAL_MARGIN_VIA_B_AFTER_MARGIN_EDIT
       );
+      await timesStopsTablePage.verifyMarginsDifferenceText(
+        via2Row,
+        MARGINS_DIFFERENCE_VIA_B_AFTER_MARGIN_EDIT
+      );
+      await timesStopsTablePage.verifyRealMarginText(via2Row, REAL_MARGIN_VIA_B);
+    });
+
+    await test.step(`Switching unit to ${MARGIN_MIN_PER_100KM_DISPLAY} and committing updates the display accordingly`, async () => {
+      await timesStopsTablePage.startEditingRequestedMargin(waypointRow);
+      await timesStopsTablePage.verifyActiveMarginUnit(waypointRow, MARGIN_UNIT_PERCENT);
+      await timesStopsTablePage.switchMarginUnit(waypointRow, MARGIN_UNIT_MIN_PER_100KM);
+      await timesStopsTablePage.verifyActiveMarginUnit(waypointRow, MARGIN_UNIT_MIN_PER_100KM);
+      await timesStopsTablePage.fillRequestedMargin(waypointRow, MARGIN_MIN_PER_100KM_VALUE);
       await timesStopsTablePage.verifyRequestedTheoreticalMarginText(
         waypointRow,
         MARGIN_MIN_PER_100KM_DISPLAY

--- a/front/tests/assets/operation-studies/simulation-result/times-stops-table-const.ts
+++ b/front/tests/assets/operation-studies/simulation-result/times-stops-table-const.ts
@@ -16,12 +16,15 @@ export const STOP_DURATION_VIA_B = '00h10m00s';
 export const STOP_DURATION_NONE = '00h00m00s';
 export const REQUESTED_ARRIVAL_VIA_B = '00:03:54';
 export const REQUESTED_DEPARTURE_VIA_B = '00:13:54';
+export const DAY_CHANGE_LABEL = '28 mai 2026';
 
 export const EMPTY_TIME_PLACEHOLDER = 'hh:mm:ss';
 export const EDIT_ARRIVAL_VIA_A = '21:30:00';
 export const EDIT_DEPARTURE_VIA_B = '00:15:00';
 export const COMPUTED_THEORETICAL_MARGIN_DEPARTURE = '00m19s';
 export const REAL_MARGIN_DEPARTURE = '158m07s';
+export const MARGINS_DIFFERENCE_DEPARTURE = '+157m48s';
+export const MARGINS_DIFFERENCE_VIA_B = '-00m07s';
 
 export const STOP_DURATION_EDIT_DIGITS = '0500';
 export const STOP_DURATION_EDIT_DISPLAY = '00h05m00s';
@@ -29,6 +32,15 @@ export const MARGIN_EDIT_VALUE = '5';
 export const MARGIN_EDIT_DISPLAY = '5%';
 export const NO_POWER_RESTRICTION_VALUE = 'NO_POWER_RESTRICTION';
 export const POWER_RESTRICTION_C1 = 'C1';
+const POWER_RESTRICTION_C2 = 'C2';
+export const TRACK_NAME_ORIGIN = 'V1';
+
+export const EXPECTED_POWER_RESTRICTION_OPTIONS = [
+  '',
+  NO_POWER_RESTRICTION_VALUE,
+  POWER_RESTRICTION_C1,
+  POWER_RESTRICTION_C2,
+];
 
 export const myTrain: TrainSchedule[] = readJsonFile(
   './tests/assets/operation-studies/simulation-result/train.json'

--- a/front/tests/assets/operation-studies/simulation-result/times-stops-table-const.ts
+++ b/front/tests/assets/operation-studies/simulation-result/times-stops-table-const.ts
@@ -35,7 +35,6 @@ export const myTrain: TrainSchedule[] = readJsonFile(
 );
 
 export const STATUS_CLASSES = {
-  NONE: '',
   WARNING_MARGIN: 'warning-margin',
   WARNING_SCHEDULE: 'warning-schedule',
   SUCCESS_SCHEDULE: 'success-schedule',

--- a/front/tests/assets/operation-studies/simulation-result/times-stops-table-const.ts
+++ b/front/tests/assets/operation-studies/simulation-result/times-stops-table-const.ts
@@ -21,10 +21,15 @@ export const DAY_CHANGE_LABEL = '28 mai 2026';
 export const EMPTY_TIME_PLACEHOLDER = 'hh:mm:ss';
 export const EDIT_ARRIVAL_VIA_A = '21:30:00';
 export const EDIT_DEPARTURE_VIA_B = '00:15:00';
+export const EDIT_DEPARTURE_VIA_A = '21:35:00';
 export const COMPUTED_THEORETICAL_MARGIN_DEPARTURE = '00m19s';
 export const REAL_MARGIN_DEPARTURE = '158m07s';
 export const MARGINS_DIFFERENCE_DEPARTURE = '+157m48s';
 export const MARGINS_DIFFERENCE_VIA_B = '-00m07s';
+export const COMPUTED_THEORETICAL_MARGIN_VIA_B = '00m07s';
+export const REAL_MARGIN_VIA_B = '00m00s';
+export const COMPUTED_THEORETICAL_MARGIN_VIA_B_AFTER_MARGIN_EDIT = '00m15s';
+export const MARGINS_DIFFERENCE_VIA_B_AFTER_MARGIN_EDIT = '-00m15s';
 
 export const STOP_DURATION_EDIT_DIGITS = '0500';
 export const STOP_DURATION_EDIT_DISPLAY = '00h05m00s';
@@ -56,6 +61,7 @@ export const EXPECTED_COLUMN_COUNT = 18;
 export const MARGIN_MIN_PER_100KM_VALUE = '3';
 export const MARGIN_MIN_PER_100KM_DISPLAY = '3min/100km';
 export const MARGIN_UNIT_MIN_PER_100KM = 'minPer100km';
+export const MARGIN_UNIT_PERCENT = 'percent';
 export const REQUESTED_MARGIN_DEPARTURE = '2%';
 
 export const ROW_INDEX_DISPLAY_ORDER: ReadonlyArray<[number, string]> = [

--- a/front/tests/pages/operational-studies/times-stops-table-page.ts
+++ b/front/tests/pages/operational-studies/times-stops-table-page.ts
@@ -7,7 +7,10 @@ import {
   removeWhitespace,
   stripTimeColons,
 } from '../../utils/data-normalizer';
-import type { TimesStopsTableRow } from '../../utils/times-stops-table-types';
+import type {
+  TimesStopsTableRow,
+  TimesStopsTableStatusClass,
+} from '../../utils/times-stops-table-types';
 import OpSimulationResultPage from './simulation-results-page';
 
 class TimesStopsTablePage extends OpSimulationResultPage {
@@ -204,16 +207,12 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await expect(this.realMargin(row)).not.toBeAttached();
   }
 
-  async verifyRowStatus(
-    row: Locator,
-    expectedStatus:
-      | 'warning-margin'
-      | 'warning-schedule'
-      | 'success-schedule'
-      | 'invalid-path-step'
-      | ''
-  ): Promise<void> {
+  async verifyRowStatus(row: Locator, expectedStatus: TimesStopsTableStatusClass): Promise<void> {
     await expect(this.stepStatusCell(row)).toContainClass(expectedStatus);
+  }
+
+  async verifyRowStatusNeutral(row: Locator): Promise<void> {
+    await expect(this.stepStatusCell(row)).toHaveClass('');
   }
 
   async verifyRequestedArrivalValue(row: Locator, value: string): Promise<void> {
@@ -342,10 +341,15 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await expect(row.getByRole('cell')).toHaveCount(expectedCount);
   }
 
-  async verifyComputedArrivalReadOnly(row: Locator): Promise<void> {
-    await expect(
-      this.computedArrival(row).getByTestId('computed-arrival-input')
-    ).not.toBeAttached();
+  private async verifyCellIsReadOnly(cell: Locator): Promise<void> {
+    await expect(cell.getByRole('textbox')).toHaveCount(0);
+    await expect(cell.getByRole('combobox')).toHaveCount(0);
+    await cell.click();
+    await expect(cell).not.toBeFocused();
+  }
+
+  async verifyComputedArrivalIsReadOnly(row: Locator): Promise<void> {
+    await this.verifyCellIsReadOnly(this.computedArrival(row));
   }
 
   async verifyComputedDepartureIsEmpty(row: Locator): Promise<void> {

--- a/front/tests/pages/operational-studies/times-stops-table-page.ts
+++ b/front/tests/pages/operational-studies/times-stops-table-page.ts
@@ -290,14 +290,6 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     return (await this.computedDeparture(row).textContent()) ?? '';
   }
 
-  async getRealMarginText(row: Locator): Promise<string> {
-    return (
-      (await this.realMargin(row)
-        .textContent()
-        .catch(() => '')) ?? ''
-    );
-  }
-
   async clickSignalReceptionClosed(row: Locator): Promise<void> {
     await this.signalReceptionClosedCheckbox(row).click();
   }
@@ -306,8 +298,7 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await this.shortSlipDistanceCheckbox(row).click();
   }
 
-  async editRequestedArrival(row: Locator, timeValue: string): Promise<void> {
-    const input = this.requestedArrivalInput(row);
+  private async editTimeCell(input: Locator, timeValue: string): Promise<void> {
     const isEmpty = (await input.inputValue()) === EMPTY_TIME_PLACEHOLDER;
     if (isEmpty) {
       // Focus directly to avoid triggering FOCUSED_WITH_PREFILL via placeholder click
@@ -322,23 +313,25 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await input.press('Enter');
   }
 
+  private async clearTimeCell(input: Locator): Promise<void> {
+    await input.click();
+    await this.durationCellClearButton.click();
+  }
+
+  async editRequestedArrival(row: Locator, timeValue: string): Promise<void> {
+    await this.editTimeCell(this.requestedArrivalInput(row), timeValue);
+  }
+
   async editRequestedDeparture(row: Locator, timeValue: string): Promise<void> {
-    const input = this.requestedDepartureInput(row);
-    const isEmpty = (await input.inputValue()) === EMPTY_TIME_PLACEHOLDER;
-    if (isEmpty) {
-      await input.focus();
-    } else {
-      await input.click();
-      await input.press('ArrowLeft');
-      await input.press('ArrowLeft');
-    }
-    await input.pressSequentially(stripTimeColons(timeValue));
-    await input.press('Enter');
+    await this.editTimeCell(this.requestedDepartureInput(row), timeValue);
   }
 
   async clearRequestedArrival(row: Locator): Promise<void> {
-    await this.requestedArrivalInput(row).click();
-    await this.durationCellClearButton.click();
+    await this.clearTimeCell(this.requestedArrivalInput(row));
+  }
+
+  async clearRequestedDeparture(row: Locator): Promise<void> {
+    await this.clearTimeCell(this.requestedDepartureInput(row));
   }
 
   async editStopDuration(row: Locator, digits: string): Promise<void> {
@@ -347,21 +340,28 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await this.durationCell(row).press('Enter');
   }
 
-  async editRequestedMargin(row: Locator, value: string): Promise<void> {
+  async startEditingRequestedMargin(row: Locator): Promise<void> {
     const placeholder = this.marginCellPlaceholder(row);
     if (await placeholder.isVisible()) {
       await placeholder.click();
     } else {
       await this.marginCellEditable(row).click();
     }
+  }
+
+  async fillRequestedMargin(row: Locator, value: string): Promise<void> {
     await this.marginCellInput(row).fill(value);
     await this.marginCellInput(row).press('Enter');
   }
 
+  async editRequestedMargin(row: Locator, value: string): Promise<void> {
+    await this.startEditingRequestedMargin(row);
+    await this.fillRequestedMargin(row, value);
+  }
+
   async clearRequestedMargin(row: Locator): Promise<void> {
     await this.marginCellEditable(row).click();
-    await this.marginCellInput(row).fill('');
-    await this.marginCellInput(row).press('Enter');
+    await this.fillRequestedMargin(row, '');
   }
 
   async selectPowerRestriction(row: Locator, value: string): Promise<void> {
@@ -468,15 +468,9 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     value: string,
     unit: 'percent' | 'minPer100km'
   ): Promise<void> {
-    const placeholder = this.marginCellPlaceholder(row);
-    if (await placeholder.isVisible()) {
-      await placeholder.click();
-    } else {
-      await this.marginCellEditable(row).click();
-    }
+    await this.startEditingRequestedMargin(row);
     await this.switchMarginUnit(row, unit);
-    await this.marginCellInput(row).fill(value);
-    await this.marginCellInput(row).press('Enter');
+    await this.fillRequestedMargin(row, value);
   }
 
   // Wait for simulation triggered by a previous edit to complete.

--- a/front/tests/pages/operational-studies/times-stops-table-page.ts
+++ b/front/tests/pages/operational-studies/times-stops-table-page.ts
@@ -117,6 +117,24 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     return row.getByTestId('op-name-dot');
   }
 
+  private trackNameDot(row: Locator): Locator {
+    return row.getByTestId('track-name-dot');
+  }
+
+  private timeCellPlaceholder(
+    row: Locator,
+    field: 'requested-arrival' | 'requested-departure'
+  ): Locator {
+    return row
+      .getByRole('cell')
+      .filter({ has: this.page.getByTestId(field) })
+      .getByTestId('input-cell-placeholder');
+  }
+
+  private durationCellPlaceholder(row: Locator): Locator {
+    return this.durationCell(row).getByTestId('input-cell-placeholder');
+  }
+
   private marginUnitBtnPercent(row: Locator): Locator {
     return this.requestedTheoreticalMargin(row).getByTestId('margin-unit-btn-percent');
   }
@@ -176,6 +194,15 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await expect(this.powerRestrictionCombobox(row).getByTestId(testId)).toHaveCount(count);
   }
 
+  async verifyPowerRestrictionOptions(row: Locator, expectedValues: string[]): Promise<void> {
+    await expect(this.powerRestrictionCombobox(row).getByRole('option')).toHaveCount(
+      expectedValues.length
+    );
+    for (const value of expectedValues) {
+      await this.verifyPowerRestrictionHasOption(row, value, 1);
+    }
+  }
+
   async verifyRequestedTheoreticalMarginText(row: Locator, marginText: string): Promise<void> {
     await expect(this.requestedTheoreticalMargin(row)).toHaveText(marginText);
     if (marginText === '') {
@@ -229,6 +256,10 @@ class TimesStopsTablePage extends OpSimulationResultPage {
 
   async verifyDateSeparatorVisible(): Promise<void> {
     await expect(this.dateSeparatorRows).toBeVisible();
+  }
+
+  async verifyDateSeparatorText(expectedDate: string): Promise<void> {
+    await expect(this.dateSeparatorRows.first()).toContainText(expectedDate);
   }
 
   async verifyComputedArrivalChanged(row: Locator, previousText: string): Promise<void> {
@@ -352,6 +383,10 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await this.verifyCellIsReadOnly(this.computedArrival(row));
   }
 
+  async verifyComputedDepartureIsReadOnly(row: Locator): Promise<void> {
+    await this.verifyCellIsReadOnly(this.computedDeparture(row));
+  }
+
   async verifyComputedDepartureIsEmpty(row: Locator): Promise<void> {
     await expect(this.computedDeparture(row)).toHaveClass(/cell-empty-dot/);
   }
@@ -364,8 +399,44 @@ class TimesStopsTablePage extends OpSimulationResultPage {
     await expect(this.opNameDot(row)).not.toBeAttached();
   }
 
-  async verifyMarginsDifferencePresent(row: Locator): Promise<void> {
-    await expect(this.marginsDifference(row)).toBeVisible();
+  async verifyTrackNameDotVisible(row: Locator): Promise<void> {
+    await expect(this.trackNameDot(row)).toBeVisible();
+  }
+
+  async verifyTrackNameDotAbsent(row: Locator): Promise<void> {
+    await expect(this.trackNameDot(row)).not.toBeAttached();
+  }
+
+  async verifyTrackName(row: Locator, expectedName: string): Promise<void> {
+    await expect(this.trackName(row)).toHaveText(expectedName);
+  }
+
+  async verifyArrivalPlaceholderVisible(row: Locator): Promise<void> {
+    await expect(this.timeCellPlaceholder(row, 'requested-arrival')).toBeVisible();
+  }
+
+  async verifyArrivalPlaceholderHidden(row: Locator): Promise<void> {
+    await expect(this.timeCellPlaceholder(row, 'requested-arrival')).toBeHidden();
+  }
+
+  async verifyDeparturePlaceholderVisible(row: Locator): Promise<void> {
+    await expect(this.timeCellPlaceholder(row, 'requested-departure')).toBeVisible();
+  }
+
+  async verifyDeparturePlaceholderHidden(row: Locator): Promise<void> {
+    await expect(this.timeCellPlaceholder(row, 'requested-departure')).toBeHidden();
+  }
+
+  async verifyDurationPlaceholderVisible(row: Locator): Promise<void> {
+    await expect(this.durationCellPlaceholder(row)).toBeVisible();
+  }
+
+  async verifyDurationPlaceholderHidden(row: Locator): Promise<void> {
+    await expect(this.durationCellPlaceholder(row)).toBeHidden();
+  }
+
+  async verifyMarginsDifferenceText(row: Locator, text: string): Promise<void> {
+    await expect(this.marginsDifference(row)).toHaveText(text);
   }
 
   async verifyComputedTheoreticalMarginPresent(row: Locator): Promise<void> {

--- a/front/tests/utils/times-stops-table-types.ts
+++ b/front/tests/utils/times-stops-table-types.ts
@@ -5,12 +5,13 @@ type TimesStopsTableMargin = {
   difference: string;
 };
 
-type TimesStopsTableRowStatus =
+export type TimesStopsTableStatusClass =
   | 'warning-margin'
   | 'warning-schedule'
   | 'success-schedule'
-  | 'invalid-path-step'
-  | '';
+  | 'invalid-path-step';
+
+type TimesStopsTableRowStatus = TimesStopsTableStatusClass | '';
 
 export type TimesStopsTableRow = {
   index: number;


### PR DESCRIPTION
- Fix tests that could never fail, so they now really check the row status, the read-only computed cells and the margins difference.
- Add display checks: date separator, track name and its dot, the + on empty cells, the power restriction options and the margins difference values.
- Add edit checks: clearing a requested departure, switching the margin unit, and the margin columns being recomputed after a margin change 