### PR TITLE
front: enable pan without pressing SHIFT in SSD

### DIFF
--- a/front/ui/ui-charts/src/speedSpaceChart/components/helpers/layersManager.ts
+++ b/front/ui/ui-charts/src/speedSpaceChart/components/helpers/layersManager.ts
@@ -10,7 +10,7 @@ export const resetZoom = () =>
 export const zoom = (setStore: React.Dispatch<React.SetStateAction<Store>>) =>
   d3zoom
     .zoom()
-    .filter((event) => event.shiftKey)
+    .filter((event) => event.shiftKey || event.type === 'mousedown')
     .on('zoom', () => {
       const canvas = d3selection.select(FRONT_INTERACTIVITY_LAYER_ID) as d3selection.Selection<
         Element,


### PR DESCRIPTION
Closes #16275.
Remark for reviewers : Oxc changed +23-26 lines, but I only removed a single line : `.filter((event) => event.shiftKey)`.