### PR TITLE
front: fix suggestion op in new itinerary modal

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ComboBoxCustomList/ListElementComponent.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTrainSchedule/Itinerary/ComboBoxCustomList/ListElementComponent.tsx
@@ -72,7 +72,6 @@ export const ListElementComponent = ({
               'op-suggestion-secondary-code--best': secondaryCode.isBestSuggestion,
               'op-suggestion-secondary-code--inactive': secondaryCode.isCandidate === false,
             })}
-            disabled={secondaryCode.isCandidate === false}
             onMouseDown={(e) => {
               e.preventDefault();
               e.stopPropagation();


### PR DESCRIPTION
fixes #16151 

When a secondary code wasn't the best match for the current search, it was marked `isCandidate: false` which disabled the button and prevented selection.
The fix removes the disabled attribute from `ListElementComponent`.