### PR TITLE
front: use Plex on operational studies navbar

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -4,6 +4,8 @@
   --board-vertical-gap: 16px;
 }
 .scenario-header-container {
+  font-family: 'IBM Plex Sans', sans-serif;
+
   .scenario-header {
     position: relative;
     z-index: 4;


### PR DESCRIPTION
It was the only always-visible component that used Avenir in the Operational Studies app, even though it should be IBM Plex Sans according to our mockups.

<img width="1065" height="117" alt="image" src="https://github.com/user-attachments/assets/c1c101aa-1fb4-4002-839f-c96278c0c78e" />

