### PR TITLE
front: make power restriction selection range inclusive

### DIFF
--- a/front/src/modules/timesStops/helpers/__tests__/powerRestrictionIncompatibility.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/powerRestrictionIncompatibility.spec.ts
@@ -217,7 +217,7 @@ describe('computeRowPowerRestrictionStatus', () => {
     expect(result.get('f')?.isBlockStart).toBe(false);
   });
 
-  it('uses semi-open interval: begin is inclusive, end is exclusive', () => {
+  it('uses semi-open interval: begin is inclusive, end is inclusive', () => {
     const rows = [row('a', 0), row('b', 1), row('c', 2), row('d', 3)];
     const positions = new Map([
       [0, 100],
@@ -225,7 +225,7 @@ describe('computeRowPowerRestrictionStatus', () => {
       [2, 300],
       [3, 400],
     ]);
-    // Row at position 200 should be IN (>= begin), row at 400 should be OUT (< end)
+    // Row at position 200 should be IN (>= begin), row at 400 should be IN (<= end)
     const warningRanges = [{ begin: 200, end: 400 }];
 
     const result = computeRowPowerRestrictionStatus(rows, positions, warningRanges, []);
@@ -233,7 +233,7 @@ describe('computeRowPowerRestrictionStatus', () => {
     expect(result.get('a')?.hasWarning).toBe(false); // 100 < 200
     expect(result.get('b')?.hasWarning).toBe(true); // 200 >= 200
     expect(result.get('c')?.hasWarning).toBe(true); // 300 >= 200 && < 400
-    expect(result.get('d')?.hasWarning).toBe(false); // 400 not < 400
+    expect(result.get('d')?.hasWarning).toBe(true); // 400 <= 400
   });
 
   it('splits a visually contiguous warning into two blocks when the active restriction changes', () => {

--- a/front/src/modules/timesStops/helpers/powerRestrictionIncompatibility.ts
+++ b/front/src/modules/timesStops/helpers/powerRestrictionIncompatibility.ts
@@ -76,7 +76,7 @@ export const computeRowPowerRestrictionStatus = (
     const rowPosition = operationalPointPositions.get(row.opOnPathIndex);
     const hasWarning =
       rowPosition !== undefined &&
-      warningRanges.some((w) => rowPosition >= w.begin && rowPosition < w.end);
+      warningRanges.some((w) => rowPosition >= w.begin && rowPosition <= w.end);
 
     // 3. Detect block boundaries. A block represents a contiguous run of rows
     //    where the *same* active restriction is incompatible. So a new block

--- a/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
+++ b/front/tests/02-operational-studies/simulation-result/002-times-stops-table-display.spec.ts
@@ -110,10 +110,11 @@ test.describe('Times Stops Table — Display', { tag: ['@op', '@times-stops'] },
     const destRow = timesStopsTablePage.getRow(ROW_INDEX_DESTINATION);
 
     await test.step('Verify power restriction combobox is visible on all rows with correct initial values', async () => {
-      for (const row of [departureRow, via1Row, waypointRow, destRow]) {
+      for (const row of [departureRow, via1Row, waypointRow]) {
         await timesStopsTablePage.verifyPowerRestriction(row, '');
       }
       await timesStopsTablePage.verifyPowerRestriction(via2Row, POWER_RESTRICTION_C1);
+      await timesStopsTablePage.verifyPowerRestriction(destRow, POWER_RESTRICTION_C1);
     });
 
     await test.step(`Verify computed theoretical margin shows ${COMPUTED_THEORETICAL_MARGIN_DEPARTURE} on departure row and is absent on intermediate rows`, async () => {


### PR DESCRIPTION
Closes https://github.com/OpenRailAssociation/osrd/issues/17885

The range was considered exclusive on the upper bound which does not make sens in this case. It should be inclusive instead