### PR TITLE
front: fix train count language when switching language

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -130,7 +130,13 @@ const TimetableBoardWrapper = ({
     }
 
     return `${pacedTrainLabel}, ${uniqueTrainLabel}`;
-  }, [totalUniqueTrainCount, totalPacedTrainCount, selectedUniqueTrainIds, selectedPacedTrainIds]);
+  }, [
+    t,
+    totalUniqueTrainCount,
+    totalPacedTrainCount,
+    selectedUniqueTrainIds,
+    selectedPacedTrainIds,
+  ]);
   // --- END BOARD WRAPPER TITLE MANAGEMENT ---------------------
 
   const handleTrainsDelete = async (


### PR DESCRIPTION
In the train list header, the language used to display the train count was not updated when switching language.