### PR TITLE
front: fix request times count before applying computed times

### DIFF
--- a/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
+++ b/front/src/modules/timesStops/TimeStopsTableWrapper.tsx
@@ -370,9 +370,7 @@ const TimeStopsTableWrapper = ({
 
   const handleApplyTimesFromSimulation = (field: RequestedTimeField, mode: TimeFillMode): void => {
     const computedField = field === 'requestedArrival' ? 'computedArrival' : 'computedDeparture';
-    const targetRows = getRowsToUpdateFromSimulation(rows, field, mode).filter(
-      (row) => row.opOnPathIndex !== 0
-    );
+    const targetRows = getRowsToUpdateFromSimulation(rows, field, mode);
     const edits: PendingEdit[] = targetRows.map((row) => ({
       rowId: row.id,
       field,

--- a/front/src/modules/timesStops/TimesStopsTable.tsx
+++ b/front/src/modules/timesStops/TimesStopsTable.tsx
@@ -1003,7 +1003,6 @@ const TimesStopsTable = ({
                           table.options.meta!.powerRestrictionBlocks.get(row.original.id)
                             ?.hasWarning,
                         'requested-cell-highlighted-arrival':
-                          cell.row.index !== 0 &&
                           cell.column.id === 'requestedArrival' &&
                           highlightedRowIds.has(row.original.id) &&
                           mouseOverTimeField === 'requestedArrival',
@@ -1012,9 +1011,7 @@ const TimesStopsTable = ({
                           highlightedRowIds.has(row.original.id) &&
                           mouseOverTimeField === 'requestedDeparture',
                         'requested-cell-highlighted--connect-top':
-                          !hasDayChanged &&
-                          !(rowIndex === 1 && cell.column.id === 'requestedArrival') &&
-                          isCellHighlighted(rowIndex - 1, cell.column.id),
+                          !hasDayChanged && isCellHighlighted(rowIndex - 1, cell.column.id),
                         'requested-cell-highlighted--connect-bottom':
                           !nextHasDayChanged && isCellHighlighted(rowIndex + 1, cell.column.id),
                       })}

--- a/front/src/modules/timesStops/helpers/__tests__/fillTimesFromSimulation.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/fillTimesFromSimulation.spec.ts
@@ -9,7 +9,7 @@ const _10H30 = new Date('2025-01-01T10:30:00Z');
 const buildRow = (overrides: Partial<TimesStopsRowNew> = {}): TimesStopsRowNew => ({
   id: 'row-1',
   pathStepId: 'step-1',
-  opOnPathIndex: 0,
+  opOnPathIndex: 1,
   stepStatus: 'allHonored',
   name: 'Some station',
   track: 'track',

--- a/front/src/modules/timesStops/helpers/fillTimesFromSimulation.ts
+++ b/front/src/modules/timesStops/helpers/fillTimesFromSimulation.ts
@@ -8,6 +8,8 @@ export const getRowsToUpdateFromSimulation = (
   const computedField = field === 'requestedArrival' ? 'computedArrival' : 'computedDeparture';
   return rows.filter(
     (row) =>
+      // The origin is excluded since its computed and requested times are always the same
+      row.opOnPathIndex !== 0 &&
       row.pathStepId !== null &&
       row[computedField] !== null &&
       (mode === 'overwrite' || row[field] === null)


### PR DESCRIPTION
This PR is related to this bug https://github.com/OpenRailAssociation/osrd/issues/18497.
The [first fix](https://github.com/OpenRailAssociation/osrd/pull/18508) was only focused on the highlight of the cell but the count displayed was still inconsistent.

Here, we explicitly exclude origin of the update logic which is fixing both the count and the highlight.