### PR TITLE
front: add default name for track offset op

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -422,6 +422,7 @@
       "alertMissingRequestedPoint": "At least two path steps are required to define an itinerary",
       "cancel": "Cancel",
       "cancelMapSelection": "Cancel",
+      "destination": "Destination",
       "focusLocationOnMap": "Focus the map on this operational point",
       "frameAll": "Center on all path steps on map",
       "intermediateWaypointsPanel": {
@@ -443,6 +444,7 @@
       "opId": "Operational point identifier",
       "opName": "Operational point name",
       "opType": "Type",
+      "origin": "Origin",
       "pass": "Pass",
       "requestedPoint": "Point on map",
       "stop": "Stop",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -422,6 +422,7 @@
       "alertMissingRequestedPoint": "Il faut au minimum deux points de passage pour définir un itinéraire",
       "cancel": "Annuler",
       "cancelMapSelection": "Annuler",
+      "destination": "Destination",
       "focusLocationOnMap": "Centrer la carte sur ce point remarquable",
       "frameAll": "Centrer sur tous les points de passage sur la carte",
       "intermediateWaypointsPanel": {
@@ -443,6 +444,7 @@
       "opId": "Identifiant de point",
       "opName": "Nom du point remarquable",
       "opType": "Type",
+      "origin": "Origine",
       "pass": "Passage",
       "requestedPoint": "Point sur la carte",
       "stop": "Arrêt",

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -6,6 +6,7 @@ import bbox from '@turf/bbox';
 import { lineString } from '@turf/helpers';
 import cx from 'classnames';
 import type { Position } from 'geojson';
+import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
 import useCategoryColors from 'applications/operationalStudies/hooks/useCategoryColors';
@@ -180,14 +181,14 @@ export function setupStateWithTrainSchedule(
 }
 
 const createDefaultTrainName = (
+  t: TFunction<'operational-studies', 'manageTrainSchedule.itineraryModal'>,
   stepsWithLocationOrInput: PathStepV2[],
   pathStepsMetadataById: Map<string, PathStepMetadata>
 ): string => {
-  const createDefaultStepName = (pathStep: PathStepV2): string => {
+  const createDefaultStepName = (pathStep: PathStepV2, trackOffsetDefault: string): string => {
     const location = pathStep.location;
     if (!location) return '';
-    if (location.type === 'track_offset')
-      return `${location.track}+${Math.round(location.offset / 1000)}`;
+    if (location.type === 'track_offset') return trackOffsetDefault;
     const op = location.operational_point;
     if (op.type === 'domestic') return op.main_code;
     const metadata = pathStepsMetadataById.get(pathStep.id);
@@ -197,7 +198,7 @@ const createDefaultTrainName = (
 
   const origin = stepsWithLocationOrInput[0];
   const destination = stepsWithLocationOrInput[stepsWithLocationOrInput.length - 1];
-  return `${createDefaultStepName(origin)} → ${createDefaultStepName(destination)}`;
+  return `${createDefaultStepName(origin, t('origin'))} → ${createDefaultStepName(destination, t('destination'))}`;
 };
 
 const ItineraryModal = ({
@@ -770,7 +771,7 @@ const ItineraryModal = ({
     if (stepsWithLocationOrInput.length < 2) return;
 
     const name = isNameEmpty
-      ? createDefaultTrainName(stepsWithLocationOrInput, pathStepsMetadataById)
+      ? createDefaultTrainName(t, stepsWithLocationOrInput, pathStepsMetadataById)
       : modalFormState.name;
 
     const stepsWithStopAtDestination = stepsWithLocationOrInput.map((step, i) =>


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/18488

If the first or last path item is a track offset, name it with (resp.) `Origin` or `Destination`

<img width="379" height="287" alt="image" src="https://github.com/user-attachments/assets/e829c6e4-fa05-4117-894f-f3c8b9e626ad" />
