### PR TITLE
front: make `matchOpRefAndWaypoint()` an internal function

### DIFF
--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -169,6 +169,11 @@ export const transformElectricalBoundariesToRanges = (
   return formattedData;
 };
 
+/**
+ * Do *not* use this function from outside of buildPathWaypointsFromRawOPs():
+ * this breaks when an OP appears multiple times on a path. Instead, use
+ * pathStepId or pathItemId.
+ */
 export const matchOpRefAndWaypoint = (
   location: PathItemLocation,
   waypoint: CoreOperationalPointOnPath

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -174,7 +174,7 @@ export const transformElectricalBoundariesToRanges = (
  * this breaks when an OP appears multiple times on a path. Instead, use
  * pathStepId or pathItemId.
  */
-export const matchOpRefAndWaypoint = (
+const matchOpRefAndWaypoint = (
   location: PathItemLocation,
   waypoint: CoreOperationalPointOnPath
 ) => {

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/IntermediateWaypointsPanel.tsx
@@ -3,8 +3,8 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ItineraryPathProperties } from 'applications/operationalStudies/types';
-import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
 import DotsLoader from 'common/DotsLoader';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 import { groupOperationalPoints } from './utils';
@@ -13,14 +13,16 @@ import WaypointGroup from './WaypointGroup';
 type IntermediateWaypointsPanelProps = {
   pathSteps: PathStepV2[];
   pathProperties: ItineraryPathProperties | undefined;
+  pathWaypoints: PathWaypoint[] | null;
   status: 'idle' | 'loading' | 'error' | 'success';
   onHide: () => void;
-  onAddWaypoint: (op: CoreOperationalPointOnPath, afterStepId: string) => void;
+  onAddWaypoint: (op: PathWaypoint, afterStepId: string) => void;
 };
 
 const IntermediateWaypointsPanel = ({
   pathSteps,
   pathProperties,
+  pathWaypoints,
   status,
   onHide,
   onAddWaypoint,
@@ -51,9 +53,8 @@ const IntermediateWaypointsPanel = ({
   }, [pathSteps, pathProperties]);
 
   const groups = useMemo(
-    () =>
-      groupOperationalPoints(pathProperties?.operational_points ?? [], pathSteps, positionByStepId),
-    [pathProperties, pathSteps, positionByStepId]
+    () => groupOperationalPoints(pathWaypoints ?? [], pathSteps, positionByStepId),
+    [pathWaypoints, pathSteps, positionByStepId]
   );
 
   const [collapsedStepIds, setCollapsedStepIds] = useState<Set<string>>(new Set());

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointGroup.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, ChevronUp } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
-import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 
 import type { WaypointGroup as WaypointGroupType } from './types';
 import WaypointRow from './WaypointRow';
@@ -9,7 +9,7 @@ import WaypointRow from './WaypointRow';
 type WaypointGroupProps = {
   group: WaypointGroupType;
   requestedLabel: string;
-  onAdd: (op: CoreOperationalPointOnPath) => void;
+  onAdd: (op: PathWaypoint) => void;
   expanded: boolean;
   onToggle: () => void;
 };
@@ -52,7 +52,7 @@ const WaypointGroup = ({
       {expanded && hasIntermediates && (
         <ul className="intermediate-waypoints-panel__group-body">
           {group.intermediates.map((op) => (
-            <li key={`${op.id}-${op.position}`}>
+            <li key={op.waypointId}>
               <WaypointRow op={op} onAdd={() => onAdd(op)} />
             </li>
           ))}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointRow.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/WaypointRow.tsx
@@ -2,14 +2,14 @@ import { Dot, Plus } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 
 type WaypointRowProps = {
   /**
    * The OP to show, or undefined for a requested step that matches no OP along
    * the path (for instance a map-click waypoint), rendered as a placeholder
    */
-  op: CoreOperationalPointOnPath | undefined;
+  op: PathWaypoint | undefined;
   /**
    * Name shown when `op` has none (a requested step matching no OP, like a
    * track-offset point for instance)

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/__tests__/utils.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 import { groupOperationalPoints } from '../utils';
@@ -28,13 +28,20 @@ const makeTrackOffsetStep = (id: string): PathStepV2 => ({
 });
 
 const makeOp = (
-  id: string,
+  pathItemId: string | null,
+  opId: string | null,
   uic: number,
   secondaryCode = 'BV',
   position = 0
-): CoreOperationalPointOnPath => ({
-  id,
-  name: `op-${id}`,
+): PathWaypoint => ({
+  waypointId: `path-item-${pathItemId}`,
+  pathItemId,
+  opId,
+  location: {
+    type: 'operational_point_part_reference',
+    operational_point: { type: 'uic', uic, secondary_code: secondaryCode },
+  },
+  name: `op-${opId}`,
   uic,
   secondary_code: secondaryCode,
   main_code: '',
@@ -49,18 +56,18 @@ const makeOp = (
 const summarize = (groups: ReturnType<typeof groupOperationalPoints>) =>
   groups.map((group) => ({
     step: group.requestedStep.id,
-    requestedOp: group.requestedOp?.id,
-    intermediates: group.intermediates.map((op) => op.id),
+    requestedOp: group.requestedOp?.opId,
+    intermediates: group.intermediates.map((op) => op.opId),
   }));
 
 describe('groupOperationalPoints', () => {
   it('puts intermediate OPs between two requested steps in the first group', () => {
     const steps = [makeStep('s1', 1), makeStep('s2', 2)];
     const ops = [
-      makeOp('o1', 1, 'BV', 0),
-      makeOp('o2', 99, 'BV', 100),
-      makeOp('o3', 98, 'BV', 200),
-      makeOp('o4', 2, 'BV', 300),
+      makeOp('s1', 'o1', 1, 'BV', 0),
+      makeOp(null, 'o2', 99, 'BV', 100),
+      makeOp(null, 'o3', 98, 'BV', 200),
+      makeOp('s2', 'o4', 2, 'BV', 300),
     ];
 
     expect(summarize(groupOperationalPoints(ops, steps))).toEqual([
@@ -72,10 +79,10 @@ describe('groupOperationalPoints', () => {
   it('handles two adjacent requested steps with no intermediates between them', () => {
     const steps = [makeStep('s1', 1), makeStep('s2', 2), makeStep('s3', 3)];
     const ops = [
-      makeOp('o1', 1, 'BV', 0),
-      makeOp('o2', 2, 'BV', 100),
-      makeOp('oMid', 99, 'BV', 150),
-      makeOp('o3', 3, 'BV', 200),
+      makeOp('s1', 'o1', 1, 'BV', 0),
+      makeOp('s2', 'o2', 2, 'BV', 100),
+      makeOp(null, 'oMid', 99, 'BV', 150),
+      makeOp('s3', 'o3', 3, 'BV', 200),
     ];
 
     expect(summarize(groupOperationalPoints(ops, steps))).toEqual([
@@ -87,15 +94,15 @@ describe('groupOperationalPoints', () => {
 
   it('returns an empty array when there are no valid/located steps', () => {
     const emptyStep = { ...makeStep('s1', 1), location: null };
-    expect(groupOperationalPoints([makeOp('o1', 1)], [emptyStep])).toEqual([]);
+    expect(groupOperationalPoints([makeOp('s1', 'o1', 1)], [emptyStep])).toEqual([]);
   });
 
   describe('with a middle step that matches no OP', () => {
     const steps = [makeStep('s1', 1), makeTrackOffsetStep('s2'), makeStep('s3', 3)];
     const ops = [
-      makeOp('o1', 1, 'BV', 0),
-      makeOp('oMid', 99, 'BV', 100),
-      makeOp('o3', 3, 'BV', 200),
+      makeOp('s1', 'o1', 1, 'BV', 0),
+      makeOp(null, 'oMid', 99, 'BV', 100),
+      makeOp('s3', 'o3', 3, 'BV', 200),
     ];
 
     it('without positions, falls oMid back under the previous matched step (s1)', () => {
@@ -124,10 +131,10 @@ describe('groupOperationalPoints', () => {
     // The step targets the OP's second crossing (dupSecond, position 300)
     const steps = [makeStep('s1', 1), makeStep('sDup', 2), makeStep('s3', 3)];
     const ops = [
-      makeOp('o1', 1, 'BV', 0),
-      makeOp('dupFirst', 2, 'BV', 100),
-      makeOp('dupSecond', 2, 'BV', 300),
-      makeOp('o3', 3, 'BV', 400),
+      makeOp('s1', 'o1', 1, 'BV', 0),
+      makeOp('sDup', 'dupFirst', 2, 'BV', 100),
+      makeOp(null, 'dupSecond', 2, 'BV', 300),
+      makeOp('s3', 'o3', 3, 'BV', 400),
     ];
 
     it('without positions, falls back to the first crossing claiming the step', () => {
@@ -160,15 +167,15 @@ describe('groupOperationalPoints', () => {
           local_track_name: 'V2',
         },
       };
-      const onTrack = (op: CoreOperationalPointOnPath, localTrackName: string) => ({
+      const onTrack = (op: PathWaypoint, localTrackName: string) => ({
         ...op,
         part: { ...op.part, local_track_name: localTrackName },
       });
       const trackedOps = [
-        makeOp('o1', 1, 'BV', 0),
-        onTrack(makeOp('dupFirst', 2, 'BV', 100), 'V1'),
-        onTrack(makeOp('dupSecond', 2, 'BV', 300), 'V2'),
-        makeOp('o3', 3, 'BV', 400),
+        makeOp('s1', 'o1', 1, 'BV', 0),
+        onTrack(makeOp(null, 'dupFirst', 2, 'BV', 100), 'V1'),
+        onTrack(makeOp('sDup', 'dupSecond', 2, 'BV', 300), 'V2'),
+        makeOp('s3', 'o3', 3, 'BV', 400),
       ];
 
       expect(
@@ -189,14 +196,18 @@ describe('groupOperationalPoints', () => {
       makeStep('sDupB', 2),
       makeStep('s3', 3),
     ];
-    const ops = [makeOp('o1', 1, 'BV', 0), makeOp('o2', 2, 'BV', 100), makeOp('o3', 3, 'BV', 200)];
+    const ops = [
+      makeOp('s1', 'o1', 1, 'BV', 0),
+      makeOp('sDupB', 'o2', 2, 'BV', 100),
+      makeOp('s3', 'o3', 3, 'BV', 200),
+    ];
 
     it('collapses them into one group carrying a count', () => {
       const groups = groupOperationalPoints(ops, steps);
       expect(
         groups.map((group) => ({
           step: group.requestedStep.id,
-          requestedOp: group.requestedOp?.id,
+          requestedOp: group.requestedOp?.opId,
           count: group.duplicatesCount,
         }))
       ).toEqual([

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/types.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/types.ts
@@ -1,9 +1,9 @@
-import type { CoreOperationalPointOnPath } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 export type WaypointGroup = {
   requestedStep: PathStepV2;
-  requestedOp: CoreOperationalPointOnPath | undefined;
-  intermediates: CoreOperationalPointOnPath[];
+  requestedOp: PathWaypoint | undefined;
+  intermediates: PathWaypoint[];
   duplicatesCount: number;
 };

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/IntermediateWaypointsPanel/utils.ts
@@ -1,8 +1,5 @@
-import { matchOpRefAndWaypoint } from 'applications/operationalStudies/utils';
-import type {
-  CoreOperationalPointOnPath,
-  OperationalPointReference,
-} from 'common/api/osrdEditoastApi';
+import type { OperationalPointReference } from 'common/api/osrdEditoastApi';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import type { PathStepV2 } from 'reducers/osrdconf/types';
 
 import type { WaypointGroup } from './types';
@@ -44,7 +41,7 @@ const isSameWaypoint = (a: LocatedStep, b: LocatedStep) => {
  * stands for.
  */
 export function groupOperationalPoints(
-  operationalPoints: CoreOperationalPointOnPath[],
+  waypoints: PathWaypoint[],
   pathSteps: PathStepV2[],
   positionByStepId?: Map<string, number>
 ): WaypointGroup[] {
@@ -73,42 +70,31 @@ export function groupOperationalPoints(
     duplicatesCount,
   }));
 
-  const isStepBeforeOp = (step: LocatedStep, op: CoreOperationalPointOnPath) => {
+  const isStepBeforeWaypoint = (step: LocatedStep, waypoint: PathWaypoint) => {
     const position = positionByStepId?.get(step.id);
-    return position !== undefined && position < op.position;
+    return position !== undefined && position < waypoint.position;
   };
 
   // Walk the OPs in path order, moving a cursor onto the latest requested step
   // each op has reached, then filing the op under that step's group.
   let currentGroupIndex = -1;
-  operationalPoints.forEach((op) => {
+  waypoints.forEach((waypoint) => {
     // Reach a step by position:
     while (
       currentGroupIndex + 1 < collapsedSteps.length &&
-      isStepBeforeOp(collapsedSteps[currentGroupIndex + 1].step, op)
+      isStepBeforeWaypoint(collapsedSteps[currentGroupIndex + 1].step, waypoint)
     ) {
       currentGroupIndex += 1;
     }
 
     // Reach a step by identity:
-    const matchedIndex = collapsedSteps.findIndex(({ step }, index) => {
-      if (index <= currentGroupIndex || !matchOpRefAndWaypoint(step.location, op)) return false;
-      // An OP crossed twice matches both steps by identity. Pick the right
-      // crossing: by position if known, else by pinned track.
-      const position = positionByStepId?.get(step.id);
-      if (position !== undefined) return position === op.position;
-      const pinnedTrack =
-        step.location.type === 'operational_point_part_reference'
-          ? step.location.local_track_name
-          : undefined;
-      return !pinnedTrack || pinnedTrack === op.part.local_track_name;
-    });
+    const matchedIndex = collapsedSteps.findIndex(({ step }) => step.id === waypoint.pathItemId);
 
     if (matchedIndex !== -1) {
       currentGroupIndex = matchedIndex;
-      groups[currentGroupIndex].requestedOp = op;
+      groups[currentGroupIndex].requestedOp = waypoint;
     } else if (currentGroupIndex >= 0) {
-      groups[currentGroupIndex].intermediates.push(op);
+      groups[currentGroupIndex].intermediates.push(waypoint);
     }
   });
 

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -16,6 +16,7 @@ import {
 import { useOperationalPointSearch } from 'applications/operationalStudies/hooks/useOperationalPointSearch';
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PowerRestriction } from 'applications/operationalStudies/types';
+import { buildPathWaypointsFromRawOPs } from 'applications/operationalStudies/utils';
 import type {
   CoreOperationalPointOnPath,
   OperationalPointReference,
@@ -698,6 +699,14 @@ const ItineraryModal = ({
     }
   }, [pathProperties]);
 
+  const pathWaypoints = useMemo(() => {
+    if (!displayedPathProperties) return null;
+    return buildPathWaypointsFromRawOPs(
+      displayedPathProperties.operational_points,
+      pathfindingSteps.map((step) => ({ ...step, location: step.location! }))
+    );
+  }, [displayedPathProperties, pathfindingSteps]);
+
   const openModal = () => {
     modalRef.current?.showModal();
   };
@@ -1122,6 +1131,7 @@ const ItineraryModal = ({
           pathSteps={pathSteps}
           pathStepsMetadata={pathStepsMetadataById}
           pathProperties={displayedPathProperties}
+          pathWaypoints={pathWaypoints}
           selectedStepId={mapSelectionStepId ?? undefined}
           isMapSelectionMode={mapSelectionStepId !== null}
           onMapSelectionClick={handleMapSelectionClick}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModal.tsx
@@ -18,7 +18,6 @@ import { useScenarioContext } from 'applications/operationalStudies/hooks/useSce
 import type { PowerRestriction } from 'applications/operationalStudies/types';
 import { buildPathWaypointsFromRawOPs } from 'applications/operationalStudies/utils';
 import type {
-  CoreOperationalPointOnPath,
   OperationalPointReference,
   PathProperties,
   PathItemLocation,
@@ -34,6 +33,7 @@ import IncompatibleConstraints from 'modules/pathfinding/components/Incompatible
 import TypeAndPath from 'modules/pathfinding/components/Pathfinding/TypeAndPath';
 import reversePathSteps from 'modules/pathfinding/helpers/reversePathSteps';
 import usePathfindingV2 from 'modules/pathfinding/hooks/usePathfindingV2';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import computeBasePathStep from 'modules/trainSchedule/helpers/computeBasePathStep';
 import {
   DEFAULT_PACED_TRAIN_INTERVAL,
@@ -422,7 +422,7 @@ const ItineraryModal = ({
   };
 
   const handleAddWaypoint = useCallback(
-    (op: CoreOperationalPointOnPath, afterStepId: string) => {
+    (op: PathWaypoint, afterStepId: string) => {
       const insertIndex = pathSteps.findIndex((step) => step.id === afterStepId) + 1;
       if (insertIndex === 0) return;
 
@@ -1115,6 +1115,7 @@ const ItineraryModal = ({
           <IntermediateWaypointsPanel
             pathSteps={pathSteps}
             pathProperties={displayedPathProperties}
+            pathWaypoints={pathWaypoints}
             status={waypointsPanelStatus}
             onHide={() => setWaypointsPanelOpen(false)}
             onAddWaypoint={handleAddWaypoint}

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalMap.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ItineraryModalMap.tsx
@@ -4,7 +4,6 @@ import type { Feature, Position } from 'geojson';
 import { useTranslation } from 'react-i18next';
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 
-import { matchOpRefAndWaypoint } from 'applications/operationalStudies/utils';
 import {
   osrdEditoastApi,
   type OperationalPoint,
@@ -19,6 +18,7 @@ import { MapContextProvider } from 'common/Map/useMapContext';
 import { useInfraID } from 'common/osrdContext';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 import Itinerary from 'modules/simulationResult/components/SimulationResultsMap/RenderItinerary';
+import type { PathWaypoint } from 'modules/simulationResult/types';
 import { useMapSettings, useMapSettingsActions } from 'reducers/commonMap';
 import type { MapSettings, Viewport } from 'reducers/commonMap/types';
 import { setFailure } from 'reducers/main';
@@ -46,6 +46,7 @@ type ItineraryModalMapProps = {
   pathSteps?: PathStepV2[];
   pathStepsMetadata?: Map<string, PathStepMetadata>;
   pathProperties?: PathProperties;
+  pathWaypoints: PathWaypoint[] | null;
   selectedStepId?: string;
   isMapSelectionMode?: boolean;
   onMapSelectionClick?: (featureInfoClick: FeatureInfoClick) => void;
@@ -58,6 +59,7 @@ const ItineraryModalMap = ({
   pathSteps,
   pathStepsMetadata,
   pathProperties,
+  pathWaypoints,
   selectedStepId,
   isMapSelectionMode,
   onMapSelectionClick,
@@ -356,14 +358,12 @@ const ItineraryModalMap = ({
             if (!pathStepMetadata || !pathStepLocation || pathStepMetadata.isInvalid) return null;
 
             let coordinates: Position | undefined;
-            if (pathProperties?.operational_points) {
+            if (pathWaypoints) {
               // If there is a pathfinding, we use it to get the simulated coordinates
               if (pathStepMetadata.type === 'trackOffset') {
                 coordinates = pathStepMetadata.coordinates;
               } else {
-                const matchedOp = pathProperties.operational_points.find((op) =>
-                  matchOpRefAndWaypoint(pathStepLocation, op)
-                );
+                const matchedOp = pathWaypoints.find((waypoint) => waypoint.pathItemId === step.id);
                 const trackMetadata = pathStepMetadata.parts.find(
                   (part) => part.type === 'valid' && part.trackId === matchedOp?.part.track
                 );


### PR DESCRIPTION
Same idea as https://github.com/OpenRailAssociation/osrd/pull/17984, but for `matchOpRefAndWaypoint()`.

Depends on https://github.com/OpenRailAssociation/osrd/pull/18509