### PR TITLE
front: do not modify first path step when applying computed arrival times

### DIFF
--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -982,6 +982,7 @@ const TimesStopsTable = ({
                           table.options.meta!.powerRestrictionBlocks.get(row.original.id)
                             ?.hasWarning,
                         'requested-cell-highlighted-arrival':
+                          cell.row.index !== 0 &&
                           cell.column.id === 'requestedArrival' &&
                           highlightedRowIds.has(row.original.id) &&
                           mouseOverTimeField === 'requestedArrival',
@@ -990,7 +991,9 @@ const TimesStopsTable = ({
                           highlightedRowIds.has(row.original.id) &&
                           mouseOverTimeField === 'requestedDeparture',
                         'requested-cell-highlighted--connect-top':
-                          !hasDayChanged && isCellHighlighted(rowIndex - 1, cell.column.id),
+                          !hasDayChanged &&
+                          !(rowIndex === 1 && cell.column.id === 'requestedArrival') &&
+                          isCellHighlighted(rowIndex - 1, cell.column.id),
                         'requested-cell-highlighted--connect-bottom':
                           !nextHasDayChanged && isCellHighlighted(rowIndex + 1, cell.column.id),
                       })}


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/18497


https://github.com/user-attachments/assets/025dc162-027b-47ff-93ac-5a1885afa39b

The video is a bit laggy but the first path step is not highlighted anymore.

No logic change is needed as it was [already in place](https://github.com/OpenRailAssociation/osrd/blob/edacbfa70a8cc71839a97315e439500569b437e8/front/src/modules/timesStops/TimeStopsTableWrapper.tsx#L399). The highlighting was just incoherent